### PR TITLE
Ignore link local addresses during doorbird ssdp config flow

### DIFF
--- a/homeassistant/components/doorbird/.translations/en.json
+++ b/homeassistant/components/doorbird/.translations/en.json
@@ -1,34 +1,36 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "This DoorBird is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect, please try again",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "host": "Host (IP Address)",
-                    "name": "Device Name",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "title": "Connect to the DoorBird"
+   "options" : {
+      "step" : {
+         "init" : {
+            "data" : {
+               "events" : "Comma separated list of events."
+            },
+            "description" : "Add an comma separated event name for each event you wish to track. After entering them here, use the DoorBird app to assign them to a specific event. See the documentation at https://www.home-assistant.io/integrations/doorbird/#events. Example: somebody_pressed_the_button, motion"
+         }
+      }
+   },
+   "config" : {
+      "step" : {
+         "user" : {
+            "title" : "Connect to the DoorBird",
+            "data" : {
+               "password" : "Password",
+               "host" : "Host (IP Address)",
+               "name" : "Device Name",
+               "username" : "Username"
             }
-        },
-        "title": "DoorBird"
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "events": "Comma separated list of events."
-                },
-                "description": "Add an comma separated event name for each event you wish to track. After entering them here, use the DoorBird app to assign them to a specific event. See the documentation at https://www.home-assistant.io/integrations/doorbird/#events. Example: somebody_pressed_the_button, motion"
-            }
-        }
-    }
+         }
+      },
+      "abort" : {
+         "already_configured" : "This DoorBird is already configured",
+         "link_local_address": "Link local addresses are not supported",
+         "not_doorbird_device": "This device is not a DoorBird"
+      },
+      "title" : "DoorBird",
+      "error" : {
+         "invalid_auth" : "Invalid authentication",
+         "unknown" : "Unexpected error",
+         "cannot_connect" : "Failed to connect, please try again"
+      }
+   }
 }

--- a/homeassistant/components/doorbird/config_flow.py
+++ b/homeassistant/components/doorbird/config_flow.py
@@ -90,6 +90,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if macaddress[:6] != DOORBIRD_OUI:
             return self.async_abort(reason="not_doorbird_device")
+        if discovery_info[CONF_HOST].startswith("169.254"):
+            return self.async_abort(reason="link_local_address")
 
         await self.async_set_unique_id(macaddress)
 

--- a/homeassistant/components/doorbird/strings.json
+++ b/homeassistant/components/doorbird/strings.json
@@ -22,7 +22,9 @@
          }
       },
       "abort" : {
-         "already_configured" : "This DoorBird is already configured"
+         "already_configured" : "This DoorBird is already configured",
+         "link_local_address": "Link local addresses are not supported",
+         "not_doorbird_device": "This device is not a DoorBird"
       },
       "title" : "DoorBird",
       "error" : {


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ignore link local addresses during doorbird ssdp config flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
