### PR TITLE
Add ability to specify group when creating user

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -215,12 +215,14 @@ class AuthManager:
 
         return user
 
-    async def async_create_user(self, name: str) -> models.User:
+    async def async_create_user(
+        self, name: str, group_ids: Optional[List[str]] = None
+    ) -> models.User:
         """Create a user."""
         kwargs: Dict[str, Any] = {
             "name": name,
             "is_active": True,
-            "group_ids": [GROUP_ID_ADMIN],
+            "group_ids": group_ids or [GROUP_ID_ADMIN],
         }
 
         if await self._user_should_be_owner():

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -222,7 +222,7 @@ class AuthManager:
         kwargs: Dict[str, Any] = {
             "name": name,
             "is_active": True,
-            "group_ids": group_ids or [GROUP_ID_ADMIN],
+            "group_ids": group_ids or [],
         }
 
         if await self._user_should_be_owner():

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -3,6 +3,7 @@ import asyncio
 
 import voluptuous as vol
 
+from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import callback
@@ -99,7 +100,7 @@ class UserOnboardingView(_BaseOnboardingView):
             provider = _async_get_hass_provider(hass)
             await provider.async_initialize()
 
-            user = await hass.auth.async_create_user(data["name"])
+            user = await hass.auth.async_create_user(data["name"], [GROUP_ID_ADMIN])
             await hass.async_add_executor_job(
                 provider.data.add_auth, data["username"], data["password"]
             )

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -899,8 +899,8 @@ async def test_async_remove_user(hass):
     assert events[0].data["user_id"] == user.id
 
 
-async def test_new_users_admin(mock_hass):
-    """Test newly created users are admin."""
+async def test_new_users(mock_hass):
+    """Test newly created users."""
     manager = await auth.auth_manager_from_config(
         mock_hass,
         [
@@ -911,7 +911,17 @@ async def test_new_users_admin(mock_hass):
                         "username": "test-user",
                         "password": "test-pass",
                         "name": "Test Name",
-                    }
+                    },
+                    {
+                        "username": "test-user-2",
+                        "password": "test-pass",
+                        "name": "Test Name",
+                    },
+                    {
+                        "username": "test-user-3",
+                        "password": "test-pass",
+                        "name": "Test Name",
+                    },
                 ],
             }
         ],
@@ -920,7 +930,18 @@ async def test_new_users_admin(mock_hass):
     ensure_auth_manager_loaded(manager)
 
     user = await manager.async_create_user("Hello")
+    # first user in the system is owner and admin
+    assert user.is_owner
     assert user.is_admin
+    assert user.groups == []
+
+    user = await manager.async_create_user("Hello 2")
+    assert not user.is_admin
+    assert user.groups == []
+
+    user = await manager.async_create_user("Hello 3", ["system-admin"])
+    assert user.is_admin
+    assert user.groups[0].id == "system-admin"
 
     user_cred = await manager.async_get_or_create_user(
         auth_models.Credentials(

--- a/tests/components/config/test_auth.py
+++ b/tests/components/config/test_auth.py
@@ -156,9 +156,7 @@ async def test_create(hass, hass_ws_client, hass_access_token):
 
     assert len(await hass.auth.async_get_users()) == 1
 
-    await client.send_json(
-        {"id": 5, "type": auth_config.WS_TYPE_CREATE, "name": "Paulus"}
-    )
+    await client.send_json({"id": 5, "type": "config/auth/create", "name": "Paulus"})
 
     result = await client.receive_json()
     assert result["success"], result
@@ -176,7 +174,7 @@ async def test_create_requires_admin(hass, hass_ws_client, hass_read_only_access
     """Test create command requires an admin."""
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
-    await client.send_json({"id": 5, "type": auth_config.WS_TYPE_CREATE, "name": "YO"})
+    await client.send_json({"id": 5, "type": "config/auth/create", "name": "YO"})
 
     result = await client.receive_json()
     assert not result["success"], result


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add ability to specify a group when creating a new user

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
