### PR TITLE
Make zone dependency of device tracker an after dep

### DIFF
--- a/homeassistant/components/device_tracker/manifest.json
+++ b/homeassistant/components/device_tracker/manifest.json
@@ -3,8 +3,8 @@
   "name": "Device Tracker",
   "documentation": "https://www.home-assistant.io/integrations/device_tracker",
   "requirements": [],
-  "dependencies": ["zone"],
-  "after_dependencies": [],
+  "dependencies": [],
+  "after_dependencies": ["zone"],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -160,8 +160,10 @@ async def test_webhook_handle_get_zones(hass, create_registrations, webhook_clie
     assert resp.status == 200
 
     json = await resp.json()
-    assert len(json) == 1
-    assert json[0]["entity_id"] == "zone.home"
+    assert len(json) == 2
+    zones = sorted(json, key=lambda entry: entry["entity_id"])
+    assert zones[0]["entity_id"] == "zone.home"
+    assert zones[1]["entity_id"] == "zone.test"
 
 
 async def test_webhook_handle_get_config(hass, create_registrations, webhook_client):

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -109,7 +109,7 @@ async def test_no_clients(hass):
     """Test the update_clients function when no clients are found."""
     await setup_unifi_integration(hass)
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_tracked_devices(hass):
@@ -124,7 +124,7 @@ async def test_tracked_devices(hass):
         devices_response=[DEVICE_1, DEVICE_2],
         known_wireless_clients=(CLIENT_4["mac"],),
     )
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 5
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -185,7 +185,7 @@ async def test_controller_state_change(hass):
     controller = await setup_unifi_integration(
         hass, clients_response=[CLIENT_1], devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     # Controller unavailable
     controller.async_unifi_signalling_callback(
@@ -215,7 +215,7 @@ async def test_option_track_clients(hass):
     controller = await setup_unifi_integration(
         hass, clients_response=[CLIENT_1, CLIENT_2], devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -260,7 +260,7 @@ async def test_option_track_wired_clients(hass):
     controller = await setup_unifi_integration(
         hass, clients_response=[CLIENT_1, CLIENT_2], devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -305,7 +305,7 @@ async def test_option_track_devices(hass):
     controller = await setup_unifi_integration(
         hass, clients_response=[CLIENT_1, CLIENT_2], devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -350,7 +350,7 @@ async def test_option_ssid_filter(hass):
     controller = await setup_unifi_integration(
         hass, options={CONF_SSID_FILTER: ["ssid"]}, clients_response=[CLIENT_3],
     )
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
     # SSID filter active
     client_3 = hass.states.get("device_tracker.client_3")
@@ -388,7 +388,7 @@ async def test_wireless_client_go_wired_issue(hass):
     client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
 
     controller = await setup_unifi_integration(hass, clients_response=[client_1_client])
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -461,7 +461,7 @@ async def test_restoring_client(hass):
         clients_response=[CLIENT_2],
         clients_all_response=[CLIENT_1],
     )
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     device_1 = hass.states.get("device_tracker.client_1")
     assert device_1 is not None
@@ -475,7 +475,7 @@ async def test_dont_track_clients(hass):
         clients_response=[CLIENT_1],
         devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is None
@@ -493,7 +493,7 @@ async def test_dont_track_devices(hass):
         clients_response=[CLIENT_1],
         devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -510,7 +510,7 @@ async def test_dont_track_wired_clients(hass):
         options={unifi.controller.CONF_TRACK_WIRED_CLIENTS: False},
         clients_response=[CLIENT_1, CLIENT_2],
     )
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -55,7 +55,7 @@ async def test_no_clients(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_sensors(hass):
@@ -71,7 +71,7 @@ async def test_sensors(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 4
 
     wired_client_rx = hass.states.get("sensor.wired_client_name_rx")
     assert wired_client_rx.state == "1234.0"

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -209,7 +209,7 @@ async def test_no_clients(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_controller_not_client(hass):
@@ -222,7 +222,7 @@ async def test_controller_not_client(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
     cloudkey = hass.states.get("switch.cloud_key")
     assert cloudkey is None
 
@@ -240,7 +240,7 @@ async def test_not_admin(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_switches(hass):
@@ -258,7 +258,7 @@ async def test_switches(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     switch_1 = hass.states.get("switch.poe_client_1")
     assert switch_1 is not None
@@ -312,7 +312,7 @@ async def test_new_client_discovered_on_block_control(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
     blocked = hass.states.get("switch.block_client_1")
     assert blocked is None
@@ -324,7 +324,7 @@ async def test_new_client_discovered_on_block_control(hass):
     controller.api.session_handler("data")
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
     blocked = hass.states.get("switch.block_client_1")
     assert blocked is not None
 
@@ -336,7 +336,7 @@ async def test_option_block_clients(hass):
         options={CONF_BLOCK_CLIENT: [BLOCKED["mac"]]},
         clients_all_response=[BLOCKED, UNBLOCKED],
     )
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     # Add a second switch
     hass.config_entries.async_update_entry(
@@ -344,28 +344,28 @@ async def test_option_block_clients(hass):
         options={CONF_BLOCK_CLIENT: [BLOCKED["mac"], UNBLOCKED["mac"]]},
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     # Remove the second switch again
     hass.config_entries.async_update_entry(
         controller.config_entry, options={CONF_BLOCK_CLIENT: [BLOCKED["mac"]]},
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     # Enable one and remove another one
     hass.config_entries.async_update_entry(
         controller.config_entry, options={CONF_BLOCK_CLIENT: [UNBLOCKED["mac"]]},
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     # Remove one
     hass.config_entries.async_update_entry(
         controller.config_entry, options={CONF_BLOCK_CLIENT: []},
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_new_client_discovered_on_poe_control(hass):
@@ -378,7 +378,7 @@ async def test_new_client_discovered_on_poe_control(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     controller.api.websocket._data = {
         "meta": {"message": "sta:sync"},
@@ -391,7 +391,7 @@ async def test_new_client_discovered_on_poe_control(hass):
         "switch", "turn_off", {"entity_id": "switch.poe_client_1"}, blocking=True
     )
     assert len(controller.mock_requests) == 5
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
     assert controller.mock_requests[4] == {
         "json": {
             "port_overrides": [{"port_idx": 1, "portconf_id": "1a1", "poe_mode": "off"}]
@@ -430,7 +430,7 @@ async def test_ignore_multiple_poe_clients_on_same_port(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     switch_1 = hass.states.get("switch.poe_client_1")
     switch_2 = hass.states.get("switch.poe_client_2")
@@ -481,7 +481,7 @@ async def test_restoring_client(hass):
     )
 
     assert len(controller.mock_requests) == 4
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     device_1 = hass.states.get("switch.client_1")
     assert device_1 is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the "zone" device tracker dependency to be an "after_dependency". Device tracker still functions without it being set up.

This will prevent the device tracker from not being set up if zone is misconfigured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
