### PR TITLE
Fix scheduled update time-drift in data update coordinator

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -70,7 +70,7 @@ class DataUpdateCoordinator:
 
         # This is the first listener, set up interval.
         if schedule_refresh:
-            self._schedule_refresh()
+            self._schedule_refresh(timedelta())
 
     @callback
     def async_remove_listener(self, update_callback: CALLBACK_TYPE) -> None:
@@ -82,14 +82,18 @@ class DataUpdateCoordinator:
             self._unsub_refresh = None
 
     @callback
-    def _schedule_refresh(self) -> None:
+    def _schedule_refresh(self, last_took: timedelta) -> None:
         """Schedule a refresh."""
         if self._unsub_refresh:
             self._unsub_refresh()
             self._unsub_refresh = None
 
+        # Correct next trigger time with the time it took.
+        # Another approach could be to just use:
+        # `utcnow().replace(microsecond=0) + self.update_interval`
+        delta = max(self.update_interval - 1.2 * last_took, timedelta(seconds=0.5))
         self._unsub_refresh = async_track_point_in_utc_time(
-            self.hass, self._handle_refresh_interval, utcnow() + self.update_interval
+            self.hass, self._handle_refresh_interval, utcnow() + delta
         )
 
     async def _handle_refresh_interval(self, _now: datetime) -> None:
@@ -152,12 +156,11 @@ class DataUpdateCoordinator:
                 self.logger.info("Fetching %s data recovered", self.name)
 
         finally:
+            took = monotonic() - start
             self.logger.debug(
-                "Finished fetching %s data in %.3f seconds",
-                self.name,
-                monotonic() - start,
+                "Finished fetching %s data in %.3f seconds", self.name, took
             )
-            self._schedule_refresh()
+            self._schedule_refresh(timedelta(seconds=took))
 
         for update_callback in self._listeners:
             update_callback()


### PR DESCRIPTION
In `DataUpdateCoordinator` the periodic refresh is drifting 1 second over the desired `update_interval`.

As next schedule is calculated **after** the update is done, setting now + update_interval makes 1-second drift in practice, as the HA tick is of 1Hz (so for t.0x, it will trigger in t+1, instead of t, where x is the fraction of time the update took).

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Subtract the time it took from the `update_interval` timedelta so the next schedule is not drifted. 

Apply some safety factor (1.2x, 20%) for extra time lost in operation.

### Other approaches

Another approach would be to just _floor_ `utcnow` to remove sub-second time lost in the operation, making sure that new "point_in_time" is an exact one, by doing:
`utcnow().replace(microsecond=0) + self.update_interval`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
