### PR TITLE
Fix packages for schemas without a default

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -77,7 +77,11 @@ PERSON_SCHEMA = vol.Schema(
 )
 
 CONFIG_SCHEMA = vol.Schema(
-    {vol.Optional(DOMAIN): vol.All(cv.ensure_list, cv.remove_falsy, [PERSON_SCHEMA])},
+    {
+        vol.Optional(DOMAIN, default=[]): vol.All(
+            cv.ensure_list, cv.remove_falsy, [PERSON_SCHEMA]
+        )
+    },
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -571,7 +571,9 @@ def _identify_config_schema(module: ModuleType) -> Tuple[Optional[str], Optional
 
     schema = module.CONFIG_SCHEMA.schema[key]  # type: ignore
 
-    if hasattr(key, "default"):
+    if hasattr(key, "default") and not isinstance(
+        key.default, vol.schema_builder.Undefined
+    ):
         default_value = schema(key.default())
 
         if isinstance(default_value, dict):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In 0.107.2 the loading of zones was fixed by inspecting the default from the configuration schema. (See #33027)

However, the default is not always explicitly set and thus an instance of `Undefined` in Voluptuous, causing Home Assistant to crash on startup.

See: #33038


Some testing/searching showed the following integrations are affected (probably more):

- `person`
- `ifttt`
- `discovery`
- `geofency`
- `hassio`
- `twilio`
- `sleepiq`

If any of those integrations were to be used in a packaged based configuration, Home Assistant 0.107.2 would crash instantly:

![image](https://user-images.githubusercontent.com/195327/77169621-19f26a00-6aba-11ea-81f9-4aa5a2b03525.png)


This PR addresses this issue by checking the default is not an instance of `Undefined`. 

Furthermore, I've added the missing default to the `persons` integration. It is the only integration in the above list that actually expects a list and isn't defining a default.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
homeassistant:
  # Load packages
  packages: !include_dir_named integrations
```

```yaml
# Example integrations/person.yaml
person:
  - name: Ada
    id: ada6789
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33038
- This PR is related to issue: #33027
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
