### PR TITLE
Add support for occupancy/vacancy groups in Lutron Caseta component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -211,6 +211,7 @@ homeassistant/components/luci/* @fbradyirl @mzdrale
 homeassistant/components/luftdaten/* @fabaff
 homeassistant/components/lupusec/* @majuss
 homeassistant/components/lutron/* @JonGilmore
+homeassistant/components/lutron_caseta/* @swails
 homeassistant/components/mastodon/* @fabaff
 homeassistant/components/matrix/* @tinloaf
 homeassistant/components/mcp23017/* @jardiamj

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -99,11 +99,6 @@ class LutronCasetaDevice(Entity):
         return self._device["serial"]
 
     @property
-    def model(self):
-        """Return the model number of the device."""
-        return self._device["model"]
-
-    @property
     def unique_id(self):
         """Return the unique ID of the device (serial)."""
         return str(self.serial)

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -33,8 +33,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-LUTRON_CASETA_COMPONENTS = ["light", "switch", "cover", "scene", "fan",
-                            "binary_sensor"]
+LUTRON_CASETA_COMPONENTS = ["light", "switch", "cover", "scene", "fan", "binary_sensor"]
 
 
 async def async_setup(hass, base_config):
@@ -91,8 +90,9 @@ class LutronCasetaDevice(Entity):
                 "manufacturer": "Lutron",
             }
         except Exception:
-            _LOGGER.exception("Failed generating device info for %s and device %s",
-                              self, self._device)
+            _LOGGER.exception(
+                "Failed generating device info for %s and device %s", self, self._device
+            )
 
     async def async_added_to_hass(self):
         """Register callbacks."""
@@ -116,7 +116,7 @@ class LutronCasetaDevice(Entity):
     @property
     def model(self):
         """Return the model number of the device."""
-        return self._device['model']
+        return self._device["model"]
 
     @property
     def unique_id(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -81,9 +81,7 @@ class LutronCasetaDevice(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._smartbridge.add_subscriber(
-            self.device_id, self.async_write_ha_state
-        )
+        self._smartbridge.add_subscriber(self.device_id, self.async_write_ha_state)
 
     @property
     def device_id(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -33,7 +33,8 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-LUTRON_CASETA_COMPONENTS = ["light", "switch", "cover", "scene", "fan"]
+LUTRON_CASETA_COMPONENTS = ["light", "switch", "cover", "scene", "fan",
+                            "binary_sensor"]
 
 
 async def async_setup(hass, base_config):
@@ -79,6 +80,20 @@ class LutronCasetaDevice(Entity):
         self._device = device
         self._smartbridge = bridge
 
+    @property
+    def device_info(self):
+        """Unique device identification"""
+        try:
+            return {
+                "identifiers": {(DOMAIN, self.serial)},
+                "name": self.name,
+                "model": self.model,
+                "manufacturer": "Lutron",
+            }
+        except Exception:
+            _LOGGER.exception("Failed generating device info for %s and device %s",
+                              self, self._device)
+
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._smartbridge.add_subscriber(self.device_id, self.async_write_ha_state)
@@ -97,6 +112,11 @@ class LutronCasetaDevice(Entity):
     def serial(self):
         """Return the serial number of the device."""
         return self._device["serial"]
+
+    @property
+    def model(self):
+        """Return the model number of the device."""
+        return self._device['model']
 
     @property
     def unique_id(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -79,24 +79,11 @@ class LutronCasetaDevice(Entity):
         self._device = device
         self._smartbridge = bridge
 
-    @property
-    def device_info(self):
-        """Unique device identification"""
-        try:
-            return {
-                "identifiers": {(DOMAIN, self.serial)},
-                "name": self.name,
-                "model": self.model,
-                "manufacturer": "Lutron",
-            }
-        except Exception:
-            _LOGGER.exception(
-                "Failed generating device info for %s and device %s", self, self._device
-            )
-
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._smartbridge.add_subscriber(self.device_id, self.async_write_ha_state)
+        self._smartbridge.add_subscriber(
+            self.device_id, self.async_write_ha_state
+        )
 
     @property
     def device_id(self):

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -51,11 +51,6 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
         return f"caseta_occupancygroup_{self.device_id}"
 
     @property
-    def model(self):
-        """Return a model number."""
-        return "PD-OSENS-WH"
-
-    @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {"Device ID": self.device_id}
+        return {"device_id": self.device_id}

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -47,7 +47,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
         return self._device["occupancy_group_id"]
 
     @property
-    def serial(self):
+    def unique_id(self):
         """Return a unique identifier."""
         return f"caseta_occupancygroup_{self.device_id}"
 

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -48,7 +48,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
     @property
     def unique_id(self):
         """Return a unique identifier."""
-        return f"caseta_occupancygroup_{self.device_id}"
+        return f"occupancygroup_{self.device_id}"
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -9,19 +9,17 @@ from homeassistant.components.binary_sensor import (
 from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED, OCCUPANCY_GROUP_UNOCCUPIED
 from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Lutron Caseta lights."""
-    devs = []
+    entities = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
     occupancy_groups = bridge.occupancy_groups
     for occupancy_group in occupancy_groups.values():
-        dev = LutronOccupancySensor(occupancy_group, bridge)
-        devs.append(dev)
+        entity = LutronOccupancySensor(occupancy_group, bridge)
+        entities.append(entity)
 
-    async_add_entities(devs, True)
+    async_add_entities(entities, True)
 
 
 class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
@@ -40,7 +38,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._smartbridge.add_occupancy_subscriber(
-            self.device_id, self.async_schedule_update_ha_state
+            self.device_id, self.async_write_ha_state
         )
 
     @property

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -4,6 +4,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice,
 )
 from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED
+
 from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
 
 

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -1,0 +1,65 @@
+"""Support for Lutron Caseta Occupancy/Vacancy Sensors."""
+import logging
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_OCCUPANCY,
+    DOMAIN,
+    BinarySensorDevice,
+)
+from pylutron_caseta import (OCCUPANCY_GROUP_OCCUPIED,
+                             OCCUPANCY_GROUP_UNOCCUPIED)
+from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the Lutron Caseta lights."""
+    devs = []
+    bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
+    occupancy_groups = bridge.occupancy_groups
+    for occupancy_group in occupancy_groups.values():
+        dev = LutronOccupancySensor(occupancy_group, bridge)
+        devs.append(dev)
+
+    async_add_entities(devs, True)
+
+
+class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
+    """Representation of a Lutron occupancy group."""
+
+    @property
+    def device_class(self):
+        """Flag supported features."""
+        return DEVICE_CLASS_OCCUPANCY
+
+    @property
+    def is_on(self):
+        """Return the brightness of the light."""
+        return self._device['status'] == OCCUPANCY_GROUP_OCCUPIED
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self._smartbridge.add_occupancy_subscriber(
+            self.device_id, self.async_schedule_update_ha_state
+        )
+
+    @property
+    def device_id(self):
+        """Return the device ID used for calling pylutron_caseta."""
+        return self._device["occupancy_group_id"]
+
+    @property
+    def serial(self):
+        """Return a unique identifier."""
+        return f"caseta_occupancygroup_{self.device_id}"
+
+    @property
+    def model(self):
+        """Return a model number"""
+        return "PD-OSENS-WH"
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {"Device ID": self.device_id}

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -1,12 +1,9 @@
 """Support for Lutron Caseta Occupancy/Vacancy Sensors."""
-import logging
-
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OCCUPANCY,
-    DOMAIN,
     BinarySensorDevice,
 )
-from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED, OCCUPANCY_GROUP_UNOCCUPIED
+from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED
 from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
 
 
@@ -53,7 +50,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
 
     @property
     def model(self):
-        """Return a model number"""
+        """Return a model number."""
         return "PD-OSENS-WH"
 
     @property

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -6,8 +6,7 @@ from homeassistant.components.binary_sensor import (
     DOMAIN,
     BinarySensorDevice,
 )
-from pylutron_caseta import (OCCUPANCY_GROUP_OCCUPIED,
-                             OCCUPANCY_GROUP_UNOCCUPIED)
+from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED, OCCUPANCY_GROUP_UNOCCUPIED
 from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,7 +35,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return the brightness of the light."""
-        return self._device['status'] == OCCUPANCY_GROUP_OCCUPIED
+        return self._device["status"] == OCCUPANCY_GROUP_OCCUPIED
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -1,9 +1,10 @@
 """Support for Lutron Caseta Occupancy/Vacancy Sensors."""
+from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED
+
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OCCUPANCY,
     BinarySensorDevice,
 )
-from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED
 
 from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
 

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -2,7 +2,7 @@
   "domain": "lutron_caseta",
   "name": "Lutron Caseta",
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
-  "requirements": ["pylutron-caseta==0.5.1"],
+  "requirements": ["pylutron-caseta==0.6.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
   "requirements": ["pylutron-caseta==0.6.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@swails"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1364,7 +1364,7 @@ pylitejet==0.1
 pyloopenergy==0.1.3
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.5.1
+pylutron-caseta==0.6.0
 
 # homeassistant.components.lutron
 pylutron==0.2.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This adds support for occupancy groups (Lutron Caseta's version of motion sensors) for which support was recently added to Lutron Caseta system.

This follows updates to pylutron-caseta to add support for these
devices. This code works for me as a custom component in Home Assistant
Core with pylutron-caseta 0.6.0 (currently unreleased).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml - no change from previous versions
lutron_caseta:
  host: 192.168.1.15
  keyfile: caseta.key
  certfile: caseta.crt
  ca_certs: caseta-bridge.crt

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12466

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
