### PR TITLE
Overhaul the Slack integration (async and Block Kit support)

### DIFF
--- a/homeassistant/components/slack/manifest.json
+++ b/homeassistant/components/slack/manifest.json
@@ -2,7 +2,7 @@
   "domain": "slack",
   "name": "Slack",
   "documentation": "https://www.home-assistant.io/integrations/slack",
-  "requirements": ["slacker==0.14.0"],
+  "requirements": ["slackclient==2.5.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -124,7 +124,7 @@ class SlackNotificationService(BaseNotificationService):
         for target, result in zip(tasks, results):
             if isinstance(result, SlackApiError):
                 _LOGGER.error(
-                    "There was a Slack API error while sending a message to %s: %s",
+                    "There was a Slack API error while sending to %s: %s",
                     target,
                     result,
                 )

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -4,9 +4,6 @@ import logging
 import os
 from urllib.parse import urlparse
 
-import requests
-from requests.auth import HTTPBasicAuth, HTTPDigestAuth
-from requests.exceptions import RequestException
 from slack import WebClient
 from slack.errors import SlackApiError
 import voluptuous as vol
@@ -18,26 +15,15 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_ICON,
-    CONF_USERNAME,
-    HTTP_BASIC_AUTHENTICATION,
-    HTTP_DIGEST_AUTHENTICATION,
-)
+from homeassistant.const import CONF_API_KEY, CONF_ICON, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ATTACHMENTS = "attachments"
-ATTR_AUTH_TYPE = "auth"
 ATTR_BLOCKS = "blocks"
 ATTR_FILE = "file"
-ATTR_FILE_URL = "url"
-ATTR_FILE_PATH = "path"
-ATTR_PASSWORD = "password"
-ATTR_USERNAME = "username"
 
 CONF_DEFAULT_CHANNEL = "default_channel"
 
@@ -72,31 +58,6 @@ async def async_get_service(hass, config, discovery_info=None):
         username=config.get(CONF_USERNAME),
         icon=config.get(CONF_ICON),
     )
-
-
-def _get_remote_file_contents(url, username=None, password=None, auth_type=None):
-    """Retrieve a remote file via URL and return its binary content.
-
-    Note that we use a sync method (and the requests library) because aiohttp does not
-    currently have a helper for digest authentication.
-    """
-    if auth_type == HTTP_BASIC_AUTHENTICATION:
-        resp = requests.get(
-            url,
-            auth=HTTPBasicAuth(username, password),
-            timeout=DEFAULT_TIMEOUT_SECONDS,
-        )
-    elif auth_type == HTTP_DIGEST_AUTHENTICATION:
-        resp = requests.get(
-            url,
-            auth=HTTPDigestAuth(username, password),
-            timeout=DEFAULT_TIMEOUT_SECONDS,
-        )
-    else:
-        resp = requests.get(url, timeout=DEFAULT_TIMEOUT_SECONDS)
-
-    resp.raise_for_status()
-    return resp.content
 
 
 @callback
@@ -148,7 +109,7 @@ class SlackNotificationService(BaseNotificationService):
         except SlackApiError as err:
             _LOGGER.error("Error while uploading file-based message: %s", err)
 
-    async def _async_send_regular_message(
+    async def _async_send_text_only_message(
         self, targets, message, title, attachments, blocks
     ):
         """Send a text-only message."""
@@ -174,31 +135,6 @@ class SlackNotificationService(BaseNotificationService):
                     result,
                 )
 
-    async def _async_send_remote_file_message(
-        self, url, targets, message, title, username, password, auth_type
-    ):
-        """Upload a remote file (with message) to Slack."""
-        try:
-            file_as_bytes = await self._hass.async_add_executor_job(
-                _get_remote_file_contents, url, username, password, auth_type
-            )
-        except RequestException as err:
-            _LOGGER.error("Error while retrieving %s: %s", url, err)
-            return
-
-        filename = _async_get_filename_from_url(url)
-
-        try:
-            await self._client.files_upload(
-                channels=",".join(targets),
-                file=file_as_bytes,
-                filename=filename,
-                initial_comment=message,
-                title=title or filename,
-            )
-        except SlackApiError as err:
-            _LOGGER.error("Error while uploading file-based message: %s", err)
-
     async def async_send_message(self, message, **kwargs):
         """Send a message to Slack."""
         data = kwargs[ATTR_DATA] or {}
@@ -207,37 +143,20 @@ class SlackNotificationService(BaseNotificationService):
             kwargs.get(ATTR_TARGET, [self._default_channel])
         )
 
-        if ATTR_FILE not in data:
-            attachments = data.get(ATTR_ATTACHMENTS, {})
-            if attachments:
-                _LOGGER.warning(
-                    "Attachments are now part of Slack's legacy API; "
-                    "in most cases, Blocks should be used instead: "
-                    "https://www.home-assistant.io/integrations/slack/"
-                )
-            blocks = data.get(ATTR_BLOCKS, {})
-
-            return await self._async_send_regular_message(
-                targets, message, title, attachments, blocks
-            )
-
-        file_data = data[ATTR_FILE]
-
-        if ATTR_FILE_PATH not in file_data and ATTR_FILE_URL not in file_data:
-            _LOGGER.error('A file path/URL must be provided when using the "file" key')
-            return
-
-        if ATTR_FILE_PATH in file_data:
+        if ATTR_FILE in data:
             return await self._async_send_local_file_message(
-                file_data[ATTR_FILE_PATH], targets, message, title
+                data[ATTR_FILE], targets, message, title
             )
 
-        return await self._async_send_remote_file_message(
-            file_data[ATTR_FILE_URL],
-            targets,
-            message,
-            title,
-            data.get(ATTR_USERNAME),
-            data.get(ATTR_PASSWORD),
-            data.get(ATTR_AUTH_TYPE),
+        attachments = data.get(ATTR_ATTACHMENTS, {})
+        if attachments:
+            _LOGGER.warning(
+                "Attachments are now part of Slack's legacy API; "
+                "in most cases, Blocks should be used instead: "
+                "https://www.home-assistant.io/integrations/slack/"
+            )
+        blocks = data.get(ATTR_BLOCKS, {})
+
+        return await self._async_send_text_only_message(
+            targets, message, title, attachments, blocks
         )

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -61,13 +61,6 @@ async def async_get_service(hass, config, discovery_info=None):
 
 
 @callback
-def _async_get_filename_from_url(url):
-    """Return the filename of a passed URL."""
-    parsed_url = urlparse(url)
-    return os.path.basename(parsed_url.path)
-
-
-@callback
 def _async_sanitize_channel_names(channel_list):
     """Remove any # symbols from a channel list."""
     return [channel.replace("#", "") for channel in channel_list]
@@ -96,7 +89,8 @@ class SlackNotificationService(BaseNotificationService):
             _LOGGER.error("Path does not exist or is not allowed: %s", path)
             return
 
-        filename = _async_get_filename_from_url(path)
+        parsed_url = urlparse(path)
+        filename = os.path.basename(parsed_url.path)
 
         try:
             await self._client.files_upload(

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -75,7 +75,11 @@ async def async_get_service(hass, config, discovery_info=None):
 
 
 def _get_remote_file_contents(url, username=None, password=None, auth_type=None):
-    """Retrieve a remote file via URL and return its binary content."""
+    """Retrieve a remote file via URL and return its binary content.
+
+    Note that we use a sync method (and the requests library) because aiohttp does not
+    currently have a helper for digest authentication.
+    """
     if auth_type == HTTP_BASIC_AUTHENTICATION:
         resp = requests.get(
             url,

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -142,9 +142,9 @@ class SlackNotificationService(BaseNotificationService):
         attachments = data.get(ATTR_ATTACHMENTS, {})
         if attachments:
             _LOGGER.warning(
-                "Attachments are now part of Slack's legacy API; "
-                "in most cases, Blocks should be used instead: "
-                "https://www.home-assistant.io/integrations/slack/"
+                "Attachments are deprecated and part of Slack's legacy API; support "
+                "for them will be dropped in 0.114.0. In most cases, Blocks should be "
+                "used instead: https://www.home-assistant.io/integrations/slack/"
             )
         blocks = data.get(ATTR_BLOCKS, {})
 

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -1,10 +1,14 @@
 """Slack platform for notify component."""
+import asyncio
 import logging
+import os
+from urllib.parse import urlparse
 
 import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
-import slacker
-from slacker import Slacker
+from requests.exceptions import RequestException
+from slack import WebClient
+from slack.errors import SlackApiError
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -14,158 +18,222 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
-from homeassistant.const import CONF_API_KEY, CONF_ICON, CONF_USERNAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_ICON,
+    CONF_USERNAME,
+    HTTP_BASIC_AUTHENTICATION,
+    HTTP_DIGEST_AUTHENTICATION,
+)
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client, config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_CHANNEL = "default_channel"
-CONF_TIMEOUT = 15
-
-# Top level attributes in 'data'
 ATTR_ATTACHMENTS = "attachments"
+ATTR_AUTH_TYPE = "auth"
+ATTR_BLOCKS = "blocks"
 ATTR_FILE = "file"
-# Attributes contained in file
 ATTR_FILE_URL = "url"
 ATTR_FILE_PATH = "path"
-ATTR_FILE_USERNAME = "username"
-ATTR_FILE_PASSWORD = "password"
-ATTR_FILE_AUTH = "auth"
-# Any other value or absence of 'auth' lead to basic authentication being used
-ATTR_FILE_AUTH_DIGEST = "digest"
+ATTR_PASSWORD = "password"
+ATTR_USERNAME = "username"
+
+CONF_DEFAULT_CHANNEL = "default_channel"
+
+DEFAULT_TIMEOUT_SECONDS = 15
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_API_KEY): cv.string,
-        vol.Required(CONF_CHANNEL): cv.string,
+        vol.Required(CONF_DEFAULT_CHANNEL): cv.string,
         vol.Optional(CONF_ICON): cv.string,
         vol.Optional(CONF_USERNAME): cv.string,
     }
 )
 
 
-def get_service(hass, config, discovery_info=None):
-    """Get the Slack notification service."""
-
-    channel = config.get(CONF_CHANNEL)
-    api_key = config.get(CONF_API_KEY)
-    username = config.get(CONF_USERNAME)
-    icon = config.get(CONF_ICON)
+async def async_get_service(hass, config, discovery_info=None):
+    """Set up the Slack notification service."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = WebClient(token=config[CONF_API_KEY], run_async=True, session=session)
 
     try:
-        return SlackNotificationService(
-            channel, api_key, username, icon, hass.config.is_allowed_path
-        )
+        await client.auth_test()
+    except SlackApiError as err:
+        _LOGGER.error("Error while setting up integration: %s", err)
+        return
 
-    except slacker.Error:
-        _LOGGER.exception("Authentication failed")
-        return None
+    return SlackNotificationService(
+        hass,
+        client,
+        session,
+        config[CONF_DEFAULT_CHANNEL],
+        username=config.get(CONF_USERNAME),
+        icon=config.get(CONF_ICON),
+    )
+
+
+def _get_remote_file_contents(url, username=None, password=None, auth_type=None):
+    """Retrieve a remote file via URL and return its binary content."""
+    if auth_type == HTTP_BASIC_AUTHENTICATION:
+        resp = requests.get(
+            url,
+            auth=HTTPBasicAuth(username, password),
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+    elif auth_type == HTTP_DIGEST_AUTHENTICATION:
+        resp = requests.get(
+            url,
+            auth=HTTPDigestAuth(username, password),
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+    else:
+        resp = requests.get(url, timeout=DEFAULT_TIMEOUT_SECONDS)
+
+    resp.raise_for_status()
+    return resp.content
+
+
+@callback
+def _async_get_filename_from_url(url):
+    """Return the filename of a passed URL."""
+    parsed_url = urlparse(url)
+    return os.path.basename(parsed_url.path)
+
+
+@callback
+def _async_sanitize_channel_names(channel_list):
+    """Remove any # symbols from a channel list."""
+    return [channel.replace("#", "") for channel in channel_list]
 
 
 class SlackNotificationService(BaseNotificationService):
-    """Implement the notification service for Slack."""
+    """Define the Slack notification logic."""
 
-    def __init__(self, default_channel, api_token, username, icon, is_allowed_path):
-        """Initialize the service."""
-
+    def __init__(self, hass, client, session, default_channel, username, icon):
+        """Initialize."""
+        self._client = client
         self._default_channel = default_channel
-        self._api_token = api_token
-        self._username = username
+        self._hass = hass
         self._icon = icon
+        self._session = session
+        self._username = username
+
         if self._username or self._icon:
             self._as_user = False
         else:
             self._as_user = True
 
-        self.is_allowed_path = is_allowed_path
-        self.slack = Slacker(self._api_token)
-        self.slack.auth.test()
+    async def _async_send_local_file_message(self, path, targets, message, title):
+        """Upload a local file (with message) to Slack."""
+        if not self._hass.config.is_allowed_path(path):
+            _LOGGER.error("Path does not exist or is not allowed: %s", path)
+            return
 
-    def send_message(self, message="", **kwargs):
-        """Send a message to a user."""
+        filename = _async_get_filename_from_url(path)
 
-        if kwargs.get(ATTR_TARGET) is None:
-            targets = [self._default_channel]
-        else:
-            targets = kwargs.get(ATTR_TARGET)
-
-        data = kwargs.get(ATTR_DATA)
-        attachments = data.get(ATTR_ATTACHMENTS) if data else None
-        file = data.get(ATTR_FILE) if data else None
-        title = kwargs.get(ATTR_TITLE)
-
-        for target in targets:
-            try:
-                if file is not None:
-                    # Load from file or URL
-                    file_as_bytes = self.load_file(
-                        url=file.get(ATTR_FILE_URL),
-                        local_path=file.get(ATTR_FILE_PATH),
-                        username=file.get(ATTR_FILE_USERNAME),
-                        password=file.get(ATTR_FILE_PASSWORD),
-                        auth=file.get(ATTR_FILE_AUTH),
-                    )
-                    # Choose filename
-                    if file.get(ATTR_FILE_URL):
-                        filename = file.get(ATTR_FILE_URL)
-                    else:
-                        filename = file.get(ATTR_FILE_PATH)
-                    # Prepare structure for Slack API
-                    data = {
-                        "content": None,
-                        "filetype": None,
-                        "filename": filename,
-                        # If optional title is none use the filename
-                        "title": title if title else filename,
-                        "initial_comment": message,
-                        "channels": target,
-                    }
-                    # Post to slack
-                    self.slack.files.post(
-                        "files.upload", data=data, files={"file": file_as_bytes}
-                    )
-                else:
-                    self.slack.chat.post_message(
-                        target,
-                        message,
-                        as_user=self._as_user,
-                        username=self._username,
-                        icon_emoji=self._icon,
-                        attachments=attachments,
-                        link_names=True,
-                    )
-            except slacker.Error as err:
-                _LOGGER.error("Could not send notification. Error: %s", err)
-
-    def load_file(
-        self, url=None, local_path=None, username=None, password=None, auth=None
-    ):
-        """Load image/document/etc from a local path or URL."""
         try:
-            if url:
-                # Check whether authentication parameters are provided
-                if username:
-                    # Use digest or basic authentication
-                    if ATTR_FILE_AUTH_DIGEST == auth:
-                        auth_ = HTTPDigestAuth(username, password)
-                    else:
-                        auth_ = HTTPBasicAuth(username, password)
-                    # Load file from URL with authentication
-                    req = requests.get(url, auth=auth_, timeout=CONF_TIMEOUT)
-                else:
-                    # Load file from URL without authentication
-                    req = requests.get(url, timeout=CONF_TIMEOUT)
-                return req.content
+            await self._client.files_upload(
+                channels=",".join(targets),
+                file=path,
+                filename=filename,
+                initial_comment=message,
+                title=title or filename,
+            )
+        except SlackApiError as err:
+            _LOGGER.error("Error while uploading file-based message: %s", err)
 
-            if local_path:
-                # Check whether path is whitelisted in configuration.yaml
-                if self.is_allowed_path(local_path):
-                    return open(local_path, "rb")
-                _LOGGER.warning("'%s' is not secure to load data from!", local_path)
-            else:
-                _LOGGER.warning("Neither URL nor local path found in parameters!")
+    async def _async_send_regular_message(
+        self, targets, message, title, attachments, blocks
+    ):
+        """Send a text-only message."""
+        tasks = {
+            target: self._client.chat_postMessage(
+                channel=target,
+                text=message,
+                as_user=self._as_user,
+                attachments=attachments,
+                blocks=blocks,
+                icon_emoji=self._icon,
+                link_names=True,
+            )
+            for target in targets
+        }
 
-        except OSError as error:
-            _LOGGER.error("Can't load from URL or local path: %s", error)
+        results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+        for target, result in zip(tasks, results):
+            if isinstance(result, SlackApiError):
+                _LOGGER.error(
+                    "There was a Slack API error while sending a message to %s: %s",
+                    target,
+                    result,
+                )
 
-        return None
+    async def _async_send_remote_file_message(
+        self, url, targets, message, title, username, password, auth_type
+    ):
+        """Upload a remote file (with message) to Slack."""
+        try:
+            file_as_bytes = await self._hass.async_add_executor_job(
+                _get_remote_file_contents, url, username, password, auth_type
+            )
+        except RequestException as err:
+            _LOGGER.error("Error while retrieving %s: %s", url, err)
+            return
+
+        filename = _async_get_filename_from_url(url)
+
+        try:
+            await self._client.files_upload(
+                channels=",".join(targets),
+                file=file_as_bytes,
+                filename=filename,
+                initial_comment=message,
+                title=title or filename,
+            )
+        except SlackApiError as err:
+            _LOGGER.error("Error while uploading file-based message: %s", err)
+
+    async def async_send_message(self, message, **kwargs):
+        """Send a message to Slack."""
+        data = kwargs[ATTR_DATA] or {}
+        title = kwargs.get(ATTR_TITLE)
+        targets = _async_sanitize_channel_names(
+            kwargs.get(ATTR_TARGET, [self._default_channel])
+        )
+
+        if ATTR_FILE not in data:
+            attachments = data.get(ATTR_ATTACHMENTS, {})
+            if attachments:
+                _LOGGER.warning(
+                    "Attachments are now part of Slack's legacy API; "
+                    "in most cases, Blocks should be used instead: "
+                    "https://www.home-assistant.io/integrations/slack/"
+                )
+            blocks = data.get(ATTR_BLOCKS, {})
+
+            return await self._async_send_regular_message(
+                targets, message, title, attachments, blocks
+            )
+
+        file_data = data[ATTR_FILE]
+
+        if ATTR_FILE_PATH not in file_data and ATTR_FILE_URL not in file_data:
+            _LOGGER.error('A file path/URL must be provided when using the "file" key')
+            return
+
+        if ATTR_FILE_PATH in file_data:
+            return await self._async_send_local_file_message(
+                file_data[ATTR_FILE_PATH], targets, message, title
+            )
+
+        return await self._async_send_remote_file_message(
+            file_data[ATTR_FILE_URL],
+            targets,
+            message,
+            title,
+            data.get(ATTR_USERNAME),
+            data.get(ATTR_PASSWORD),
+            data.get(ATTR_AUTH_TYPE),
+        )

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -63,7 +63,7 @@ async def async_get_service(hass, config, discovery_info=None):
 @callback
 def _async_sanitize_channel_names(channel_list):
     """Remove any # symbols from a channel list."""
-    return [channel.replace("#", "") for channel in channel_list]
+    return [channel.lstrip("#", "") for channel in channel_list]
 
 
 class SlackNotificationService(BaseNotificationService):

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -53,7 +53,6 @@ async def async_get_service(hass, config, discovery_info=None):
     return SlackNotificationService(
         hass,
         client,
-        session,
         config[CONF_DEFAULT_CHANNEL],
         username=config.get(CONF_USERNAME),
         icon=config.get(CONF_ICON),
@@ -63,22 +62,20 @@ async def async_get_service(hass, config, discovery_info=None):
 @callback
 def _async_sanitize_channel_names(channel_list):
     """Remove any # symbols from a channel list."""
-    return [channel.lstrip("#", "") for channel in channel_list]
+    return [channel.lstrip("#") for channel in channel_list]
 
 
 class SlackNotificationService(BaseNotificationService):
     """Define the Slack notification logic."""
 
-    def __init__(self, hass, client, session, default_channel, username, icon):
+    def __init__(self, hass, client, default_channel, username, icon):
         """Initialize."""
         self._client = client
         self._default_channel = default_channel
         self._hass = hass
         self._icon = icon
-        self._session = session
-        self._username = username
 
-        if self._username or self._icon:
+        if username or self._icon:
             self._as_user = False
         else:
             self._as_user = True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1873,7 +1873,7 @@ sisyphus-control==2.2.1
 skybellpy==0.4.0
 
 # homeassistant.components.slack
-slacker==0.14.0
+slackclient==2.5.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `configuration.yaml` schema for this integration has changed; please read the documentation. Additionally, because it represents an unacceptable security risk, remote files (i.e., those that do not exist in a whitelisted directory local to Home Assistant) can no longer be sent to Slack via this integration.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR makes the following changes to the `slack` integration.

- It replaces [`slacker`](https://github.com/os/slacker) with [`slackclient`](https://github.com/slackapi/python-slackclient), which moves the integration to async.
- It cleans up the code to our current standards
- It adds support for Slack's Block Kit ([which is now favored in place of the still-supported-but-legacy Attachments framework for rich messaging](https://api.slack.com/messaging/composing/layouts#attachments)) – this was only a 2-line addition, so even though it is a new feature on top of the cleanup, it made sense to include here.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
notify:
  - platform: slack
    api_key: !secret slack_api_key
    default_channel: "#home-assistant"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12518

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
