### PR TITLE
Fix setting HomeKit temperatures with imperial units

### DIFF
--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -12,7 +12,6 @@ from homeassistant.components.climate.const import (
     ATTR_MIN_TEMP,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    ATTR_TARGET_TEMP_STEP,
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
@@ -55,7 +54,6 @@ from .const import (
     DEFAULT_MAX_TEMP_WATER_HEATER,
     DEFAULT_MIN_TEMP_WATER_HEATER,
     PROP_MAX_VALUE,
-    PROP_MIN_STEP,
     PROP_MIN_VALUE,
     SERV_THERMOSTAT,
 )
@@ -67,6 +65,7 @@ HC_HOMEKIT_VALID_MODES_WATER_HEATER = {
     "Heat": 1,
 }
 UNIT_HASS_TO_HOMEKIT = {TEMP_CELSIUS: 0, TEMP_FAHRENHEIT: 1}
+
 UNIT_HOMEKIT_TO_HASS = {c: s for s, c in UNIT_HASS_TO_HOMEKIT.items()}
 HC_HASS_TO_HOMEKIT = {
     HVAC_MODE_OFF: 0,
@@ -99,9 +98,6 @@ class Thermostat(HomeAccessory):
         self._flag_coolingthresh = False
         self._flag_heatingthresh = False
         min_temp, max_temp = self.get_temperature_range()
-        temp_step = self.hass.states.get(self.entity_id).attributes.get(
-            ATTR_TARGET_TEMP_STEP, 0.5
-        )
 
         # Add additional characteristics if auto mode is supported
         self.chars = []
@@ -162,11 +158,10 @@ class Thermostat(HomeAccessory):
         self.char_target_temp = serv_thermostat.configure_char(
             CHAR_TARGET_TEMPERATURE,
             value=21.0,
-            properties={
-                PROP_MIN_VALUE: min_temp,
-                PROP_MAX_VALUE: max_temp,
-                PROP_MIN_STEP: temp_step,
-            },
+            # We do not set PROP_MIN_STEP here and instead use the HomeKit
+            # default of 0.1 in order to have enough precision to convert
+            # temperature units and avoid setting to 73F will result in 74F
+            properties={PROP_MIN_VALUE: min_temp, PROP_MAX_VALUE: max_temp},
             setter_callback=self.set_target_temperature,
         )
 
@@ -182,22 +177,20 @@ class Thermostat(HomeAccessory):
             self.char_cooling_thresh_temp = serv_thermostat.configure_char(
                 CHAR_COOLING_THRESHOLD_TEMPERATURE,
                 value=23.0,
-                properties={
-                    PROP_MIN_VALUE: min_temp,
-                    PROP_MAX_VALUE: max_temp,
-                    PROP_MIN_STEP: temp_step,
-                },
+                # We do not set PROP_MIN_STEP here and instead use the HomeKit
+                # default of 0.1 in order to have enough precision to convert
+                # temperature units and avoid setting to 73F will result in 74F
+                properties={PROP_MIN_VALUE: min_temp, PROP_MAX_VALUE: max_temp},
                 setter_callback=self.set_cooling_threshold,
             )
         if CHAR_HEATING_THRESHOLD_TEMPERATURE in self.chars:
             self.char_heating_thresh_temp = serv_thermostat.configure_char(
                 CHAR_HEATING_THRESHOLD_TEMPERATURE,
                 value=19.0,
-                properties={
-                    PROP_MIN_VALUE: min_temp,
-                    PROP_MAX_VALUE: max_temp,
-                    PROP_MIN_STEP: temp_step,
-                },
+                # We do not set PROP_MIN_STEP here and instead use the HomeKit
+                # default of 0.1 in order to have enough precision to convert
+                # temperature units and avoid setting to 73F will result in 74F
+                properties={PROP_MIN_VALUE: min_temp, PROP_MAX_VALUE: max_temp},
                 setter_callback=self.set_heating_threshold,
             )
 
@@ -370,11 +363,10 @@ class WaterHeater(HomeAccessory):
         self.char_target_temp = serv_thermostat.configure_char(
             CHAR_TARGET_TEMPERATURE,
             value=50.0,
-            properties={
-                PROP_MIN_VALUE: min_temp,
-                PROP_MAX_VALUE: max_temp,
-                PROP_MIN_STEP: 0.5,
-            },
+            # We do not set PROP_MIN_STEP here and instead use the HomeKit
+            # default of 0.1 in order to have enough precision to convert
+            # temperature units and avoid setting to 73F will result in 74F
+            properties={PROP_MIN_VALUE: min_temp, PROP_MAX_VALUE: max_temp},
             setter_callback=self.set_target_temperature,
         )
 

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -102,7 +102,7 @@ async def test_thermostat(hass, hk_driver, cls, events):
 
     assert acc.char_target_temp.properties[PROP_MAX_VALUE] == DEFAULT_MAX_TEMP
     assert acc.char_target_temp.properties[PROP_MIN_VALUE] == DEFAULT_MIN_TEMP
-    assert acc.char_target_temp.properties[PROP_MIN_STEP] == 0.5
+    assert acc.char_target_temp.properties[PROP_MIN_STEP] == 0.1
 
     hass.states.async_set(
         entity_id,
@@ -276,10 +276,10 @@ async def test_thermostat_auto(hass, hk_driver, cls, events):
 
     assert acc.char_cooling_thresh_temp.properties[PROP_MAX_VALUE] == DEFAULT_MAX_TEMP
     assert acc.char_cooling_thresh_temp.properties[PROP_MIN_VALUE] == DEFAULT_MIN_TEMP
-    assert acc.char_cooling_thresh_temp.properties[PROP_MIN_STEP] == 0.5
+    assert acc.char_cooling_thresh_temp.properties[PROP_MIN_STEP] == 0.1
     assert acc.char_heating_thresh_temp.properties[PROP_MAX_VALUE] == DEFAULT_MAX_TEMP
     assert acc.char_heating_thresh_temp.properties[PROP_MIN_VALUE] == DEFAULT_MIN_TEMP
-    assert acc.char_heating_thresh_temp.properties[PROP_MIN_STEP] == 0.5
+    assert acc.char_heating_thresh_temp.properties[PROP_MIN_STEP] == 0.1
 
     hass.states.async_set(
         entity_id,
@@ -517,7 +517,7 @@ async def test_thermostat_temperature_step_whole(hass, hk_driver, cls):
     await hass.async_add_job(acc.run)
     await hass.async_block_till_done()
 
-    assert acc.char_target_temp.properties[PROP_MIN_STEP] == 1.0
+    assert acc.char_target_temp.properties[PROP_MIN_STEP] == 0.1
 
 
 async def test_thermostat_restore(hass, hk_driver, cls, events):
@@ -618,7 +618,7 @@ async def test_water_heater(hass, hk_driver, cls, events):
     assert (
         acc.char_target_temp.properties[PROP_MIN_VALUE] == DEFAULT_MIN_TEMP_WATER_HEATER
     )
-    assert acc.char_target_temp.properties[PROP_MIN_STEP] == 0.5
+    assert acc.char_target_temp.properties[PROP_MIN_STEP] == 0.1
 
     hass.states.async_set(
         entity_id,


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In PR #24804 the step size was changed to match the step size
of the device that HomeKit is controlling. Since HomeKit
is always working in TEMP_CELSIUS and the step size is based on
the Home Assistant units setting, we were mixing data with different
units of measure when Home Assistant was using imperial units.

This regression presented the symptom that setting the
temperature to 73F would result in 74F.  Other values are affected
where the math doesn't happen to work out.

HomeKit currently has a default of 0.1 in the spec and the override
of this value has been removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
