### PR TITLE
Support openid connect like authentication providers

### DIFF
--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -22,6 +22,8 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
 
+REQUIREMENTS = ["python-jose=3.1.0"]
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ISSUER = "issuer"

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -40,6 +40,7 @@ CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
 )
 
 AUTH_CALLBACK_PATH = "/api/openid/redirect"
+OPENID_CONFIGURATION_PATH = ".well-known/openid-configuration"
 DATA_OPENID_VIEW = "openid_view"
 
 
@@ -89,9 +90,7 @@ class OpenIdAuthProvider(AuthProvider):
     @property
     def discovery_url(self) -> str:
         """Construct discovery url based on config."""
-        return str(
-            URL(self.config[CONF_ISSUER]).with_path(".well-known/openid-configuration")
-        )
+        return str(URL(self.config[CONF_ISSUER]).with_path(OPENID_CONFIGURATION_PATH))
 
     @property
     def redirect_uri(self) -> str:

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -75,10 +75,6 @@ class OpenIdAuthProvider(AuthProvider):
     _discovery_document: Dict[str, Any]
     _jwks: Dict[str, Any]
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Extend parent's __init__."""
-        super().__init__(*args, **kwargs)
-
     async def async_get_discovery_document(self) -> None:
         """Cache discovery document for openid."""
         if hasattr(self, "._discovery_document"):

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
 
-REQUIREMENTS = ["python-jose=3.1.0"]
+REQUIREMENTS = ["python-jose==3.1.0"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -1,4 +1,4 @@
-"""OpenId based authentication provider."""
+"""OpenID based authentication provider."""
 
 import logging
 import re
@@ -92,7 +92,7 @@ class OpenIdAuthProvider(AuthProvider):
     _jwks: Dict[str, Any]
 
     async def async_get_configuration(self) -> Dict[str, Any]:
-        """Get discovery document for openid."""
+        """Get discovery document for OpenID."""
         session = async_get_clientsession(self.hass)
         async with session.get(self.config[CONF_CONFIGURATION]) as response:
             await raise_for_status(response)

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -50,8 +50,8 @@ class InvalidAuthError(HomeAssistantError):
 
 async def raise_for_status(response: ClientResponse) -> None:
     """Raise exception on data failure with logging."""
-    if 400 <= response.status:
-        e = ClientResponseError(
+    if response.status >= 400:
+        standard = ClientResponseError(
             response.request_info,
             response.history,
             code=response.status,
@@ -59,7 +59,7 @@ async def raise_for_status(response: ClientResponse) -> None:
         )
         data = await response.text()
         _LOGGER.error("Request failed: %s", data)
-        raise InvalidAuthError(data) from e
+        raise InvalidAuthError(data) from standard
 
 
 WANTED_SCOPES = set(["openid", "email", "profile"])

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -203,10 +203,10 @@ class OpenIdAuthProvider(AuthProvider):
 
         for credential in await self.async_credentials():
             if credential.data["sub"] == subject:
-                _LOGGER.info("Accepting credential for %s", flow_result["email"])
+                _LOGGER.info("Accepting credential for %s", subject)
                 return credential
 
-        _LOGGER.info("Creating credential for %s", flow_result["email"])
+        _LOGGER.info("Creating credential for %s", subject)
         return self.async_create_credentials(flow_result)
 
     async def async_user_meta_for_credentials(

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -187,8 +187,10 @@ class OpenIdAuthProvider(AuthProvider):
 
         for credential in await self.async_credentials():
             if credential.data["sub"] == subject:
+                _LOGGER.info("Accepting credential for %s", flow_result["email"])
                 return credential
 
+        _LOGGER.info("Creating credential for %s", flow_result["email"])
         return self.async_create_credentials(flow_result)
 
     async def async_user_meta_for_credentials(

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -148,7 +148,7 @@ class OpenIdAuthProvider(AuthProvider):
         self, token: Dict[str, Any], nonce: str
     ) -> Dict[str, Any]:
         """Validate a token."""
-        from jose import jwt
+        from jose import jwt  # noqa: pylint: disable=import-outside-toplevel
 
         algorithms = self._configuration["id_token_signing_alg_values_supported"]
         issuer = self._configuration["issuer"]

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -37,8 +37,8 @@ CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
         vol.Required(CONF_CONFIGURATION): str,
         vol.Required(CONF_CLIENT_ID): str,
         vol.Required(CONF_CLIENT_SECRET): str,
-        vol.Optional(CONF_EMAILS, default=[]): [str],
-        vol.Optional(CONF_SUBJECTS, default=[]): [str],
+        vol.Optional(CONF_EMAILS): [str],
+        vol.Optional(CONF_SUBJECTS): [str],
     },
     extra=vol.PREVENT_EXTRA,
 )
@@ -169,12 +169,12 @@ class OpenIdAuthProvider(AuthProvider):
         if id_token.get("nonce") != nonce:
             raise InvalidAuthError("Nonce mismatch in id_token")
 
-        if id_token["sub"] in self.config[CONF_SUBJECTS]:
+        if id_token["sub"] in self.config.get(CONF_SUBJECTS, []):
             return id_token
 
         if "email" in id_token and "email_verified" in id_token:
             if (
-                id_token["email"] in self.config[CONF_EMAILS]
+                id_token["email"] in self.config.get(CONF_EMAILS, [])
                 and id_token["email_verified"]
             ):
                 return id_token

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -86,7 +86,7 @@ WANTED_SCOPES = {"openid", "email", "profile"}
 
 @AUTH_PROVIDERS.register("openid")
 class OpenIdAuthProvider(AuthProvider):
-    """Example auth provider based on hardcoded usernames and passwords."""
+    """Auth provider using openid connect as the authentication source."""
 
     DEFAULT_TITLE = "OpenID Connect"
 

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-import secrets
+from secrets import token_hex
 from typing import Any, Dict, Optional, cast
 
 from aiohttp import ClientResponseError
@@ -236,7 +236,7 @@ class OpenIdLoginFlow(LoginFlow):
         if user_input:
             self.external_data = str(user_input)
             return self.async_external_step_done(next_step_id="authorize")
-        self.nonce = secrets.token_hex()
+        self.nonce = token_hex()
         url = await provider.async_generate_authorize_url(self.flow_id, self.nonce)
         return self.async_external_step(step_id="authenticate", url=url)
 

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -63,7 +63,7 @@ async def raise_for_status(response: ClientResponse) -> None:
         raise InvalidAuthError(data) from standard
 
 
-WANTED_SCOPES = set(["openid", "email", "profile"])
+WANTED_SCOPES = {"openid", "email", "profile"}
 
 
 @AUTH_PROVIDERS.register("openid")

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -139,10 +139,18 @@ class OpenIdAuthProvider(AuthProvider):
         """Validate a token."""
         from jose import jwt
 
+        algorithms = self._discovery_document.get(
+            "id_token_signing_alg_values_supported", ["RS256"]
+        )
+
+        issuer = self._discovery_document.get("issuer", None)
+
         id_token = cast(
             Dict[str, Any],
             jwt.decode(
                 token["id_token"],
+                algorithms=algorithms,
+                issuer=issuer,
                 key=self._jwks,
                 audience=self.config[CONF_CLIENT_ID],
                 access_token=token["access_token"],

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -29,8 +29,6 @@ CONF_TOKEN_URI = "token_uri"
 CONF_AUTHORIZATION_URI = "authorization_uri"
 CONF_EMAILS = "emails"
 
-DATA_JWT_SECRET = "openid_jwt_secret"
-
 CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
     {
         vol.Required(CONF_ISSUER): str,

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -205,10 +205,10 @@ class OpenIdAuthProvider(AuthProvider):
         self, flow_result: Dict[str, str]
     ) -> Credentials:
         """Get credentials based on the flow result."""
-        email = flow_result["email"]
+        subject = flow_result["sub"]
 
         for credential in await self.async_credentials():
-            if credential.data["email"] == email:
+            if credential.data["sub"] == subject:
                 return credential
 
         return self.async_create_credentials(flow_result)

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -169,7 +169,7 @@ class OpenIdAuthProvider(AuthProvider):
             "client_id": self.config["client_id"],
             "redirect_uri": self.redirect_uri,
             "state": _encode_jwt(self.hass, {"flow_id": flow_id, "flow_type": "login"}),
-            "scope": " ".join(scopes),
+            "scope": " ".join(sorted(scopes)),
             "nonce": nonce,
         }
 

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Optional, cast
 
 from aiohttp import ClientResponseError
 from aiohttp.client import ClientResponse
-from jose import jwt
 import voluptuous as vol
 from yarl import URL
 
@@ -142,6 +141,8 @@ class OpenIdAuthProvider(AuthProvider):
         self, token: Dict[str, Any], nonce: str
     ) -> Dict[str, Any]:
         """Validate a token."""
+        from jose import jwt
+
         id_token = cast(
             Dict[str, Any],
             jwt.decode(

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -86,11 +86,8 @@ class OpenIdAuthProvider(AuthProvider):
 
         async with session.post(uri, data=payload) as response:
             if 400 <= response.status:
-                if "json" in response.headers.get("CONTENT-TYPE", ""):
-                    data = await response.json()
-                else:
-                    data = await response.text()
-                raise InvalidAuthError(f"Token validation failed with error: {data}")
+                data = await response.text()
+                raise InvalidAuthError(f"Token retrieveal failed with error: {data}")
             return cast(Dict[str, Any], await response.json())
 
     async def async_validate_token(self, token: Dict[str, Any]) -> Dict[str, Any]:

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -1,5 +1,6 @@
 """OpenId based authentication provider."""
 
+import json
 import logging
 import re
 import secrets
@@ -8,6 +9,7 @@ from typing import Any, Dict, Optional, cast
 from aiohttp import ClientResponseError
 from aiohttp.client import ClientResponse
 from aiohttp.web import HTTPBadRequest, Request, Response
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 import jwt
 import voluptuous as vol
 from yarl import URL
@@ -63,6 +65,21 @@ async def raise_for_status(response: ClientResponse) -> None:
         raise InvalidAuthError(data) from standard
 
 
+def convert_jwks_to_pem(jwks: Dict[str, Any]) -> bytes:
+    """Convert a JWKS key set into a PEM combined certificate string."""
+
+    algorithms = jwt.algorithms.get_default_algorithms()
+    pems = bytes()
+    for key in jwks["keys"]:
+        algorithm = algorithms[key["alg"]]
+        public_key = algorithm.from_jwk(json.dumps(key))
+        pem = public_key.public_bytes(
+            encoding=Encoding.PEM, format=PublicFormat.SubjectPublicKeyInfo
+        )
+        pems += pem
+    return pems
+
+
 WANTED_SCOPES = set(["openid", "email", "profile"])
 
 
@@ -73,6 +90,7 @@ class OpenIdAuthProvider(AuthProvider):
     DEFAULT_TITLE = "OpenId Connect"
 
     _discovery_document: Dict[str, Any]
+    _jwks_pem: bytes
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Extend parent's __init__."""
@@ -88,6 +106,18 @@ class OpenIdAuthProvider(AuthProvider):
             await raise_for_status(response)
             self._discovery_document = cast(Dict[str, Any], await response.json())
 
+    async def async_get_jwks_pem(self) -> None:
+        """Cache the keys for id verification."""
+        if hasattr(self, "._jwks_pem"):
+            return
+
+        session = async_get_clientsession(self.hass)
+        async with session.get(self._discovery_document["jwks_uri"]) as response:
+            await raise_for_status(response)
+            jwks = cast(Dict[str, Any], await response.json())
+
+        self._jwks_pem = convert_jwks_to_pem(jwks)
+
     @property
     def discovery_url(self) -> str:
         """Construct discovery url based on config."""
@@ -102,6 +132,7 @@ class OpenIdAuthProvider(AuthProvider):
         """Return a flow to login."""
 
         await self.async_get_discovery_document()
+        await self.async_get_jwks_pem()
 
         if DATA_OPENID_VIEW not in self.hass.data:
             self.hass.data[DATA_OPENID_VIEW] = self.hass.http.register_view(  # type: ignore
@@ -130,7 +161,9 @@ class OpenIdAuthProvider(AuthProvider):
 
     async def async_decode_id_token(self, id_token: str) -> Dict[str, Any]:
         """Decode a token."""
-        return jwt.decode(id_token, verify=False)
+        return jwt.decode(
+            id_token, key=self._jwks_pem, audience=self.config[CONF_CLIENT_ID]
+        )
 
     async def async_validate_token(
         self, token: Dict[str, Any], nonce: str

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -1,7 +1,6 @@
 """OpenID based authentication provider."""
 
 import logging
-import re
 from secrets import token_hex
 from typing import Any, Dict, Optional, cast
 
@@ -229,12 +228,7 @@ class OpenIdAuthProvider(AuthProvider):
         elif "name" in credentials.data:
             name = credentials.data["name"]
         elif "email" in credentials.data:
-            email = credentials.data["email"]
-            match = re.match(r"[^@]+", email)
-            if match:
-                name = str(match.group(0))
-            else:
-                name = str(email)
+            name = cast(str, credentials.data["email"]).split("@", 1)[0]
         else:
             name = credentials.data["sub"]
 

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -137,9 +137,9 @@ class OpenIdAuthProvider(AuthProvider):
         Will be used to populate info when creating a new user.
         """
         email = credentials.data["email"]
-        match = re.match(r"([^@]+)", email)
+        match = re.match(r"[^@]+", email)
         if match:
-            name = str(match.groups(0))
+            name = str(match.group(0))
         else:
             name = str(email)
 

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -90,9 +90,13 @@ class OpenIdAuthProvider(AuthProvider):
                 raise InvalidAuthError(f"Token retrieveal failed with error: {data}")
             return cast(Dict[str, Any], await response.json())
 
+    async def async_decode_id_token(self, id_token: str) -> Dict[str, Any]:
+        """Decode a token."""
+        return jwt.decode(id_token, verify=False)
+
     async def async_validate_token(self, token: Dict[str, Any]) -> Dict[str, Any]:
         """Validate a token."""
-        id_token = jwt.decode(token["id_token"])
+        id_token = await self.async_decode_id_token(token["id_token"])
 
         if id_token["email"] not in self.config[CONF_EMAILS]:
             raise InvalidAuthError(f"Email {id_token['email']} not in allowed users")

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -152,6 +152,11 @@ class OpenIdAuthProvider(AuthProvider):
 
         return str(URL(data["authorization_endpoint"]).with_query(query))
 
+    @property
+    def support_mfa(self) -> bool:
+        """Return whether multi-factor auth supported by the auth provider."""
+        return False
+
     async def async_get_or_create_credentials(
         self, flow_result: Dict[str, str]
     ) -> Credentials:

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -216,15 +216,21 @@ class OpenIdAuthProvider(AuthProvider):
 
         Will be used to populate info when creating a new user.
         """
-        email = credentials.data["email"]
-        if "name" in credentials.data:
+        if "preferred_username" in credentials.data:
+            name = credentials.data["preferred_username"]
+        elif "given_name" in credentials.data:
+            name = credentials.data["given_name"]
+        elif "name" in credentials.data:
             name = credentials.data["name"]
-        else:
+        elif "email" in credentials.data:
+            email = credentials.data["email"]
             match = re.match(r"[^@]+", email)
             if match:
                 name = str(match.group(0))
             else:
                 name = str(email)
+        else:
+            name = credentials.data["sub"]
 
         return UserMeta(name=name, is_active=True)
 

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     _encode_jwt,
     async_register_view,
 )
+from homeassistant.helpers.network import get_url
 
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
@@ -109,7 +110,8 @@ class OpenIdAuthProvider(AuthProvider):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        return f"{self.hass.config.api.base_url}{AUTH_CALLBACK_PATH}"  # type: ignore
+        url = URL(get_url(self.hass, prefer_external=True, allow_cloud=False))
+        return str(url.with_path(AUTH_CALLBACK_PATH))
 
     async def async_login_flow(self, context: Optional[Dict]) -> LoginFlow:
         """Return a flow to login."""

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -86,7 +86,7 @@ WANTED_SCOPES = {"openid", "email", "profile"}
 class OpenIdAuthProvider(AuthProvider):
     """Example auth provider based on hardcoded usernames and passwords."""
 
-    DEFAULT_TITLE = "OpenId Connect"
+    DEFAULT_TITLE = "OpenID Connect"
 
     _configuration: Dict[str, Any]
     _jwks: Dict[str, Any]

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -1,0 +1,223 @@
+"""OpenId based authentication provider."""
+
+import logging
+import re
+from typing import Any, Dict, Optional, cast
+
+from aiohttp.web import HTTPBadRequest, Request, Response
+import jwt
+import voluptuous as vol
+from yarl import URL
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.config_entry_oauth2_flow import _decode_jwt, _encode_jwt
+
+from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
+from ..models import Credentials, UserMeta
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_CLIENT_ID = "client_id"
+CONF_CLIENT_SECRET = "client_secret"
+CONF_TOKEN_URI = "token_uri"
+CONF_AUTHORIZATION_URI = "authorization_uri"
+CONF_EMAILS = "emails"
+
+DATA_JWT_SECRET = "openid_jwt_secret"
+
+CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
+    {
+        vol.Required(CONF_CLIENT_ID): str,
+        vol.Required(CONF_CLIENT_SECRET): str,
+        vol.Required(CONF_TOKEN_URI): str,
+        vol.Required(CONF_AUTHORIZATION_URI): str,
+        vol.Required(CONF_EMAILS): [str],
+    },
+    extra=vol.PREVENT_EXTRA,
+)
+
+AUTH_CALLBACK_PATH = "/api/openid/redirect"
+
+
+class InvalidAuthError(HomeAssistantError):
+    """Raised when submitting invalid authentication."""
+
+
+registered = False
+
+
+@AUTH_PROVIDERS.register("openid")
+class OpenIdAuthProvider(AuthProvider):
+    """Example auth provider based on hardcoded usernames and passwords."""
+
+    DEFAULT_TITLE = "OpenId Connect"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Extend parent's __init__."""
+        super().__init__(*args, **kwargs)
+
+    @property
+    def redirect_uri(self) -> str:
+        """Return the redirect uri."""
+        return f"{self.hass.config.api.base_url}{AUTH_CALLBACK_PATH}"  # type: ignore
+
+    async def async_login_flow(self, context: Optional[Dict]) -> LoginFlow:
+        """Return a flow to login."""
+        global registered
+        if not registered:
+            self.hass.http.register_view(OpenIdCallbackView())  # type: ignore
+        registered = True
+        return OpenIdLoginFlow(self)
+
+    async def async_retrieve_token(self, code: str) -> Dict[str, Any]:
+        """Convert a token code into an actual token."""
+        payload = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_uri,
+            "client_id": self.config[CONF_CLIENT_ID],
+            "client_secret": self.config[CONF_CLIENT_SECRET],
+        }
+        uri = self.config[CONF_TOKEN_URI]
+        session = async_get_clientsession(self.hass)
+
+        async with session.post(uri, data=payload) as response:
+            if 400 <= response.status:
+                if "json" in response.headers.get("CONTENT-TYPE", ""):
+                    data = await response.json()
+                else:
+                    data = await response.text()
+                raise InvalidAuthError(f"Token validation failed with error: {data}")
+            return cast(Dict[str, Any], await response.json())
+
+    async def async_validate_token(self, token: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate a token."""
+        id_token = jwt.decode(token["id_token"])
+
+        if id_token["email"] not in self.config[CONF_EMAILS]:
+            raise InvalidAuthError(f"Email {id_token['email']} not in allowed users")
+        return id_token
+
+    @callback
+    def async_generate_authorize_url(self, flow_id: str) -> str:
+        """Generate a authorization url for a given flow."""
+        return str(
+            URL(self.config["authorization_uri"]).with_query(
+                {
+                    "response_type": "code",
+                    "client_id": self.config["client_id"],
+                    "redirect_uri": self.redirect_uri,
+                    "state": _encode_jwt(self.hass, {"flow_id": flow_id}),
+                    "scope": "openid email",
+                }
+            )
+        )
+
+    async def async_get_or_create_credentials(
+        self, flow_result: Dict[str, str]
+    ) -> Credentials:
+        """Get credentials based on the flow result."""
+        email = flow_result["email"]
+
+        for credential in await self.async_credentials():
+            if credential.data["email"] == email:
+                return credential
+
+        # Create new credentials.
+        return self.async_create_credentials(flow_result)
+
+    async def async_user_meta_for_credentials(
+        self, credentials: Credentials
+    ) -> UserMeta:
+        """Return extra user metadata for credentials.
+
+        Will be used to populate info when creating a new user.
+        """
+        email = credentials.data["email"]
+        match = re.match(r"([^@]+)", email)
+        if match:
+            name = str(match.groups(0))
+        else:
+            name = str(email)
+
+        return UserMeta(name=name, is_active=True)
+
+
+class OpenIdLoginFlow(LoginFlow):
+    """Handler for the login flow."""
+
+    external_data: str
+
+    async def async_step_init(
+        self, user_input: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """Handle the step of the form."""
+        return await self.async_step_authenticate()
+
+    async def async_step_authenticate(
+        self, user_input: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """Authenticate user using external step."""
+
+        provider = cast(OpenIdAuthProvider, self._auth_provider)
+
+        if user_input:
+            self.external_data = str(user_input)
+            return self.async_external_step_done(next_step_id="authorize")
+
+        url = provider.async_generate_authorize_url(self.flow_id)
+        return self.async_external_step(step_id="authenticate", url=url)
+
+    async def async_step_authorize(
+        self, user_input: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """Authorize user received from external step."""
+
+        provider = cast(OpenIdAuthProvider, self._auth_provider)
+        try:
+            token = await provider.async_retrieve_token(self.external_data)
+            result = await provider.async_validate_token(token)
+        except InvalidAuthError:
+            return self.async_abort(reason="invalid_auth")
+        return await self.async_finish(result)
+
+
+class OpenIdCallbackView(HomeAssistantView):
+    """Handle openid callback."""
+
+    url = AUTH_CALLBACK_PATH
+    name = "api:openid:redirect"
+    requires_auth = False
+
+    def __init__(self) -> None:
+        """Initialize instance of the view."""
+        super().__init__()
+
+    async def get(self, request: Request) -> Response:
+        """Handle oauth token request."""
+        hass = cast(HomeAssistant, request.app["hass"])
+
+        def check_get(param: str) -> Any:
+            if param not in request.query:
+                _LOGGER.error("State missing in request.")
+                raise HTTPBadRequest(text="Parameter {} not found".format(param))
+            return request.query[param]
+
+        state = check_get("state")
+        code = check_get("code")
+
+        state = _decode_jwt(hass, state)
+        if state is None:
+            _LOGGER.error("State failed to decode.")
+            raise HTTPBadRequest(text="Invalid state")
+
+        auth_manager = hass.auth  # type: ignore
+        await auth_manager.login_flow.async_configure(state["flow_id"], user_input=code)
+
+        return Response(
+            headers={"content-type": "text/html"},
+            text="<script>window.close()</script>",
+        )

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -45,13 +45,16 @@ OPENID_CONFIGURATION_SCHEMA = vol.Schema(
         vol.Required("issuer"): str,
         vol.Required("jwks_uri"): str,
         vol.Required("id_token_signing_alg_values_supported"): list,
-        vol.Optional("scopes_supported"): list,
+        vol.Optional("scopes_supported"): vol.Contains("openid"),
         vol.Required("token_endpoint"): str,
         vol.Required("authorization_endpoint"): str,
         vol.Required("response_types_supported"): vol.Contains("code"),
-        vol.Required("token_endpoint_auth_methods_supported"): vol.Contains(
-            "client_secret_post"
-        ),
+        vol.Optional(
+            "token_endpoint_auth_methods_supported", default=["client_secret_basic"]
+        ): vol.Contains("client_secret_post"),
+        vol.Optional(
+            "grant_types_supported", default=["authorization_code", "implicit"]
+        ): vol.Contains("authorization_code"),
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -139,11 +139,8 @@ class OpenIdAuthProvider(AuthProvider):
         """Validate a token."""
         from jose import jwt
 
-        algorithms = self._discovery_document.get(
-            "id_token_signing_alg_values_supported", ["RS256"]
-        )
-
-        issuer = self._discovery_document.get("issuer", None)
+        algorithms = self._discovery_document["id_token_signing_alg_values_supported"]
+        issuer = self._discovery_document["issuer"]
 
         id_token = cast(
             Dict[str, Any],

--- a/homeassistant/auth/providers/openid.py
+++ b/homeassistant/auth/providers/openid.py
@@ -71,7 +71,7 @@ class OpenIdAuthProvider(AuthProvider):
 
     DEFAULT_TITLE = "OpenId Connect"
 
-    _discovery_document: Optional[Dict[str, Any]]
+    _discovery_document: Optional[Dict[str, Any]] = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Extend parent's __init__."""

--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -1,7 +1,7 @@
 """Account linking via the cloud."""
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import aiohttp
 from hass_nabucasa import account_link
@@ -112,9 +112,6 @@ class CloudOAuth2Implementation(config_entry_oauth2_flow.AbstractOAuth2Implement
     async def async_generate_authorize_url(
         self,
         flow_id: str,
-        flow_type: Optional[str] = None,
-        nonce: Optional[str] = None,
-        scope: Optional[str] = None,
     ) -> str:
         """Generate a url for the user to authorize."""
         helper = account_link.AuthorizeAccountHelper(

--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -1,7 +1,7 @@
 """Account linking via the cloud."""
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import aiohttp
 from hass_nabucasa import account_link
@@ -109,7 +109,13 @@ class CloudOAuth2Implementation(config_entry_oauth2_flow.AbstractOAuth2Implement
         """Domain that is providing the implementation."""
         return DOMAIN
 
-    async def async_generate_authorize_url(self, flow_id: str) -> str:
+    async def async_generate_authorize_url(
+        self,
+        flow_id: str,
+        flow_type: Optional[str] = None,
+        nonce: Optional[str] = None,
+        scope: Optional[str] = None,
+    ) -> str:
         """Generate a url for the user to authorize."""
         helper = account_link.AuthorizeAccountHelper(
             self.hass.data[DOMAIN], self.service

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -148,13 +148,13 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
             "client_id": self.client_id,
             "redirect_uri": self.redirect_uri,
             "state": _encode_jwt(
-                self.hass, {"flow_type": flow_type, "flow_id": flow_id}
+                self.hass, {"flow_id": flow_id, "flow_type": flow_type}
             ),
         }
-        if nonce:
-            query["nonce"] = nonce
         if scope:
             query["scope"] = scope
+        if nonce:
+            query["nonce"] = nonce
 
         return str(URL(self.authorize_url).with_query(query).update_query(self.extra_authorize_data))
 

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -139,6 +139,9 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
         flow_id: str,
     ) -> str:
         """Generate a url for the user to authorize."""
+        state = {"flow_id": flow_id}
+        if self.flow_type:
+            state["flow_type"] = self.flow_type
         return str(
             URL(self.authorize_url)
             .with_query(
@@ -146,9 +149,7 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
                     "response_type": "code",
                     "client_id": self.client_id,
                     "redirect_uri": self.redirect_uri,
-                    "state": _encode_jwt(
-                        self.hass, {"flow_id": flow_id, "flow_type": self.flow_type}
-                    ),
+                    "state": _encode_jwt(self.hass, state),
                 }
             )
             .update_query(self.extra_authorize_data)

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -48,7 +48,13 @@ class AbstractOAuth2Implementation(ABC):
         """Domain that is providing the implementation."""
 
     @abstractmethod
-    async def async_generate_authorize_url(self, flow_id: str) -> str:
+    async def async_generate_authorize_url(
+        self,
+        flow_id: str,
+        flow_type: Optional[str] = None,
+        nonce: Optional[str] = None,
+        scope: Optional[str] = None,
+    ) -> str:
         """Generate a url for the user to authorize.
 
         This step is called when a config flow is initialized. It should redirect the
@@ -129,20 +135,28 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
         """Extra data that needs to be appended to the authorize url."""
         return {}
 
-    async def async_generate_authorize_url(self, flow_id: str) -> str:
+    async def async_generate_authorize_url(
+        self,
+        flow_id: str,
+        flow_type: Optional[str] = None,
+        nonce: Optional[str] = None,
+        scope: Optional[str] = None,
+    ) -> str:
         """Generate a url for the user to authorize."""
-        return str(
-            URL(self.authorize_url)
-            .with_query(
-                {
-                    "response_type": "code",
-                    "client_id": self.client_id,
-                    "redirect_uri": self.redirect_uri,
-                    "state": _encode_jwt(self.hass, {"flow_id": flow_id}),
-                }
-            )
-            .update_query(self.extra_authorize_data)
-        )
+        query = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "state": _encode_jwt(
+                self.hass, {"flow_type": flow_type, "flow_id": flow_id}
+            ),
+        }
+        if nonce:
+            query["nonce"] = nonce
+        if scope:
+            query["scope"] = scope
+
+        return str(URL(self.authorize_url).with_query(query).update_query(self.extra_authorize_data))
 
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Resolve the authorization code to tokens."""

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -419,7 +419,7 @@ class OAuth2AuthorizeCallbackView(HomeAssistantView):
 
         return web.Response(
             headers={"content-type": "text/html"},
-            text="<script>window.close()</script>",
+            text="<script>if (window.opener) { window.opener.postMessage({type: 'externalCallback'}); } window.close();</script>",
         )
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1759,6 +1759,9 @@ python-izone==1.1.2
 # homeassistant.components.joaoapps_join
 python-join-api==0.0.6
 
+# homeassistant.auth.providers.openid
+python-jose==3.1.0
+
 # homeassistant.components.juicenet
 python-juicenet==1.0.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -843,6 +843,9 @@ python-forecastio==1.4.0
 # homeassistant.components.izone
 python-izone==1.1.2
 
+# homeassistant.auth.providers.openid
+python-jose==3.1.0
+
 # homeassistant.components.juicenet
 python-juicenet==1.0.1
 

--- a/tests/auth/providers/test_openid.py
+++ b/tests/auth/providers/test_openid.py
@@ -1,0 +1,115 @@
+"""Test openid auth provider."""
+from datetime import datetime, timezone
+
+from asynctest import patch
+from jose import jwt
+import pytest
+
+from homeassistant import data_entry_flow
+from homeassistant.auth import auth_manager_from_config
+from homeassistant.helpers.config_entry_oauth2_flow import _encode_jwt
+from homeassistant.setup import async_setup_component
+
+CONST_CLIENT_ID = "123client_id456"
+CONST_CLIENT_SECRET = "123client_secret456"
+
+CONST_JWKS_URI = "https://jwks.test/jwks"
+CONST_JWKS_KEY = "bla"
+CONST_JWKS = {"keys": [CONST_JWKS_KEY]}
+
+CONST_AUTHORIZATION_ENDPOINT = "https://openid.test/authorize"
+CONST_TOKEN_ENDPOINT = "https://openid.test/authorize"
+
+CONST_DESCRIPTION_URI = "https://openid.test/.well-known/openid-configuration"
+CONST_DESCRIPTION = {
+    "issuer": "https://openid.test/",
+    "jwks_uri": CONST_JWKS_URI,
+    "authorization_endpoint": CONST_AUTHORIZATION_ENDPOINT,
+    "token_endpoint": CONST_TOKEN_ENDPOINT,
+    "scopes_supported": ["openid", "email", "profile"],
+}
+
+CONST_ACCESS_TOKEN = "dummy_access_token"
+
+CONST_NONCE = "dummy_nonce"
+CONST_EMAIL = "john.doe@openid.test"
+
+CONST_ID_TOKEN = {
+    "iss": "https://openid.test/",
+    "sub": "248289761001",
+    "aud": CONST_CLIENT_ID,
+    "nonce": CONST_NONCE,
+    "exp": datetime(2099, 1, 1, tzinfo=timezone.utc).timestamp(),
+    "iat": datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp(),
+    "name": "John Doe",
+    "email": CONST_EMAIL,
+}
+
+
+@pytest.fixture(name="openid_server")
+async def openid_server_fixture(hass, aioclient_mock):
+    """Mock openid server."""
+    aioclient_mock.get(
+        CONST_DESCRIPTION_URI, json=CONST_DESCRIPTION,
+    )
+
+    aioclient_mock.get(
+        CONST_JWKS_URI, json=CONST_JWKS,
+    )
+
+    aioclient_mock.post(
+        CONST_TOKEN_ENDPOINT,
+        json={
+            "access_token": CONST_ACCESS_TOKEN,
+            "type": "bearer",
+            "expires_in": 60,
+            "id_token": jwt.encode(
+                CONST_ID_TOKEN, CONST_JWKS_KEY, access_token=CONST_ACCESS_TOKEN
+            ),
+        },
+    )
+
+
+async def test_login_flow_validates(hass, aiohttp_client, openid_server):
+    """Test login flow."""
+    assert await async_setup_component(hass, "http", {})
+
+    hass.config.api.base_url = "https://example.com"
+
+    manager = await auth_manager_from_config(
+        hass,
+        [
+            {
+                "type": "openid",
+                "issuer": "https://openid.test/",
+                "client_id": CONST_CLIENT_ID,
+                "client_secret": CONST_CLIENT_SECRET,
+                "emails": [CONST_EMAIL],
+            }
+        ],
+        [],
+    )
+    hass.auth = manager
+
+    with patch("homeassistant.auth.providers.openid.token_hex") as token_hex:
+        token_hex.return_value = CONST_NONCE
+        result = await manager.login_flow.async_init(("openid", None))
+
+    state = _encode_jwt(hass, {"flow_id": result["flow_id"], "flow_type": "login"})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["url"] == (
+        f"{CONST_AUTHORIZATION_ENDPOINT}?response_type=code&client_id={CONST_CLIENT_ID}"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}&scope=email+openid+profile&nonce={CONST_NONCE}"
+    )
+
+    client = await aiohttp_client(hass.http.app)
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    result = await manager.login_flow.async_configure(result["flow_id"])
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"]["email"] == CONST_EMAIL

--- a/tests/auth/providers/test_openid.py
+++ b/tests/auth/providers/test_openid.py
@@ -38,7 +38,7 @@ CONST_NONCE = "dummy_nonce"
 CONST_EMAIL = "john.doe@openid.test"
 
 CONST_ID_TOKEN = {
-    "iss": CONST_DESCRIPTION_URI,
+    "iss": "https://openid.test/",
     "sub": "248289761001",
     "aud": CONST_CLIENT_ID,
     "nonce": CONST_NONCE,

--- a/tests/auth/providers/test_openid.py
+++ b/tests/auth/providers/test_openid.py
@@ -46,6 +46,7 @@ CONST_ID_TOKEN = {
     "iat": datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp(),
     "name": "John Doe",
     "email": CONST_EMAIL,
+    "email_verified": True,
 }
 
 

--- a/tests/auth/providers/test_openid.py
+++ b/tests/auth/providers/test_openid.py
@@ -77,7 +77,7 @@ async def test_login_flow_validates(hass, aiohttp_client, openid_server):
     """Test login flow."""
     assert await async_setup_component(hass, "http", {})
 
-    hass.config.api.base_url = "https://example.com"
+    hass.config.external_url = "https://example.com"
 
     manager = await auth_manager_from_config(
         hass,

--- a/tests/auth/providers/test_openid.py
+++ b/tests/auth/providers/test_openid.py
@@ -26,7 +26,10 @@ CONST_DESCRIPTION = {
     "jwks_uri": CONST_JWKS_URI,
     "authorization_endpoint": CONST_AUTHORIZATION_ENDPOINT,
     "token_endpoint": CONST_TOKEN_ENDPOINT,
+    "token_endpoint_auth_methods_supported": "client_secret_post",
+    "id_token_signing_alg_values_supported": ["RS256", "HS256"],
     "scopes_supported": ["openid", "email", "profile"],
+    "response_types_supported": "code",
 }
 
 CONST_ACCESS_TOKEN = "dummy_access_token"
@@ -35,7 +38,7 @@ CONST_NONCE = "dummy_nonce"
 CONST_EMAIL = "john.doe@openid.test"
 
 CONST_ID_TOKEN = {
-    "iss": "https://openid.test/",
+    "iss": CONST_DESCRIPTION_URI,
     "sub": "248289761001",
     "aud": CONST_CLIENT_ID,
     "nonce": CONST_NONCE,
@@ -81,7 +84,7 @@ async def test_login_flow_validates(hass, aiohttp_client, openid_server):
         [
             {
                 "type": "openid",
-                "issuer": "https://openid.test/",
+                "configuration": CONST_DESCRIPTION_URI,
                 "client_id": CONST_CLIENT_ID,
                 "client_secret": CONST_CLIENT_SECRET,
                 "emails": [CONST_EMAIL],

--- a/tests/auth/providers/test_openid.py
+++ b/tests/auth/providers/test_openid.py
@@ -153,3 +153,31 @@ async def test_login_flow_validates_subject(hass, aiohttp_client, openid_server)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"]["sub"] == CONST_SUBJECT
+
+
+async def test_login_flow_not_whitelisted(hass, aiohttp_client, openid_server):
+    """Test login flow."""
+    assert await async_setup_component(hass, "http", {})
+
+    hass.config.external_url = "https://example.com"
+
+    manager = await auth_manager_from_config(
+        hass,
+        [
+            {
+                "type": "openid",
+                "configuration": CONST_DESCRIPTION_URI,
+                "client_id": CONST_CLIENT_ID,
+                "client_secret": CONST_CLIENT_SECRET,
+                "subjects": [],
+            }
+        ],
+        [],
+    )
+    hass.auth = manager
+
+    flow_id = await _run_external_flow(hass, manager, aiohttp_client)
+
+    result = await manager.login_flow.async_configure(flow_id)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -31,7 +31,9 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     result = await hass.config_entries.flow.async_init(
         "home_connect", context={"source": config_entries.SOURCE_USER}
     )
-    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass, {"flow_id": result["flow_id"], "flow_type": None}
+    )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
     assert result["url"] == (

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -31,9 +31,7 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     result = await hass.config_entries.flow.async_init(
         "home_connect", context={"source": config_entries.SOURCE_USER}
     )
-    state = config_entry_oauth2_flow._encode_jwt(
-        hass, {"flow_id": result["flow_id"], "flow_type": None}
-    )
+    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
     assert result["url"] == (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for using OAuth2/OpenId authentication providers like google, facebook


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml for google openid provider
homeassistant:

  auth_providers:
    - type: openid
      name: "Google"
      client_id: "1234"
      client_secret: "4567"
      configuration: https://accounts.google.com/.well-known/openid-configuration
      emails:
        - "john.doh@gmail.com"
```

```yaml
# Example configuration.yaml for auth0 provider supporting a multitude of underlying providers
homeassistant:

  auth_providers:
    - type: openid
      name: "Auth0"
      client_id: "1234"
      client_secret: "4567"
      configuration: https://xxx.auth0.com/.well-known/openid-configuration
      emails:
        - "john.doh@gmail.com"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This requires changes in frontend to work correctly with external flows.

Users are whitelisted based on their (verified) email address. That however does require the email scope of openid, which we don't really need. Also email is not really considered a "stable" identifier. That said, the link between a home assistant user and the "upstream" user is based "sub" (subject) identifer. So even if email where to change, we'd still keep the link to same home assistant user.


- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/pull/5258
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
