### PR TITLE
Add enable_wake_on_start option to Tesla

### DIFF
--- a/homeassistant/components/tesla/.translations/en.json
+++ b/homeassistant/components/tesla/.translations/en.json
@@ -1,30 +1,31 @@
 {
-    "config": {
-        "error": {
-            "connection_error": "Error connecting; check network and retry",
-            "identifier_exists": "Email already registered",
-            "invalid_credentials": "Invalid credentials",
-            "unknown_error": "Unknown error, please report log info"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "password": "Password",
-                    "username": "Email Address"
-                },
-                "description": "Please enter your information.",
-                "title": "Tesla - Configuration"
-            }
-        },
-        "title": "Tesla"
+  "config": {
+    "error": {
+      "connection_error": "Error connecting; check network and retry",
+      "identifier_exists": "Email already registered",
+      "invalid_credentials": "Invalid credentials",
+      "unknown_error": "Unknown error, please report log info"
     },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Seconds between scans"
-                }
-            }
+    "step": {
+      "user": {
+        "data": {
+          "username": "Email Address",
+          "password": "Password"
+        },
+        "description": "Please enter your information.",
+        "title": "Tesla - Configuration"
+      }
+    },
+    "title": "Tesla"
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Seconds between scans",
+          "enable_wake_on_start": "Force cars awake on startup"
         }
+      }
     }
+  }
 }

--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -28,8 +28,10 @@ from .config_flow import (
     validate_input,
 )
 from .const import (
+    CONF_WAKE_ON_START,
     DATA_LISTENER,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WAKE_ON_START,
     DOMAIN,
     ICONS,
     MIN_SCAN_INTERVAL,
@@ -71,7 +73,10 @@ async def async_setup(hass, base_config):
 
     def _update_entry(email, data=None, options=None):
         data = data or {}
-        options = options or {CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL}
+        options = options or {
+            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+            CONF_WAKE_ON_START: DEFAULT_WAKE_ON_START,
+        }
         for entry in hass.config_entries.async_entries(DOMAIN):
             if email != entry.title:
                 continue
@@ -131,7 +136,11 @@ async def async_setup_entry(hass, config_entry):
                 CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
             ),
         )
-        (refresh_token, access_token) = await controller.connect()
+        (refresh_token, access_token) = await controller.connect(
+            wake_if_asleep=config_entry.options.get(
+                CONF_WAKE_ON_START, DEFAULT_WAKE_ON_START
+            )
+        )
     except TeslaException as ex:
         _LOGGER.error("Unable to communicate with Tesla API: %s", ex.message)
         return False

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -15,7 +15,13 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, MIN_SCAN_INTERVAL
+from .const import (
+    CONF_WAKE_ON_START,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WAKE_ON_START,
+    DOMAIN,
+    MIN_SCAN_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +109,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     default=self.config_entry.options.get(
                         CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                     ),
-                ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL))
+                ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
+                vol.Optional(
+                    CONF_WAKE_ON_START,
+                    default=self.config_entry.options.get(
+                        CONF_WAKE_ON_START, DEFAULT_WAKE_ON_START
+                    ),
+                ): bool,
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/tesla/const.py
+++ b/homeassistant/components/tesla/const.py
@@ -1,7 +1,9 @@
 """Const file for Tesla cars."""
+CONF_WAKE_ON_START = "enable_wake_on_start"
 DOMAIN = "tesla"
 DATA_LISTENER = "listener"
 DEFAULT_SCAN_INTERVAL = 660
+DEFAULT_WAKE_ON_START = False
 MIN_SCAN_INTERVAL = 60
 TESLA_COMPONENTS = [
     "sensor",

--- a/homeassistant/components/tesla/strings.json
+++ b/homeassistant/components/tesla/strings.json
@@ -22,7 +22,8 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Seconds between scans"
+          "scan_interval": "Seconds between scans",
+          "enable_wake_on_start": "Force cars awake on startup"
         }
       }
     }

--- a/tests/components/tesla/test_config_flow.py
+++ b/tests/components/tesla/test_config_flow.py
@@ -4,7 +4,13 @@ from unittest.mock import patch
 from teslajsonpy import TeslaException
 
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.tesla.const import DOMAIN, MIN_SCAN_INTERVAL
+from homeassistant.components.tesla.const import (
+    CONF_WAKE_ON_START,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WAKE_ON_START,
+    DOMAIN,
+    MIN_SCAN_INTERVAL,
+)
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_PASSWORD,
@@ -137,10 +143,34 @@ async def test_option_flow(hass):
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={CONF_SCAN_INTERVAL: 350}
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 350, CONF_WAKE_ON_START: True},
     )
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_SCAN_INTERVAL: 350}
+    assert result["data"] == {
+        CONF_SCAN_INTERVAL: 350,
+        CONF_WAKE_ON_START: True,
+    }
+
+
+async def test_option_flow_defaults(hass):
+    """Test config flow options."""
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options=None)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] == "create_entry"
+    assert result["data"] == {
+        CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+        CONF_WAKE_ON_START: DEFAULT_WAKE_ON_START,
+    }
 
 
 async def test_option_flow_input_floor(hass):
@@ -157,4 +187,7 @@ async def test_option_flow_input_floor(hass):
         result["flow_id"], user_input={CONF_SCAN_INTERVAL: 1}
     )
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_SCAN_INTERVAL: MIN_SCAN_INTERVAL}
+    assert result["data"] == {
+        CONF_SCAN_INTERVAL: MIN_SCAN_INTERVAL,
+        CONF_WAKE_ON_START: DEFAULT_WAKE_ON_START,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an option for users to decide whether the Tesla component should wake up all cars on Home Assistant startup. This allows a user to choose whether cars should continue to sleep (and not update information) or to wake up the cars potentially interrupting long term hibernation and increasing vampire drain. Users who need to restart Home Assistant while their cars are parked away from charging (e.g., airports) would benefit with this option.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12449

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
