### PR TITLE
Fix dynamically add/remove WLED strip segments

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -1,4 +1,5 @@
 """Support for LED lights."""
+from functools import partial
 import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -20,8 +21,12 @@ from homeassistant.components.light import (
     Light,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_registry import (
+    async_get_registry as async_get_entity_registry,
+)
 from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.color as color_util
 
@@ -70,12 +75,12 @@ async def async_setup_entry(
         "async_effect",
     )
 
-    lights = [
-        WLEDLight(entry.entry_id, coordinator, light.segment_id)
-        for light in coordinator.data.state.segments
-    ]
+    update_segments = partial(
+        async_update_segments, entry, coordinator, {}, async_add_entities
+    )
 
-    async_add_entities(lights, True)
+    coordinator.async_add_listener(update_segments)
+    update_segments()
 
 
 class WLEDLight(Light, WLEDDeviceEntity):
@@ -259,3 +264,47 @@ class WLEDLight(Light, WLEDDeviceEntity):
             data[ATTR_SPEED] = speed
 
         await self.coordinator.wled.light(**data)
+
+
+@callback
+def async_update_segments(
+    entry: ConfigEntry,
+    coordinator: WLEDDataUpdateCoordinator,
+    current: Dict[int, WLEDLight],
+    async_add_entities,
+) -> None:
+    """Update segments."""
+    segment_ids = [light.segment_id for light in coordinator.data.state.segments]
+
+    # Process new segments, add them to Home Assistant
+    new_segments = []
+    for segment_id in segment_ids:
+        if segment_id in current:
+            continue
+        current[segment_id] = WLEDLight(entry.entry_id, coordinator, segment_id)
+        new_segments.append(current[segment_id])
+
+    if new_segments:
+        async_add_entities(new_segments)
+
+    # Process deleted segments, remove them from Home Assistant
+    for segment_id in current:
+        if segment_id in segment_ids:
+            continue
+        coordinator.hass.async_create_task(
+            async_remove_segment(segment_id, coordinator, current)
+        )
+
+
+async def async_remove_segment(
+    segment_id: int,
+    coordinator: WLEDDataUpdateCoordinator,
+    current: Dict[int, WLEDLight],
+) -> None:
+    """Remove WLED segment light from Home Assistant."""
+    entity = current[segment_id]
+    await entity.async_remove()
+    registry = await async_get_entity_registry(coordinator.hass)
+    if entity.entity_id in registry.entities:
+        registry.async_remove(entity.entity_id)
+    del current[segment_id]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

WLED allows a user to split a single LED strip into multiple segments and control these separately.

Recent a recent update to WLED, it possible for the user to add/remove segments via the UI on the fly (before it was an API only feature).

With the release of WLED 0.10, users can just really easy click and change the segments from the web interface. This break HA.

This PR makes a start on fixing that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
