### PR TITLE
Abort rachio homekit config when one is already setup

### DIFF
--- a/homeassistant/components/rachio/config_flow.py
+++ b/homeassistant/components/rachio/config_flow.py
@@ -84,6 +84,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_homekit(self, homekit_info):
         """Handle HomeKit discovery."""
+        if self._async_current_entries():
+            # We can see myq on the network to tell them to configure
+            # it, but since the device will not give up the account it is
+            # bound to and there can be multiple myq gateways on a single
+            # account, we avoid showing the device as discovered once
+            # they already have one configured as they can always
+            # add a new one via "+"
+            return self.async_abort(reason="already_configured")
         return await self.async_step_user()
 
     async def async_step_import(self, user_input):

--- a/homeassistant/components/rachio/config_flow.py
+++ b/homeassistant/components/rachio/config_flow.py
@@ -87,7 +87,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_current_entries():
             # We can see rachio on the network to tell them to configure
             # it, but since the device will not give up the account it is
-            # bound to and there can be multiple rachio gateways on a single
+            # bound to and there can be multiple rachio systems on a single
             # account, we avoid showing the device as discovered once
             # they already have one configured as they can always
             # add a new one via "+"

--- a/homeassistant/components/rachio/config_flow.py
+++ b/homeassistant/components/rachio/config_flow.py
@@ -85,9 +85,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_homekit(self, homekit_info):
         """Handle HomeKit discovery."""
         if self._async_current_entries():
-            # We can see myq on the network to tell them to configure
+            # We can see rachio on the network to tell them to configure
             # it, but since the device will not give up the account it is
-            # bound to and there can be multiple myq gateways on a single
+            # bound to and there can be multiple rachio gateways on a single
             # account, we avoid showing the device as discovered once
             # they already have one configured as they can always
             # add a new one via "+"

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -123,3 +123,4 @@ async def test_form_homekit(hass):
         DOMAIN, context={"source": "homekit"}
     )
     assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -107,7 +107,7 @@ async def test_form_cannot_connect(hass):
 
 
 async def test_form_homekit(hass):
-    """Test that we abort from homekit if myq is already setup."""
+    """Test that we abort from homekit if rachio is already setup."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.components.rachio.const import (
 )
 from homeassistant.const import CONF_API_KEY
 
+from tests.common import MockConfigEntry
+
 
 def _mock_rachio_return_value(get=None, getInfo=None):
     rachio_mock = MagicMock()
@@ -102,3 +104,22 @@ async def test_form_cannot_connect(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_homekit(hass):
+    """Test that we abort from homekit if myq is already setup."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "homekit"}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_API_KEY: "api_key"})
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "homekit"}
+    )
+    assert result["type"] == "abort"


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We can see rachio on the network to tell them to configure
it, but since the device will not give up the account it is
bound to and there can be multiple rachio controllers on a single
account, we avoid showing the device as discovered once
they already have one configured as they can always
add a new one via "+"

Same fix as #33218 for rachio

This can't actually be detected until https://github.com/home-assistant/core/pull/33274 goes in

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
