### PR TITLE
Fix ZHA IAS warning device commands

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -950,6 +950,15 @@ def async_load_api(hass):
         schema=SERVICE_SCHEMAS[SERVICE_ISSUE_ZIGBEE_GROUP_COMMAND],
     )
 
+    def _get_ias_wd_channel(zha_device):
+        """Get the IASWD channel for a device."""
+        cluster_channels = {
+            ch.name: ch
+            for pool in zha_device.channels.pools
+            for ch in pool.claimed_channels.values()
+        }
+        return cluster_channels.get(CHANNEL_IAS_WD)
+
     async def warning_device_squawk(service):
         """Issue the squawk command for an IAS warning device."""
         ieee = service.data[ATTR_IEEE]
@@ -959,9 +968,9 @@ def async_load_api(hass):
 
         zha_device = zha_gateway.get_device(ieee)
         if zha_device is not None:
-            channel = zha_device.cluster_channels.get(CHANNEL_IAS_WD)
+            channel = _get_ias_wd_channel(zha_device)
             if channel:
-                await channel.squawk(mode, strobe, level)
+                await channel.issue_squawk(mode, strobe, level)
             else:
                 _LOGGER.error(
                     "Squawking IASWD: %s: [%s] is missing the required IASWD channel!",
@@ -1003,9 +1012,9 @@ def async_load_api(hass):
 
         zha_device = zha_gateway.get_device(ieee)
         if zha_device is not None:
-            channel = zha_device.cluster_channels.get(CHANNEL_IAS_WD)
+            channel = _get_ias_wd_channel(zha_device)
             if channel:
-                await channel.start_warning(
+                await channel.issue_start_warning(
                     mode, strobe, level, duration, duty_mode, intensity
                 )
             else:

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -51,7 +51,7 @@ class IasWd(ZigbeeChannel):
         """Get the specified bit from the value."""
         return (value & (1 << bit)) != 0
 
-    async def squawk(
+    async def issue_squawk(
         self,
         mode=WARNING_DEVICE_SQUAWK_MODE_ARMED,
         strobe=WARNING_DEVICE_STROBE_YES,
@@ -76,7 +76,7 @@ class IasWd(ZigbeeChannel):
 
         await self.squawk(value)
 
-    async def start_warning(
+    async def issue_start_warning(
         self,
         mode=WARNING_DEVICE_MODE_EMERGENCY,
         strobe=WARNING_DEVICE_STROBE_YES,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR corrects an issue with getting the `IasWd` channel for the IAS WD commands that was introduced in a recent refactoring and it also corrects a recursive calling issue caused by the command names themselves. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
