### PR TITLE
Make sure entity platform services work for all platforms of domain

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -254,14 +254,16 @@ class EntityComponent:
 
         This method must be run in the event loop.
         """
-        tasks = [platform.async_reset() for platform in self._platforms.values()]
+        tasks = []
+
+        for key, platform in self._platforms.items():
+            if key == self.domain:
+                tasks.append(platform.async_reset())
+            else:
+                tasks.append(platform.async_destroy())
 
         if tasks:
             await asyncio.wait(tasks)
-
-        for key, platform in self._platforms.items():
-            if key != self.domain:
-                platform.async_destroy()
 
         self._platforms = {self.domain: self._platforms[self.domain]}
         self.config = None

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -259,6 +259,10 @@ class EntityComponent:
         if tasks:
             await asyncio.wait(tasks)
 
+        for key, platform in self._platforms.items():
+            if key != self.domain:
+                platform.async_destroy()
+
         self._platforms = {self.domain: self._platforms[self.domain]}
         self.config = None
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 SLOW_SETUP_WARNING = 10
 SLOW_SETUP_MAX_WAIT = 60
 PLATFORM_NOT_READY_RETRIES = 10
+DATA_ENTITY_PLATFORM = "entity_platform"
 
 
 class EntityPlatform:
@@ -57,15 +58,15 @@ class EntityPlatform:
         self._async_cancel_retry_setup: Optional[CALLBACK_TYPE] = None
         self._process_updates: Optional[asyncio.Lock] = None
 
+        self.parallel_updates: Optional[asyncio.Semaphore] = None
+
         # Platform is None for the EntityComponent "catch-all" EntityPlatform
         # which powers entity_component.add_entities
-        if platform is None:
-            self.parallel_updates_created = True
-            self.parallel_updates: Optional[asyncio.Semaphore] = None
-            return
+        self.parallel_updates_created = platform is None
 
-        self.parallel_updates_created = False
-        self.parallel_updates = None
+        hass.data.setdefault(DATA_ENTITY_PLATFORM, {}).setdefault(
+            self.platform_name, []
+        ).append(self)
 
     @callback
     def _get_parallel_updates_semaphore(
@@ -453,6 +454,8 @@ class EntityPlatform:
             self._async_cancel_retry_setup()
             self._async_cancel_retry_setup = None
 
+        self.hass.data[DATA_ENTITY_PLATFORM][self.platform_name].remove(self)
+
         if not self.entities:
             return
 
@@ -488,14 +491,24 @@ class EntityPlatform:
 
     @callback
     def async_register_entity_service(self, name, schema, func, required_features=None):
-        """Register an entity service."""
+        """Register an entity service.
+
+        Services will automatically be shared by all platforms of the same domain.
+        """
+        if self.hass.services.has_service(self.platform_name, name):
+            return
+
         if isinstance(schema, dict):
             schema = cv.make_entity_service_schema(schema)
 
         async def handle_service(call):
             """Handle the service."""
             await service.entity_service_call(
-                self.hass, [self], func, call, required_features
+                self.hass,
+                self.hass.data[DATA_ENTITY_PLATFORM][self.platform_name],
+                func,
+                call,
+                required_features,
             )
 
         self.hass.services.async_register(

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -465,12 +465,12 @@ class EntityPlatform:
             self._async_unsub_polling()
             self._async_unsub_polling = None
 
-    @callback
-    def async_destroy(self) -> None:
+    async def async_destroy(self) -> None:
         """Destroy an entity platform.
 
         Call before discarding the object.
         """
+        await self.async_reset()
         self.hass.data[DATA_ENTITY_PLATFORM][self.platform_name].remove(self)
 
     async def async_remove_entity(self, entity_id: str) -> None:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -454,8 +454,6 @@ class EntityPlatform:
             self._async_cancel_retry_setup()
             self._async_cancel_retry_setup = None
 
-        self.hass.data[DATA_ENTITY_PLATFORM][self.platform_name].remove(self)
-
         if not self.entities:
             return
 
@@ -466,6 +464,14 @@ class EntityPlatform:
         if self._async_unsub_polling is not None:
             self._async_unsub_polling()
             self._async_unsub_polling = None
+
+    @callback
+    def async_destroy(self) -> None:
+        """Destroy an entity platform.
+
+        Call before discarding the object.
+        """
+        self.hass.data[DATA_ENTITY_PLATFORM][self.platform_name].remove(self)
 
     async def async_remove_entity(self, entity_id: str) -> None:
         """Remove entity id from platform."""

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -871,6 +871,9 @@ async def test_platforms_sharing_services(hass):
         entities.append(entity)
 
     entity_platform1.async_register_entity_service("hello", {}, handle_service)
+    entity_platform2.async_register_entity_service(
+        "hello", {}, Mock(side_effect=AssertionError("Should not be called"))
+    )
 
     await hass.services.async_call(
         "mock_platform", "hello", {"entity_id": "all"}, blocking=True
@@ -879,6 +882,3 @@ async def test_platforms_sharing_services(hass):
     assert len(entities) == 2
     assert entity1 in entities
     assert entity2 in entities
-
-    # Make sure this doesn't riase
-    entity_platform2.async_register_entity_service("hello", {}, handle_service)

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -8,6 +8,7 @@ import asynctest
 import pytest
 
 from homeassistant.const import UNIT_PERCENTAGE
+from homeassistant.core import callback
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import entity_platform, entity_registry
 from homeassistant.helpers.entity import async_generate_entity_id
@@ -847,3 +848,37 @@ async def test_platform_with_no_setup(hass, caplog):
         "The mock-platform platform for the mock-integration integration does not support platform setup."
         in caplog.text
     )
+
+
+async def test_platforms_sharing_services(hass):
+    """Test platforms share services."""
+    entity_platform1 = MockEntityPlatform(
+        hass, domain="mock_integration", platform_name="mock_platform", platform=None
+    )
+    entity1 = MockEntity(entity_id="mock_integration.entity_1")
+    await entity_platform1.async_add_entities([entity1])
+
+    entity_platform2 = MockEntityPlatform(
+        hass, domain="mock_integration", platform_name="mock_platform", platform=None
+    )
+    entity2 = MockEntity(entity_id="mock_integration.entity_2")
+    await entity_platform2.async_add_entities([entity2])
+
+    entities = []
+
+    @callback
+    def handle_service(entity, data):
+        entities.append(entity)
+
+    entity_platform1.async_register_entity_service("hello", {}, handle_service)
+
+    await hass.services.async_call(
+        "mock_platform", "hello", {"entity_id": "all"}, blocking=True
+    )
+
+    assert len(entities) == 2
+    assert entity1 in entities
+    assert entity2 in entities
+
+    # Make sure this doesn't riase
+    entity_platform2.async_register_entity_service("hello", {}, handle_service)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Entity platforms that register services will now have those services work with all entities provided by any entity platform of that integration. This will make it safe to register a service inside `async_setup_entry` of your platform and it will work if you have multiple config entries.

Fixes https://github.com/home-assistant/core/pull/33078#issuecomment-602007549 by @MartinHjelmare 

CC @bdraco 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
