### PR TITLE
Allow more than one AirVisual config entry with the same API key

### DIFF
--- a/homeassistant/components/airvisual/.translations/en.json
+++ b/homeassistant/components/airvisual/.translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "This API key is already in use."
+            "already_configured": "These coordinates have already been registered."
         },
         "error": {
             "invalid_api_key": "Invalid API key"

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -82,9 +82,7 @@ def async_get_geography_id(geography_dict):
 
 async def async_setup(hass, config):
     """Set up the AirVisual component."""
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][DATA_CLIENT] = {}
-    hass.data[DOMAIN][DATA_LISTENER] = {}
+    hass.data[DOMAIN] = {DATA_CLIENT: {}, DATA_LISTENER: {}}
 
     if DOMAIN not in config:
         return True

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -22,7 +22,6 @@ from homeassistant.helpers.event import async_track_time_interval
 from .const import (
     CONF_CITY,
     CONF_COUNTRY,
-    CONF_GEOGRAPHIES,
     DATA_CLIENT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -35,7 +34,7 @@ DATA_LISTENER = "listener"
 
 DEFAULT_OPTIONS = {CONF_SHOW_ON_MAP: True}
 
-CONF_NODE_ID = "node_id"
+CONF_GEOGRAPHIES = "geographies"
 
 GEOGRAPHY_COORDINATES_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -156,14 +156,13 @@ async def async_migrate_entry(hass, config_entry):
 
     # 1 -> 2: One geography per config entry
     if version == 1:
-        # Update the config entry to only include the first geography (there is always
-        # guaranteed to be at least one):
         version = config_entry.version = 2
 
-        # geographies = dict(config_entry.data).pop(CONF_GEOGRAPHIES)
+        # Update the config entry to only include the first geography (there is always
+        # guaranteed to be at least one):
         data = {**config_entry.data}
         geographies = data.pop(CONF_GEOGRAPHIES)
-        first_geography = geographies[0]
+        first_geography = geographies.pop(0)
         first_id = async_get_geography_id(first_geography)
 
         hass.config_entries.async_update_entry(

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -1,5 +1,4 @@
 """The airvisual component."""
-import asyncio
 import logging
 
 from pyairvisual import Client
@@ -70,14 +69,14 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: CLOUD_API_SCHEMA}, extra=vol.ALLOW_EXTRA)
 def async_get_geography_id(geography_dict):
     """Generate a unique ID from a geography dict."""
     if CONF_CITY in geography_dict:
-        return ",".join(
+        return ", ".join(
             (
                 geography_dict[CONF_CITY],
                 geography_dict[CONF_STATE],
                 geography_dict[CONF_COUNTRY],
             )
         )
-    return ",".join(
+    return ", ".join(
         (str(geography_dict[CONF_LATITUDE]), str(geography_dict[CONF_LONGITUDE]))
     )
 
@@ -93,11 +92,17 @@ async def async_setup(hass, config):
 
     conf = config[DOMAIN]
 
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+    for geography in conf.get(
+        CONF_GEOGRAPHIES,
+        [{CONF_LATITUDE: hass.config.latitude, CONF_LONGITUDE: hass.config.longitude}],
+    ):
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data={CONF_API_KEY: conf[CONF_API_KEY], **geography},
+            )
         )
-    )
 
     return True
 
@@ -144,6 +149,46 @@ async def async_setup_entry(hass, config_entry):
     return True
 
 
+async def async_migrate_entry(hass, config_entry):
+    """Migrate an old config entry."""
+    version = config_entry.version
+
+    _LOGGER.debug("Migrating from version %s", version)
+
+    # 1 -> 2: One geography per config entry
+    if version == 1:
+        # Update the config entry to only include the first geography (there is always
+        # guaranteed to be at least one):
+        version = config_entry.version = 2
+
+        # geographies = dict(config_entry.data).pop(CONF_GEOGRAPHIES)
+        data = {**config_entry.data}
+        geographies = data.pop(CONF_GEOGRAPHIES)
+        first_geography = geographies[0]
+        first_id = async_get_geography_id(first_geography)
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            unique_id=first_id,
+            title=f"Cloud API ({first_id})",
+            data={CONF_API_KEY: config_entry.data[CONF_API_KEY], **first_geography},
+        )
+
+        # For any geographies that remain, create a new config entry for each one:
+        for geography in geographies:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data={CONF_API_KEY: config_entry.data[CONF_API_KEY], **geography},
+                )
+            )
+
+    _LOGGER.info("Migration to version %s successful", version)
+
+    return True
+
+
 async def async_unload_entry(hass, config_entry):
     """Unload an AirVisual config entry."""
     hass.data[DOMAIN][DATA_CLIENT].pop(config_entry.entry_id)
@@ -170,40 +215,28 @@ class AirVisualData:
         self._client = client
         self._hass = hass
         self.data = {}
+        self.geography_data = config_entry.data
+        self.geography_id = config_entry.unique_id
         self.options = config_entry.options
-
-        self.geographies = {
-            async_get_geography_id(geography): geography
-            for geography in config_entry.data[CONF_GEOGRAPHIES]
-        }
 
     async def async_update(self):
         """Get new data for all locations from the AirVisual cloud API."""
-        tasks = []
+        if CONF_CITY in self.geography_data:
+            api_coro = self._client.api.city(
+                self.geography_data[CONF_CITY],
+                self.geography_data[CONF_STATE],
+                self.geography_data[CONF_COUNTRY],
+            )
+        else:
+            api_coro = self._client.api.nearest_city(
+                self.geography_data[CONF_LATITUDE], self.geography_data[CONF_LONGITUDE],
+            )
 
-        for geography in self.geographies.values():
-            if CONF_CITY in geography:
-                tasks.append(
-                    self._client.api.city(
-                        geography[CONF_CITY],
-                        geography[CONF_STATE],
-                        geography[CONF_COUNTRY],
-                    )
-                )
-            else:
-                tasks.append(
-                    self._client.api.nearest_city(
-                        geography[CONF_LATITUDE], geography[CONF_LONGITUDE],
-                    )
-                )
-
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        for geography_id, result in zip(self.geographies, results):
-            if isinstance(result, AirVisualError):
-                _LOGGER.error("Error while retrieving data: %s", result)
-                self.data[geography_id] = {}
-                continue
-            self.data[geography_id] = result
+        try:
+            self.data[self.geography_id] = await api_coro
+        except AirVisualError as err:
+            _LOGGER.error("Error while retrieving data: %s", err)
+            self.data[self.geography_id] = {}
 
         _LOGGER.debug("Received new data")
         async_dispatcher_send(self._hass, TOPIC_UPDATE)

--- a/homeassistant/components/airvisual/const.py
+++ b/homeassistant/components/airvisual/const.py
@@ -5,7 +5,6 @@ DOMAIN = "airvisual"
 
 CONF_CITY = "city"
 CONF_COUNTRY = "country"
-CONF_GEOGRAPHIES = "geographies"
 
 DATA_CLIENT = "client"
 

--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -191,16 +191,19 @@ class AirVisualSensor(Entity):
                 }
             )
 
-        geography = self._airvisual.geographies[self._geography_id]
-        if CONF_LATITUDE in geography:
+        if CONF_LATITUDE in self._airvisual.geography_data:
             if self._airvisual.options[CONF_SHOW_ON_MAP]:
-                self._attrs[ATTR_LATITUDE] = geography[CONF_LATITUDE]
-                self._attrs[ATTR_LONGITUDE] = geography[CONF_LONGITUDE]
+                self._attrs[ATTR_LATITUDE] = self._airvisual.geography_data[
+                    CONF_LATITUDE
+                ]
+                self._attrs[ATTR_LONGITUDE] = self._airvisual.geography_data[
+                    CONF_LONGITUDE
+                ]
                 self._attrs.pop("lati", None)
                 self._attrs.pop("long", None)
             else:
-                self._attrs["lati"] = geography[CONF_LATITUDE]
-                self._attrs["long"] = geography[CONF_LONGITUDE]
+                self._attrs["lati"] = self._airvisual.geography_data[CONF_LATITUDE]
+                self._attrs["long"] = self._airvisual.geography_data[CONF_LONGITUDE]
                 self._attrs.pop(ATTR_LATITUDE, None)
                 self._attrs.pop(ATTR_LONGITUDE, None)
 

--- a/homeassistant/components/airvisual/strings.json
+++ b/homeassistant/components/airvisual/strings.json
@@ -16,7 +16,7 @@
       "invalid_api_key": "Invalid API key"
     },
     "abort": {
-      "already_configured": "This API key is already in use."
+      "already_configured": "These coordinates have already been registered."
     }
   },
   "options": {

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -3,7 +3,11 @@ from asynctest import patch
 from pyairvisual.errors import InvalidKeyError
 
 from homeassistant import data_entry_flow
-from homeassistant.components.airvisual import CONF_GEOGRAPHIES, DOMAIN
+from homeassistant.components.airvisual import (
+    CONF_GEOGRAPHIES,
+    DOMAIN,
+    async_migrate_entry,
+)
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import (
     CONF_API_KEY,
@@ -17,9 +21,15 @@ from tests.common import MockConfigEntry
 
 async def test_duplicate_error(hass):
     """Test that errors are shown when duplicates are added."""
-    conf = {CONF_API_KEY: "abcde12345"}
+    conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
 
-    MockConfigEntry(domain=DOMAIN, unique_id="abcde12345", data=conf).add_to_hass(hass)
+    MockConfigEntry(
+        domain=DOMAIN, unique_id="51.528308, -0.3817765", data=conf
+    ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=conf
@@ -31,7 +41,11 @@ async def test_duplicate_error(hass):
 
 async def test_invalid_api_key(hass):
     """Test that invalid credentials throws an error."""
-    conf = {CONF_API_KEY: "abcde12345"}
+    conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
 
     with patch(
         "pyairvisual.api.API.nearest_city", side_effect=InvalidKeyError,
@@ -40,6 +54,29 @@ async def test_invalid_api_key(hass):
             DOMAIN, context={"source": SOURCE_USER}, data=conf
         )
         assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
+
+
+async def test_migration_1_2(hass):
+    """Test migrating from version 1 to version 2."""
+    conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_GEOGRAPHIES: [{CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765}],
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, version=1, unique_id="abcde12345", data=conf
+    )
+    config_entry.add_to_hass(hass)
+
+    await async_migrate_entry(hass, config_entry)
+
+    assert config_entry.unique_id == "51.528308, -0.3817765"
+    assert config_entry.title == "Cloud API (51.528308, -0.3817765)"
+    assert config_entry.data == {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
 
 
 async def test_options_flow(hass):
@@ -84,7 +121,8 @@ async def test_step_import(hass):
     """Test that the import step works."""
     conf = {
         CONF_API_KEY: "abcde12345",
-        CONF_GEOGRAPHIES: [{CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765}],
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
     }
 
     with patch(
@@ -95,10 +133,11 @@ async def test_step_import(hass):
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Cloud API (API key: abcd...)"
+        assert result["title"] == "Cloud API (51.528308, -0.3817765)"
         assert result["data"] == {
             CONF_API_KEY: "abcde12345",
-            CONF_GEOGRAPHIES: [{CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765}],
+            CONF_LATITUDE: 51.528308,
+            CONF_LONGITUDE: -0.3817765,
         }
 
 
@@ -117,8 +156,9 @@ async def test_step_user(hass):
             DOMAIN, context={"source": SOURCE_USER}, data=conf
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Cloud API (API key: abcd...)"
+        assert result["title"] == "Cloud API (32.87336, -117.22743)"
         assert result["data"] == {
             CONF_API_KEY: "abcde12345",
-            CONF_GEOGRAPHIES: [{CONF_LATITUDE: 32.87336, CONF_LONGITUDE: -117.22743}],
+            CONF_LATITUDE: 32.87336,
+            CONF_LONGITUDE: -117.22743,
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously, the AirVisual integration would only allow one use of a particular API key when configured via the UI; this prevented the valid use case of using the same API key for tracking multiple geographies. This PR alters the `unique_id` of these config entries to be the location info themselves (thus freeing up the API key to be used more than once) and migrates any old config entries to the new format.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
airvisual:
  api_key: !secret airvisual_api_key
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/33069
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
