### PR TITLE
General code cleanups for lutron_caseta component

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -81,9 +81,7 @@ class LutronCasetaDevice(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._smartbridge.add_subscriber(
-            self.device_id, self.async_update_ha_state
-        )
+        self._smartbridge.add_subscriber(self.device_id, self.async_update_ha_state)
 
     @property
     def device_id(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -82,7 +82,7 @@ class LutronCasetaDevice(Entity):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._smartbridge.add_subscriber(
-            self.device_id, self.async_schedule_update_ha_state
+            self.device_id, self.async_update_ha_state
         )
 
     @property
@@ -108,7 +108,7 @@ class LutronCasetaDevice(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {"Device ID": self.device_id, "Zone ID": self._device["zone"]}
+        attr = {"device_id": self.device_id, "zone_id": self._device["zone"]}
         return attr
 
     @property

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -81,7 +81,7 @@ class LutronCasetaDevice(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._smartbridge.add_subscriber(self.device_id, self.async_update_ha_state)
+        self._smartbridge.add_subscriber(self.device_id, self.async_write_ha_state)
 
     @property
     def device_id(self):

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -17,14 +17,14 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Lutron Caseta shades as a cover device."""
-    devs = []
+    entities = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
     cover_devices = bridge.get_devices_by_domain(DOMAIN)
     for cover_device in cover_devices:
-        dev = LutronCasetaCover(cover_device, bridge)
-        devs.append(dev)
+        entity = LutronCasetaCover(cover_device, bridge)
+        entities.append(entity)
 
-    async_add_entities(devs, True)
+    async_add_entities(entities, True)
 
 
 class LutronCasetaCover(LutronCasetaDevice, CoverDevice):

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -25,14 +25,14 @@ def to_hass_level(level):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Lutron Caseta lights."""
-    devs = []
+    entities = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
     light_devices = bridge.get_devices_by_domain(DOMAIN)
     for light_device in light_devices:
-        dev = LutronCasetaLight(light_device, bridge)
-        devs.append(dev)
+        entity = LutronCasetaLight(light_device, bridge)
+        entities.append(entity)
 
-    async_add_entities(devs, True)
+    async_add_entities(entities, True)
 
 
 class LutronCasetaLight(LutronCasetaDevice, Light):

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -10,14 +10,14 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Lutron Caseta lights."""
-    devs = []
+    entities = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
     scenes = bridge.get_scenes()
     for scene in scenes:
-        dev = LutronCasetaScene(scenes[scene], bridge)
-        devs.append(dev)
+        entity = LutronCasetaScene(scenes[scene], bridge)
+        entities.append(entity)
 
-    async_add_entities(devs, True)
+    async_add_entities(entities, True)
 
 
 class LutronCasetaScene(Scene):

--- a/homeassistant/components/lutron_caseta/switch.py
+++ b/homeassistant/components/lutron_caseta/switch.py
@@ -10,15 +10,15 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up Lutron switch."""
-    devs = []
+    entities = []
     bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
     switch_devices = bridge.get_devices_by_domain(DOMAIN)
 
     for switch_device in switch_devices:
-        dev = LutronCasetaLight(switch_device, bridge)
-        devs.append(dev)
+        entity = LutronCasetaLight(switch_device, bridge)
+        entities.append(entity)
 
-    async_add_entities(devs, True)
+    async_add_entities(entities, True)
     return True
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `Device ID` and `Zone ID` attributes of Lutron Caseta devices have been renamed to `device_id` and `zone_id` to match the convention of the rest of Home Assistant.  If you have any automations that reference these attributes, they will need to be updated.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

These are small code cleanups pulled into a separate PR for existing platforms requested in #33032 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml - no change from previous versions
lutron_caseta:
  host: 192.168.1.15
  keyfile: caseta.key
  certfile: caseta.crt
  ca_certs: caseta-bridge.crt
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #33032 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
