### PR TITLE
Add effect service to WLED integration

### DIFF
--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -17,6 +17,7 @@ ATTR_ON = "on"
 ATTR_PALETTE = "palette"
 ATTR_PLAYLIST = "playlist"
 ATTR_PRESET = "preset"
+ATTR_REVERSE = "reverse"
 ATTR_SEGMENT_ID = "segment_id"
 ATTR_SOFTWARE_VERSION = "sw_version"
 ATTR_SPEED = "speed"
@@ -26,3 +27,6 @@ ATTR_UDP_PORT = "udp_port"
 # Units of measurement
 CURRENT_MA = "mA"
 SIGNAL_DBM = "dBm"
+
+# Services
+SERVICE_EFFECT = "effect"

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -44,13 +44,6 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
-SERVICE_EFFECT_SCHEMA = {
-    vol.Optional(ATTR_EFFECT): vol.Any(cv.positive_int, cv.string),
-    vol.Optional(ATTR_INTENSITY): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
-    vol.Optional(ATTR_REVERSE): cv.boolean,
-    vol.Optional(ATTR_SPEED): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
-}
-
 
 async def async_setup_entry(
     hass: HomeAssistantType,
@@ -63,7 +56,18 @@ async def async_setup_entry(
     platform = entity_platform.current_platform.get()
 
     platform.async_register_entity_service(
-        SERVICE_EFFECT, SERVICE_EFFECT_SCHEMA, "async_effect",
+        SERVICE_EFFECT,
+        {
+            vol.Optional(ATTR_EFFECT): vol.Any(cv.positive_int, cv.string),
+            vol.Optional(ATTR_INTENSITY): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=255)
+            ),
+            vol.Optional(ATTR_REVERSE): cv.boolean,
+            vol.Optional(ATTR_SPEED): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=255)
+            ),
+        },
+        "async_effect",
     )
 
     lights = [

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -1,6 +1,8 @@
 """Support for LED lights."""
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -18,6 +20,7 @@ from homeassistant.components.light import (
     Light,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.color as color_util
@@ -30,14 +33,23 @@ from .const import (
     ATTR_PALETTE,
     ATTR_PLAYLIST,
     ATTR_PRESET,
+    ATTR_REVERSE,
     ATTR_SEGMENT_ID,
     ATTR_SPEED,
     DOMAIN,
+    SERVICE_EFFECT,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
+
+SERVICE_EFFECT_SCHEMA = {
+    vol.Optional(ATTR_EFFECT): vol.Any(cv.positive_int, cv.string),
+    vol.Optional(ATTR_INTENSITY): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+    vol.Optional(ATTR_REVERSE): cv.boolean,
+    vol.Optional(ATTR_SPEED): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+}
 
 
 async def async_setup_entry(
@@ -47,6 +59,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up WLED light based on a config entry."""
     coordinator: WLEDDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    platform = entity_platform.current_platform.get()
+
+    platform.async_register_entity_service(
+        SERVICE_EFFECT, SERVICE_EFFECT_SCHEMA, "async_effect",
+    )
 
     lights = [
         WLEDLight(entry.entry_id, coordinator, light.segment_id)
@@ -94,16 +112,14 @@ class WLEDLight(Light, WLEDDeviceEntity):
         if preset == -1:
             preset = None
 
+        segment = self.coordinator.data.state.segments[self._segment]
         return {
-            ATTR_INTENSITY: self.coordinator.data.state.segments[
-                self._segment
-            ].intensity,
-            ATTR_PALETTE: self.coordinator.data.state.segments[
-                self._segment
-            ].palette.name,
+            ATTR_INTENSITY: segment.intensity,
+            ATTR_PALETTE: segment.palette.name,
             ATTR_PLAYLIST: playlist,
             ATTR_PRESET: preset,
-            ATTR_SPEED: self.coordinator.data.state.segments[self._segment].speed,
+            ATTR_REVERSE: segment.reverse,
+            ATTR_SPEED: segment.speed,
         }
 
     @property
@@ -212,5 +228,30 @@ class WLEDLight(Light, WLEDDeviceEntity):
                 data[ATTR_COLOR_PRIMARY] += (kwargs[ATTR_WHITE_VALUE],)
             else:
                 data[ATTR_COLOR_PRIMARY] += (self.white_value,)
+
+        await self.coordinator.wled.light(**data)
+
+    @wled_exception_handler
+    async def async_effect(
+        self,
+        effect: Optional[Union[int, str]] = None,
+        intensity: Optional[int] = None,
+        reverse: Optional[bool] = None,
+        speed: Optional[int] = None,
+    ) -> None:
+        """Set the effect of a WLED light."""
+        data = {ATTR_SEGMENT_ID: self._segment}
+
+        if effect is not None:
+            data[ATTR_EFFECT] = effect
+
+        if intensity is not None:
+            data[ATTR_INTENSITY] = intensity
+
+        if reverse is not None:
+            data[ATTR_REVERSE] = reverse
+
+        if speed is not None:
+            data[ATTR_SPEED] = speed
 
         await self.coordinator.wled.light(**data)

--- a/homeassistant/components/wled/services.yaml
+++ b/homeassistant/components/wled/services.yaml
@@ -1,0 +1,18 @@
+effect:
+  description: Controls the effect settings of WLED
+  fields:
+    entity_id:
+      description: Name of the WLED light entity.
+      example: "light.wled"
+    effect:
+      description: Name or ID of the WLED light effect.
+      example: "Rainbow"
+    intensity:
+      description: Intensity of the effect
+      example: 100
+    speed:
+      description: Speed of the effect. Number between 0 (slow) and 255 (fast).
+      example: 150
+    reverse:
+      description: Reverse the effect. Either true to reverse or false otherwise.
+      example: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `wled.effect` service to the WLED integration.

This allows the user to finetune the effects running on the WLED light (or set the light into a specific effect state, before turning it on.

Allows controlling:

- The effect (using an effect name or ID)
- The speed of the effect
- The intensity of the effect
- Reverse the effect

Additionally, the `reverse` attribute has been added to the light (since I figured it would be helpful if one could see the current state if one could set it.)

Tests are added to keep the full coverage:

```
----------- coverage: platform linux, python 3.7.6-final-0 -----------
Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
homeassistant/components/wled/__init__.py         97      0   100%
homeassistant/components/wled/config_flow.py      56      0   100%
homeassistant/components/wled/const.py            22      0   100%
homeassistant/components/wled/light.py           110      0   100%
homeassistant/components/wled/sensor.py           51      0   100%
homeassistant/components/wled/switch.py           66      0   100%
------------------------------------------------------------------
TOTAL                                            402      0   100%
Coverage XML written to file cov.xml


Results (1.83s):
      28 passed
```



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example automation
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example automation
automation:
  - alias: Alarm system
    trigger:
      platform: state
      entity_id: binary_sensor.motion_buglar
      to: 'on'
    condition: []
    action:
      - service: wled.effect
        entity_id: light.wled
        data:
          effect: police
          intensity: 255
          speed: 255
          reverse: true
      - service: light.turn_on
        entity_id: light.wled
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12461
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
