### PR TITLE
Fix dispatcher logging

### DIFF
--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -47,7 +47,10 @@ def async_dispatcher_connect(
     wrapped_target = catch_log_exception(
         target,
         lambda *args: "Exception in {} when dispatching '{}': {}".format(
-            target.__name__, signal, args
+            # Functions wrapped in partial do not have a __name__
+            getattr(target, "__name__", None) or str(target),
+            signal,
+            args,
         ),
     )
 

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -1,5 +1,6 @@
 """Test dispatcher helpers."""
 import asyncio
+from functools import partial
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
@@ -147,9 +148,13 @@ async def test_callback_exception_gets_logged(hass, caplog):
         """Record calls."""
         raise Exception("This is a bad message callback")
 
-    async_dispatcher_connect(hass, "test", bad_handler)
+    # wrap in partial to test message logging.
+    async_dispatcher_connect(hass, "test", partial(bad_handler))
     dispatcher_send(hass, "test", "bad")
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
-    assert "Exception in bad_handler when dispatching 'test': ('bad',)" in caplog.text
+    assert (
+        f"Exception in functools.partial({bad_handler}) when dispatching 'test': ('bad',)"
+        in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dispatcher would crash in error logging if the callback did not have a `__name__` attribute, which happens when you use `functools.partial`.


```
Traceback (most recent call last): 
File "/usr/src/homeassistant/homeassistant/util/logging.py", line 165,
 in async_wrapper log_exception(*args) 
File "/usr/src/homeassistant/homeassistant/util/logging.py", line 148,
 in log_exception friendly_msg = format_err(*args) 
File "/usr/src/homeassistant/homeassistant/helpers/dispatcher.py", line 50,
 in <lambda> target.__name__, signal, args 
AttributeError: 'functools.partial' object has no attribute '__name__'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
