### PR TITLE
Handle Plex certificate updates

### DIFF
--- a/homeassistant/components/plex/errors.py
+++ b/homeassistant/components/plex/errors.py
@@ -12,3 +12,7 @@ class NoServersFound(PlexException):
 
 class ServerNotSpecified(PlexException):
     """Multiple servers linked to account without choice provided."""
+
+
+class ShouldUpdateConfigEntry(PlexException):
+    """Config entry data is out of date and should be updated."""

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -1,5 +1,7 @@
 """Shared class to maintain Plex server instances."""
 import logging
+import ssl
+from urllib.parse import urlparse
 
 import plexapi.myplex
 import plexapi.playqueue
@@ -26,7 +28,7 @@ from .const import (
     X_PLEX_PRODUCT,
     X_PLEX_VERSION,
 )
-from .errors import NoServersFound, ServerNotSpecified
+from .errors import NoServersFound, ServerNotSpecified, ShouldUpdateConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +42,7 @@ plexapi.X_PLEX_VERSION = X_PLEX_VERSION
 class PlexServer:
     """Manages a single Plex server connection."""
 
-    def __init__(self, hass, server_config, options=None):
+    def __init__(self, hass, server_config, known_server_id=None, options=None):
         """Initialize a Plex server instance."""
         self._hass = hass
         self._plex_server = None
@@ -50,6 +52,7 @@ class PlexServer:
         self._token = server_config.get(CONF_TOKEN)
         self._server_name = server_config.get(CONF_SERVER)
         self._verify_ssl = server_config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+        self._server_id = known_server_id
         self.options = options
         self.server_choice = None
         self._accounts = []
@@ -64,6 +67,7 @@ class PlexServer:
 
     def connect(self):
         """Connect to a Plex server directly, obtaining direct URL if necessary."""
+        config_entry_update_needed = False
 
         def _connect_with_token():
             account = plexapi.myplex.MyPlexAccount(token=self._token)
@@ -92,8 +96,34 @@ class PlexServer:
                 self._url, self._token, session
             )
 
+        def _update_plexdirect_hostname():
+            account = plexapi.myplex.MyPlexAccount(token=self._token)
+            matching_server = [
+                x.name
+                for x in account.resources()
+                if x.clientIdentifier == self._server_id
+            ][0]
+            self._plex_server = account.resource(matching_server).connect(timeout=10)
+
         if self._url:
-            _connect_with_url()
+            try:
+                _connect_with_url()
+            except requests.exceptions.SSLError as error:
+                context = error.__context__
+                while context and not isinstance(context, ssl.SSLCertVerificationError):
+                    context = context.__context__  # pylint: disable=no-member
+                if isinstance(context, ssl.SSLCertVerificationError):
+                    domain = urlparse(self._url).netloc.split(":")[0]
+                    if domain.endswith("plex.direct") and context.args[0].startswith(
+                        f"hostname '{domain}' doesn't match"
+                    ):
+                        _LOGGER.warning(
+                            "Plex SSL certificate's hostname changed, updating."
+                        )
+                        _update_plexdirect_hostname()
+                        config_entry_update_needed = True
+                else:
+                    raise
         else:
             _connect_with_token()
 
@@ -112,6 +142,9 @@ class PlexServer:
             self._owner_username = owner_account[0]
 
         self._version = self._plex_server.version
+
+        if config_entry_update_needed:
+            raise ShouldUpdateConfigEntry
 
     def refresh_entity(self, machine_identifier, device, session):
         """Forward refresh dispatch to media_player."""

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -109,12 +109,11 @@ class PlexServer:
             try:
                 _connect_with_url()
             except requests.exceptions.SSLError as error:
-                context = error.__context__
-                while context and not isinstance(context, ssl.SSLCertVerificationError):
-                    context = context.__context__  # pylint: disable=no-member
-                if isinstance(context, ssl.SSLCertVerificationError):
+                while error and not isinstance(error, ssl.SSLCertVerificationError):
+                    error = error.__context__  # pylint: disable=no-member
+                if isinstance(error, ssl.SSLCertVerificationError):
                     domain = urlparse(self._url).netloc.split(":")[0]
-                    if domain.endswith("plex.direct") and context.args[0].startswith(
+                    if domain.endswith("plex.direct") and error.args[0].startswith(
                         f"hostname '{domain}' doesn't match"
                     ):
                         _LOGGER.warning(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Apparently the `*.HASH.plex.direct` domain certificates issued by Plex can change in some circumstances, leading to SSL errors and the inability to connect securely as we persist the hostname in the config entry.

This PR will detect these certificate changes and query Plex services to find out the new hostname for the previously known Plex server.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
