### PR TITLE
Improve sense timeout exception handling

### DIFF
--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     SENSE_DEVICE_UPDATE,
     SENSE_DEVICES_DATA,
     SENSE_DISCOVERED_DEVICES_DATA,
+    SENSE_TIMEOUT_EXCEPTIONS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,7 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except SenseAuthenticationException:
         _LOGGER.error("Could not authenticate with sense server")
         return False
-    except SenseAPITimeoutException:
+    except SENSE_TIMEOUT_EXCEPTIONS:
         raise ConfigEntryNotReady
 
     sense_devices_data = SenseDevicesData()

--- a/homeassistant/components/sense/config_flow.py
+++ b/homeassistant/components/sense/config_flow.py
@@ -1,17 +1,13 @@
 """Config flow for Sense integration."""
 import logging
 
-from sense_energy import (
-    ASyncSenseable,
-    SenseAPITimeoutException,
-    SenseAuthenticationException,
-)
+from sense_energy import ASyncSenseable, SenseAuthenticationException
 import voluptuous as vol
 
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TIMEOUT
 
-from .const import ACTIVE_UPDATE_RATE, DEFAULT_TIMEOUT
+from .const import ACTIVE_UPDATE_RATE, DEFAULT_TIMEOUT, SENSE_TIMEOUT_EXCEPTIONS
 
 from .const import DOMAIN  # pylint:disable=unused-import; pylint:disable=unused-import
 
@@ -55,7 +51,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await validate_input(self.hass, user_input)
                 await self.async_set_unique_id(user_input[CONF_EMAIL])
                 return self.async_create_entry(title=info["title"], data=user_input)
-            except SenseAPITimeoutException:
+            except SENSE_TIMEOUT_EXCEPTIONS:
                 errors["base"] = "cannot_connect"
             except SenseAuthenticationException:
                 errors["base"] = "invalid_auth"

--- a/homeassistant/components/sense/const.py
+++ b/homeassistant/components/sense/const.py
@@ -1,4 +1,9 @@
 """Constants for monitoring a Sense energy sensor."""
+
+import asyncio
+
+from sense_energy import SenseAPITimeoutException
+
 DOMAIN = "sense"
 DEFAULT_TIMEOUT = 10
 ACTIVE_UPDATE_RATE = 60
@@ -17,6 +22,8 @@ PRODUCTION_NAME = "Production"
 PRODUCTION_ID = "production"
 
 ICON = "mdi:flash"
+
+SENSE_TIMEOUT_EXCEPTIONS = (asyncio.TimeoutError, SenseAPITimeoutException)
 
 MDI_ICONS = {
     "ac": "air-conditioner",

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -2,8 +2,6 @@
 from datetime import timedelta
 import logging
 
-from sense_energy import SenseAPITimeoutException
-
 from homeassistant.const import DEVICE_CLASS_POWER, ENERGY_KILO_WATT_HOUR, POWER_WATT
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -24,6 +22,7 @@ from .const import (
     SENSE_DEVICE_UPDATE,
     SENSE_DEVICES_DATA,
     SENSE_DISCOVERED_DEVICES_DATA,
+    SENSE_TIMEOUT_EXCEPTIONS,
 )
 
 MIN_TIME_BETWEEN_DAILY_UPDATES = timedelta(seconds=300)
@@ -256,7 +255,7 @@ class SenseTrendsSensor(Entity):
 
         try:
             await self.update_sensor()
-        except SenseAPITimeoutException:
+        except SENSE_TIMEOUT_EXCEPTIONS:
             _LOGGER.error("Timeout retrieving data")
             return
 


### PR DESCRIPTION
asyncio.Timeout needs to be trapped as well


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I've been seeing this rather frequently.
```
2020-03-22 01:04:09 ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.daily_usage_2 fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 279, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 474, in async_device_update
    await self.async_update()
  File "/usr/src/homeassistant/homeassistant/components/sense/sensor.py", line 258, in async_update
    await self.update_sensor()
  File "/usr/src/homeassistant/homeassistant/components/sense/sensor.py", line 72, in update_trends
    await data.update_trend_data()
  File "/usr/local/lib/python3.7/site-packages/sense_energy/asyncsenseable.py", line 92, in update_trend_data
    await self.get_trend_data(scale)
  File "/usr/local/lib/python3.7/site-packages/sense_energy/asyncsenseable.py", line 88, in get_trend_data
    self._trend_data[scale] = await json
  File "/usr/local/lib/python3.7/site-packages/sense_energy/asyncsenseable.py", line 76, in api_call
    data=payload) as resp:
  File "/usr/local/lib/python3.7/site-packages/aiohttp/client.py", line 1012, in __aenter__
    self._resp = await self._coro
  File "/usr/local/lib/python3.7/site-packages/aiohttp/client.py", line 582, in _request
    break
  File "/usr/local/lib/python3.7/site-packages/aiohttp/helpers.py", line 586, in __exit__
    raise asyncio.TimeoutError from None
concurrent.futures._base.TimeoutError

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
