### PR TITLE
Fix setting up options due to config data freeze

### DIFF
--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -332,16 +332,17 @@ class MikrotikHub:
     async def async_add_options(self):
         """Populate default options for Mikrotik."""
         if not self.config_entry.options:
+            data = dict(self.config_entry.data)
             options = {
-                CONF_ARP_PING: self.config_entry.data.pop(CONF_ARP_PING, False),
-                CONF_FORCE_DHCP: self.config_entry.data.pop(CONF_FORCE_DHCP, False),
-                CONF_DETECTION_TIME: self.config_entry.data.pop(
+                CONF_ARP_PING: data.pop(CONF_ARP_PING, False),
+                CONF_FORCE_DHCP: data.pop(CONF_FORCE_DHCP, False),
+                CONF_DETECTION_TIME: data.pop(
                     CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME
                 ),
             }
 
             self.hass.config_entries.async_update_entry(
-                self.config_entry, options=options
+                self.config_entry, data=data, options=options
             )
 
     async def request_update(self):


### PR DESCRIPTION
## Proposed change
This PR fixes setting up options due to the config_entry data freeze.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
