### PR TITLE
Fix tankerkoenig with more than 10 stations

### DIFF
--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -1,6 +1,7 @@
 """Ask tankerkoenig.de for petrol price information."""
 from datetime import timedelta
 import logging
+from math import ceil
 from uuid import UUID
 
 import pytankerkoenig
@@ -180,27 +181,41 @@ class TankerkoenigData:
                 )
                 return False
             self.add_station(additional_station_data["station"])
+        if len(self.stations) > 10:
+            _LOGGER.warning(
+                "Found more than 10 stations to check. "
+                "This might invalidate your api-key on the long run. "
+                "Try using a smaller radius."
+            )
         return True
 
     async def fetch_data(self):
         """Get the latest data from tankerkoenig.de."""
         _LOGGER.debug("Fetching new data from tankerkoenig.de")
         station_ids = list(self.stations)
-        data = await self._hass.async_add_executor_job(
-            pytankerkoenig.getPriceList, self._api_key, station_ids
-        )
 
-        if data["ok"]:
+        prices = {}
+
+        # The API seems to only return at most 10 results, so split the list in chunks of 10
+        # and merge it together.
+        for index in range(ceil(len(station_ids) / 10)):
+            data = await self._hass.async_add_executor_job(
+                pytankerkoenig.getPriceList,
+                self._api_key,
+                station_ids[index * 10 : (index + 1) * 10],
+            )
+
             _LOGGER.debug("Received data: %s", data)
+            if not data["ok"]:
+                _LOGGER.error(
+                    "Error fetching data from tankerkoenig.de: %s", data["message"]
+                )
+                raise TankerkoenigError(data["message"])
             if "prices" not in data:
                 _LOGGER.error("Did not receive price information from tankerkoenig.de")
                 raise TankerkoenigError("No prices in data")
-        else:
-            _LOGGER.error(
-                "Error fetching data from tankerkoenig.de: %s", data["message"]
-            )
-            raise TankerkoenigError(data["message"])
-        return data["prices"]
+            prices.update(data["prices"])
+        return prices
 
     def add_station(self, station: dict):
         """Add fuel station to the entity list."""

--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -185,7 +185,7 @@ class TankerkoenigData:
             _LOGGER.warning(
                 "Found more than 10 stations to check. "
                 "This might invalidate your api-key on the long run. "
-                "Try using a smaller radius."
+                "Try using a smaller radius"
             )
         return True
 


### PR DESCRIPTION
There seemed to be a problem, if more than 10 fuel stations were tracked.
Added a warning in this case, and split the calls to the API in chunks of
10, so that the data can be fetched anyway.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix issue #33061

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
tankerkoenig:
  api_key: my-key
  fuel_types: 
    - diesel
  radius: 5
  scan_interval: "0:10:00"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33061
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
