### PR TITLE
Options flow for Monoprice sources

### DIFF
--- a/homeassistant/components/monoprice/__init__.py
+++ b/homeassistant/components/monoprice/__init__.py
@@ -33,6 +33,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.error("Error connecting to Monoprice controller at %s", port)
         raise ConfigEntryNotReady
 
+    entry.add_update_listener(_update_listener)
+
     for component in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
@@ -53,3 +55,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     return unload_ok
+
+
+async def _update_listener(hass: HomeAssistant, entry: ConfigEntry):
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/monoprice/config_flow.py
+++ b/homeassistant/components/monoprice/config_flow.py
@@ -96,6 +96,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return MonopriceOptionsFlowHandler(config_entry)
 
 
+@core.callback
+def _key_for_source(index, source, previous_sources):
+    if str(index) in previous_sources:
+        key = vol.Optional(source, default=previous_sources[str(index)])
+    else:
+        key = vol.Optional(source)
+
+    return key
+
+
 class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Monoprice options flow."""
 
@@ -106,16 +116,11 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
     @core.callback
     def _previous_sources(self):
         if CONF_SOURCES in self.config_entry.options:
-            return self.config_entry.options[CONF_SOURCES]
+            previous = self.config_entry.options[CONF_SOURCES]
         else:
-            return self.config_entry.data[CONF_SOURCES]
+            previous = self.config_entry.data[CONF_SOURCES]
 
-    @core.callback
-    def _key_for_source(self, index, source, previous_sources):
-        if str(index) in previous_sources:
-            return vol.Optional(source, default=previous_sources[str(index)])
-        else:
-            return vol.Optional(source)
+        return previous
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""
@@ -127,7 +132,7 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
         previous_sources = self._previous_sources()
 
         options = {
-            self._key_for_source(idx + 1, source, previous_sources): str
+            _key_for_source(idx + 1, source, previous_sources): str
             for idx, source in enumerate(SOURCES)
         }
 

--- a/homeassistant/components/monoprice/config_flow.py
+++ b/homeassistant/components/monoprice/config_flow.py
@@ -21,17 +21,31 @@ from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_PORT): str,
-        vol.Optional(CONF_SOURCE_1): str,
-        vol.Optional(CONF_SOURCE_2): str,
-        vol.Optional(CONF_SOURCE_3): str,
-        vol.Optional(CONF_SOURCE_4): str,
-        vol.Optional(CONF_SOURCE_5): str,
-        vol.Optional(CONF_SOURCE_6): str,
+SOURCES = [
+    CONF_SOURCE_1,
+    CONF_SOURCE_2,
+    CONF_SOURCE_3,
+    CONF_SOURCE_4,
+    CONF_SOURCE_5,
+    CONF_SOURCE_6,
+]
+
+OPTIONS_FOR_DATA = {vol.Optional(source): str for source in SOURCES}
+
+DATA_SCHEMA = vol.Schema({vol.Required(CONF_PORT): str, **OPTIONS_FOR_DATA})
+
+
+@core.callback
+def _sources_from_config(data):
+    sources_config = {
+        str(idx + 1): data.get(source) for idx, source in enumerate(SOURCES)
     }
-)
+
+    return {
+        index: name.strip()
+        for index, name in sources_config.items()
+        if (name is not None and name.strip() != "")
+    }
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -45,19 +59,8 @@ async def validate_input(hass: core.HomeAssistant, data):
         _LOGGER.error("Error connecting to Monoprice controller")
         raise CannotConnect
 
-    sources_config = {
-        1: data.get(CONF_SOURCE_1),
-        2: data.get(CONF_SOURCE_2),
-        3: data.get(CONF_SOURCE_3),
-        4: data.get(CONF_SOURCE_4),
-        5: data.get(CONF_SOURCE_5),
-        6: data.get(CONF_SOURCE_6),
-    }
-    sources = {
-        index: name.strip()
-        for index, name in sources_config.items()
-        if (name is not None and name.strip() != "")
-    }
+    sources = _sources_from_config(data)
+
     # Return info that you want to store in the config entry.
     return {CONF_PORT: data[CONF_PORT], CONF_SOURCES: sources}
 
@@ -85,6 +88,50 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
+
+    @staticmethod
+    @core.callback
+    def async_get_options_flow(config_entry):
+        """Define the config flow to handle options."""
+        return MonopriceOptionsFlowHandler(config_entry)
+
+
+class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a Monoprice options flow."""
+
+    def __init__(self, config_entry):
+        """Initialize."""
+        self.config_entry = config_entry
+
+    @core.callback
+    def _previous_sources(self):
+        if CONF_SOURCES in self.config_entry.options:
+            return self.config_entry.options[CONF_SOURCES]
+        else:
+            return self.config_entry.data[CONF_SOURCES]
+
+    @core.callback
+    def _key_for_source(self, index, source, previous_sources):
+        if str(index) in previous_sources:
+            return vol.Optional(source, default=previous_sources[str(index)])
+        else:
+            return vol.Optional(source)
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="", data={CONF_SOURCES: _sources_from_config(user_input)}
+            )
+
+        previous_sources = self._previous_sources()
+
+        options = {
+            self._key_for_source(idx + 1, source, previous_sources): str
+            for idx, source in enumerate(SOURCES)
+        }
+
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(options),)
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -1,6 +1,7 @@
 """Support for interfacing with Monoprice 6 zone home audio controller."""
 import logging
 
+from homeassistant import core
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
@@ -27,7 +28,10 @@ SUPPORT_MONOPRICE = (
 )
 
 
-def _get_sources(sources_config):
+@core.callback
+def _get_sources_from_dict(data):
+    sources_config = data[CONF_SOURCES]
+
     source_id_name = {int(index): name for index, name in sources_config.items()}
 
     source_name_id = {v: k for k, v in source_id_name.items()}
@@ -37,13 +41,22 @@ def _get_sources(sources_config):
     return [source_id_name, source_name_id, source_names]
 
 
+@core.callback
+def _get_sources(config_entry):
+    if CONF_SOURCES in config_entry.options:
+        data = config_entry.options
+    else:
+        data = config_entry.data
+    return _get_sources_from_dict(data)
+
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Monoprice 6-zone amplifier platform."""
     port = config_entry.data[CONF_PORT]
 
     monoprice = hass.data[DOMAIN][config_entry.entry_id]
 
-    sources = _get_sources(config_entry.data.get(CONF_SOURCES))
+    sources = _get_sources(config_entry)
 
     entities = []
     for i in range(1, 4):

--- a/homeassistant/components/monoprice/strings.json
+++ b/homeassistant/components/monoprice/strings.json
@@ -22,5 +22,20 @@
     "abort": {
       "already_configured": "Device is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure sources",
+        "data": {
+          "source_1": "Name of source #1",
+          "source_2": "Name of source #2",
+          "source_3": "Name of source #3",
+          "source_4": "Name of source #4",
+          "source_5": "Name of source #5",
+          "source_6": "Name of source #6"
+        }
+      }
+    }
   }
 }

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -2,7 +2,7 @@
 from asynctest import patch
 from serial import SerialException
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.monoprice.const import (
     CONF_SOURCE_1,
     CONF_SOURCE_4,
@@ -11,6 +11,8 @@ from homeassistant.components.monoprice.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_PORT
+
+from tests.common import MockConfigEntry
 
 CONFIG = {
     CONF_PORT: "/test/port",
@@ -45,7 +47,7 @@ async def test_form(hass):
     assert result2["title"] == CONFIG[CONF_PORT]
     assert result2["data"] == {
         CONF_PORT: CONFIG[CONF_PORT],
-        CONF_SOURCES: {1: CONFIG[CONF_SOURCE_1], 4: CONFIG[CONF_SOURCE_4]},
+        CONF_SOURCES: {"1": CONFIG[CONF_SOURCE_1], "4": CONFIG[CONF_SOURCE_4]},
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -86,3 +88,32 @@ async def test_generic_exception(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "unknown"}
+
+
+async def test_options_flow(hass):
+    """Test config flow options."""
+    conf = {CONF_PORT: "/test/port", CONF_SOURCES: {"4": "four"}}
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        # unique_id="abcde12345",
+        data=conf,
+        # options={CONF_SHOW_ON_MAP: True},
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.monoprice.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_SOURCE_1: "one", CONF_SOURCE_4: "", CONF_SOURCE_5: "five"},
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert config_entry.options[CONF_SOURCES] == {"1": "one", "5": "five"}

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -37,6 +37,7 @@ from homeassistant.helpers.entity_component import async_update_entity
 from tests.common import MockConfigEntry
 
 MOCK_CONFIG = {CONF_PORT: "fake port", CONF_SOURCES: {"1": "one", "3": "three"}}
+MOCK_OPTIONS = {CONF_SOURCES: {"2": "two", "4": "four"}}
 
 ZONE_1_ID = "media_player.zone_11"
 ZONE_2_ID = "media_player.zone_12"
@@ -110,6 +111,20 @@ async def _setup_monoprice(hass, monoprice):
         "homeassistant.components.monoprice.get_monoprice", new=lambda *a: monoprice,
     ):
         config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        # setup_component(self.hass, DOMAIN, MOCK_CONFIG)
+        # self.hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+
+async def _setup_monoprice_with_options(hass, monoprice):
+    with patch(
+        "homeassistant.components.monoprice.get_monoprice", new=lambda *a: monoprice,
+    ):
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, data=MOCK_CONFIG, options=MOCK_OPTIONS
+        )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         # setup_component(self.hass, DOMAIN, MOCK_CONFIG)
@@ -303,6 +318,15 @@ async def test_source_list(hass):
     state = hass.states.get(ZONE_1_ID)
     # Note, the list is sorted!
     assert ["one", "three"] == state.attributes[ATTR_INPUT_SOURCE_LIST]
+
+
+async def test_source_list_with_options(hass):
+    """Test source list property."""
+    await _setup_monoprice_with_options(hass, MockMonoprice())
+
+    state = hass.states.get(ZONE_1_ID)
+    # Note, the list is sorted!
+    assert ["two", "four"] == state.attributes[ATTR_INPUT_SOURCE_LIST]
 
 
 async def test_select_source(hass):

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -271,7 +271,6 @@ async def test_restore_without_snapshort(hass):
 
 async def test_update(hass):
     """Test updating values from monoprice."""
-    """Test snapshot save/restore service calls."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Following up on the recent changes to the Monoprice integration, this PR enables the use of options flow to reconfigure sources.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12500

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
