### PR TITLE
En ocean 1 bs support

### DIFF
--- a/tests/components/enocean/__init__.py
+++ b/tests/components/enocean/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ENOcean integration."""

--- a/tests/components/enocean/test_binarySensor.py
+++ b/tests/components/enocean/test_binarySensor.py
@@ -1,0 +1,107 @@
+"""Tests for emulated_roku library bindings."""
+import unittest
+
+from enocean.protocol.constants import PACKET
+from enocean.protocol.packet import RadioPacket
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_DOOR,
+    DEVICE_CLASS_GARAGE_DOOR,
+    DEVICE_CLASS_WINDOW,
+    DEVICE_CLASSES_SCHEMA,
+)
+from homeassistant.components.enocean.binary_sensor import EnOceanBinarySensor
+
+from tests.common import get_test_home_assistant
+
+
+class TestEnOceanBinarySensor(unittest.TestCase):
+    """Unit tests for the ENOcean binary sensors."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Tear down unit test data."""
+        self.hass.stop()
+
+    def create_test_sensor(self, type, initial_state):
+        """Create a sensor using the test hass instance, and with a given initial state."""
+        sensor = EnOceanBinarySensor("device ID", "device name", type)
+        sensor.hass = self.hass
+        sensor.onoff = initial_state
+        return sensor
+
+    def create_packet(self, is_opened):
+        """Create an ENOcean 1BS packet with provided status."""
+        payload = 0x08 if is_opened else 0x09
+        return RadioPacket(
+            PACKET.RADIO,
+            data=[0xD5, payload, 0x00, 0x00, 0x00, 0x00, 0x00],
+            optional=[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        )
+
+    def test_1BS_close_frame_sets_generic_sensor_to_on(self):
+        """Test generic sensor state after receiving a close frame."""
+
+        # prepare
+        sensor = self.create_test_sensor(DEVICE_CLASSES_SCHEMA, 0)
+        packet = self.create_packet(is_opened=False)
+
+        # execute
+        sensor.value_changed(packet)
+
+        # assert
+        assert sensor.is_on is True
+
+    def test_1BS_open_frame_sets_generic_sensor_to_off(self):
+        """Test generic sensor state after receiving an open frame."""
+
+        # prepare
+        sensor = self.create_test_sensor(DEVICE_CLASSES_SCHEMA, 1)
+        packet = self.create_packet(is_opened=True)
+
+        # execute
+        sensor.value_changed(packet)
+
+        # assert
+        assert sensor.is_on is False
+
+    def test_1BS_close_frame_sets_window_door_garage_sensor_to_off(self):
+        """Test door, window of garage door sensor state after receiving a close frame."""
+
+        # prepare
+        window_sensor = self.create_test_sensor(DEVICE_CLASS_WINDOW, 1)
+        door_sensor = self.create_test_sensor(DEVICE_CLASS_DOOR, 1)
+        garage_sensor = self.create_test_sensor(DEVICE_CLASS_GARAGE_DOOR, 1)
+        packet = self.create_packet(is_opened=False)
+
+        # execute
+        window_sensor.value_changed(packet)
+        door_sensor.value_changed(packet)
+        garage_sensor.value_changed(packet)
+
+        # assert
+        assert window_sensor.is_on is False
+        assert door_sensor.is_on is False
+        assert garage_sensor.is_on is False
+
+    def test_1BS_open_frame_sets_window_door_garage_sensor_to_on(self):
+        """Test door, window of garage door sensor state after receiving an open frame."""
+
+        # prepare
+        window_sensor = self.create_test_sensor(DEVICE_CLASS_WINDOW, 0)
+        door_sensor = self.create_test_sensor(DEVICE_CLASS_DOOR, 0)
+        garage_sensor = self.create_test_sensor(DEVICE_CLASS_GARAGE_DOOR, 0)
+        packet = self.create_packet(is_opened=True)
+
+        # execute
+        window_sensor.value_changed(packet)
+        door_sensor.value_changed(packet)
+        garage_sensor.value_changed(packet)
+
+        # assert
+        assert window_sensor.is_on is True
+        assert door_sensor.is_on is True
+        assert garage_sensor.is_on is True


### PR DESCRIPTION
## Breaking change
This is a good question, I would like the opinion of the reviewers on that point:
this PR adds an implementation of is_on to the enOcean binary sensor.
This changes the behavior of existing configurations, but the new behavior is purely additive.
Do you think this should be considered as a breaking change ?

## Proposed change
This changes adds support of 1BS enOcean devices, such as NodON window sensors.
It sets the state to ON when the status bit reported by the sensor is 1 for most types of sensorts, but inverts the logic for window, door and garage door sensors, so that a status bit of 0 converts into an "open" state in the UI.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
binary_sensor:
  - platform: enocean
    id: [0x05,0x1A,0x98,0x95]
    name: Sleeping room window
    device_class: window
```

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12472

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
