### PR TITLE
Try all Samsung TV websocket ports

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -229,6 +229,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 LOGGER.debug("Failing config: %s, error: %s", config, err)
         else:
             if result:
+                # pylint: disable=useless-else-on-loop
                 return result
 
         return RESULT_NOT_SUCCESSFUL

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -206,6 +206,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 CONF_TIMEOUT: 31,
             }
 
+            result = None
             try:
                 LOGGER.debug("Try config: %s", config)
                 with SamsungTVWS(
@@ -223,10 +224,12 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 return RESULT_SUCCESS
             except WebSocketException:
                 LOGGER.debug("Working but unsupported config: %s", config)
-                if self.port != 8001:
-                    return RESULT_NOT_SUPPORTED
+                result = RESULT_NOT_SUPPORTED
             except (OSError, ConnectionFailure) as err:
                 LOGGER.debug("Failing config: %s, error: %s", config, err)
+        else:
+            if result:
+                return result
 
         return RESULT_NOT_SUCCESSFUL
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -227,9 +227,9 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 result = RESULT_NOT_SUPPORTED
             except (OSError, ConnectionFailure) as err:
                 LOGGER.debug("Failing config: %s, error: %s", config, err)
+        # pylint: disable=useless-else-on-loop
         else:
             if result:
-                # pylint: disable=useless-else-on-loop
                 return result
 
         return RESULT_NOT_SUCCESSFUL

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -223,7 +223,8 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 return RESULT_SUCCESS
             except WebSocketException:
                 LOGGER.debug("Working but unsupported config: %s", config)
-                return RESULT_NOT_SUPPORTED
+                if self.port != 8001:
+                    return RESULT_NOT_SUPPORTED
             except (OSError, ConnectionFailure) as err:
                 LOGGER.debug("Failing config: %s, error: %s", config, err)
 

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -463,6 +463,38 @@ async def test_autodetect_websocket(hass, remote, remotews):
         ]
 
 
+async def test_autodetect_websocket_ssl(hass, remote, remotews):
+    """Test for send key with autodetection of protocol."""
+    with patch(
+        "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError("Boom"),
+    ), patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        side_effect=[WebSocketProtocolException("Boom"), mock.DEFAULT],
+    ) as remotews:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
+        )
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_METHOD] == "websocket"
+        assert remotews.call_count == 2
+        assert remotews.call_args_list == [
+            call(
+                host="fake_host",
+                name="HomeAssistant",
+                port=8001,
+                timeout=31,
+                token=None,
+            ),
+            call(
+                host="fake_host",
+                name="HomeAssistant",
+                port=8002,
+                timeout=31,
+                token=None,
+            ),
+        ]
+
+
 async def test_autodetect_auth_missing(hass, remote):
     """Test for send key with autodetection of protocol."""
     with patch(

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,5 +1,5 @@
 """Tests for Samsung TV config flow."""
-from unittest.mock import call, patch
+from unittest.mock import Mock, PropertyMock, call, patch
 
 from asynctest import mock
 import pytest
@@ -19,7 +19,7 @@ from homeassistant.components.ssdp import (
     ATTR_UPNP_MODEL_NAME,
     ATTR_UPNP_UDN,
 )
-from homeassistant.const import CONF_HOST, CONF_ID, CONF_METHOD, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_ID, CONF_METHOD, CONF_NAME, CONF_TOKEN
 
 MOCK_USER_DATA = {CONF_HOST: "fake_host", CONF_NAME: "fake_name"}
 MOCK_SSDP_DATA = {
@@ -45,6 +45,20 @@ AUTODETECT_LEGACY = {
     "port": None,
     "host": "fake_host",
     "timeout": 31,
+}
+AUTODETECT_WEBSOCKET_PLAIN = {
+    "host": "fake_host",
+    "name": "HomeAssistant",
+    "port": 8001,
+    "timeout": 31,
+    "token": None,
+}
+AUTODETECT_WEBSOCKET_SSL = {
+    "host": "fake_host",
+    "name": "HomeAssistant",
+    "port": 8002,
+    "timeout": 31,
+    "token": None,
 }
 
 
@@ -446,21 +460,21 @@ async def test_autodetect_websocket(hass, remote, remotews):
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError("Boom"),
     ), patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remotews:
+        enter = Mock()
+        type(enter).token = PropertyMock(return_value="123456789")
+        remote = Mock()
+        remote.__enter__ = Mock(return_value=enter)
+        remote.__exit__ = Mock(return_value=False)
+        remotews.return_value = remote
+
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
         )
         assert result["type"] == "create_entry"
         assert result["data"][CONF_METHOD] == "websocket"
+        assert result["data"][CONF_TOKEN] == "123456789"
         assert remotews.call_count == 1
-        assert remotews.call_args_list == [
-            call(
-                host="fake_host",
-                name="HomeAssistant",
-                port=8001,
-                timeout=31,
-                token=None,
-            )
-        ]
+        assert remotews.call_args_list == [call(**AUTODETECT_WEBSOCKET_PLAIN)]
 
 
 async def test_autodetect_websocket_ssl(hass, remote, remotews):
@@ -471,27 +485,23 @@ async def test_autodetect_websocket_ssl(hass, remote, remotews):
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
         side_effect=[WebSocketProtocolException("Boom"), mock.DEFAULT],
     ) as remotews:
+        enter = Mock()
+        type(enter).token = PropertyMock(return_value="123456789")
+        remote = Mock()
+        remote.__enter__ = Mock(return_value=enter)
+        remote.__exit__ = Mock(return_value=False)
+        remotews.return_value = remote
+
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
         )
         assert result["type"] == "create_entry"
         assert result["data"][CONF_METHOD] == "websocket"
+        assert result["data"][CONF_TOKEN] == "123456789"
         assert remotews.call_count == 2
         assert remotews.call_args_list == [
-            call(
-                host="fake_host",
-                name="HomeAssistant",
-                port=8001,
-                timeout=31,
-                token=None,
-            ),
-            call(
-                host="fake_host",
-                name="HomeAssistant",
-                port=8002,
-                timeout=31,
-                token=None,
-            ),
+            call(**AUTODETECT_WEBSOCKET_PLAIN),
+            call(**AUTODETECT_WEBSOCKET_SSL),
         ]
 
 
@@ -556,18 +566,6 @@ async def test_autodetect_none(hass, remote, remotews):
         ]
         assert remotews.call_count == 2
         assert remotews.call_args_list == [
-            call(
-                host="fake_host",
-                name="HomeAssistant",
-                port=8001,
-                timeout=31,
-                token=None,
-            ),
-            call(
-                host="fake_host",
-                name="HomeAssistant",
-                port=8002,
-                timeout=31,
-                token=None,
-            ),
+            call(**AUTODETECT_WEBSOCKET_PLAIN),
+            call(**AUTODETECT_WEBSOCKET_SSL),
         ]

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -211,7 +211,7 @@ async def test_setup_websocket_2(hass, mock_now):
     assert len(config_entries) == 1
     assert entry is config_entries[0]
 
-    assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {}) is True
+    assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
     await hass.async_block_till_done()
 
     next_update = mock_now + timedelta(minutes=5)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -34,8 +34,11 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_SUPPORTED_FEATURES,
     CONF_HOST,
+    CONF_IP_ADDRESS,
+    CONF_METHOD,
     CONF_NAME,
     CONF_PORT,
+    CONF_TOKEN,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
@@ -51,7 +54,7 @@ from homeassistant.const import (
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 ENTITY_ID = f"{DOMAIN}.fake"
 MOCK_CONFIG = {
@@ -64,16 +67,39 @@ MOCK_CONFIG = {
         }
     ]
 }
-
 MOCK_CONFIGWS = {
     SAMSUNGTV_DOMAIN: [
         {
             CONF_HOST: "fake",
             CONF_NAME: "fake",
             CONF_PORT: 8001,
+            CONF_TOKEN: "123456789",
             CONF_ON_ACTION: [{"delay": "00:00:01"}],
         }
     ]
+}
+MOCK_CALLS_WS = {
+    "host": "fake",
+    "port": 8001,
+    "token": None,
+    "timeout": 31,
+    "name": "HomeAssistant",
+}
+
+MOCK_ENTRY_WS = {
+    CONF_IP_ADDRESS: "test",
+    CONF_HOST: "fake",
+    CONF_METHOD: "websocket",
+    CONF_NAME: "fake",
+    CONF_PORT: 8001,
+    CONF_TOKEN: "abcde",
+}
+MOCK_CALLS_ENTRY_WS = {
+    "host": "fake",
+    "name": "HomeAssistant",
+    "port": 8001,
+    "timeout": 1,
+    "token": "abcde",
 }
 
 ENTITY_ID_NOTURNON = f"{DOMAIN}.fake_noturnon"
@@ -153,6 +179,52 @@ async def test_setup_without_turnon(hass, remote):
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert hass.states.get(ENTITY_ID_NOTURNON)
+
+
+async def test_setup_websocket(hass, remotews, mock_now):
+    """Test setup of platform."""
+    with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
+        enter = mock.Mock()
+        type(enter).token = mock.PropertyMock(return_value="987654321")
+        remote = mock.Mock()
+        remote.__enter__ = mock.Mock(return_value=enter)
+        remote.__exit__ = mock.Mock()
+        remote_class.return_value = remote
+
+        await setup_samsungtv(hass, MOCK_CONFIGWS)
+
+        assert remote_class.call_count == 1
+        assert remote_class.call_args_list == [call(**MOCK_CALLS_WS)]
+        assert hass.states.get(ENTITY_ID)
+
+
+async def test_setup_websocket_2(hass, mock_now):
+    """Test setup of platform from config entry."""
+    entity_id = f"{DOMAIN}.fake"
+
+    entry = MockConfigEntry(
+        domain=SAMSUNGTV_DOMAIN, data=MOCK_ENTRY_WS, unique_id=entity_id,
+    )
+    entry.add_to_hass(hass)
+
+    config_entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    assert len(config_entries) == 1
+    assert entry is config_entries[0]
+
+    assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {}) is True
+    await hass.async_block_till_done()
+
+    next_update = mock_now + timedelta(minutes=5)
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS"
+    ) as remote, patch("homeassistant.util.dt.utcnow", return_value=next_update):
+        async_fire_time_changed(hass, next_update)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert remote.call_count == 1
+    assert remote.call_args_list == [call(**MOCK_CALLS_ENTRY_WS)]
 
 
 async def test_update_on(hass, remote, mock_now):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the Samsung TV integration does only try to connect port 8001. This fix will also try 8002.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32942
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
