### PR TITLE
Add battery information to BLE devices

### DIFF
--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -1,6 +1,7 @@
 """Tracking for bluetooth low energy devices."""
 import asyncio
 import logging
+from uuid import UUID
 
 import pygatt  # pylint: disable=import-error
 
@@ -20,6 +21,10 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
+# Base UUID: 00000000-0000-1000-8000-00805F9B34FB
+# Battery characteristic: 0x2a19 (https://www.bluetooth.com/specifications/gatt/characteristics/)
+BATTERY_CHARACTERISTIC_UUID = UUID("00002a19-0000-1000-8000-00805f9b34fb")
+CONF_TRACK_BATTERY = "track_battery"
 DATA_BLE = "BLE"
 DATA_BLE_ADAPTER = "ADAPTER"
 BLE_PREFIX = "BLE_"
@@ -42,7 +47,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop)
 
-    def see_device(address, name, new_device=False):
+    def see_device(address, name, new_device=False, battery=None):
         """Mark a device as seen."""
         if name is not None:
             name = name.strip("\x00")
@@ -59,6 +64,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
                     return
                 _LOGGER.debug("Adding %s to tracked devices", address)
                 devs_to_track.append(address)
+                if config.get(CONF_TRACK_BATTERY):
+                    devs_track_battery.append(address)
             else:
                 _LOGGER.debug("Seen %s for the first time", address)
                 new_devices[address] = {"seen": 1, "name": name}
@@ -68,6 +75,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
             mac=BLE_PREFIX + address,
             host_name=name,
             source_type=SOURCE_TYPE_BLUETOOTH_LE,
+            battery=battery,
         )
 
     def discover_ble_devices():
@@ -88,6 +96,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
     yaml_path = hass.config.path(YAML_DEVICES)
     devs_to_track = []
     devs_donot_track = []
+    devs_track_battery = []
 
     # Load all known devices.
     # We just need the devices so set consider_home and home range
@@ -100,6 +109,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
             if device.track:
                 _LOGGER.debug("Adding %s to BLE tracker", device.mac)
                 devs_to_track.append(device.mac[4:])
+                if config.get(CONF_TRACK_BATTERY):
+                    devs_track_battery.append(device.mac[4:])
             else:
                 _LOGGER.debug("Adding %s to BLE do not track", device.mac)
                 devs_donot_track.append(device.mac[4:])
@@ -117,13 +128,34 @@ def setup_scanner(hass, config, see, discovery_info=None):
     def update_ble(now):
         """Lookup Bluetooth LE devices and update status."""
         devs = discover_ble_devices()
+        adapter = pygatt.GATTToolBackend()
         for mac in devs_to_track:
             if mac not in devs:
                 continue
 
             if devs[mac] is None:
                 devs[mac] = mac
-            see_device(mac, devs[mac])
+
+            battery = None
+            if mac in devs_track_battery:
+                try:
+                    adapter.start(reset_on_start=True)
+                    _LOGGER.debug("Reading battery for Bluetooth LE device %s", mac)
+                    bt_device = adapter.connect(mac)
+                    # Try to get the handle; it will raise a BLEError exception if not available
+                    bt_device.get_handle(BATTERY_CHARACTERISTIC_UUID)
+                    battery = ord(bt_device.char_read(BATTERY_CHARACTERISTIC_UUID))
+                except pygatt.exceptions.NotificationTimeout:
+                    _LOGGER.warning("Timeout when trying to get battery status")
+                except pygatt.exceptions.BLEError as err:
+                    _LOGGER.warning("Could not read battery status: %s", err)
+                    # If the device does not offer battery information, there is no point in asking again later on.
+                    # Remove the device from the battery-tracked devices, so that their battery is not wasted trying to
+                    # get an unavailable information.
+                    devs_track_battery.remove(mac)
+                finally:
+                    adapter.stop()
+            see_device(mac, devs[mac], battery=battery)
 
         if track_new:
             for address in devs:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Most Bluetooth LE tracked devices are battery based devices. In order to be able to change the battery before it dies, it would be nice if the battery charge status could be read from Home Assistant.
There is a standard GATT characteristic to read the battery status from a BLE device (if the device implements it).
Enhanced the bluetooth_le device tracker to try to read this value from connected devices.
In order to not tax the device battery needlessly, reading its state is disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
device_tracker:
  - platform: bluetooth_le_tracker
    track_battery: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12507

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
