### PR TITLE
Miscellaneous ZHA code cleanup

### DIFF
--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -398,7 +398,8 @@ class ZHADevice(LogMixin):
     @callback
     def async_update_last_seen(self, last_seen):
         """Set last seen on the zigpy device."""
-        self._zigpy_device.last_seen = last_seen
+        if self._zigpy_device.last_seen is None and last_seen is not None:
+            self._zigpy_device.last_seen = last_seen
 
     @callback
     def async_get_info(self):

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -198,7 +198,7 @@ class GroupProbe:
                     entity_class,
                     (
                         group.get_domain_entity_ids(domain),
-                        f"{domain}_group_{group.group_id}",
+                        f"{domain}_zha_group_0x{group.group_id:04x}",
                         group.group_id,
                         zha_gateway.coordinator_zha_device,
                     ),

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -258,7 +258,7 @@ class ZHAGateway:
         zha_group.info("group_member_removed - endpoint: %s", endpoint)
         self._send_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_REMOVED)
         async_dispatcher_send(
-            self._hass, f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_{zigpy_group.group_id}"
+            self._hass, f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_0x{zigpy_group.group_id:04x}"
         )
 
     def group_member_added(
@@ -270,7 +270,7 @@ class ZHAGateway:
         zha_group.info("group_member_added - endpoint: %s", endpoint)
         self._send_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_ADDED)
         async_dispatcher_send(
-            self._hass, f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_{zigpy_group.group_id}"
+            self._hass, f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_0x{zigpy_group.group_id:04x}"
         )
 
     def group_added(self, zigpy_group: ZigpyGroupType) -> None:
@@ -286,7 +286,7 @@ class ZHAGateway:
         zha_group = self._groups.pop(zigpy_group.group_id, None)
         zha_group.info("group_removed")
         async_dispatcher_send(
-            self._hass, f"{SIGNAL_REMOVE_GROUP}_{zigpy_group.group_id}"
+            self._hass, f"{SIGNAL_REMOVE_GROUP}_0x{zigpy_group.group_id:04x}"
         )
 
     def _send_group_gateway_message(

--- a/homeassistant/components/zha/core/store.py
+++ b/homeassistant/components/zha/core/store.py
@@ -78,6 +78,9 @@ class ZhaStorage:
         ieee_str: str = str(device.ieee)
         old = self.devices[ieee_str]
 
+        if old is not None and device.last_seen is None:
+            return
+
         changes = {}
         changes["last_seen"] = device.last_seen
 

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -226,7 +226,9 @@ class ZhaGroupEntity(BaseZhaEntity):
     ) -> None:
         """Initialize a light group."""
         super().__init__(unique_id, zha_device, **kwargs)
-        self._name = f"{zha_device.gateway.groups.get(group_id).name}_group_{group_id}"
+        self._name = (
+            f"{zha_device.gateway.groups.get(group_id).name}_zha_group_0x{group_id:04x}"
+        )
         self._group_id: int = group_id
         self._entity_ids: List[str] = entity_ids
         self._async_unsub_state_changed: Optional[CALLBACK_TYPE] = None
@@ -236,14 +238,14 @@ class ZhaGroupEntity(BaseZhaEntity):
         await super().async_added_to_hass()
         await self.async_accept_signal(
             None,
-            f"{SIGNAL_REMOVE_GROUP}_{self._group_id}",
+            f"{SIGNAL_REMOVE_GROUP}_0x{self._group_id:04x}",
             self.async_remove,
             signal_override=True,
         )
 
         await self.async_accept_signal(
             None,
-            f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_{self._group_id}",
+            f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_0x{self._group_id:04x}",
             self._update_group_entities,
             signal_override=True,
         )

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -248,17 +248,17 @@ class ZhaGroupEntity(BaseZhaEntity):
             signal_override=True,
         )
 
-        @callback
-        def async_state_changed_listener(
-            entity_id: str, old_state: State, new_state: State
-        ):
-            """Handle child updates."""
-            self.async_schedule_update_ha_state(True)
-
         self._async_unsub_state_changed = async_track_state_change(
-            self.hass, self._entity_ids, async_state_changed_listener
+            self.hass, self._entity_ids, self.async_state_changed_listener
         )
         await self.async_update()
+
+    @callback
+    def async_state_changed_listener(
+        self, entity_id: str, old_state: State, new_state: State
+    ):
+        """Handle child updates."""
+        self.async_schedule_update_ha_state(True)
 
     def _update_group_entities(self):
         """Update tracked entities when membership changes."""
@@ -267,15 +267,8 @@ class ZhaGroupEntity(BaseZhaEntity):
         if self._async_unsub_state_changed is not None:
             self._async_unsub_state_changed()
 
-        @callback
-        def async_state_changed_listener(
-            entity_id: str, old_state: State, new_state: State
-        ):
-            """Handle child updates."""
-            self.async_schedule_update_ha_state(True)
-
         self._async_unsub_state_changed = async_track_state_change(
-            self.hass, self._entity_ids, async_state_changed_listener
+            self.hass, self._entity_ids, self.async_state_changed_listener
         )
 
     async def async_will_remove_from_hass(self) -> None:

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -159,9 +159,7 @@ async def find_entity_id(domain, zha_device, hass):
 
 def async_find_group_entity_id(hass, domain, group):
     """Find the group entity id under test."""
-    entity_id = (
-        f"{domain}.{group.name.lower().replace(' ','_')}_group_0x{group.group_id:04x}"
-    )
+    entity_id = f"{domain}.{group.name.lower().replace(' ','_')}_zha_group_0x{group.group_id:04x}"
 
     entity_ids = hass.states.async_entity_ids(domain)
 

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -1,5 +1,6 @@
 """Test ZHA Gateway."""
 import logging
+import time
 
 import pytest
 import zigpy.profiles.zha as zha
@@ -167,3 +168,40 @@ async def test_gateway_group_methods(hass, device_light_1, device_light_2, coord
 
     # the group entity should not have been cleaned up
     assert entity_id not in hass.states.async_entity_ids(LIGHT_DOMAIN)
+
+
+async def test_updating_device_store(hass, zigpy_dev_basic, zha_dev_basic):
+    """Test saving data after a delay."""
+    zha_gateway = get_zha_gateway(hass)
+    assert zha_gateway is not None
+    await async_enable_traffic(hass, [zha_dev_basic])
+
+    assert zha_dev_basic.last_seen is not None
+    entry = zha_gateway.zha_storage.async_get_or_create_device(zha_dev_basic)
+    assert entry.last_seen == zha_dev_basic.last_seen
+
+    assert zha_dev_basic.last_seen is not None
+    last_seen = zha_dev_basic.last_seen
+
+    # test that we can't set None as last seen any more
+    zha_dev_basic.async_update_last_seen(None)
+    assert last_seen == zha_dev_basic.last_seen
+
+    # test that we won't put None in storage
+    zigpy_dev_basic.last_seen = None
+    assert zha_dev_basic.last_seen is None
+    await zha_gateway.async_update_device_storage()
+    await hass.async_block_till_done()
+    entry = zha_gateway.zha_storage.async_get_or_create_device(zha_dev_basic)
+    assert entry.last_seen == last_seen
+
+    # test that we can still set a good last_seen
+    last_seen = time.time()
+    zha_dev_basic.async_update_last_seen(last_seen)
+    assert last_seen == zha_dev_basic.last_seen
+
+    # test that we still put good values in storage
+    await zha_gateway.async_update_device_storage()
+    await hass.async_block_till_done()
+    entry = zha_gateway.zha_storage.async_get_or_create_device(zha_dev_basic)
+    assert entry.last_seen == last_seen


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up a few small nits in ZHA. 

- Address comment: https://github.com/home-assistant/core/pull/33378#discussion_r399786220 
- Update group entity name and make group entity unique_id unique
- Add guards for last_seen handling with tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/33378#discussion_r399786220 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
