### PR TITLE
Fix ONVIF camera snapshot with auth

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -5,13 +5,13 @@ import logging
 import os
 from typing import Optional
 
-from aiohttp import ClientError
 from aiohttp.client_exceptions import ClientConnectionError, ServerDisconnectedError
-import async_timeout
 from haffmpeg.camera import CameraMjpeg
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
 import onvif
 from onvif import ONVIFCamera, exceptions
+import requests
+from requests.auth import HTTPDigestAuth
 import voluptuous as vol
 from zeep.asyncio import AsyncTransport
 from zeep.exceptions import Fault
@@ -412,17 +412,12 @@ class ONVIFHassCamera(Camera):
             req.ProfileToken = profiles[self._profile_index].token
 
             snapshot_uri = await media_service.GetSnapshotUri(req)
-            uri_no_auth = snapshot_uri.Uri
-            uri_for_log = uri_no_auth.replace("http://", "http://<user>:<password>@", 1)
-            # Same authentication as rtsp
-            self._snapshot = uri_no_auth.replace(
-                "http://", f"http://{self._username}:{self._password}@", 1
-            )
+            self._snapshot = snapshot_uri.Uri
 
             _LOGGER.debug(
                 "ONVIF Camera Using the following URL for %s snapshot: %s",
                 self._name,
-                uri_for_log,
+                self._snapshot,
             )
         except exceptions.ONVIFError as err:
             _LOGGER.error("Couldn't setup camera '%s'. Error: %s", self._name, err)
@@ -509,25 +504,33 @@ class ONVIFHassCamera(Camera):
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""
-
         _LOGGER.debug("Retrieving image from camera '%s'", self._name)
+        image = None
 
         if self._snapshot is not None:
-            try:
-                websession = async_get_clientsession(self.hass)
-                with async_timeout.timeout(10):
-                    response = await websession.get(self._snapshot)
-                image = await response.read()
-            except asyncio.TimeoutError:
-                _LOGGER.error("Timeout getting image from: %s", self._name)
-                image = None
-            except ClientError as err:
-                _LOGGER.error("Error getting new camera image: %s", err)
-                image = None
+            auth = None
+            if self._username and self._password:
+                auth = HTTPDigestAuth(self._username, self._password)
 
-        if self._snapshot is None or image is None:
+            def fetch():
+                """Read image from a URL."""
+                try:
+                    response = requests.get(self._snapshot, timeout=5, auth=auth)
+                    return response.content
+                except requests.exceptions.RequestException as error:
+                    _LOGGER.error(
+                        "Fetch snapshot image failed from %s, falling back to FFmpeg; %s",
+                        self._name,
+                        error,
+                    )
+
+            image = await self.hass.async_add_job(fetch)
+
+        if image is None:
+            # Don't keep trying the snapshot URL
+            self._snapshot = None
+
             ffmpeg = ImageFrame(self.hass.data[DATA_FFMPEG].binary, loop=self.hass.loop)
-
             image = await asyncio.shield(
                 ffmpeg.get_image(
                     self._input,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes ONVIF snapshot URI support added in #33149, when the camera uses authentication.

ONVIF cameras use HTTP Digest auth, which is not supported by aiohttp.
Simplified auth handling and fallback to ffmpeg handling in general.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
camera:
  - platform: onvif
    host: 192.168.1.2
    port: 8000
    profile: 1
    username: admin
    password: password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
