### PR TITLE
Switch legacy calls to init_recorder_component using async_add_job to use async_add_executor_job in tests

### DIFF
--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -36,7 +36,9 @@ def _get_mock_doorbirdapi_side_effects(ready=None, info=None):
 
 async def test_user_form(hass):
     """Test we get the user form."""
-    await hass.async_add_job(init_recorder_component, hass)  # force in memory db
+    await hass.async_add_executor_job(
+        init_recorder_component, hass
+    )  # force in memory db
 
     await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
@@ -75,7 +77,9 @@ async def test_user_form(hass):
 
 async def test_form_import(hass):
     """Test we get the form with import source."""
-    await hass.async_add_job(init_recorder_component, hass)  # force in memory db
+    await hass.async_add_executor_job(
+        init_recorder_component, hass
+    )  # force in memory db
 
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -125,7 +129,9 @@ async def test_form_import(hass):
 
 async def test_form_zeroconf_wrong_oui(hass):
     """Test we abort when we get the wrong OUI via zeroconf."""
-    await hass.async_add_job(init_recorder_component, hass)  # force in memory db
+    await hass.async_add_executor_job(
+        init_recorder_component, hass
+    )  # force in memory db
 
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -142,7 +148,9 @@ async def test_form_zeroconf_wrong_oui(hass):
 
 async def test_form_zeroconf_correct_oui(hass):
     """Test we can setup from zeroconf with the correct OUI source."""
-    await hass.async_add_job(init_recorder_component, hass)  # force in memory db
+    await hass.async_add_executor_job(
+        init_recorder_component, hass
+    )  # force in memory db
 
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -188,7 +196,9 @@ async def test_form_zeroconf_correct_oui(hass):
 
 async def test_form_user_cannot_connect(hass):
     """Test we handle cannot connect error."""
-    await hass.async_add_job(init_recorder_component, hass)  # force in memory db
+    await hass.async_add_executor_job(
+        init_recorder_component, hass
+    )  # force in memory db
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -209,7 +219,9 @@ async def test_form_user_cannot_connect(hass):
 
 async def test_form_user_invalid_auth(hass):
     """Test we handle cannot invalid auth error."""
-    await hass.async_add_job(init_recorder_component, hass)  # force in memory db
+    await hass.async_add_executor_job(
+        init_recorder_component, hass
+    )  # force in memory db
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -617,7 +617,7 @@ class TestComponentHistory(unittest.TestCase):
 
 async def test_fetch_period_api(hass, hass_client):
     """Test the fetch period view for history."""
-    await hass.async_add_job(init_recorder_component, hass)
+    await hass.async_add_executor_job(init_recorder_component, hass)
     await async_setup_component(hass, "history", {})
     await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
     client = await hass_client()
@@ -629,7 +629,7 @@ async def test_fetch_period_api(hass, hass_client):
 
 async def test_fetch_period_api_with_include_order(hass, hass_client):
     """Test the fetch period view for history."""
-    await hass.async_add_job(init_recorder_component, hass)
+    await hass.async_add_executor_job(init_recorder_component, hass)
     await async_setup_component(
         hass,
         "history",

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1270,7 +1270,7 @@ class TestComponentLogbook(unittest.TestCase):
 
 async def test_logbook_view(hass, hass_client):
     """Test the logbook view."""
-    await hass.async_add_job(init_recorder_component, hass)
+    await hass.async_add_executor_job(init_recorder_component, hass)
     await async_setup_component(hass, "logbook", {})
     await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
     client = await hass_client()
@@ -1280,7 +1280,7 @@ async def test_logbook_view(hass, hass_client):
 
 async def test_logbook_view_period_entity(hass, hass_client):
     """Test the logbook view with period and entity."""
-    await hass.async_add_job(init_recorder_component, hass)
+    await hass.async_add_executor_job(init_recorder_component, hass)
     await async_setup_component(hass, "logbook", {})
     await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
 


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch legacy calls to init_recorder_component using async_add_job to use async_add_executor_job in tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
