### PR TITLE
Fix RainMachine not properly storing data in the config entry

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -140,7 +140,7 @@ async def async_setup_entry(hass, config_entry):
             config_entry.data[CONF_IP_ADDRESS],
             config_entry.data[CONF_PASSWORD],
             port=config_entry.data[CONF_PORT],
-            ssl=config_entry.data[CONF_SSL],
+            ssl=config_entry.data.get(CONF_SSL, DEFAULT_SSL),
         )
     except RainMachineError as err:
         _LOGGER.error("An error occurred: %s", err)
@@ -153,8 +153,10 @@ async def async_setup_entry(hass, config_entry):
         rainmachine = RainMachine(
             hass,
             controller,
-            config_entry.data[CONF_ZONE_RUN_TIME],
-            config_entry.data[CONF_SCAN_INTERVAL],
+            config_entry.data.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN),
+            config_entry.data.get(
+                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds()
+            ),
         )
 
     # Update the data object, which at this point (prior to any sensors registering

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import verify_domain_control
 
 from .const import (
+    CONF_ZONE_RUN_TIME,
     DATA_CLIENT,
     DATA_PROGRAMS,
     DATA_PROVISION_SETTINGS,
@@ -33,6 +34,8 @@ from .const import (
     DATA_ZONES,
     DATA_ZONES_DETAILS,
     DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_ZONE_RUN,
     DOMAIN,
     PROGRAM_UPDATE_TOPIC,
     SENSOR_UPDATE_TOPIC,
@@ -41,19 +44,14 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_LISTENER = "listener"
-
 CONF_CONTROLLERS = "controllers"
 CONF_PROGRAM_ID = "program_id"
 CONF_SECONDS = "seconds"
 CONF_ZONE_ID = "zone_id"
-CONF_ZONE_RUN_TIME = "zone_run_time"
 
 DEFAULT_ATTRIBUTION = "Data provided by Green Electronics LLC"
 DEFAULT_ICON = "mdi:water"
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 DEFAULT_SSL = True
-DEFAULT_ZONE_RUN = 60 * 10
 
 SERVICE_ALTER_PROGRAM = vol.Schema({vol.Required(CONF_PROGRAM_ID): cv.positive_int})
 
@@ -109,7 +107,6 @@ async def async_setup(hass, config):
     """Set up the RainMachine component."""
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][DATA_CLIENT] = {}
-    hass.data[DOMAIN][DATA_LISTENER] = {}
 
     if DOMAIN not in config:
         return True
@@ -259,9 +256,6 @@ async def async_setup_entry(hass, config_entry):
 async def async_unload_entry(hass, config_entry):
     """Unload an OpenUV config entry."""
     hass.data[DOMAIN][DATA_CLIENT].pop(config_entry.entry_id)
-
-    remove_listener = hass.data[DOMAIN][DATA_LISTENER].pop(config_entry.entry_id)
-    remove_listener()
 
     tasks = [
         hass.config_entries.async_forward_entry_unload(config_entry, component)

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -4,7 +4,7 @@ from regenmaschine.errors import RainMachineError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL
 from homeassistant.helpers import aiohttp_client
 
 from .const import DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
@@ -53,8 +53,8 @@ class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_IP_ADDRESS],
                 user_input[CONF_PASSWORD],
                 websession,
-                port=user_input.get(CONF_PORT, DEFAULT_PORT),
-                ssl=True,
+                port=user_input[CONF_PORT],
+                ssl=user_input.get(CONF_SSL, True),
             )
         except RainMachineError:
             return await self._show_form({CONF_PASSWORD: "invalid_credentials"})
@@ -63,5 +63,11 @@ class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # access token without using the IP address and password, so we have to
         # store it:
         return self.async_create_entry(
-            title=user_input[CONF_IP_ADDRESS], data=user_input
+            title=user_input[CONF_IP_ADDRESS],
+            data={
+                CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_PORT: user_input[CONF_PORT],
+                CONF_SSL: user_input.get(CONF_SSL, True),
+            },
         )

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -4,10 +4,22 @@ from regenmaschine.errors import RainMachineError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_SSL,
+)
 from homeassistant.helpers import aiohttp_client
 
-from .const import DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
+from .const import (  # pylint: disable=unused-import
+    CONF_ZONE_RUN_TIME,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_ZONE_RUN,
+    DOMAIN,
+)
 
 
 class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -69,5 +81,11 @@ class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
                 CONF_PORT: user_input[CONF_PORT],
                 CONF_SSL: user_input.get(CONF_SSL, True),
+                CONF_SCAN_INTERVAL: user_input.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds()
+                ),
+                CONF_ZONE_RUN_TIME: user_input.get(
+                    CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN
+                ),
             },
         )

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -1,5 +1,9 @@
 """Define constants for the SimpliSafe component."""
+from datetime import timedelta
+
 DOMAIN = "rainmachine"
+
+CONF_ZONE_RUN_TIME = "zone_run_time"
 
 DATA_CLIENT = "client"
 DATA_PROGRAMS = "programs"
@@ -10,6 +14,8 @@ DATA_ZONES = "zones"
 DATA_ZONES_DETAILS = "zones_details"
 
 DEFAULT_PORT = 8080
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
+DEFAULT_ZONE_RUN = 60 * 10
 
 PROGRAM_UPDATE_TOPIC = f"{DOMAIN}_program_update"
 SENSOR_UPDATE_TOPIC = f"{DOMAIN}_data_update"

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from regenmaschine.errors import RainMachineError
 
 from homeassistant import data_entry_flow
-from homeassistant.components.rainmachine import DOMAIN, config_flow
+from homeassistant.components.rainmachine import CONF_ZONE_RUN_TIME, DOMAIN, config_flow
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_IP_ADDRESS,
@@ -98,6 +98,7 @@ async def test_step_import(hass):
             CONF_PORT: 8080,
             CONF_SSL: True,
             CONF_SCAN_INTERVAL: 60,
+            CONF_ZONE_RUN_TIME: 600,
         }
 
 
@@ -129,4 +130,5 @@ async def test_step_user(hass):
             CONF_PORT: 8080,
             CONF_SSL: True,
             CONF_SCAN_INTERVAL: 60,
+            CONF_ZONE_RUN_TIME: 600,
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes the RainMachine integration by ensuring that all appropriate data is stored to the config entry in both import and UI scenarios.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_host
      password: !secret rainmachine_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/32968
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
