### PR TITLE
Add Wi-Fi sensors to WLED integration

### DIFF
--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -25,3 +25,4 @@ ATTR_UDP_PORT = "udp_port"
 
 # Units of measurement
 CURRENT_MA = "mA"
+SIGNAL_DBM = "dBm"

--- a/homeassistant/components/wled/sensor.py
+++ b/homeassistant/components/wled/sensor.py
@@ -4,13 +4,18 @@ import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_BYTES, DEVICE_CLASS_TIMESTAMP
+from homeassistant.const import (
+    DATA_BYTES,
+    DEVICE_CLASS_SIGNAL_STRENGTH,
+    DEVICE_CLASS_TIMESTAMP,
+    UNIT_PERCENTAGE,
+)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.dt import utcnow
 
 from . import WLEDDataUpdateCoordinator, WLEDDeviceEntity
-from .const import ATTR_LED_COUNT, ATTR_MAX_POWER, CURRENT_MA, DOMAIN
+from .const import ATTR_LED_COUNT, ATTR_MAX_POWER, CURRENT_MA, DOMAIN, SIGNAL_DBM
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +32,10 @@ async def async_setup_entry(
         WLEDEstimatedCurrentSensor(entry.entry_id, coordinator),
         WLEDUptimeSensor(entry.entry_id, coordinator),
         WLEDFreeHeapSensor(entry.entry_id, coordinator),
+        WLEDWifiBSSIDSensor(entry.entry_id, coordinator),
+        WLEDWifiChannelSensor(entry.entry_id, coordinator),
+        WLEDWifiRSSISensor(entry.entry_id, coordinator),
+        WLEDWifiSignalSensor(entry.entry_id, coordinator),
     ]
 
     async_add_entities(sensors, True)
@@ -142,3 +151,90 @@ class WLEDFreeHeapSensor(WLEDSensor):
     def state(self) -> Union[None, str, int, float]:
         """Return the state of the sensor."""
         return self.coordinator.data.info.free_heap
+
+
+class WLEDWifiSignalSensor(WLEDSensor):
+    """Defines a WLED Wi-Fi signal sensor."""
+
+    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+        """Initialize WLED Wi-Fi signal sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            enabled_default=False,
+            entry_id=entry_id,
+            icon="mdi:wifi",
+            key="wifi_signal",
+            name=f"{coordinator.data.info.name} Wi-Fi Signal",
+            unit_of_measurement=UNIT_PERCENTAGE,
+        )
+
+    @property
+    def state(self) -> Union[None, str, int, float]:
+        """Return the state of the sensor."""
+        return self.coordinator.data.info.wifi.signal
+
+
+class WLEDWifiRSSISensor(WLEDSensor):
+    """Defines a WLED Wi-Fi RSSI sensor."""
+
+    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+        """Initialize WLED Wi-Fi RSSI sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            enabled_default=False,
+            entry_id=entry_id,
+            icon="mdi:wifi",
+            key="wifi_rssi",
+            name=f"{coordinator.data.info.name} Wi-Fi RSSI",
+            unit_of_measurement=SIGNAL_DBM,
+        )
+
+    @property
+    def state(self) -> Union[None, str, int, float]:
+        """Return the state of the sensor."""
+        return self.coordinator.data.info.wifi.rssi
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of this sensor."""
+        return DEVICE_CLASS_SIGNAL_STRENGTH
+
+
+class WLEDWifiChannelSensor(WLEDSensor):
+    """Defines a WLED Wi-Fi Channel sensor."""
+
+    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+        """Initialize WLED Wi-Fi Channel sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            enabled_default=False,
+            entry_id=entry_id,
+            icon="mdi:wifi",
+            key="wifi_channel",
+            name=f"{coordinator.data.info.name} Wi-Fi Channel",
+        )
+
+    @property
+    def state(self) -> Union[None, str, int, float]:
+        """Return the state of the sensor."""
+        return self.coordinator.data.info.wifi.channel
+
+
+class WLEDWifiBSSIDSensor(WLEDSensor):
+    """Defines a WLED Wi-Fi BSSID sensor."""
+
+    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+        """Initialize WLED Wi-Fi BSSID sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            enabled_default=False,
+            entry_id=entry_id,
+            icon="mdi:wifi",
+            key="wifi_bssid",
+            name=f"{coordinator.data.info.name} Wi-Fi BSSID",
+        )
+
+    @property
+    def state(self) -> Union[None, str, int, float]:
+        """Return the state of the sensor."""
+        return self.coordinator.data.info.wifi.bssid

--- a/tests/fixtures/wled/rgb.json
+++ b/tests/fixtures/wled/rgb.json
@@ -62,6 +62,12 @@
     "live": false,
     "fxcount": 81,
     "palcount": 50,
+    "wifi": {
+      "bssid": "AA:AA:AA:AA:AA:BB",
+      "rssi": -62,
+      "signal": 76,
+      "channel": 11
+    },
     "arch": "esp8266",
     "core": "2_4_2",
     "freeheap": 14600,

--- a/tests/fixtures/wled/rgbw.json
+++ b/tests/fixtures/wled/rgbw.json
@@ -48,6 +48,12 @@
     "live": false,
     "fxcount": 83,
     "palcount": 50,
+    "wifi": {
+      "bssid": "AA:AA:AA:AA:AA:BB",
+      "rssi": -62,
+      "signal": 76,
+      "channel": 11
+    },
     "arch": "esp8266",
     "core": "2_5_2",
     "freeheap": 20136,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds 4 new sensors to the WLED integration:

- Wi-Fi Signal Strength in %
- Wi-Fi Signal Strength RSSI
- Wi-Fi Channel
- Wi-Fi BSSID

All sensors are disabled by default.

Tests have been added to keep coverge.

```
----------- coverage: platform linux, python 3.7.6-final-0 -----------
Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
homeassistant/components/wled/__init__.py         97      0   100%
homeassistant/components/wled/config_flow.py      56      0   100%
homeassistant/components/wled/const.py            21      0   100%
homeassistant/components/wled/light.py            92      0   100%
homeassistant/components/wled/sensor.py           78      0   100%
homeassistant/components/wled/switch.py           66      0   100%
------------------------------------------------------------------
TOTAL                                            410      0   100%
Coverage XML written to file cov.xml


Results (1.96s):
      31 passed
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12460

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
