### PR TITLE
Elv fixes

### DIFF
--- a/homeassistant/components/elv/switch.py
+++ b/homeassistant/components/elv/switch.py
@@ -45,6 +45,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Initialize the switch."""
         self._device_id = device_id
         self._name = "PCA 301"
+        self._unique_id = "elv_pca_301_" + str(device_id)
         self._state = None
         self._available = True
         self._emeter_params = {}
@@ -77,6 +78,10 @@ class SmartPlugSwitch(SwitchDevice):
     def device_state_attributes(self):
         """Return the state attributes of the device."""
         return self._emeter_params
+
+    @property
+    def unique_id(self):
+        return self._unique_id
 
     def update(self):
         """Update the PCA switch's state."""

--- a/homeassistant/components/elv/switch.py
+++ b/homeassistant/components/elv/switch.py
@@ -44,7 +44,7 @@ class SmartPlugSwitch(SwitchDevice):
     def __init__(self, pca, device_id):
         """Initialize the switch."""
         self._device_id = device_id
-        self._name = "PCA 301"
+        self._name = "PCA 301 - " + str(device_id)
         self._unique_id = "elv_pca_301_" + str(device_id)
         self._state = None
         self._available = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This PR changes the naming of ELV PCA devices and adds a unique id to the devices.
By changing the name, all previously defined ELV PCA devices will be orphaned.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The naming of the ELV PCA devices is horrible: They all have the exact same name. Identifying or renaming individual devices is not possible.
The PR changes the default naming scheme to include the device ID in the name.
It further adds a unique_id to the device which makes it renameable in the HA interface.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
