### PR TITLE
Add additional Plex test to IGNORE_UNCAUGHT_EXCEPTIONS list

### DIFF
--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -112,6 +112,7 @@ IGNORE_UNCAUGHT_EXCEPTIONS = [
     ("tests.components.plex.test_init", "test_set_config_entry_unique_id"),
     ("tests.components.plex.test_init", "test_setup_with_insecure_config_entry"),
     ("tests.components.plex.test_init", "test_setup_with_photo_session"),
+    ("tests.components.plex.test_init", "test_setup_when_certificate_changed"),
     ("tests.components.plex.test_server", "test_new_users_available"),
     ("tests.components.plex.test_server", "test_new_ignored_users_available"),
     ("tests.components.plex.test_server", "test_mark_sessions_idle"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds an additional Plex test to the ignore uncaught exceptions list to fix dev builds. Currently builds: #33391, #33393, #33395 are failing with this:

```
request = <SubRequest 'hass' for <Function test_setup_when_certificate_changed[pyloop]>>

    @pytest.fixture
    def hass(loop, hass_storage, request):
        """Fixture to provide a test instance of Home Assistant."""
    
        def exc_handle(loop, context):
            """Handle exceptions by rethrowing them, which will fail the test."""
            exceptions.append(context["exception"])
            orig_exception_handler(loop, context)
    
        exceptions = []
        hass = loop.run_until_complete(async_test_home_assistant(loop))
        orig_exception_handler = loop.get_exception_handler()
        loop.set_exception_handler(exc_handle)
    
        yield hass
    
        loop.run_until_complete(hass.async_stop(force=True))
        for ex in exceptions:
            if (
                request.module.__name__,
                request.function.__name__,
            ) in IGNORE_UNCAUGHT_EXCEPTIONS:
                continue
            if isinstance(ex, ServiceNotFound):
                continue
>           raise ex

tests/conftest.py:107: 


/usr/local/lib/python3.7/concurrent/futures/thread.py:57: in run
    result = self.fn(*self.args, **self.kwargs)
homeassistant/components/plex/__init__.py:199: in close_websocket_session
    websocket.close()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <plexwebsocket.PlexWebsocket object at 0x7f3a84466ba8>

    def close(self):
        """Close the listening websocket."""
        self._active = False
>       self._current_task.cancel()
E       AttributeError: 'NoneType' object has no attribute 'cancel'

venv/lib/python3.7/site-packages/plexwebsocket.py:156: AttributeError

```

It looks like a guard is needed around `self._current_task.cancel()` in close on `PlexWebsocket` but that is in a lib and would require a lib update. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
