### PR TITLE
Update ZHA group entity when Zigbee group membership changes

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -208,6 +208,7 @@ SIGNAL_SET_LEVEL = "set_level"
 SIGNAL_STATE_ATTR = "update_state_attribute"
 SIGNAL_UPDATE_DEVICE = "{}_zha_update_device"
 SIGNAL_REMOVE_GROUP = "remove_group"
+SIGNAL_GROUP_MEMBERSHIP_CHANGE = "group_membership_change"
 
 UNKNOWN = "unknown"
 UNKNOWN_MANUFACTURER = "unk_manufacturer"

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -52,6 +52,7 @@ from .const import (
     DEFAULT_DATABASE_NAME,
     DOMAIN,
     SIGNAL_ADD_ENTITIES,
+    SIGNAL_GROUP_MEMBERSHIP_CHANGE,
     SIGNAL_REMOVE,
     SIGNAL_REMOVE_GROUP,
     UNKNOWN_MANUFACTURER,
@@ -256,6 +257,9 @@ class ZHAGateway:
         zha_group = self._async_get_or_create_group(zigpy_group)
         zha_group.info("group_member_removed - endpoint: %s", endpoint)
         self._send_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_REMOVED)
+        async_dispatcher_send(
+            self._hass, f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_{zigpy_group.group_id}"
+        )
 
     def group_member_added(
         self, zigpy_group: ZigpyGroupType, endpoint: ZigpyEndpointType
@@ -265,6 +269,9 @@ class ZHAGateway:
         zha_group = self._async_get_or_create_group(zigpy_group)
         zha_group.info("group_member_added - endpoint: %s", endpoint)
         self._send_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_ADDED)
+        async_dispatcher_send(
+            self._hass, f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_{zigpy_group.group_id}"
+        )
 
     def group_added(self, zigpy_group: ZigpyGroupType) -> None:
         """Handle zigpy group added event."""

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -3,12 +3,13 @@
 import asyncio
 import logging
 import time
-from typing import Any, Awaitable, Dict, List
+from typing import Any, Awaitable, Dict, List, Optional
 
-from homeassistant.core import callback
+from homeassistant.core import CALLBACK_TYPE, State, callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .core.const import (
@@ -18,7 +19,9 @@ from .core.const import (
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
     DOMAIN,
+    SIGNAL_GROUP_MEMBERSHIP_CHANGE,
     SIGNAL_REMOVE,
+    SIGNAL_REMOVE_GROUP,
 )
 from .core.helpers import LogMixin
 from .core.typing import CALLABLE_T, ChannelsType, ChannelType, ZhaDeviceType
@@ -213,3 +216,71 @@ class ZhaEntity(BaseZhaEntity):
         for channel in self.cluster_channels.values():
             if hasattr(channel, "async_update"):
                 await channel.async_update()
+
+
+class ZhaGroupEntity(BaseZhaEntity):
+    """A base class for ZHA group entities."""
+
+    def __init__(
+        self, entity_ids: List[str], unique_id: str, group_id: int, zha_device, **kwargs
+    ) -> None:
+        """Initialize a light group."""
+        super().__init__(unique_id, zha_device, **kwargs)
+        self._name = f"{zha_device.gateway.groups.get(group_id).name}_group_{group_id}"
+        self._group_id: int = group_id
+        self._entity_ids: List[str] = entity_ids
+        self._async_unsub_state_changed: Optional[CALLBACK_TYPE] = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+        await self.async_accept_signal(
+            None,
+            f"{SIGNAL_REMOVE_GROUP}_{self._group_id}",
+            self.async_remove,
+            signal_override=True,
+        )
+
+        await self.async_accept_signal(
+            None,
+            f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_{self._group_id}",
+            self._update_group_entities,
+            signal_override=True,
+        )
+
+        @callback
+        def async_state_changed_listener(
+            entity_id: str, old_state: State, new_state: State
+        ):
+            """Handle child updates."""
+            self.async_schedule_update_ha_state(True)
+
+        self._async_unsub_state_changed = async_track_state_change(
+            self.hass, self._entity_ids, async_state_changed_listener
+        )
+        await self.async_update()
+
+    def _update_group_entities(self):
+        """Update tracked entities when membership changes."""
+        group = self.zha_device.gateway.get_group(self._group_id)
+        self._entity_ids = group.get_domain_entity_ids(self.platform.domain)
+        if self._async_unsub_state_changed is not None:
+            self._async_unsub_state_changed()
+
+        @callback
+        def async_state_changed_listener(
+            entity_id: str, old_state: State, new_state: State
+        ):
+            """Handle child updates."""
+            self.async_schedule_update_ha_state(True)
+
+        self._async_unsub_state_changed = async_track_state_change(
+            self.hass, self._entity_ids, async_state_changed_listener
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Handle removal from Home Assistant."""
+        await super().async_will_remove_from_hass()
+        if self._async_unsub_state_changed is not None:
+            self._async_unsub_state_changed()
+            self._async_unsub_state_changed = None

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -284,3 +284,7 @@ class ZhaGroupEntity(BaseZhaEntity):
         if self._async_unsub_state_changed is not None:
             self._async_unsub_state_changed()
             self._async_unsub_state_changed = None
+
+    async def async_update(self) -> None:
+        """Update the state of the group entity."""
+        pass

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -1,7 +1,7 @@
 """Fans on Zigbee Home Automation networks."""
 import functools
 import logging
-from typing import List, Optional
+from typing import List
 
 from zigpy.exceptions import DeliveryError
 import zigpy.zcl.clusters.hvac as hvac
@@ -16,9 +16,8 @@ from homeassistant.components.fan import (
     FanEntity,
 )
 from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import CALLBACK_TYPE, State, callback
+from homeassistant.core import State, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.event import async_track_state_change
 
 from .core import discovery
 from .core.const import (
@@ -27,10 +26,9 @@ from .core.const import (
     DATA_ZHA_DISPATCHERS,
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
-    SIGNAL_REMOVE_GROUP,
 )
 from .core.registries import ZHA_ENTITIES
-from .entity import BaseZhaEntity, ZhaEntity
+from .entity import ZhaEntity, ZhaGroupEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,7 +71,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
-class BaseFan(BaseZhaEntity, FanEntity):
+class BaseFan(FanEntity):
     """Base representation of a ZHA fan."""
 
     def __init__(self, *args, **kwargs):
@@ -122,7 +120,7 @@ class BaseFan(BaseZhaEntity, FanEntity):
 
 
 @STRICT_MATCH(channel_names=CHANNEL_FAN)
-class ZhaFan(ZhaEntity, BaseFan):
+class ZhaFan(BaseFan, ZhaEntity):
     """Representation of a ZHA fan."""
 
     def __init__(self, unique_id, zha_device, channels, **kwargs):
@@ -158,19 +156,15 @@ class ZhaFan(ZhaEntity, BaseFan):
 
 
 @GROUP_MATCH()
-class FanGroup(BaseFan):
+class FanGroup(BaseFan, ZhaGroupEntity):
     """Representation of a fan group."""
 
     def __init__(
         self, entity_ids: List[str], unique_id: str, group_id: int, zha_device, **kwargs
     ) -> None:
         """Initialize a fan group."""
-        super().__init__(unique_id, zha_device, **kwargs)
-        self._name: str = f"{zha_device.gateway.groups.get(group_id).name}_group_{group_id}"
-        self._group_id: int = group_id
+        super().__init__(entity_ids, unique_id, group_id, zha_device, **kwargs)
         self._available: bool = False
-        self._entity_ids: List[str] = entity_ids
-        self._async_unsub_state_changed: Optional[CALLBACK_TYPE] = None
         group = self.zha_device.gateway.get_group(self._group_id)
         self._fan_channel = group.endpoint[hvac.Fan.cluster_id]
 
@@ -184,35 +178,6 @@ class FanGroup(BaseFan):
                 return
 
         self._fan_channel.async_set_speed = async_set_speed
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await super().async_added_to_hass()
-        await self.async_accept_signal(
-            None,
-            f"{SIGNAL_REMOVE_GROUP}_{self._group_id}",
-            self.async_remove,
-            signal_override=True,
-        )
-
-        @callback
-        def async_state_changed_listener(
-            entity_id: str, old_state: State, new_state: State
-        ):
-            """Handle child updates."""
-            self.async_schedule_update_ha_state(True)
-
-        self._async_unsub_state_changed = async_track_state_change(
-            self.hass, self._entity_ids, async_state_changed_listener
-        )
-        await self.async_update()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Handle removal from Home Assistant."""
-        await super().async_will_remove_from_hass()
-        if self._async_unsub_state_changed is not None:
-            self._async_unsub_state_changed()
-            self._async_unsub_state_changed = None
 
     async def async_update(self):
         """Attempt to retrieve on off state from the fan."""

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -118,6 +118,11 @@ class BaseFan(FanEntity):
         await self._fan_channel.async_set_speed(SPEED_TO_VALUE[speed])
         self.async_set_state(0, "fan_mode", speed)
 
+    @callback
+    def async_set_state(self, attr_id, attr_name, value):
+        """Handle state update from channel."""
+        pass
+
 
 @STRICT_MATCH(channel_names=CHANNEL_FAN)
 class ZhaFan(BaseFan, ZhaEntity):

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -30,12 +30,9 @@ from homeassistant.components.light import (
     SUPPORT_WHITE_VALUE,
 )
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_ON, STATE_UNAVAILABLE
-from homeassistant.core import CALLBACK_TYPE, State, callback
+from homeassistant.core import State, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.event import (
-    async_track_state_change,
-    async_track_time_interval,
-)
+from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.util.color as color_util
 
 from .core import discovery, helpers
@@ -50,12 +47,11 @@ from .core.const import (
     EFFECT_DEFAULT_VARIANT,
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
-    SIGNAL_REMOVE_GROUP,
     SIGNAL_SET_LEVEL,
 )
 from .core.registries import ZHA_ENTITIES
 from .core.typing import ZhaDeviceType
-from .entity import BaseZhaEntity, ZhaEntity
+from .entity import ZhaEntity, ZhaGroupEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,7 +96,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
-class BaseLight(BaseZhaEntity, light.Light):
+class BaseLight(light.Light):
     """Operations common to all light entities."""
 
     def __init__(self, *args, **kwargs):
@@ -307,7 +303,7 @@ class BaseLight(BaseZhaEntity, light.Light):
 
 
 @STRICT_MATCH(channel_names=CHANNEL_ON_OFF, aux_channels={CHANNEL_COLOR, CHANNEL_LEVEL})
-class Light(ZhaEntity, BaseLight):
+class Light(BaseLight, ZhaEntity):
     """Representation of a ZHA or ZLL light."""
 
     _REFRESH_INTERVAL = (45, 75)
@@ -471,52 +467,19 @@ class HueLight(Light):
 
 
 @GROUP_MATCH()
-class LightGroup(BaseLight):
+class LightGroup(BaseLight, ZhaGroupEntity):
     """Representation of a light group."""
 
     def __init__(
         self, entity_ids: List[str], unique_id: str, group_id: int, zha_device, **kwargs
     ) -> None:
         """Initialize a light group."""
-        super().__init__(unique_id, zha_device, **kwargs)
-        self._name = f"{zha_device.gateway.groups.get(group_id).name}_group_{group_id}"
-        self._group_id: int = group_id
-        self._entity_ids: List[str] = entity_ids
+        super().__init__(entity_ids, unique_id, group_id, zha_device, **kwargs)
         group = self.zha_device.gateway.get_group(self._group_id)
         self._on_off_channel = group.endpoint[OnOff.cluster_id]
         self._level_channel = group.endpoint[LevelControl.cluster_id]
         self._color_channel = group.endpoint[Color.cluster_id]
         self._identify_channel = group.endpoint[Identify.cluster_id]
-        self._async_unsub_state_changed: Optional[CALLBACK_TYPE] = None
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await super().async_added_to_hass()
-        await self.async_accept_signal(
-            None,
-            f"{SIGNAL_REMOVE_GROUP}_{self._group_id}",
-            self.async_remove,
-            signal_override=True,
-        )
-
-        @callback
-        def async_state_changed_listener(
-            entity_id: str, old_state: State, new_state: State
-        ):
-            """Handle child updates."""
-            self.async_schedule_update_ha_state(True)
-
-        self._async_unsub_state_changed = async_track_state_change(
-            self.hass, self._entity_ids, async_state_changed_listener
-        )
-        await self.async_update()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Handle removal from Home Assistant."""
-        await super().async_will_remove_from_hass()
-        if self._async_unsub_state_changed is not None:
-            self._async_unsub_state_changed()
-            self._async_unsub_state_changed = None
 
     async def async_update(self) -> None:
         """Query all members and determine the light group state."""

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -97,7 +97,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
-class BaseLight(light.Light, LogMixin):
+class BaseLight(LogMixin, light.Light):
     """Operations common to all light entities."""
 
     def __init__(self, *args, **kwargs):

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -49,6 +49,7 @@ from .core.const import (
     SIGNAL_ATTR_UPDATED,
     SIGNAL_SET_LEVEL,
 )
+from .core.helpers import LogMixin
 from .core.registries import ZHA_ENTITIES
 from .core.typing import ZhaDeviceType
 from .entity import ZhaEntity, ZhaGroupEntity
@@ -96,7 +97,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 
 
-class BaseLight(light.Light):
+class BaseLight(light.Light, LogMixin):
     """Operations common to all light entities."""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates ZHA group entitles when group membership changes. It also removes a fair amount of code duplication between the supported domains. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
