### PR TITLE
Bump wled 0.3.0, reduce calls stability improvements

### DIFF
--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -26,7 +26,7 @@ from .const import (
     DOMAIN,
 )
 
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=5)
 WLED_COMPONENTS = (LIGHT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ def wled_exception_handler(func):
     async def handler(self, *args, **kwargs):
         try:
             await func(self, *args, **kwargs)
-            await self.coordinator.async_refresh()
+            self.coordinator.update_listeners()
 
         except WLEDConnectionError as error:
             _LOGGER.error("Error communicating with API: %s", error)
@@ -128,7 +128,7 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> WLEDDevice:
         """Fetch data from WLED."""
         try:
-            return await self.wled.update()
+            return await self.wled.update(full_update=not self.last_update_success)
         except WLEDError as error:
             raise UpdateFailed(f"Invalid response from API: {error}")
 

--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -3,7 +3,7 @@
   "name": "WLED",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wled",
-  "requirements": ["wled==0.2.1"],
+  "requirements": ["wled==0.3.0"],
   "dependencies": [],
   "zeroconf": ["_wled._tcp.local."],
   "codeowners": ["@frenck"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2105,7 +2105,7 @@ wirelesstagpy==0.4.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.2.1
+wled==0.3.0
 
 # homeassistant.components.wunderlist
 wunderpy2==0.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -736,7 +736,7 @@ watchdog==0.8.3
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.2.1
+wled==0.3.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest

--- a/tests/components/wled/__init__.py
+++ b/tests/components/wled/__init__.py
@@ -25,7 +25,19 @@ async def init_integration(
 
     aioclient_mock.post(
         "http://example.local:80/json/state",
-        json={"success": True},
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+
+    aioclient_mock.get(
+        "http://example.local:80/json/info",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+
+    aioclient_mock.get(
+        "http://example.local:80/json/state",
+        json={},
         headers={"Content-Type": "application/json"},
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps WLED to v0.3.0.
Changelog: <https://github.com/frenck/python-wled/releases/tag/v0.3.0>

Adjusted the integration for that bump, ensure it takes advantage of the new features.

- Reduces API call's that are heavy for less capable ESP chips. Instead of polling for all data (including effects and pallets), it generally only polls for the states. Except when (re)connecting, it will query the full data set again (e.g., because of user changes or firmware upgrades).
- It now requests WLED to return its current state after changing the state, which removes the needs for an additional refresh/poll after changing states.
- Scan interval has been lowered from 10 to 5 seconds, which still keeps plenty of room for the chip to breathe because of the above changes.
- The general robustness of the client library improved, handling a lot more errors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
