### PR TITLE
Update alarmdotcom to use ajax library

### DIFF
--- a/homeassistant/components/alarmdotcom/alarm_control_panel.py
+++ b/homeassistant/components/alarmdotcom/alarm_control_panel.py
@@ -26,6 +26,8 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Alarm.com"
+CONF_FORCE_BYPASS = "force_bypass"
+CONF_NO_ENTRY_DELAY = "no_entry_delay"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -57,7 +59,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class AlarmDotCom(alarm.AlarmControlPanel):
     """Representation of an Alarm.com status."""
 
-    def __init__(self, hass, name, code, username, password):
+    def __init__(
+        self, hass, name, code, username, password, force_bypass, no_entry_delay
+    ):
         """Initialize the Alarm.com status."""
 
         _LOGGER.debug("Setting up Alarm.com...")

--- a/homeassistant/components/alarmdotcom/manifest.json
+++ b/homeassistant/components/alarmdotcom/manifest.json
@@ -2,7 +2,7 @@
   "domain": "alarmdotcom",
   "name": "Alarm.com",
   "documentation": "https://www.home-assistant.io/integrations/alarmdotcom",
-  "requirements": ["pyalarmdotcomajax==0.1.0"],
+  "requirements": ["pyalarmdotcomajax==0.1.1"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/alarmdotcom/manifest.json
+++ b/homeassistant/components/alarmdotcom/manifest.json
@@ -2,7 +2,7 @@
   "domain": "alarmdotcom",
   "name": "Alarm.com",
   "documentation": "https://www.home-assistant.io/integrations/alarmdotcom",
-  "requirements": ["pyalarmdotcom==0.3.2"],
+  "requirements": ["pyalarmdotcomajax==0.1.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1149,7 +1149,7 @@ pyaftership==0.1.2
 pyairvisual==3.0.1
 
 # homeassistant.components.alarmdotcom
-pyalarmdotcom==0.3.2
+pyalarmdotcomajax==0.1.0
 
 # homeassistant.components.almond
 pyalmond==0.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1149,7 +1149,7 @@ pyaftership==0.1.2
 pyairvisual==3.0.1
 
 # homeassistant.components.alarmdotcom
-pyalarmdotcomajax==0.1.0
+pyalarmdotcomajax==0.1.1
 
 # homeassistant.components.almond
 pyalmond==0.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The existing alarmdotcom component's pypi package used a pda version of the alarm.com website, but that pda version of the site seems to have just been taken offline. I submitted a PR to the pypi package owner back in January which used the regular website instead of the pda website, but it never got pulled. Since the PDA site no longer works I just added my changes as a different pypi package, and I've updated the component code here to use this new package.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
alarm_control_panel:
  platform: alarmdotcom
  username: yourlogin
  password: yourpass
  force_bypass: true
  no_entry_delay: false
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I did add 2 minor pieces of functionality (that was one of the motivations behind the original PR to the pypi library). Specifically, you can set whether the system should use force_bypass or no_entry_delay when arming. These settings can be picked up from the  config as shown above.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
