### PR TITLE
Improve vicare scan_interval

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -7,7 +7,12 @@ from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareHeatPump import HeatPump
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
@@ -40,6 +45,9 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
+                vol.Optional(CONF_SCAN_INTERVAL, default=60): vol.All(
+                    cv.time_period, lambda value: value.total_seconds()
+                ),
                 vol.Optional(CONF_CIRCUIT): int,
                 vol.Optional(CONF_NAME, default="ViCare"): cv.string,
                 vol.Optional(CONF_HEATING_TYPE, default=DEFAULT_HEATING_TYPE): cv.enum(
@@ -58,6 +66,8 @@ def setup(hass, config):
     params = {"token_file": hass.config.path(STORAGE_DIR, "vicare_token.save")}
     if conf.get(CONF_CIRCUIT) is not None:
         params["circuit"] = conf[CONF_CIRCUIT]
+
+    params["cacheDuration"] = conf.get(CONF_SCAN_INTERVAL)
 
     heating_type = conf[CONF_HEATING_TYPE]
 

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -1,5 +1,4 @@
 """Viessmann ViCare climate device."""
-from datetime import timedelta
 import logging
 
 import requests
@@ -79,9 +78,6 @@ HA_TO_VICARE_PRESET_HEATING = {
 }
 
 PYVICARE_ERROR = "error"
-
-# Scan interval of 15 minutes seems to be safe to not hit the ViCare server rate limit
-SCAN_INTERVAL = timedelta(seconds=900)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "dependencies": [],
   "codeowners": ["@oischinger"],
-  "requirements": ["PyViCare==0.1.7"]
+  "requirements": ["PyViCare==0.1.10"]
 }

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -1,5 +1,4 @@
 """Viessmann ViCare water_heater device."""
-from datetime import timedelta
 import logging
 
 import requests
@@ -42,9 +41,6 @@ HA_TO_VICARE_HVAC_DHW = {
 }
 
 PYVICARE_ERROR = "error"
-
-# Scan interval of 15 minutes seems to be safe to not hit the ViCare server rate limit
-SCAN_INTERVAL = timedelta(seconds=900)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -78,7 +78,7 @@ PySocks==1.7.1
 PyTransportNSW==0.1.1
 
 # homeassistant.components.vicare
-PyViCare==0.1.7
+PyViCare==0.1.10
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.12.4


### PR DESCRIPTION
This upgrades to PyVicare 0.1.10 which allows to combine multiple
requests into a single HTTP GET. This in turn allows us to increase
the scan_interval to 60 seconds by default.
Additionally scan_interval has been introduced as a config parameter.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
    This upgrades to PyVicare 0.1.10 which allows to combine multiple
    requests into a single HTTP GET. This in turn allows us to increase
    the scan_interval to 60 seconds by default.
    Additionally scan_interval has been introduced as a config parameter.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/12528

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
