### PR TITLE
0.107.4

### DIFF
--- a/homeassistant/components/asuswrt/__init__.py
+++ b/homeassistant/components/asuswrt/__init__.py
@@ -73,8 +73,8 @@ async def async_setup(hass, config):
         conf.get("ssh_key", conf.get("pub_key", "")),
         conf[CONF_MODE],
         conf[CONF_REQUIRE_IP],
-        conf[CONF_INTERFACE],
-        conf[CONF_DNSMASQ],
+        interface=conf[CONF_INTERFACE],
+        dnsmasq=conf[CONF_DNSMASQ],
     )
 
     await api.connection.async_connect()

--- a/homeassistant/components/asuswrt/manifest.json
+++ b/homeassistant/components/asuswrt/manifest.json
@@ -2,7 +2,7 @@
   "domain": "asuswrt",
   "name": "ASUSWRT",
   "documentation": "https://www.home-assistant.io/integrations/asuswrt",
-  "requirements": ["aioasuswrt==1.2.2"],
+  "requirements": ["aioasuswrt==1.2.3"],
   "dependencies": [],
   "codeowners": ["@kennedyshead"]
 }

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==9.0.3"],
+  "requirements": ["simplisafe-python==9.0.4"],
   "dependencies": [],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -574,7 +574,9 @@ def _identify_config_schema(module: ModuleType) -> Optional[str]:
     if hasattr(key, "default") and not isinstance(
         key.default, vol.schema_builder.Undefined
     ):
-        default_value = schema(key.default())
+        default_value = module.CONFIG_SCHEMA({module.DOMAIN: key.default()})[  # type: ignore
+            module.DOMAIN  # type: ignore
+        ]
 
         if isinstance(default_value, dict):
             return "dict"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 107
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1856,7 +1856,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==9.0.3
+simplisafe-python==9.0.4
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -139,7 +139,7 @@ aio_georss_gdacs==0.3
 aioambient==1.0.4
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.2.2
+aioasuswrt==1.2.3
 
 # homeassistant.components.automatic
 aioautomatic==0.6.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -649,7 +649,7 @@ sentry-sdk==0.13.5
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==9.0.3
+simplisafe-python==9.0.4
 
 # homeassistant.components.sleepiq
 sleepyq==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -50,7 +50,7 @@ aio_georss_gdacs==0.3
 aioambient==1.0.4
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.2.2
+aioasuswrt==1.2.3
 
 # homeassistant.components.automatic
 aioautomatic==0.6.5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -995,8 +995,20 @@ async def test_component_config_exceptions(hass, caplog):
 @pytest.mark.parametrize(
     "domain, schema, expected",
     [
-        ("zone", vol.Schema({vol.Optional("zone", default=[]): list}), "list"),
-        ("zone", vol.Schema({vol.Optional("zone", default=dict): dict}), "dict"),
+        ("zone", vol.Schema({vol.Optional("zone", default=list): [int]}), "list"),
+        ("zone", vol.Schema({vol.Optional("zone", default=[]): [int]}), "list"),
+        (
+            "zone",
+            vol.Schema({vol.Optional("zone", default={}): {vol.Optional("hello"): 1}}),
+            "dict",
+        ),
+        (
+            "zone",
+            vol.Schema(
+                {vol.Optional("zone", default=dict): {vol.Optional("hello"): 1}}
+            ),
+            "dict",
+        ),
         ("zone", vol.Schema({vol.Optional("zone"): int}), None),
         ("zone", vol.Schema({"zone": int}), None),
         ("not_existing", vol.Schema({vol.Optional("zone", default=dict): dict}), None,),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -722,7 +722,7 @@ async def test_merge_id_schema(hass):
     for domain, expected_type in types.items():
         integration = await async_get_integration(hass, domain)
         module = integration.get_component()
-        typ, _ = config_util._identify_config_schema(module)
+        typ = config_util._identify_config_schema(module)
         assert typ == expected_type, f"{domain} expected {expected_type}, got {typ}"
 
 
@@ -997,13 +997,16 @@ async def test_component_config_exceptions(hass, caplog):
     [
         ("zone", vol.Schema({vol.Optional("zone", default=[]): list}), "list"),
         ("zone", vol.Schema({vol.Optional("zone", default=dict): dict}), "dict"),
+        ("zone", vol.Schema({vol.Optional("zone"): int}), None),
+        ("zone", vol.Schema({"zone": int}), None),
+        ("not_existing", vol.Schema({vol.Optional("zone", default=dict): dict}), None,),
+        ("non_existing", vol.Schema({"zone": int}), None),
+        ("zone", vol.Schema({}), None),
     ],
 )
 def test_identify_config_schema(domain, schema, expected):
     """Test identify config schema."""
     assert (
-        config_util._identify_config_schema(Mock(DOMAIN=domain, CONFIG_SCHEMA=schema))[
-            0
-        ]
+        config_util._identify_config_schema(Mock(DOMAIN=domain, CONFIG_SCHEMA=schema))
         == expected
     )


### PR DESCRIPTION
- Add negative tests for identify schema for packages ([@balloob] - [#33050])
- Bump simplisafe-python to 9.0.4 ([@bachya] - [#33059]) ([simplisafe docs])
- Bump aioasuswrt to 1.2.3 and fix asuswrt sensor ([@Knapoc] - [#33064]) ([asuswrt docs])
- Fix package default extraction ([@balloob] - [#33071])

[#33050]: https://github.com/home-assistant/core/pull/33050
[#33059]: https://github.com/home-assistant/core/pull/33059
[#33064]: https://github.com/home-assistant/core/pull/33064
[#33071]: https://github.com/home-assistant/core/pull/33071
[@Knapoc]: https://github.com/Knapoc
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[asuswrt docs]: https://www.home-assistant.io/integrations/asuswrt/
[simplisafe docs]: https://www.home-assistant.io/integrations/simplisafe/