### PR TITLE
Use new HMIP labels for HomematicIP Cloud multi devices

### DIFF
--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -171,7 +171,7 @@ class HomematicipGenericDevice(Entity):
     def _get_label_by_channel(self, channel: int) -> str:
         """Return the name of the channel."""
         name = self._device.functionalChannels[channel].label
-        if name and self._home.name is not None and self._home.name != "":
+        if name and self._home.name:
             name = f"{self._home.name} {name}"
         return name
 

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -162,16 +162,16 @@ class HomematicipGenericDevice(Entity):
     def name(self) -> str:
         """Return the name of the generic device."""
         name = self._device.label
-        if self._home.name is not None and self._home.name != "":
+        if name and self._home.name:
             name = f"{self._home.name} {name}"
-        if self.post is not None and self.post != "":
+        if name and self.post:
             name = f"{name} {self.post}"
         return name
 
     def _get_label_by_channel(self, channel: int) -> str:
         """Return the name of the channel."""
         name = self._device.functionalChannels[channel].label
-        if name and self._home.name is not None and self._home.name != "":
+        if name and self._home.name:
             name = f"{self._home.name} {name}"
         return name
 

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -168,6 +168,13 @@ class HomematicipGenericDevice(Entity):
             name = f"{name} {self.post}"
         return name
 
+    def _get_label_by_channel(self, channel: int) -> str:
+        """Return the name of the channel."""
+        name = self._device.functionalChannels[channel].label
+        if name and self._home.name is not None and self._home.name != "":
+            name = f"{self._home.name} {name}"
+        return name
+
     @property
     def should_poll(self) -> bool:
         """No polling needed."""

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -72,6 +72,14 @@ class HomematicipLight(HomematicipGenericDevice, Light):
         super().__init__(hap, device)
 
     @property
+    def name(self) -> str:
+        """Return the name of the multi switch channel."""
+        label = self._get_label_by_channel(1)
+        if label:
+            return label
+        return super().name
+
+    @property
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self._device.on
@@ -193,6 +201,9 @@ class HomematicipNotificationLight(HomematicipGenericDevice, Light):
     @property
     def name(self) -> str:
         """Return the name of the generic device."""
+        label = self._get_label_by_channel(self.channel)
+        if label:
+            return label
         return f"{super().name} Notification"
 
     @property

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -154,6 +154,14 @@ class HomematicipMultiSwitch(HomematicipGenericDevice, SwitchDevice):
         super().__init__(hap, device, f"Channel{channel}")
 
     @property
+    def name(self) -> str:
+        """Return the name of the multi switch channel."""
+        label = self._get_label_by_channel(self.channel)
+        if label:
+            return label
+        return super().name
+
+    @property
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self.__class__.__name__}_{self.post}_{self._device.id}"

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -26,11 +26,11 @@ async def test_hmip_load_all_supported_devices(hass, default_mock_hap_factory):
 
 async def test_hmip_remove_device(hass, default_mock_hap_factory):
     """Test Remove of hmip device."""
-    entity_id = "light.treppe"
-    entity_name = "Treppe"
+    entity_id = "light.treppe_ch"
+    entity_name = "Treppe CH"
     device_model = "HmIP-BSL"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Treppe"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -58,11 +58,11 @@ async def test_hmip_remove_device(hass, default_mock_hap_factory):
 
 async def test_hmip_add_device(hass, default_mock_hap_factory, hmip_config_entry):
     """Test Remove of hmip device."""
-    entity_id = "light.treppe"
-    entity_name = "Treppe"
+    entity_id = "light.treppe_ch"
+    entity_name = "Treppe CH"
     device_model = "HmIP-BSL"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Treppe"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -137,11 +137,11 @@ async def test_all_devices_unavailable_when_hap_not_connected(
     hass, default_mock_hap_factory
 ):
     """Test make all devices unavaulable when hap is not connected."""
-    entity_id = "light.treppe"
-    entity_name = "Treppe"
+    entity_id = "light.treppe_ch"
+    entity_name = "Treppe CH"
     device_model = "HmIP-BSL"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Treppe"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -161,11 +161,11 @@ async def test_all_devices_unavailable_when_hap_not_connected(
 
 async def test_hap_reconnected(hass, default_mock_hap_factory):
     """Test reconnect hap."""
-    entity_id = "light.treppe"
-    entity_name = "Treppe"
+    entity_id = "light.treppe_ch"
+    entity_name = "Treppe CH"
     device_model = "HmIP-BSL"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Treppe"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -192,8 +192,8 @@ async def test_hap_reconnected(hass, default_mock_hap_factory):
 async def test_hap_with_name(hass, mock_connection, hmip_config_entry):
     """Test hap with name."""
     home_name = "TestName"
-    entity_id = f"light.{home_name.lower()}_treppe"
-    entity_name = f"{home_name} Treppe"
+    entity_id = f"light.{home_name.lower()}_treppe_ch"
+    entity_name = f"{home_name} Treppe CH"
     device_model = "HmIP-BSL"
 
     hmip_config_entry.data = {**hmip_config_entry.data, "name": home_name}

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -27,11 +27,11 @@ async def test_manually_configured_platform(hass):
 
 async def test_hmip_light(hass, default_mock_hap_factory):
     """Test HomematicipLight."""
-    entity_id = "light.treppe"
-    entity_name = "Treppe"
+    entity_id = "light.treppe_ch"
+    entity_name = "Treppe CH"
     device_model = "HmIP-BSL"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        test_devices=[entity_name]
+        test_devices=["Treppe"]
     )
 
     ha_state, hmip_device = get_and_check_entity_basics(
@@ -66,8 +66,8 @@ async def test_hmip_light(hass, default_mock_hap_factory):
 
 async def test_hmip_notification_light(hass, default_mock_hap_factory):
     """Test HomematicipNotificationLight."""
-    entity_id = "light.treppe_top_notification"
-    entity_name = "Treppe Top Notification"
+    entity_id = "light.alarm_status"
+    entity_name = "Alarm Status"
     device_model = "HmIP-BSL"
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
         test_devices=["Treppe"]

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -1591,7 +1591,7 @@
                     "groupIndex": 1,
                     "groups": [],
                     "index": 1,
-                    "label": "",
+                    "label": "Treppe CH",
                     "on": true,
                     "profileMode": "AUTOMATIC",
                     "userDesiredProfileMode": "AUTOMATIC"
@@ -1603,7 +1603,7 @@
                     "groupIndex": 2,
                     "groups": [],
                     "index": 2,
-                    "label": "",
+                    "label": "Alarm Status",
                     "on": null,
                     "profileMode": "AUTOMATIC",
                     "simpleRGBColorState": "RED",
@@ -4576,7 +4576,7 @@
                         "00000000-0000-0000-0000-000000000042"
                     ],
                     "index": 1,
-                    "label": "",
+                    "label": "SW1",
                     "on": false,
                     "profileMode": "AUTOMATIC",
                     "userDesiredProfileMode": "AUTOMATIC"
@@ -4590,7 +4590,7 @@
                         "00000000-0000-0000-0000-000000000040"
                     ],
                     "index": 2,
-                    "label": "",
+                    "label": "SW2",
                     "on": false,
                     "profileMode": "AUTOMATIC",
                     "userDesiredProfileMode": "AUTOMATIC"


### PR DESCRIPTION
## Breaking change
If the labels of a multi channel device have been change in the native Homemamtic IP Cloud App, then the entity names will change accordingly.

## Proposed change
After HmIP Cloud Maintanance (17.3.2020) it's possible to define labels for each channel of a multi device.
This is the HA implmentation.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
