### PR TITLE
Poll Hue lights in ZHA

### DIFF
--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -202,11 +202,11 @@ class MatchRule:
 
         Most specific matches should be preferred over less specific. Model matching
         rules have a priority over manufacturer matching rules and rules matching a
-        single model/manufacturer get a better prioirty over rules matching multiple
+        single model/manufacturer get a better priority over rules matching multiple
         models/manufacturers. And any model or manufacturers matching rules get better
         priority over rules matching only channels.
         But in case of a channel name/channel id matching, we give rules matching
-        multiple channels a better prioirty over rules matching a single channel.
+        multiple channels a better priority over rules matching a single channel.
         """
         weight = 0
         if self.models:

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -196,6 +196,24 @@ class MatchRule:
         factory=frozenset, converter=set_or_callable
     )
 
+    @property
+    def weight(self) -> int:
+        """Return the weight of the matching rule.
+
+        Most specific matches should be preferred over less specific.
+        """
+        weight = 0
+        if self.models:
+            weight += 401 - len(self.models)
+
+        if self.manufacturers:
+            weight += 301 - len(self.manufacturers)
+
+        weight += 10 * len(self.channel_names)
+        weight += 5 * len(self.generic_ids)
+        weight += 1 * len(self.aux_channels)
+        return weight
+
     def claim_channels(self, channel_pool: List[ChannelType]) -> List[ChannelType]:
         """Return a list of channels this rule matches + aux channels."""
         claimed = []
@@ -268,7 +286,8 @@ class ZHAEntityRegistry:
         default: CALLABLE_T = None,
     ) -> Tuple[CALLABLE_T, List[ChannelType]]:
         """Match a ZHA Channels to a ZHA Entity class."""
-        for match in self._strict_registry[component]:
+        matches = self._strict_registry[component]
+        for match in sorted(matches, key=lambda x: x.weight, reverse=True):
             if match.strict_matched(manufacturer, model, channels):
                 claimed = match.claim_channels(channels)
                 return self._strict_registry[component][match], claimed

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -200,7 +200,13 @@ class MatchRule:
     def weight(self) -> int:
         """Return the weight of the matching rule.
 
-        Most specific matches should be preferred over less specific.
+        Most specific matches should be preferred over less specific. Model matching
+        rules have a priority over manufacturer matching rules and rules matching a
+        single model/manufacturer get a better prioirty over rules matching multiple
+        models/manufacturers. And any model or manufacturers matching rules get better
+        priority over rules matching only channels.
+        But in case of a channel name/channel id matching, we give rules matching
+        multiple channels a better prioirty over rules matching a single channel.
         """
         weight = 0
         if self.models:

--- a/tests/components/zha/test_registries.py
+++ b/tests/components/zha/test_registries.py
@@ -254,3 +254,63 @@ def test_match_rule_claim_channels(rule, match, channel, channels):
 
     claimed = rule.claim_channels(channels)
     assert match == set([ch.name for ch in claimed])
+
+
+@pytest.fixture
+def entity_registry():
+    """Registry fixture."""
+    return registries.ZHAEntityRegistry()
+
+
+@pytest.mark.parametrize(
+    "manufacturer, model, match_name",
+    (
+        ("random manufacturer", "random model", "OnOff"),
+        ("random manufacturer", MODEL, "OnOffModel"),
+        (MANUFACTURER, "random model", "OnOffManufacturer"),
+        (MANUFACTURER, MODEL, "OnOffModelManufacturer"),
+        (MANUFACTURER, "some model", "OnOffMultimodel"),
+    ),
+)
+def test_weighted_match(channel, entity_registry, manufacturer, model, match_name):
+    """Test weightedd match."""
+
+    s = mock.sentinel
+
+    @entity_registry.strict_match(
+        s.component,
+        channel_names="on_off",
+        models={MODEL, "another model", "some model"},
+    )
+    class OnOffMultimodel:
+        pass
+
+    @entity_registry.strict_match(s.component, channel_names="on_off")
+    class OnOff:
+        pass
+
+    @entity_registry.strict_match(
+        s.component, channel_names="on_off", manufacturers=MANUFACTURER
+    )
+    class OnOffManufacturer:
+        pass
+
+    @entity_registry.strict_match(s.component, channel_names="on_off", models=MODEL)
+    class OnOffModel:
+        pass
+
+    @entity_registry.strict_match(
+        s.component, channel_names="on_off", models=MODEL, manufacturers=MANUFACTURER
+    )
+    class OnOffModelManufacturer:
+        pass
+
+    ch_on_off = channel("on_off", 6)
+    ch_level = channel("level", 8)
+
+    match, claimed = entity_registry.get_entity(
+        s.component, manufacturer, model, [ch_on_off, ch_level]
+    )
+
+    assert match.__name__ == match_name
+    assert claimed == [ch_on_off]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nope (or not on purpose)

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hue lights do not report attribute changes which requires them to be polled. So this PR polls HUE lights and relies on attribute updates for the rest of the lights.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
