### PR TITLE
Add support for Vizio sound mode

### DIFF
--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -63,6 +63,9 @@ SUPPORTED_COMMANDS = {
     ),
 }
 
+VIZIO_SOUND_MODE = "eq"
+VIZIO_AUDIO_SETTINGS = "audio"
+
 # Since Vizio component relies on device class, this dict will ensure that changes to
 # the values of DEVICE_CLASS_SPEAKER or DEVICE_CLASS_TV don't require changes to pyvizio.
 VIZIO_DEVICE_CLASSES = {

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "Vizio SmartCast",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.1.44"],
+  "requirements": ["pyvizio==0.1.45"],
   "dependencies": [],
   "codeowners": ["@raman325"],
   "config_flow": true,

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -9,6 +9,7 @@ from pyvizio.const import APP_HOME, APPS, INPUT_APPS, NO_APP_RUNNING, UNKNOWN_AP
 
 from homeassistant.components.media_player import (
     DEVICE_CLASS_SPEAKER,
+    SUPPORT_SELECT_SOUND_MODE,
     MediaPlayerDevice,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -133,6 +134,8 @@ class VizioDevice(MediaPlayerDevice):
         self._current_input = None
         self._current_app = None
         self._current_app_config = None
+        self._current_sound_mode = None
+        self._available_sound_modes = None
         self._available_inputs = []
         self._available_apps = []
         self._conf_apps = config_entry.options.get(CONF_APPS, {})
@@ -191,16 +194,30 @@ class VizioDevice(MediaPlayerDevice):
             self._current_app = None
             self._current_app_config = None
             self._available_apps = None
+            self._current_sound_mode = None
+            self._available_sound_modes = None
             return
 
         self._state = STATE_ON
 
-        audio_settings = await self._device.get_all_audio_settings(
-            log_api_exception=False
+        audio_settings = await self._device.get_all_settings(
+            "audio", log_api_exception=False
         )
         if audio_settings is not None:
             self._volume_level = float(audio_settings["volume"]) / self._max_volume
             self._is_muted = audio_settings["mute"].lower() == "on"
+
+            if "eq" in audio_settings:
+                self._supported_commands = (
+                    SUPPORTED_COMMANDS[self._device_class] | SUPPORT_SELECT_SOUND_MODE
+                )
+                self._current_sound_mode = audio_settings["eq"]
+                if self._available_sound_modes is None:
+                    self._available_sound_modes = await self._device.get_setting_options(
+                        "audio", "eq"
+                    )
+            else:
+                self._supported_commands = SUPPORTED_COMMANDS[self._device_class]
 
         input_ = await self._device.get_current_input(log_api_exception=False)
         if input_ is not None:
@@ -367,7 +384,7 @@ class VizioDevice(MediaPlayerDevice):
         return self._config_entry.unique_id
 
     @property
-    def device_info(self):
+    def device_info(self) -> Dict[str, Any]:
         """Return device registry information."""
         return {
             "identifiers": {(DOMAIN, self._config_entry.unique_id)},
@@ -378,9 +395,24 @@ class VizioDevice(MediaPlayerDevice):
         }
 
     @property
-    def device_class(self):
+    def device_class(self) -> str:
         """Return device class for entity."""
         return self._device_class
+
+    @property
+    def sound_mode(self) -> Optional[str]:
+        """Name of the current sound mode."""
+        return self._current_sound_mode
+
+    @property
+    def sound_mode_list(self) -> Optional[List[str]]:
+        """List of available sound modes."""
+        return self._available_sound_modes
+
+    async def async_select_sound_mode(self, sound_mode):
+        """Select sound mode."""
+        if sound_mode in self._available_sound_modes:
+            await self._device.set_setting("audio", "eq", sound_mode)
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -210,18 +210,14 @@ class VizioDevice(MediaPlayerDevice):
             self._is_muted = audio_settings["mute"].lower() == "on"
 
             if VIZIO_SOUND_MODE in audio_settings:
-                self._supported_commands = (
-                    self._supported_commands | SUPPORT_SELECT_SOUND_MODE
-                )
+                self._supported_commands |= SUPPORT_SELECT_SOUND_MODE
                 self._current_sound_mode = audio_settings[VIZIO_SOUND_MODE]
                 if self._available_sound_modes is None:
                     self._available_sound_modes = await self._device.get_setting_options(
                         VIZIO_AUDIO_SETTINGS, VIZIO_SOUND_MODE
                     )
             else:
-                self._supported_commands = (
-                    self._supported_commands ^ SUPPORT_SELECT_SOUND_MODE
-                )
+                self._supported_commands ^= SUPPORT_SELECT_SOUND_MODE
 
         input_ = await self._device.get_current_input(log_api_exception=False)
         if input_ is not None:
@@ -416,7 +412,9 @@ class VizioDevice(MediaPlayerDevice):
     async def async_select_sound_mode(self, sound_mode):
         """Select sound mode."""
         if sound_mode in self._available_sound_modes:
-            await self._device.set_setting("audio", "eq", sound_mode)
+            await self._device.set_setting(
+                VIZIO_AUDIO_SETTINGS, VIZIO_SOUND_MODE, sound_mode
+            )
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -209,7 +209,7 @@ class VizioDevice(MediaPlayerDevice):
 
             if "eq" in audio_settings:
                 self._supported_commands = (
-                    SUPPORTED_COMMANDS[self._device_class] | SUPPORT_SELECT_SOUND_MODE
+                    self._supported_commands | SUPPORT_SELECT_SOUND_MODE
                 )
                 self._current_sound_mode = audio_settings["eq"]
                 if self._available_sound_modes is None:
@@ -217,7 +217,9 @@ class VizioDevice(MediaPlayerDevice):
                         "audio", "eq"
                     )
             else:
-                self._supported_commands = SUPPORTED_COMMANDS[self._device_class]
+                self._supported_commands = (
+                    self._supported_commands ^ SUPPORT_SELECT_SOUND_MODE
+                )
 
         input_ = await self._device.get_current_input(log_api_exception=False)
         if input_ is not None:

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -42,7 +42,9 @@ from .const import (
     DOMAIN,
     ICON,
     SUPPORTED_COMMANDS,
+    VIZIO_AUDIO_SETTINGS,
     VIZIO_DEVICE_CLASSES,
+    VIZIO_SOUND_MODE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -201,7 +203,7 @@ class VizioDevice(MediaPlayerDevice):
         self._state = STATE_ON
 
         audio_settings = await self._device.get_all_settings(
-            "audio", log_api_exception=False
+            VIZIO_AUDIO_SETTINGS, log_api_exception=False
         )
         if audio_settings is not None:
             self._volume_level = float(audio_settings["volume"]) / self._max_volume
@@ -211,10 +213,10 @@ class VizioDevice(MediaPlayerDevice):
                 self._supported_commands = (
                     self._supported_commands | SUPPORT_SELECT_SOUND_MODE
                 )
-                self._current_sound_mode = audio_settings["eq"]
+                self._current_sound_mode = audio_settings[VIZIO_SOUND_MODE]
                 if self._available_sound_modes is None:
                     self._available_sound_modes = await self._device.get_setting_options(
-                        "audio", "eq"
+                        VIZIO_AUDIO_SETTINGS, VIZIO_SOUND_MODE
                     )
             else:
                 self._supported_commands = (

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -209,7 +209,7 @@ class VizioDevice(MediaPlayerDevice):
             self._volume_level = float(audio_settings["volume"]) / self._max_volume
             self._is_muted = audio_settings["mute"].lower() == "on"
 
-            if "eq" in audio_settings:
+            if VIZIO_SOUND_MODE in audio_settings:
                 self._supported_commands = (
                     self._supported_commands | SUPPORT_SELECT_SOUND_MODE
                 )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1732,7 +1732,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.44
+pyvizio==0.1.45
 
 # homeassistant.components.velux
 pyvlx==0.2.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -635,7 +635,7 @@ pyvera==0.3.7
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.44
+pyvizio==0.1.45
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -8,7 +8,9 @@ from .const import (
     APP_LIST,
     CH_TYPE,
     CURRENT_APP_CONFIG,
+    CURRENT_EQ,
     CURRENT_INPUT,
+    EQ_LIST,
     INPUT_LIST,
     INPUT_LIST_WITH_APPS,
     MODEL,
@@ -135,11 +137,15 @@ def vizio_update_fixture():
         "homeassistant.components.vizio.media_player.VizioAsync.can_connect_with_auth_check",
         return_value=True,
     ), patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.get_all_audio_settings",
+        "homeassistant.components.vizio.media_player.VizioAsync.get_all_settings",
         return_value={
             "volume": int(MAX_VOLUME[DEVICE_CLASS_SPEAKER] / 2),
+            "eq": CURRENT_EQ,
             "mute": "Off",
         },
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_setting_options",
+        return_value=EQ_LIST,
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_current_input",
         return_value=CURRENT_INPUT,

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -64,6 +64,9 @@ class MockCompletePairingResponse(object):
         self.auth_token = auth_token
 
 
+CURRENT_EQ = "Music"
+EQ_LIST = ["Music", "Movie"]
+
 CURRENT_INPUT = "HDMI"
 INPUT_LIST = ["HDMI", "USB", "Bluetooth", "AUX"]
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds sound mode support for vizio devices that support it. As mentioned in #32727 I will be submitting a separate PR to remove conditional logic out of my helper functions so that the tests are more readable

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
