### PR TITLE
Support contemporary entity selectors for LIFX services

### DIFF
--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -289,21 +289,12 @@ class LIFXManager:
     def register_set_state(self):
         """Register the LIFX set_state service call."""
 
-        async def service_handler(service):
+        async def service_handler(entity, service):
             """Apply a service."""
-            tasks = []
-            for light in await self.platform.async_extract_from_service(service):
-                if service.service == SERVICE_LIFX_SET_STATE:
-                    task = light.set_state(**service.data)
-                tasks.append(self.hass.async_create_task(task))
-            if tasks:
-                await asyncio.wait(tasks)
+            await entity.set_state(**service.data)
 
-        self.hass.services.async_register(
-            LIFX_DOMAIN,
-            SERVICE_LIFX_SET_STATE,
-            service_handler,
-            schema=LIFX_SET_STATE_SCHEMA,
+        self.platform.async_register_entity_service(
+            SERVICE_LIFX_SET_STATE, LIFX_SET_STATE_SCHEMA, service_handler
         )
 
     def register_effects(self):

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -35,18 +35,12 @@ from homeassistant.components.light import (
     Light,
     preprocess_turn_on_alternatives,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_MODE,
-    ENTITY_MATCH_ALL,
-    ENTITY_MATCH_NONE,
-    EVENT_HOMEASSISTANT_STOP,
-)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
+from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.service import async_extract_entity_ids
 import homeassistant.util.color as color_util
 
 from . import (
@@ -105,15 +99,13 @@ PULSE_MODES = [
     PULSE_MODE_SOLID,
 ]
 
-LIFX_EFFECT_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-        vol.Optional(ATTR_POWER_ON, default=True): cv.boolean,
-    }
-)
+LIFX_EFFECT_SCHEMA = {
+    vol.Optional(ATTR_POWER_ON, default=True): cv.boolean,
+}
 
-LIFX_EFFECT_PULSE_SCHEMA = LIFX_EFFECT_SCHEMA.extend(
+LIFX_EFFECT_PULSE_SCHEMA = cv.make_entity_service_schema(
     {
+        **LIFX_EFFECT_SCHEMA,
         ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
         ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
         vol.Exclusive(ATTR_COLOR_NAME, COLOR_GROUP): cv.string,
@@ -144,8 +136,9 @@ LIFX_EFFECT_PULSE_SCHEMA = LIFX_EFFECT_SCHEMA.extend(
     }
 )
 
-LIFX_EFFECT_COLORLOOP_SCHEMA = LIFX_EFFECT_SCHEMA.extend(
+LIFX_EFFECT_COLORLOOP_SCHEMA = cv.make_entity_service_schema(
     {
+        **LIFX_EFFECT_SCHEMA,
         ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
         ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
         ATTR_PERIOD: vol.All(vol.Coerce(float), vol.Clamp(min=0.05)),
@@ -155,7 +148,7 @@ LIFX_EFFECT_COLORLOOP_SCHEMA = LIFX_EFFECT_SCHEMA.extend(
     }
 )
 
-LIFX_EFFECT_STOP_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids})
+LIFX_EFFECT_STOP_SCHEMA = cv.make_entity_service_schema({})
 
 
 def aiolifx():
@@ -191,7 +184,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             # Priority 3: default interface
             interfaces = [{}]
 
-    lifx_manager = LIFXManager(hass, async_add_entities)
+    platform = entity_platform.current_platform.get()
+    lifx_manager = LIFXManager(hass, platform, async_add_entities)
     hass.data[DATA_LIFX_MANAGER] = lifx_manager
 
     for interface in interfaces:
@@ -242,10 +236,11 @@ def merge_hsbk(base, change):
 class LIFXManager:
     """Representation of all known LIFX entities."""
 
-    def __init__(self, hass, async_add_entities):
+    def __init__(self, hass, platform, async_add_entities):
         """Initialize the light."""
         self.entities = {}
         self.hass = hass
+        self.platform = platform
         self.async_add_entities = async_add_entities
         self.effects_conductor = aiolifx_effects().Conductor(hass.loop)
         self.discoveries = []
@@ -297,7 +292,7 @@ class LIFXManager:
         async def service_handler(service):
             """Apply a service."""
             tasks = []
-            for light in await self.async_service_to_entities(service):
+            for light in await self.platform.async_extract_from_service(service):
                 if service.service == SERVICE_LIFX_SET_STATE:
                     task = light.set_state(**service.data)
                 tasks.append(self.hass.async_create_task(task))
@@ -316,7 +311,7 @@ class LIFXManager:
 
         async def service_handler(service):
             """Apply a service, i.e. start an effect."""
-            entities = await self.async_service_to_entities(service)
+            entities = await self.platform.async_extract_from_service(service)
             if entities:
                 await self.start_effect(entities, service.service, **service.data)
 
@@ -372,21 +367,6 @@ class LIFXManager:
             await self.effects_conductor.start(effect, bulbs)
         elif service == SERVICE_EFFECT_STOP:
             await self.effects_conductor.stop(bulbs)
-
-    async def async_service_to_entities(self, service):
-        """Return the known entities that a service call mentions."""
-        if service.data.get(ATTR_ENTITY_ID) == ENTITY_MATCH_NONE:
-            return []
-
-        if service.data.get(ATTR_ENTITY_ID) == ENTITY_MATCH_ALL:
-            return self.entities.values()
-
-        entity_ids = await async_extract_entity_ids(self.hass, service)
-        return [
-            entity
-            for entity in self.entities.values()
-            if entity.entity_id in entity_ids
-        ]
 
     @callback
     def register(self, bulb):

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -288,13 +288,8 @@ class LIFXManager:
 
     def register_set_state(self):
         """Register the LIFX set_state service call."""
-
-        async def service_handler(entity, service):
-            """Apply a service."""
-            await entity.set_state(**service.data)
-
         self.platform.async_register_entity_service(
-            SERVICE_LIFX_SET_STATE, LIFX_SET_STATE_SCHEMA, service_handler
+            SERVICE_LIFX_SET_STATE, LIFX_SET_STATE_SCHEMA, "set_state"
         )
 
     def register_effects(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

All right, I found this issue when I was unable to stop a full-house disco going on with all my lights.

The PR updates the LIFX light platform with the new helpers so it supports `area_id: X`, `entity_id: none` and (most importantly) `entity_id: all` for all its services.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
