### PR TITLE
Extend knx brightness with rgb brightness if brightness addresses are not supported

### DIFF
--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -184,6 +184,7 @@ class KNXLight(Light):
             return self.device.current_brightness
         if self.device.supports_color and self._hsv_color:
             return round(self._hsv_color[-1] / 100 * 255)
+        return None
 
     @property
     def hs_color(self):

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -182,9 +182,9 @@ class KNXLight(Light):
         """Return the brightness of this light between 0..255."""
         if self.device.supports_brightness:
             return self.device.current_brightness
-        if self.device.supports_color and self._hsv_color:
-            hsv_color = self._hsv_color
-            return round(hsv_color[-1] / 100 * 255) if hsv_color else None
+        hsv_color = self._hsv_color
+        if self.device.supports_color and hsv_color:
+            return round(hsv_color[-1] / 100 * 255)
         return None
 
     @property

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -180,9 +180,10 @@ class KNXLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        if not self.device.supports_brightness:
-            return None
-        return self.device.current_brightness
+        if self.device.supports_brightness:
+            return self.device.current_brightness
+        if self.device.supports_color and self._hsv_color:
+            return round(self._hsv_color[-1] / 100 * 255)
 
     @property
     def hs_color(self):
@@ -191,6 +192,14 @@ class KNXLight(Light):
         if self.device.supports_rgbw or self.device.supports_color:
             rgb, _ = self.device.current_color
         return color_util.color_RGB_to_hs(*rgb) if rgb else None
+
+    @property
+    def _hsv_color(self):
+        """Return the HSV color value."""
+        rgb = None
+        if self.device.supports_rgbw or self.device.supports_color:
+            rgb, _ = self.device.current_color
+        return color_util.color_RGB_to_hsv(*rgb) if rgb else None
 
     @property
     def white_value(self):

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -184,6 +184,7 @@ class KNXLight(Light):
             return self.device.current_brightness
         hsv_color = self._hsv_color
         if self.device.supports_color and hsv_color:
+            # pylint: disable=unsubscriptable-object
             return round(hsv_color[-1] / 100 * 255)
         return None
 

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -183,7 +183,8 @@ class KNXLight(Light):
         if self.device.supports_brightness:
             return self.device.current_brightness
         if self.device.supports_color and self._hsv_color:
-            return round(self._hsv_color[-1] / 100 * 255)
+            hsv_color = self._hsv_color
+            return round(hsv_color[-1] / 100 * 255) if hsv_color else None
         return None
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the documentation of the KNX light is an example to configure a RGB light. This also includes the group addresses for the brightness. My LED controllers only have color addresses (DPT 232.600) and no brightness addresses. So in this case I only configure the color addresses. The consequence is that there is no correct feedback on the set brightness on the color DPT. ALso, if I change the color, the brightness does a fallback to the default brightness (255):
https://github.com/home-assistant/home-assistant/blob/bea7aae8cd87aaef58359383d8c0ac0c34ef6abd/homeassistant/components/knx/light.py#L293-L294

The change proposed provides feedback on the brightness of the selected color and if only the color is changed, it gets the current brightness and doesn't fall back to the default brightness anymore. So 2 fixes for the price of one. 😉 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml for RGB without dedicated brightness addresses:
  - platform: knx
    name: Test RGB
    address: '0/5/6'
    state_address: '3/4/6'
    color_address: '0/5/7'
    color_state_address: '3/4/7'

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- There is no issue recorded for this bug.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
