### PR TITLE
Blacklist auto_backup

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -20,6 +20,8 @@ DATA_DEPS_REQS = "deps_reqs_processed"
 
 SLOW_SETUP_WARNING = 10
 
+BLACKLIST = set(["auto_backup"])
+
 
 def setup_component(hass: core.HomeAssistant, domain: str, config: ConfigType) -> bool:
     """Set up a component and all its dependencies."""
@@ -37,6 +39,12 @@ async def async_setup_component(
     """
     if domain in hass.config.components:
         return True
+
+    if domain in BLACKLIST:
+        _LOGGER.error(
+            "Integration %s is blacklisted because it is causing issues.", domain
+        )
+        return False
 
     setup_tasks = hass.data.setdefault(DATA_SETUP, {})
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -540,7 +540,7 @@ async def test_setup_import_blows_up(hass):
 
 async def test_blacklist(caplog):
     """Test setup blacklist."""
-    with patch("homeassistant.setup.BLACKLIST", ["bad_integration"]):
+    with patch("homeassistant.setup.BLACKLIST", {"bad_integration"}):
         assert not await setup.async_setup_component(
             mock.Mock(config=mock.Mock(components=[])), "bad_integration", {}
         )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -6,6 +6,7 @@ import os
 import threading
 from unittest import mock
 
+from asynctest import patch
 import voluptuous as vol
 
 from homeassistant import setup
@@ -535,3 +536,15 @@ async def test_setup_import_blows_up(hass):
         "homeassistant.loader.Integration.get_component", side_effect=ValueError
     ):
         assert not await setup.async_setup_component(hass, "sun", {})
+
+
+async def test_blacklist(caplog):
+    """Test setup blacklist."""
+    with patch("homeassistant.setup.BLACKLIST", ["bad_integration"]):
+        assert not await setup.async_setup_component(
+            mock.Mock(config=mock.Mock(components=[])), "bad_integration", {}
+        )
+    assert (
+        "Integration bad_integration is blacklisted because it is causing issues."
+        in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We've been getting reports from users that in the beta the supervisor tab is no longer showing. This tab is what people use to update Home Assistant, it is crucial that this tab is always shown.

Someone figured out that it was caused by the [`auto_backup`](https://github.com/jcwillox/hass-auto-backup/pull/10) custom integration. I don't know how it's possible, but we should avoid it to happen at all costs.

I am introducing a blacklist feature to allow blacklisting integrations from being set up. Right now it's built into the source as it's a stopgap measure to make sure the final release does not break the supervisor tab for anyone.

We need to figure out how it is possible for them to break it and prevent that. 

It's not only necessary for auto_backup to be fixed, the fix also needs to be rolled out to all users. This does not seem possible before 107.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
