### PR TITLE
Extend time pattern trigger to handle multiple values

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -229,6 +229,8 @@ def parse_time_expression(parameter: Any, min_value: int, max_value: int) -> Lis
     elif isinstance(parameter, str) and parameter.startswith("/"):
         parameter = int(parameter[1:])
         res = [x for x in range(min_value, max_value + 1) if x % parameter == 0]
+    elif isinstance(parameter, str) and parameter.find(",") >= 0:
+        res = [int(x) for x in parameter.split(",") if x]
     elif not hasattr(parameter, "__iter__"):
         res = [int(parameter)]
     else:

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -185,6 +185,20 @@ def test_parse_time_expression():
 
     assert [42] == dt_util.parse_time_expression(42, 0, 59)
 
+    assert [21, 22, 23] == dt_util.parse_time_expression("21,22,23", 0, 23)
+
+    assert [0, 3, 4, 12, 20, 21, 22] == dt_util.parse_time_expression(
+        "0,3,4,12,20,21,22", 0, 23
+    )
+
+    assert [8] == dt_util.parse_time_expression("8,", 0, 23)
+
+    assert [8] == dt_util.parse_time_expression("8,,,", 0, 23)
+
+    assert [] == dt_util.parse_time_expression(",", 0, 23)
+
+    assert [] == dt_util.parse_time_expression(",,,,,", 0, 23)
+
     with pytest.raises(ValueError):
         dt_util.parse_time_expression(61, 0, 60)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.

## Proposed change
This is extension to Time Pattern Trigger in automations (see https://www.home-assistant.io/docs/automation/trigger/#time-pattern-trigger) that supports crontab-like time values separated by commas, ie:
```
automation:
  trigger:
    platform: time_pattern
    hours: 8,20
    minutes: 10,15,45,50
    seconds: 0
```
This will fire trigger at 8:10, 8:15, 8:45, 8:50, 20:10, 20:15, 20:45, 20:50.
Comma separated values are valid for hours, minutes and seconds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
automation:
  trigger:
    platform: time_pattern
    hours: 8,20
    minutes: 10,15,45,50
    seconds: 0
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12527

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
