### PR TITLE
Use PEP 526 syntax with NamedTuples

### DIFF
--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -123,4 +123,8 @@ class Credentials:
     is_new = attr.ib(type=bool, default=True)
 
 
-UserMeta = NamedTuple("UserMeta", [("name", Optional[str]), ("is_active", bool)])
+class UserMeta(NamedTuple):
+    """User metadata."""
+
+    name: Optional[str]
+    is_active: bool

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -75,30 +75,26 @@ def brightness_from_percentage(percent):
     return (percent * 255.0) / 100.0
 
 
-LightState = NamedTuple(
-    "LightState",
-    (
-        ("state", bool),
-        ("brightness", int),
-        ("color_temp", float),
-        ("hs", Tuple[int, int]),
-        ("emeter_params", dict),
-    ),
-)
+class LightState(NamedTuple):
+    """Light state."""
+
+    state: bool
+    brightness: int
+    color_temp: float
+    hs: Tuple[int, int]
+    emeter_params: dict
 
 
-LightFeatures = NamedTuple(
-    "LightFeatures",
-    (
-        ("sysinfo", Dict[str, Any]),
-        ("mac", str),
-        ("alias", str),
-        ("model", str),
-        ("supported_features", int),
-        ("min_mireds", float),
-        ("max_mireds", float),
-    ),
-)
+class LightFeatures(NamedTuple):
+    """Light features."""
+
+    sysinfo: Dict[str, Any]
+    mac: str
+    alias: str
+    model: str
+    supported_features: int
+    min_mireds: float
+    max_mireds: float
 
 
 class TPLinkSmartBulb(Light):

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -26,20 +26,19 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-LightMockData = NamedTuple(
-    "LightMockData",
-    (
-        ("sys_info", dict),
-        ("light_state", dict),
-        ("set_light_state", Callable[[dict], None]),
-        ("set_light_state_mock", Mock),
-        ("get_light_state_mock", Mock),
-        ("current_consumption_mock", Mock),
-        ("get_sysinfo_mock", Mock),
-        ("get_emeter_daily_mock", Mock),
-        ("get_emeter_monthly_mock", Mock),
-    ),
-)
+
+class LightMockData(NamedTuple):
+    """Mock light data."""
+
+    sys_info: dict
+    light_state: dict
+    set_light_state: Callable[[dict], None]
+    set_light_state_mock: Mock
+    get_light_state_mock: Mock
+    current_consumption_mock: Mock
+    get_sysinfo_mock: Mock
+    get_emeter_daily_mock: Mock
+    get_emeter_monthly_mock: Mock
 
 
 @pytest.fixture(name="light_mock_data")

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -9,7 +9,11 @@ from homeassistant.components.vera import CONF_CONTROLLER, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-ComponentData = NamedTuple("ComponentData", (("controller", VeraController),))
+
+class ComponentData(NamedTuple):
+    """Component data."""
+
+    controller: VeraController
 
 
 class ComponentFactory:


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
