### PR TITLE
Add support for Broadlink BG1 devices

### DIFF
--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -142,8 +142,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         broadlink_device = broadlink.bg1((ip_addr, 80), mac_addr, None)
         switches = []
         parent_device = BroadlinkBG1Switch(broadlink_device, retry_times)
-        switches.append(BroadlinkBG1Slot(friendly_name + " left", broadlink_device, 1, parent_device, retry_times))
-        switches.append(BroadlinkBG1Slot(friendly_name + " right", broadlink_device, 2, parent_device, retry_times))
+        switches.append(
+            BroadlinkBG1Slot(
+                friendly_name + " left", broadlink_device, 1, parent_device, retry_times
+            )
+        )
+        switches.append(
+            BroadlinkBG1Slot(
+                friendly_name + " right",
+                broadlink_device,
+                2,
+                parent_device,
+                retry_times,
+            )
+        )
 
     broadlink_device.timeout = config.get(CONF_TIMEOUT)
     try:
@@ -508,13 +520,9 @@ class BroadlinkBG1Switch:
         """Update the state of the device."""
         states = None
         try:
-            # states = self._device.check_power()
             resp = self._device.get_state()
             if resp is not None:
-                states = {
-                    "s1": resp["pwr1"],  # Left
-                    "s2": resp["pwr2"]   # Right
-                }
+                states = {"s1": resp["pwr1"], "s2": resp["pwr2"]}  # Left  # Right
                 _LOGGER.debug(states)
         except (socket.timeout, ValueError) as error:
             _LOGGER.debug("Polling timeout, trying again: %s", retry)

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -89,7 +89,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Broadlink switches."""
-
     devices = config.get(CONF_SWITCHES)
     slots = config.get("slots", {})
     ip_addr = config.get(CONF_HOST)
@@ -433,17 +432,16 @@ class BroadlinkBG1Slot(BroadlinkRMSwitch):
 
     def _turn_on_off(self, state):
         if self._slot == 1:
-            r = self._device.set_state(pwr1=int(state))
+            res = self._device.set_state(pwr1=int(state))
         else:
-            r = self._device.set_state(pwr2=int(state))
-        if r:
-            _LOGGER.debug("Setting device state: " + str(r))
+            res = self._device.set_state(pwr2=int(state))
+        if res:
+            _LOGGER.debug("Setting device state: %s", res)
             self._state = int(state)
             self._parent_device.set_outlet_status(self._slot, int(state))
             self.schedule_update_ha_state()
         else:
-            _LOGGER.warn("No response from switch")
-
+            _LOGGER.warning("No response from switch")
 
     def _sendpacket(self, packet, retry):
         """Send packet to device."""
@@ -467,8 +465,8 @@ class BroadlinkBG1Slot(BroadlinkRMSwitch):
 
     @property
     def slot(self):
+        """Return the slot."""
         return self._slot
-
 
     def update(self):
         """Trigger update for all switches on the parent device."""
@@ -519,7 +517,7 @@ class BroadlinkBG1Switch:
                 }
                 _LOGGER.debug(states)
         except (socket.timeout, ValueError) as error:
-            _LOGGER.debug(f"Polling timeout, trying again: {retry}")
+            _LOGGER.debug("Polling timeout, trying again: %s", retry)
             if retry < 1:
                 _LOGGER.error("Error during updating the state: %s", error)
                 self._states = None


### PR DESCRIPTION
## Proposed change
This adds support for the British General Broadlink BG1 switches. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
switch:
- platform: custom_broadlink
  host: 192.168.0.123
  mac: "24:df:a7:aa:bb:cc"
  type: bg1
  friendly_name: "Hall socket"
  timeout: 2
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12540

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
