### PR TITLE
Handle unique WLED device using zeroconf properties

### DIFF
--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -44,7 +44,12 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
 
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context.update(
-            {CONF_HOST: host, CONF_NAME: name, "title_placeholders": {"name": name}}
+            {
+                CONF_HOST: host,
+                CONF_NAME: name,
+                CONF_MAC: user_input["properties"].get(CONF_MAC),
+                "title_placeholders": {"name": name},
+            }
         )
 
         # Prepare configuration flow
@@ -72,23 +77,22 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
         if source == SOURCE_ZEROCONF:
             # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
             user_input[CONF_HOST] = self.context.get(CONF_HOST)
+            user_input[CONF_MAC] = self.context.get(CONF_MAC)
 
-        errors = {}
-        session = async_get_clientsession(self.hass)
-        wled = WLED(user_input[CONF_HOST], session=session)
-
-        try:
-            device = await wled.update()
-        except WLEDConnectionError:
-            if source == SOURCE_ZEROCONF:
-                return self.async_abort(reason="connection_error")
-            errors["base"] = "connection_error"
-            return self._show_setup_form(errors)
+        if user_input.get(CONF_MAC) is None or not prepare:
+            session = async_get_clientsession(self.hass)
+            wled = WLED(user_input[CONF_HOST], session=session)
+            try:
+                device = await wled.update()
+            except WLEDConnectionError:
+                if source == SOURCE_ZEROCONF:
+                    return self.async_abort(reason="connection_error")
+                return self._show_setup_form({"base": "connection_error"})
+            user_input[CONF_MAC] = device.info.mac_address
 
         # Check if already configured
-        mac_address = device.info.mac_address
-        await self.async_set_unique_id(device.info.mac_address)
-        self._abort_if_unique_id_configured()
+        await self.async_set_unique_id(user_input[CONF_MAC])
+        self._abort_if_unique_id_configured(updates={CONF_HOST: user_input[CONF_HOST]})
 
         title = user_input[CONF_HOST]
         if source == SOURCE_ZEROCONF:
@@ -99,7 +103,8 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_zeroconf_confirm()
 
         return self.async_create_entry(
-            title=title, data={CONF_HOST: user_input[CONF_HOST], CONF_MAC: mac_address}
+            title=title,
+            data={CONF_HOST: user_input[CONF_HOST], CONF_MAC: user_input[CONF_MAC]},
         )
 
     def _show_setup_form(self, errors: Optional[Dict] = None) -> Dict[str, Any]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

WLED now sends out a unique identifier (mac address) in the latest firmware.
This PR leverages that, by using that mac address in the zeroconf properties if it is available. If the property is missing, it will fallback and query the device like before.

This is an improvement since HA does not need to connect to the device during discovery (on each start).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
