### PR TITLE
Filter the history of device_tracker by location attributes

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -86,7 +86,7 @@ def get_significant_states(
             last_state = states[-1] if len(states) > 0 else None
             if (
                 _is_significant(state)
-                and _has_different_location(state, last_state)
+                and _location_differs(state, last_state)
                 and not state.attributes.get(ATTR_HIDDEN, False)
             ):
                 states.append(state)
@@ -443,7 +443,7 @@ def _is_significant(state):
     return state.domain != "script" or state.attributes.get("can_cancel")
 
 
-def _has_different_location(state, other):
+def _location_differs(state, other):
     """Test if two states differ in lat, long attributes.
 
     Returns False if both states are States objects and lat/long are not None and equal.
@@ -457,6 +457,7 @@ def _has_different_location(state, other):
     lat2 = other.attributes.get(ATTR_LATITUDE)
     long2 = other.attributes.get(ATTR_LONGITUDE)
 
+    state_is_different = state.state != other.state
     lat_is_none_or_different = lat1 is None or lat1 != lat2
     long_is_none_or_different = long1 is None or long1 != long2
-    return lat_is_none_or_different or long_is_none_or_different
+    return state_is_different or lat_is_none_or_different or long_is_none_or_different

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -50,7 +50,7 @@ def get_significant_states(
     entity_ids=None,
     filters=None,
     include_start_time_state=True,
-    significant_changes_only=False,
+    significant_changes_only=True,
 ):
     """
     Return states changes during UTC period start_time - end_time.
@@ -331,7 +331,9 @@ class HistoryPeriodView(HomeAssistantView):
         if entity_ids:
             entity_ids = entity_ids.lower().split(",")
         include_start_time_state = "skip_initial_state" not in request.query
-        significant_changes_only = "significant_changes_only" in request.query
+        significant_changes_only = (
+            request.query.get("significant_changes_only", "1") != "0"
+        )
 
         hass = request.app["hass"]
 

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -188,7 +188,7 @@ class TestComponentHistory(unittest.TestCase):
         """
         zero, four, states = self.record_states()
         hist = history.get_significant_states(
-            self.hass, zero, four, filters=history.Filters(),
+            self.hass, zero, four, filters=history.Filters()
         )
         assert states == hist
 
@@ -252,7 +252,7 @@ class TestComponentHistory(unittest.TestCase):
         del states["script.can_cancel_this_one"]
 
         hist = history.get_significant_states(
-            self.hass, zero, four, ["media_player.test"], filters=history.Filters(),
+            self.hass, zero, four, ["media_player.test"], filters=history.Filters()
         )
         assert states == hist
 
@@ -513,12 +513,12 @@ class TestComponentHistory(unittest.TestCase):
         zero, four, states = self.record_states()
         entity_ids = ["media_player.test", "media_player.test2"]
         hist = history.get_significant_states(
-            self.hass, zero, four, entity_ids, filters=history.Filters(),
+            self.hass, zero, four, entity_ids, filters=history.Filters()
         )
         assert list(hist.keys()) == entity_ids
         entity_ids = ["media_player.test2", "media_player.test"]
         hist = history.get_significant_states(
-            self.hass, zero, four, entity_ids, filters=history.Filters(),
+            self.hass, zero, four, entity_ids, filters=history.Filters()
         )
         assert list(hist.keys()) == entity_ids
 

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -188,11 +188,7 @@ class TestComponentHistory(unittest.TestCase):
         """
         zero, four, states = self.record_states()
         hist = history.get_significant_states(
-            self.hass,
-            zero,
-            four,
-            filters=history.Filters(),
-            significant_changes_only=True,
+            self.hass, zero, four, filters=history.Filters(),
         )
         assert states == hist
 
@@ -219,7 +215,6 @@ class TestComponentHistory(unittest.TestCase):
             four,
             filters=history.Filters(),
             include_start_time_state=True,
-            significant_changes_only=True,
         )
         assert states == hist
 
@@ -245,7 +240,6 @@ class TestComponentHistory(unittest.TestCase):
             four,
             filters=history.Filters(),
             include_start_time_state=False,
-            significant_changes_only=True,
         )
         assert states == hist
 
@@ -258,12 +252,7 @@ class TestComponentHistory(unittest.TestCase):
         del states["script.can_cancel_this_one"]
 
         hist = history.get_significant_states(
-            self.hass,
-            zero,
-            four,
-            ["media_player.test"],
-            filters=history.Filters(),
-            significant_changes_only=True,
+            self.hass, zero, four, ["media_player.test"], filters=history.Filters(),
         )
         assert states == hist
 
@@ -280,7 +269,6 @@ class TestComponentHistory(unittest.TestCase):
             four,
             ["media_player.test", "thermostat.test"],
             filters=history.Filters(),
-            significant_changes_only=True,
         )
         assert states == hist
 
@@ -525,22 +513,12 @@ class TestComponentHistory(unittest.TestCase):
         zero, four, states = self.record_states()
         entity_ids = ["media_player.test", "media_player.test2"]
         hist = history.get_significant_states(
-            self.hass,
-            zero,
-            four,
-            entity_ids,
-            filters=history.Filters(),
-            significant_changes_only=True,
+            self.hass, zero, four, entity_ids, filters=history.Filters(),
         )
         assert list(hist.keys()) == entity_ids
         entity_ids = ["media_player.test2", "media_player.test"]
         hist = history.get_significant_states(
-            self.hass,
-            zero,
-            four,
-            entity_ids,
-            filters=history.Filters(),
-            significant_changes_only=True,
+            self.hass, zero, four, entity_ids, filters=history.Filters(),
         )
         assert list(hist.keys()) == entity_ids
 
@@ -612,9 +590,7 @@ class TestComponentHistory(unittest.TestCase):
             filters.included_entities = include.get(history.CONF_ENTITIES, [])
             filters.included_domains = include.get(history.CONF_DOMAINS, [])
 
-        hist = history.get_significant_states(
-            self.hass, zero, four, filters=filters, significant_changes_only=True
-        )
+        hist = history.get_significant_states(self.hass, zero, four, filters=filters)
         assert states == hist
 
     def record_states(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nothing breaks


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add device_tracker states to history only if the location is really different

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- This PR is related to another PR: https://github.com/home-assistant/frontend/pull/5331

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
