### PR TITLE
Add available and state valid property to PulseAudio

### DIFF
--- a/homeassistant/components/pulseaudio_loopback/switch.py
+++ b/homeassistant/components/pulseaudio_loopback/switch.py
@@ -84,6 +84,11 @@ class PAServer:
         self._buffer_size = int(buff_sz)
         self._tcp_timeout = int(tcp_timeout)
 
+    @property
+    def available(self):
+        """Return true if module state was updated."""
+        return len(self._current_module_state)
+
     def _send_command(self, cmd, response_expected):
         """Send a command to the pa server using a socket."""
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -147,12 +152,18 @@ class PALoopbackSwitch(SwitchDevice):
         self._name = name
         self._sink_name = sink_name
         self._source_name = source_name
+        self._available = False
         self._pa_svr = pa_server
 
     @property
     def name(self):
         """Return the name of the switch."""
         return self._name
+
+    @property
+    def available(self):
+        """Return true if Pulse is available and connected."""
+        return self._available
 
     @property
     def is_on(self):
@@ -186,6 +197,11 @@ class PALoopbackSwitch(SwitchDevice):
     def update(self):
         """Refresh state in case an alternate process modified this data."""
         self._pa_svr.update_module_state()
+
+        if not self._pa_svr.available:
+            return
+
         self._module_idx = self._pa_svr.get_module_idx(
             self._sink_name, self._source_name
         )
+        self._available = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Until the first response from the PulseAudio server is received, all switches are reported "off", which is not necessarily the correct representation. This change marks the switch as "not available" until the first valid list of loaded modules

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32016
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
