### PR TITLE
Add support for dashboards to lovelace cast service

### DIFF
--- a/homeassistant/components/cast/home_assistant_cast.py
+++ b/homeassistant/components/cast/home_assistant_cast.py
@@ -12,6 +12,7 @@ from .const import DOMAIN, SIGNAL_HASS_CAST_SHOW_VIEW
 
 SERVICE_SHOW_VIEW = "show_lovelace_view"
 ATTR_VIEW_PATH = "view_path"
+ATTR_URL_PATH = "dashboard_path"
 
 
 async def async_setup_ha_cast(
@@ -63,11 +64,18 @@ async def async_setup_ha_cast(
             controller,
             call.data[ATTR_ENTITY_ID],
             call.data[ATTR_VIEW_PATH],
+            call.data.get(ATTR_URL_PATH),
         )
 
     hass.helpers.service.async_register_admin_service(
         DOMAIN,
         SERVICE_SHOW_VIEW,
         handle_show_view,
-        vol.Schema({ATTR_ENTITY_ID: cv.entity_id, ATTR_VIEW_PATH: str}),
+        vol.Schema(
+            {
+                ATTR_ENTITY_ID: cv.entity_id,
+                ATTR_VIEW_PATH: str,
+                vol.Optional(ATTR_URL_PATH): str,
+            }
+        ),
     )

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -948,7 +948,11 @@ class CastDevice(MediaPlayerDevice):
         await self._async_disconnect()
 
     def _handle_signal_show_view(
-        self, controller: HomeAssistantController, entity_id: str, view_path: str
+        self,
+        controller: HomeAssistantController,
+        entity_id: str,
+        view_path: str,
+        url_path: Optional[str],
     ):
         """Handle a show view signal."""
         if entity_id != self.entity_id:
@@ -958,4 +962,4 @@ class CastDevice(MediaPlayerDevice):
             self._hass_cast_controller = controller
             self._chromecast.register_handler(controller)
 
-        self._hass_cast_controller.show_lovelace_view(view_path)
+        self._hass_cast_controller.show_lovelace_view(view_path, url_path)

--- a/homeassistant/components/cast/services.yaml
+++ b/homeassistant/components/cast/services.yaml
@@ -4,6 +4,9 @@ show_lovelace_view:
     entity_id:
       description: Media Player entity to show the Lovelace view on.
       example: "media_player.kitchen"
+    dashboard_path:
+      description: The url path of the Lovelace dashboard to show.
+      example: lovelace-cast
     view_path:
       description: The path of the Lovelace view to show.
       example: downstairs

--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -20,13 +20,38 @@ async def test_service_show_view(hass):
     )
 
     assert len(calls) == 1
-    controller, entity_id, view_path = calls[0]
+    controller, entity_id, view_path, url_path = calls[0]
     assert controller.hass_url == "http://example.com"
     assert controller.client_id is None
     # Verify user did not accidentally submit their dev app id
     assert controller.supporting_app_id == "B12CE3CA"
     assert entity_id == "media_player.kitchen"
     assert view_path == "mock_path"
+    assert url_path is None
+
+
+async def test_service_show_view_dashboard(hass):
+    """Test casting a specific dashboard."""
+    hass.config.api = Mock(base_url="http://example.com")
+    await home_assistant_cast.async_setup_ha_cast(hass, MockConfigEntry())
+    calls = async_mock_signal(hass, home_assistant_cast.SIGNAL_HASS_CAST_SHOW_VIEW)
+
+    await hass.services.async_call(
+        "cast",
+        "show_lovelace_view",
+        {
+            "entity_id": "media_player.kitchen",
+            "view_path": "mock_path",
+            "dashboard_path": "mock-dashboard",
+        },
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    _controller, entity_id, view_path, url_path = calls[0]
+    assert entity_id == "media_player.kitchen"
+    assert view_path == "mock_path"
+    assert url_path == "mock-dashboard"
 
 
 async def test_use_cloud_url(hass):


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for the new multiple dashboard function of Lovelace for the `cast.show_lovelace_view` service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
