### PR TITLE
Store HomeKit generated accessory id against unique_id where possible

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -357,7 +357,8 @@ class HomeKit:
         if not state or not self._filter(state.entity_id):
             return
 
-        if len(self.bridge.accessories) >= MAX_DEVICES:
+        # The bridge itself counts as an accessory
+        if len(self.bridge.accessories) + 1 >= MAX_DEVICES:
             _LOGGER.warning(
                 "Cannot add %s as this would exceeded the %d device limit. Consider using the filter option.",
                 state.entity_id,

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -356,6 +356,15 @@ class HomeKit:
         """Try adding accessory to bridge if configured beforehand."""
         if not state or not self._filter(state.entity_id):
             return
+
+        if len(self.bridge.accessories) >= MAX_DEVICES:
+            _LOGGER.warning(
+                "Cannot add %s as this would exceeded the %d device limit. Consider using the filter option.",
+                state.entity_id,
+                MAX_DEVICES,
+            )
+            return
+
         aid = self.hass.data[AID_STORAGE].get_or_allocate_aid_for_entity_id(
             state.entity_id
         )
@@ -399,16 +408,11 @@ class HomeKit:
 
         for state in self.hass.states.all():
             self.add_bridge_accessory(state)
+
         self.driver.add_accessory(self.bridge)
 
         if not self.driver.state.paired:
             show_setup_message(self.hass, self.driver.state.pincode)
-
-        if len(self.bridge.accessories) > MAX_DEVICES:
-            _LOGGER.warning(
-                "You have exceeded the device limit, which might "
-                "cause issues. Consider using the filter option."
-            )
 
         _LOGGER.debug("Driver start")
         self.hass.add_job(self.driver.start)

--- a/homeassistant/components/homekit/aidmanager.py
+++ b/homeassistant/components/homekit/aidmanager.py
@@ -1,0 +1,125 @@
+"""
+Manage allocation of accessory ID's.
+
+HomeKit needs to allocate unique numbers to each accessory. These need to
+be stable between reboots and upgrades.
+
+Using a hash function to generate them means collisions. It also means you
+can't change the hash without causing breakages for HA users.
+
+This module generates and stores them in a HA storage.
+"""
+import hashlib
+import logging
+import random
+from zlib import adler32
+
+from homeassistant.core import callback
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+AID_MANAGER_STORAGE_KEY = f"{DOMAIN}-aid-storage"
+AID_MANAGER_STORAGE_VERSION = 1
+AID_MANAGER_SAVE_DELAY = 2
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def generate_aids(unique_id, entity_id):
+    """Generate accessory aid with zlib adler32."""
+
+    # Backward compatibility: Previously HA used to *only* do adler32 on the entity id.
+    # Not stable if entity ID changes
+    # Not robust against collisions
+    yield adler32(entity_id.encode("utf-8"))
+
+    # Use adler32 on a sha of the unique id
+    yield adler32(hashlib.sha512(unique_id.encode("utf-8")).digest())
+
+    # If called again resort to random allocations.
+    # Given the size of the range its unlikely we'll encounter duplicates
+    # But try a few times regardless
+    for _ in range(5):
+        yield random.randrange(2, 18446744073709551615)
+
+
+class AccessoryAidStorage:
+    """
+    Holds a map of entity ID to HomeKit ID.
+
+    Will generate new ID's, ensure they are unique and store them to make sure they
+    persist over reboots.
+    """
+
+    def __init__(self, hass):
+        """Create a new entity map store."""
+        self.hass = hass
+        self.store = Store(hass, AID_MANAGER_STORAGE_VERSION, AID_MANAGER_STORAGE_KEY)
+        self.allocations = {}
+        self.allocated_aids = set()
+
+        self._entity_registry = None
+
+    async def async_initialize(self):
+        """Load the latest AID data."""
+        self._entity_registry = (
+            await self.hass.helpers.entity_registry.async_get_registry()
+        )
+
+        raw_storage = await self.store.async_load()
+        if not raw_storage:
+            # There is no data about aid allocations yet
+            return
+
+        self.allocations = raw_storage.get("unique_ids", {})
+        self.allocated_aids = set(self.allocations.values())
+
+    def get_or_allocate_aid_for_entity_id(self, entity_id):
+        """Generate a stable aid for an entity id."""
+        entity = self._entity_registry.async_get(entity_id)
+        if entity:
+            return self._get_or_allocate_aid(entity.unique_id, entity.entity_id)
+
+        _LOGGER.warning(
+            "Entity '%s' does not have a stable unique identifier so aid allocation will be unstable and may cause collisions",
+            entity_id,
+        )
+        return adler32(entity_id.encode("utf-8"))
+
+    def _get_or_allocate_aid(self, unique_id, entity_id):
+        """Allocate (and return) a new aid for an accessory."""
+        if unique_id in self.allocations:
+            return self.allocations[unique_id]
+
+        for aid in generate_aids(unique_id, entity_id):
+            if aid in (0, 1):
+                continue
+            if aid not in self.allocated_aids:
+                self.allocations[unique_id] = aid
+                self.allocated_aids.add(aid)
+                self._async_schedule_save()
+                return aid
+
+        raise ValueError(
+            f"Unable to generate unique aid allocation for {entity_id} [{unique_id}]"
+        )
+
+    def delete_aid(self, unique_id):
+        """Delete an aid allocation."""
+        if unique_id not in self.allocations:
+            return
+
+        aid = self.allocations.pop(unique_id)
+        self.allocated_aids.discard(aid)
+        self._async_schedule_save()
+
+    @callback
+    def _async_schedule_save(self):
+        """Schedule saving the entity map cache."""
+        self.store.async_delay_save(self._data_to_save, AID_MANAGER_SAVE_DELAY)
+
+    @callback
+    def _data_to_save(self):
+        """Return data of entity map to store in a file."""
+        return {"unique_ids": self.allocations}

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -5,6 +5,7 @@ DEVICE_PRECISION_LEEWAY = 6
 DOMAIN = "homekit"
 HOMEKIT_FILE = ".homekit.state"
 HOMEKIT_NOTIFY_ID = 4663548
+AID_STORAGE = "homekit-aid-allocations"
 
 
 # #### Attributes ####

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -2,6 +2,6 @@
   "domain": "homekit",
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
-  "requirements": ["HAP-python==2.8.2"],
+  "requirements": ["HAP-python==2.8.2","fnvhash==0.1.0"],
   "codeowners": ["@bdraco"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -561,6 +561,9 @@ fixerio==1.0.0a0
 # homeassistant.components.flux_led
 flux_led==0.22
 
+# homeassistant.components.homekit
+fnvhash==0.1.0
+
 # homeassistant.components.foobot
 foobot_async==0.3.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -213,6 +213,9 @@ ephem==3.7.7.0
 # homeassistant.components.feedreader
 feedparser-homeassistant==5.2.2.dev1
 
+# homeassistant.components.homekit
+fnvhash==0.1.0
+
 # homeassistant.components.foobot
 foobot_async==0.3.1
 

--- a/tests/components/homekit/test_aidmanager.py
+++ b/tests/components/homekit/test_aidmanager.py
@@ -1,0 +1,120 @@
+"""Tests for the HomeKit AID manager."""
+from asynctest import patch
+import pytest
+
+from homeassistant.components.homekit.aidmanager import (
+    AccessoryAidStorage,
+    get_system_unique_id,
+)
+from homeassistant.helpers import device_registry
+
+from tests.common import MockConfigEntry, mock_device_registry, mock_registry
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_aid_generation(hass, device_reg, entity_reg):
+    """Test generating aids."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    light_ent = entity_reg.async_get_or_create(
+        "light", "device", "unique_id", device_id=device_entry.id
+    )
+    light_ent2 = entity_reg.async_get_or_create(
+        "light", "device", "other_unique_id", device_id=device_entry.id
+    )
+    remote_ent = entity_reg.async_get_or_create(
+        "remote", "device", "unique_id", device_id=device_entry.id
+    )
+    hass.states.async_set(light_ent.entity_id, "on")
+    hass.states.async_set(light_ent2.entity_id, "on")
+    hass.states.async_set(remote_ent.entity_id, "on")
+    hass.states.async_set("remote.has_no_unique_id", "on")
+
+    with patch(
+        "homeassistant.components.homekit.aidmanager.AccessoryAidStorage.async_schedule_save"
+    ):
+        aid_storage = AccessoryAidStorage(hass)
+    await aid_storage.async_initialize()
+
+    for _ in range(0, 2):
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id(light_ent.entity_id)
+            == 1692141785
+        )
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id(light_ent2.entity_id)
+            == 2732133210
+        )
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id(remote_ent.entity_id)
+            == 1867188557
+        )
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id("remote.has_no_unique_id")
+            == 1872038229
+        )
+
+    aid_storage.delete_aid(get_system_unique_id(light_ent))
+    aid_storage.delete_aid(get_system_unique_id(light_ent2))
+    aid_storage.delete_aid(get_system_unique_id(remote_ent))
+    aid_storage.delete_aid("non-existant-one")
+
+    for _ in range(0, 2):
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id(light_ent.entity_id)
+            == 1692141785
+        )
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id(light_ent2.entity_id)
+            == 2732133210
+        )
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id(remote_ent.entity_id)
+            == 1867188557
+        )
+        assert (
+            aid_storage.get_or_allocate_aid_for_entity_id("remote.has_no_unique_id")
+            == 1872038229
+        )
+
+
+async def test_aid_adler32_collision(hass, device_reg, entity_reg):
+    """Test generating aids."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
+    with patch(
+        "homeassistant.components.homekit.aidmanager.AccessoryAidStorage.async_schedule_save"
+    ):
+        aid_storage = AccessoryAidStorage(hass)
+    await aid_storage.async_initialize()
+
+    seen_aids = set()
+
+    for unique_id in range(0, 202):
+        ent = entity_reg.async_get_or_create(
+            "light", "device", unique_id, device_id=device_entry.id
+        )
+        hass.states.async_set(ent.entity_id, "on")
+        aid = aid_storage.get_or_allocate_aid_for_entity_id(ent.entity_id)
+        assert aid not in seen_aids
+        seen_aids.add(aid)

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -214,7 +214,7 @@ async def test_homekit_setup_safe_mode(hass, hk_driver):
 
 async def test_homekit_add_accessory(hass):
     """Add accessory if config exists and get_acc returns an accessory."""
-    homekit = HomeKit("hass", None, None, None, lambda entity_id: True, {}, None, None)
+    homekit = HomeKit(hass, None, None, None, lambda entity_id: True, {}, None, None)
     homekit.driver = "driver"
     homekit.bridge = mock_bridge = Mock()
 
@@ -305,6 +305,8 @@ async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, debounce_p
     """Test HomeKit start method."""
     pin = b"123-45-678"
     entity_filter = generate_filter(["cover", "light"], ["demo.test"], [], [])
+
+    assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
     homekit = HomeKit(hass, None, None, None, entity_filter, {}, None, None)
     homekit.bridge = Mock()

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -12,10 +12,10 @@ from homeassistant.components.homekit import (
     STATUS_STOPPED,
     STATUS_WAIT,
     HomeKit,
-    generate_aid,
 )
 from homeassistant.components.homekit.accessories import HomeBridge
 from homeassistant.components.homekit.const import (
+    AID_STORAGE,
     BRIDGE_NAME,
     CONF_AUTO_START,
     CONF_SAFE_MODE,
@@ -49,17 +49,6 @@ def debounce_patcher():
     patcher = patch_debounce()
     yield patcher.start()
     patcher.stop()
-
-
-def test_generate_aid():
-    """Test generate aid method."""
-    aid = generate_aid("demo.entity")
-    assert isinstance(aid, int)
-    assert aid >= 2 and aid <= 18446744073709551615
-
-    with patch(f"{PATH_HOMEKIT}.adler32") as mock_adler32:
-        mock_adler32.side_effect = [0, 1]
-        assert generate_aid("demo.entity") is None
 
 
 async def test_setup_min(hass):
@@ -223,29 +212,30 @@ async def test_homekit_setup_safe_mode(hass, hk_driver):
     assert homekit.driver.safe_mode is True
 
 
-async def test_homekit_add_accessory():
+async def test_homekit_add_accessory(hass):
     """Add accessory if config exists and get_acc returns an accessory."""
     homekit = HomeKit("hass", None, None, None, lambda entity_id: True, {}, None, None)
     homekit.driver = "driver"
     homekit.bridge = mock_bridge = Mock()
 
-    with patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc:
+    assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
+    with patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc:
         mock_get_acc.side_effect = [None, "acc", None]
         homekit.add_bridge_accessory(State("light.demo", "on"))
-        mock_get_acc.assert_called_with("hass", "driver", ANY, 363398124, {})
+        mock_get_acc.assert_called_with(hass, "driver", ANY, 363398124, {})
         assert not mock_bridge.add_accessory.called
 
         homekit.add_bridge_accessory(State("demo.test", "on"))
-        mock_get_acc.assert_called_with("hass", "driver", ANY, 294192020, {})
+        mock_get_acc.assert_called_with(hass, "driver", ANY, 294192020, {})
         assert mock_bridge.add_accessory.called
 
         homekit.add_bridge_accessory(State("demo.test_2", "on"))
-        mock_get_acc.assert_called_with("hass", "driver", ANY, 429982757, {})
+        mock_get_acc.assert_called_with(hass, "driver", ANY, 429982757, {})
         mock_bridge.add_accessory.assert_called_with("acc")
 
 
-async def test_homekit_remove_accessory():
+async def test_homekit_remove_accessory(hass):
     """Remove accessory from bridge."""
     homekit = HomeKit("hass", None, None, None, lambda entity_id: True, {}, None, None)
     homekit.driver = "driver"
@@ -259,6 +249,8 @@ async def test_homekit_remove_accessory():
 
 async def test_homekit_entity_filter(hass):
     """Test the entity filter."""
+    assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
     entity_filter = generate_filter(["cover"], ["demo.test"], [], [])
     homekit = HomeKit(hass, None, None, None, entity_filter, {}, None, None)
 
@@ -375,7 +367,7 @@ async def test_homekit_reset_accessories(hass):
 
         assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
-        aid = generate_aid(entity_id)
+        aid = hass.data[AID_STORAGE].get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: "acc"}
         homekit.status = STATUS_RUNNING
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -397,7 +397,8 @@ async def test_homekit_too_many_accessories(hass, hk_driver):
 
     homekit = HomeKit(hass, None, None, None, entity_filter, {}, None, None)
     homekit.bridge = Mock()
-    homekit.bridge.accessories = range(MAX_DEVICES + 1)
+    # The bridge itself counts as an accessory
+    homekit.bridge.accessories = range(MAX_DEVICES)
     homekit.driver = hk_driver
 
     hass.states.async_set("light.demo", "on")


### PR DESCRIPTION
## Proposed change

Currently the entity id is turned into a numeric indentifier for HomeKit using the adler32 hash. This is prone to collisions. Additionally this is based on the entity id, so if you rename an entity its association with a HomeKit accessory is broken.

The accessory identifier needs to be stable for the lifetime of a pairing with a controller (like an iPhone). So this stores a mapping between unique_id (in the entity registry) and the generated aid.

When a new aid is requested for a unique id we first try the existing adler32 hash. This is to preserve backwards compatibility. Then we try using a sha512 hash (as suggested in a previous pr), but on the unique id. Failing that it generates a random aid. Regardless of which option works it is saved in `.storage`, meaning it is stable going forward.

If there is no unique id (if the entity is not in the registry) then the old behaviour is preserved.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
