### PR TITLE
Enable KNX tunnel auto_reconnect by default

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -29,8 +29,6 @@ CONF_KNX_CONFIG = "config_file"
 CONF_KNX_ROUTING = "routing"
 CONF_KNX_TUNNELING = "tunneling"
 CONF_KNX_LOCAL_IP = "local_ip"
-CONF_KNX_AUTO_RECONNECT = "auto_reconnect"
-CONF_KNX_AUTO_RECONNECT_WAIT = "auto_reconnect_wait"
 CONF_KNX_FIRE_EVENT = "fire_event"
 CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
 CONF_KNX_STATE_UPDATER = "state_updater"
@@ -38,9 +36,6 @@ CONF_KNX_RATE_LIMIT = "rate_limit"
 CONF_KNX_EXPOSE = "expose"
 CONF_KNX_EXPOSE_TYPE = "type"
 CONF_KNX_EXPOSE_ADDRESS = "address"
-
-DEFAULT_KNX_AUTO_RECONNECT = True
-DEFAULT_KNX_AUTO_RECONNECT_WAIT = 3
 
 SERVICE_KNX_SEND = "send"
 SERVICE_KNX_ATTR_ADDRESS = "address"
@@ -51,12 +46,6 @@ ATTR_DISCOVER_DEVICES = "devices"
 TUNNELING_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(
-            CONF_KNX_AUTO_RECONNECT, default=DEFAULT_KNX_AUTO_RECONNECT
-        ): cv.boolean,
-        vol.Optional(
-            CONF_KNX_AUTO_RECONNECT_WAIT, default=DEFAULT_KNX_AUTO_RECONNECT_WAIT
-        ): cv.positive_int,
         vol.Optional(CONF_KNX_LOCAL_IP): cv.string,
         vol.Optional(CONF_PORT): cv.port,
     }
@@ -216,15 +205,9 @@ class KNXModule:
 
     def connection_config_tunneling(self):
         """Return the connection_config if tunneling is configured."""
-        gateway_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_HOST)
+        gateway_ip = self.config[DOMAIN][CONF_KNX_TUNNELING][CONF_HOST]
         gateway_port = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_PORT)
         local_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_KNX_LOCAL_IP)
-        auto_reconnect = self.config[DOMAIN][CONF_KNX_TUNNELING][
-            CONF_KNX_AUTO_RECONNECT
-        ]
-        auto_reconnect_wait = self.config[DOMAIN][CONF_KNX_TUNNELING][
-            CONF_KNX_AUTO_RECONNECT_WAIT
-        ]
         if gateway_port is None:
             gateway_port = DEFAULT_MCAST_PORT
         return ConnectionConfig(
@@ -232,8 +215,7 @@ class KNXModule:
             gateway_ip=gateway_ip,
             gateway_port=gateway_port,
             local_ip=local_ip,
-            auto_reconnect=auto_reconnect,
-            auto_reconnect_wait=auto_reconnect_wait,
+            auto_reconnect=True,
         )
 
     def connection_config_auto(self):

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -216,7 +216,7 @@ class KNXModule:
 
     def connection_config_tunneling(self):
         """Return the connection_config if tunneling is configured."""
-        gateway_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_HOST)
+        gateway_ip = self.config[DOMAIN][CONF_KNX_TUNNELING][CONF_HOST]
         gateway_port = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_PORT)
         local_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_KNX_LOCAL_IP)
         auto_reconnect = self.config[DOMAIN][CONF_KNX_TUNNELING][

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -39,6 +39,9 @@ CONF_KNX_EXPOSE = "expose"
 CONF_KNX_EXPOSE_TYPE = "type"
 CONF_KNX_EXPOSE_ADDRESS = "address"
 
+DEFAULT_KNX_AUTO_RECONNECT = True
+DEFAULT_KNX_AUTO_RECONNECT_WAIT = 3
+
 SERVICE_KNX_SEND = "send"
 SERVICE_KNX_ATTR_ADDRESS = "address"
 SERVICE_KNX_ATTR_PAYLOAD = "payload"
@@ -48,8 +51,12 @@ ATTR_DISCOVER_DEVICES = "devices"
 TUNNELING_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_KNX_AUTO_RECONNECT, default=True): cv.boolean,
-        vol.Optional(CONF_KNX_AUTO_RECONNECT_WAIT, default=3): cv.positive_int,
+        vol.Optional(
+            CONF_KNX_AUTO_RECONNECT, default=DEFAULT_KNX_AUTO_RECONNECT
+        ): cv.boolean,
+        vol.Optional(
+            CONF_KNX_AUTO_RECONNECT_WAIT, default=DEFAULT_KNX_AUTO_RECONNECT_WAIT
+        ): cv.positive_int,
         vol.Optional(CONF_KNX_LOCAL_IP): cv.string,
         vol.Optional(CONF_PORT): cv.port,
     }
@@ -212,12 +219,12 @@ class KNXModule:
         gateway_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_HOST)
         gateway_port = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_PORT)
         local_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_KNX_LOCAL_IP)
-        auto_reconnect = self.config[DOMAIN][CONF_KNX_TUNNELING].get(
+        auto_reconnect = self.config[DOMAIN][CONF_KNX_TUNNELING][
             CONF_KNX_AUTO_RECONNECT
-        )
-        auto_reconnect_wait = self.config[DOMAIN][CONF_KNX_TUNNELING].get(
+        ]
+        auto_reconnect_wait = self.config[DOMAIN][CONF_KNX_TUNNELING][
             CONF_KNX_AUTO_RECONNECT_WAIT
-        )
+        ]
         if gateway_port is None:
             gateway_port = DEFAULT_MCAST_PORT
         return ConnectionConfig(

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -29,6 +29,8 @@ CONF_KNX_CONFIG = "config_file"
 CONF_KNX_ROUTING = "routing"
 CONF_KNX_TUNNELING = "tunneling"
 CONF_KNX_LOCAL_IP = "local_ip"
+CONF_KNX_AUTO_RECONNECT = "auto_reconnect"
+CONF_KNX_AUTO_RECONNECT_WAIT = "auto_reconnect_wait"
 CONF_KNX_FIRE_EVENT = "fire_event"
 CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
 CONF_KNX_STATE_UPDATER = "state_updater"
@@ -46,6 +48,8 @@ ATTR_DISCOVER_DEVICES = "devices"
 TUNNELING_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_KNX_AUTO_RECONNECT, default=True): cv.boolean,
+        vol.Optional(CONF_KNX_AUTO_RECONNECT_WAIT, default=3): cv.positive_int,
         vol.Optional(CONF_KNX_LOCAL_IP): cv.string,
         vol.Optional(CONF_PORT): cv.port,
     }
@@ -208,6 +212,12 @@ class KNXModule:
         gateway_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_HOST)
         gateway_port = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_PORT)
         local_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_KNX_LOCAL_IP)
+        auto_reconnect = self.config[DOMAIN][CONF_KNX_TUNNELING].get(
+            CONF_KNX_AUTO_RECONNECT
+        )
+        auto_reconnect_wait = self.config[DOMAIN][CONF_KNX_TUNNELING].get(
+            CONF_KNX_AUTO_RECONNECT_WAIT
+        )
         if gateway_port is None:
             gateway_port = DEFAULT_MCAST_PORT
         return ConnectionConfig(
@@ -215,6 +225,8 @@ class KNXModule:
             gateway_ip=gateway_ip,
             gateway_port=gateway_port,
             local_ip=local_ip,
+            auto_reconnect=auto_reconnect,
+            auto_reconnect_wait=auto_reconnect_wait,
         )
 
     def connection_config_auto(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR enables auto_reconnect for KNX tunneling code.
The xknx module supports this already but its disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33364
- This PR is related to issue: #33364
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
