### PR TITLE
Add unit_of_measurement property for air_quality entity

### DIFF
--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
@@ -44,6 +45,8 @@ PROP_TO_ATTR = {
     "particulate_matter_2_5": ATTR_PM_2_5,
     "sulphur_dioxide": ATTR_SO2,
 }
+
+VOLUME_MICROGRAMS_PER_CUBIC_METER = "µg/m³"
 
 
 async def async_setup(hass, config):
@@ -144,3 +147,8 @@ class AirQualityEntity(Entity):
     def state(self):
         """Return the current state."""
         return self.particulate_matter_2_5
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
+        return CONCENTRATION_MICROGRAMS_PER_CUBIC_METER

--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -46,8 +46,6 @@ PROP_TO_ATTR = {
     "sulphur_dioxide": ATTR_SO2,
 }
 
-VOLUME_MICROGRAMS_PER_CUBIC_METER = "µg/m³"
-
 
 async def async_setup(hass, config):
     """Set up the air quality component."""

--- a/homeassistant/components/xiaomi_miio/air_quality.py
+++ b/homeassistant/components/xiaomi_miio/air_quality.py
@@ -5,12 +5,7 @@ from miio import AirQualityMonitor, Device, DeviceException
 import voluptuous as vol
 
 from homeassistant.components.air_quality import PLATFORM_SCHEMA, AirQualityEntity
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONF_HOST,
-    CONF_NAME,
-    CONF_TOKEN,
-)
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.exceptions import NoEntitySpecifiedError, PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
@@ -93,7 +88,6 @@ class AirMonitorB1(AirQualityEntity):
         self._device = device
         self._unique_id = unique_id
         self._icon = "mdi:cloud"
-        self._unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
         self._available = None
         self._air_quality_index = None
         self._carbon_dioxide = None
@@ -184,11 +178,6 @@ class AirMonitorB1(AirQualityEntity):
                 data[attr] = value
 
         return data
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return self._unit_of_measurement
 
 
 class AirMonitorS1(AirMonitorB1):

--- a/tests/components/air_quality/test_air_quality.py
+++ b/tests/components/air_quality/test_air_quality.py
@@ -5,6 +5,10 @@ from homeassistant.components.air_quality import (
     ATTR_OZONE,
     ATTR_PM_10,
 )
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+)
 from homeassistant.setup import async_setup_component
 
 
@@ -34,3 +38,6 @@ async def test_attributes(hass):
     assert data.get(ATTR_N2O) is None
     assert data.get(ATTR_OZONE) is None
     assert data.get(ATTR_ATTRIBUTION) == "Powered by Home Assistant"
+    assert (
+        data.get(ATTR_UNIT_OF_MEASUREMENT) == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Before this change not all `air quality` entities had the `unit_of_measurement` property set. Now all `air quality` entities have the appropiate `unit_of_measurement` `µg/m³` set. Please consider this change as it can be a breaking change for people who display this kind of sensor in external systems, for example, influxdb.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the `air_quality` entity returns `particulate_matter_2_5` as `state`, but doesn't have `unit_of_measurement` property.
This PR adds the `unit_of_measurement` property and includes this property in tests. It also removes `unit_of_measurement` property from the `air_quality` entity class of `xiaomi_miio` integration, which will not be needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
