### PR TITLE
Fix detection of zone master in soundtouch media_player

### DIFF
--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -437,20 +437,37 @@ class SoundTouchDevice(MediaPlayerDevice):
         # slaves for some reason. To compensate for this shortcoming we have to fetch
         # the zone info from the master when the current device is a slave until this is
         # fixed in the SoundTouch API or libsoundtouch, or of course until somebody has a
-        # better idea on how to fix this
-        if zone_status.is_master:
+        # better idea on how to fix this.
+        # In addition to this shortcoming, libsoundtouch seems to report the "is_master"
+        # property wrong on some slaves, so the only reliable way to detect if the current
+        # devices is the master, is by comparing the master_id of the zone with the device_id
+        if zone_status.master_id == self._device.config.device_id:
             return self._build_zone_info(self.entity_id, zone_status.slaves)
 
-        master_instance = self._get_instance_by_ip(zone_status.master_ip)
-        master_zone_status = master_instance.device.zone_status()
-        return self._build_zone_info(
-            master_instance.entity_id, master_zone_status.slaves
-        )
+        # The master device has to be searched by it's ID and not IP since libsoundtouch / BOSE API
+        # do not return the IP of the master for some slave objects/responses
+        master_instance = self._get_instance_by_id(zone_status.master_id)
+        if master_instance is not None:
+            master_zone_status = master_instance.device.zone_status()
+            return self._build_zone_info(
+                master_instance.entity_id, master_zone_status.slaves
+            )
+
+        # We should never end up here since this means we haven't found a master device to get the
+        # correct zone info from. In this case, assume current device is master
+        return self._build_zone_info(self.entity_id, zone_status.slaves)
 
     def _get_instance_by_ip(self, ip_address):
         """Search and return a SoundTouchDevice instance by it's IP address."""
         for instance in self.hass.data[DATA_SOUNDTOUCH]:
             if instance and instance.config["host"] == ip_address:
+                return instance
+        return None
+
+    def _get_instance_by_id(self, instance_id):
+        """Search and return a SoundTouchDevice instance by it's ID (aka MAC address)."""
+        for instance in self.hass.data[DATA_SOUNDTOUCH]:
+            if instance and instance.device.config.device_id == instance_id:
                 return instance
         return None
 

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -33,6 +33,8 @@ from homeassistant.setup import async_setup_component
 
 DEVICE_1_IP = "192.168.0.1"
 DEVICE_2_IP = "192.168.0.2"
+DEVICE_1_ID = 1
+DEVICE_2_ID = 2
 
 
 def get_config(host=DEVICE_1_IP, port=8090, name="soundtouch"):
@@ -60,20 +62,22 @@ def one_device_fixture():
 def two_zones_fixture():
     """Mock one master and one slave."""
     device_1 = MockDevice(
+        DEVICE_1_ID,
         MockZoneStatus(
             is_master=True,
-            master_id=1,
+            master_id=DEVICE_1_ID,
             master_ip=DEVICE_1_IP,
             slaves=[MockZoneSlave(DEVICE_2_IP)],
-        )
+        ),
     )
     device_2 = MockDevice(
+        DEVICE_2_ID,
         MockZoneStatus(
             is_master=False,
-            master_id=1,
+            master_id=DEVICE_1_ID,
             master_ip=DEVICE_1_IP,
             slaves=[MockZoneSlave(DEVICE_2_IP)],
-        )
+        ),
     )
     devices = {DEVICE_1_IP: device_1, DEVICE_2_IP: device_2}
     device_patch = patch(
@@ -112,9 +116,9 @@ async def setup_soundtouch(hass, config):
 class MockDevice(STD):
     """Mock device."""
 
-    def __init__(self, zone_status=None):
+    def __init__(self, id=None, zone_status=None):
         """Init the class."""
-        self._config = MockConfig()
+        self._config = MockConfig(id)
         self._zone_status = zone_status or MockZoneStatus()
 
     def zone_status(self, refresh=True):
@@ -125,9 +129,10 @@ class MockDevice(STD):
 class MockConfig(Config):
     """Mock config."""
 
-    def __init__(self):
+    def __init__(self, id=None):
         """Init class."""
         self._name = "name"
+        self._id = id or DEVICE_1_ID
 
 
 class MockZoneStatus(ZoneStatus):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the detection of the zone master in multi-room mode of soundtouch speakers since the value returned by libsoundtouch for` zone_info.is_master` is not correct.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32976

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
