### PR TITLE
Add konnected multi output

### DIFF
--- a/homeassistant/components/konnected/.translations/en.json
+++ b/homeassistant/components/konnected/.translations/en.json
@@ -33,6 +33,7 @@
         "abort": {
             "not_konn_panel": "Not a recognized Konnected.io device"
         },
+        "error": {},
         "step": {
             "options_binary": {
                 "data": {
@@ -91,11 +92,12 @@
                 "data": {
                     "activation": "Output when on",
                     "momentary": "Pulse duration (ms) (optional)",
+                    "more_states": "Configure additional states for this zone",
                     "name": "Name (optional)",
                     "pause": "Pause between pulses (ms) (optional)",
                     "repeat": "Times to repeat (-1=infinite) (optional)"
                 },
-                "description": "Please select the output options for {zone}",
+                "description": "Please select the output options for {zone}: state {state}",
                 "title": "Configure Switchable Output"
             }
         },

--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -731,11 +731,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         for key, value in self.io_cfg.items():
             if value == CONF_IO_SWI:
                 self.active_cfg = key
-                self.current_states = list(
+                self.current_states = [
                     cfg
                     for cfg in self.current_opt.get(CONF_SWITCHES, [])
                     if cfg[CONF_ZONE] == self.active_cfg
-                )
+                ]
                 current_cfg = next(iter(self.current_states), {})
                 self.current_state = 1
                 return self.async_show_form(

--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -121,7 +121,7 @@ SWITCH_SCHEMA = vol.Schema(
         vol.Required(CONF_ZONE): vol.In(ZONES),
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_ACTIVATION, default=STATE_HIGH): vol.All(
-            vol.Lower, vol.Any(STATE_HIGH, STATE_LOW)
+            vol.Lower, vol.In([STATE_HIGH, STATE_LOW])
         ),
         vol.Optional(CONF_MOMENTARY): vol.All(vol.Coerce(int), vol.Range(min=10)),
         vol.Optional(CONF_PAUSE): vol.All(vol.Coerce(int), vol.Range(min=10)),
@@ -681,7 +681,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
             # only go to next zone if all states are entered
             self.current_state += 1
-            if user_input[CONF_MORE_STATES] is CONF_NO:
+            if user_input[CONF_MORE_STATES] == CONF_NO:
                 self.io_cfg.pop(self.active_cfg)
                 self.active_cfg = None
 
@@ -697,7 +697,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         vol.Optional(
                             CONF_ACTIVATION,
                             default=current_cfg.get(CONF_ACTIVATION, STATE_HIGH),
-                        ): vol.All(vol.Lower, vol.Any(STATE_HIGH, STATE_LOW)),
+                        ): vol.All(vol.Lower, vol.In([STATE_HIGH, STATE_LOW])),
                         vol.Optional(
                             CONF_MOMENTARY,
                             default=current_cfg.get(CONF_MOMENTARY, vol.UNDEFINED),
@@ -715,7 +715,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             default=CONF_YES
                             if len(self.current_states) > 1
                             else CONF_NO,
-                        ): vol.Any(CONF_YES, CONF_NO),
+                        ): vol.In([CONF_YES, CONF_NO]),
                     }
                 ),
                 description_placeholders={
@@ -748,7 +748,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             ): str,
                             vol.Optional(
                                 CONF_ACTIVATION,
-                                default=current_cfg.get(CONF_ACTIVATION, "high"),
+                                default=current_cfg.get(CONF_ACTIVATION, STATE_HIGH),
                             ): vol.In(["low", "high"]),
                             vol.Optional(
                                 CONF_MOMENTARY,
@@ -767,7 +767,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                                 default=CONF_YES
                                 if len(self.current_states) > 1
                                 else CONF_NO,
-                            ): vol.Any(CONF_YES, CONF_NO),
+                            ): vol.In([CONF_YES, CONF_NO]),
                         }
                     ),
                     description_placeholders={

--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -57,6 +57,10 @@ CONF_IO_BIN = "Binary Sensor"
 CONF_IO_DIG = "Digital Sensor"
 CONF_IO_SWI = "Switchable Output"
 
+CONF_MORE_STATES = "more_states"
+CONF_YES = "Yes"
+CONF_NO = "No"
+
 KONN_MANUFACTURER = "konnected.io"
 KONN_PANEL_MODEL_NAMES = {
     KONN_MODEL: "Konnected Alarm Panel",
@@ -361,6 +365,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.new_opt = {CONF_IO: {}}
         self.active_cfg = None
         self.io_cfg = {}
+        self.current_states = []
+        self.current_state = 1
 
     @callback
     def get_current_cfg(self, io_type, zone):
@@ -666,12 +672,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             zone = {"zone": self.active_cfg}
             zone.update(user_input)
+            del zone[CONF_MORE_STATES]
             self.new_opt[CONF_SWITCHES] = self.new_opt.get(CONF_SWITCHES, []) + [zone]
-            self.io_cfg.pop(self.active_cfg)
-            self.active_cfg = None
+
+            # iterate through multiple switch states
+            if self.current_states:
+                self.current_states.pop(0)
+
+            # only go to next zone if all states are entered
+            self.current_state += 1
+            if user_input[CONF_MORE_STATES] is CONF_NO:
+                self.io_cfg.pop(self.active_cfg)
+                self.active_cfg = None
 
         if self.active_cfg:
-            current_cfg = self.get_current_cfg(CONF_SWITCHES, self.active_cfg)
+            current_cfg = next(iter(self.current_states), {})
             return self.async_show_form(
                 step_id="options_switch",
                 data_schema=vol.Schema(
@@ -695,12 +710,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_REPEAT,
                             default=current_cfg.get(CONF_REPEAT, vol.UNDEFINED),
                         ): vol.All(vol.Coerce(int), vol.Range(min=-1)),
+                        vol.Required(
+                            CONF_MORE_STATES,
+                            default=CONF_YES
+                            if len(self.current_states) > 1
+                            else CONF_NO,
+                        ): vol.Any(CONF_YES, CONF_NO),
                     }
                 ),
                 description_placeholders={
                     "zone": f"Zone {self.active_cfg}"
                     if len(self.active_cfg) < 3
-                    else self.active_cfg.upper()
+                    else self.active_cfg.upper(),
+                    "state": str(self.current_state),
                 },
                 errors=errors,
             )
@@ -709,7 +731,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         for key, value in self.io_cfg.items():
             if value == CONF_IO_SWI:
                 self.active_cfg = key
-                current_cfg = self.get_current_cfg(CONF_SWITCHES, self.active_cfg)
+                self.current_states = list(
+                    cfg
+                    for cfg in self.current_opt.get(CONF_SWITCHES, [])
+                    if cfg[CONF_ZONE] == self.active_cfg
+                )
+                current_cfg = next(iter(self.current_states), {})
+                self.current_state = 1
                 return self.async_show_form(
                     step_id="options_switch",
                     data_schema=vol.Schema(
@@ -734,12 +762,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                                 CONF_REPEAT,
                                 default=current_cfg.get(CONF_REPEAT, vol.UNDEFINED),
                             ): vol.All(vol.Coerce(int), vol.Range(min=-1)),
+                            vol.Required(
+                                CONF_MORE_STATES,
+                                default=CONF_YES
+                                if len(self.current_states) > 1
+                                else CONF_NO,
+                            ): vol.Any(CONF_YES, CONF_NO),
                         }
                     ),
                     description_placeholders={
                         "zone": f"Zone {self.active_cfg}"
                         if len(self.active_cfg) < 3
-                        else self.active_cfg.upper()
+                        else self.active_cfg.upper(),
+                        "state": str(self.current_state),
                     },
                     errors=errors,
                 )

--- a/homeassistant/components/konnected/strings.json
+++ b/homeassistant/components/konnected/strings.json
@@ -80,13 +80,14 @@
       },
       "options_switch": {
         "title": "Configure Switchable Output",
-        "description": "Please select the output options for {zone}",
+        "description": "Please select the output options for {zone}: state {state}",
         "data": {
           "name": "Name (optional)",
           "activation": "Output when on",
           "momentary": "Pulse duration (ms) (optional)",
           "pause": "Pause between pulses (ms) (optional)",
-          "repeat": "Times to repeat (-1=infinite) (optional)"
+          "repeat": "Times to repeat (-1=infinite) (optional)",
+          "more_states": "Configure additional states for this zone"
         }
       },
       "options_misc": {

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -403,6 +403,14 @@ async def test_import_existing_config(hass, mock_panel):
                         "pause": 100,
                         "repeat": 4,
                     },
+                    {
+                        "zone": 8,
+                        "name": "alarm",
+                        "activation": "low",
+                        "momentary": 100,
+                        "pause": 100,
+                        "repeat": -1,
+                    },
                     {"zone": "out1"},
                     {"zone": "alarm1"},
                 ],
@@ -462,6 +470,14 @@ async def test_import_existing_config(hass, mock_panel):
                     "momentary": 50,
                     "pause": 100,
                     "repeat": 4,
+                },
+                {
+                    "zone": "8",
+                    "name": "alarm",
+                    "activation": "low",
+                    "momentary": 100,
+                    "pause": 100,
+                    "repeat": -1,
                 },
                 {"activation": "high", "zone": "out1"},
                 {"activation": "high", "zone": "alarm1"},
@@ -713,6 +729,7 @@ async def test_option_flow(hass, mock_panel):
     assert result["step_id"] == "options_switch"
     assert result["description_placeholders"] == {
         "zone": "Zone 4",
+        "state": "1",
     }
 
     # zone 4
@@ -723,6 +740,7 @@ async def test_option_flow(hass, mock_panel):
     assert result["step_id"] == "options_switch"
     assert result["description_placeholders"] == {
         "zone": "OUT",
+        "state": "1",
     }
 
     # zone out
@@ -734,6 +752,27 @@ async def test_option_flow(hass, mock_panel):
             "momentary": 50,
             "pause": 100,
             "repeat": 4,
+            "more_states": "Yes",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "options_switch"
+    assert result["description_placeholders"] == {
+        "zone": "OUT",
+        "state": "2",
+    }
+
+    # zone out - state 2
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "name": "alarm",
+            "activation": "low",
+            "momentary": 100,
+            "pause": 100,
+            "repeat": -1,
+            "more_states": "No",
         },
     )
 
@@ -767,6 +806,14 @@ async def test_option_flow(hass, mock_panel):
                 "momentary": 50,
                 "pause": 100,
                 "repeat": 4,
+            },
+            {
+                "zone": "out",
+                "name": "alarm",
+                "activation": "low",
+                "momentary": 100,
+                "pause": 100,
+                "repeat": -1,
             },
         ],
     }
@@ -977,6 +1024,14 @@ async def test_option_flow_import(hass, mock_panel):
                     "pause": 100,
                     "repeat": 4,
                 },
+                {
+                    "zone": "3",
+                    "name": "alarm",
+                    "activation": "low",
+                    "momentary": 100,
+                    "pause": 100,
+                    "repeat": -1,
+                },
             ],
         }
     )
@@ -1056,8 +1111,9 @@ async def test_option_flow_import(hass, mock_panel):
     assert schema["momentary"] == 50
     assert schema["pause"] == 100
     assert schema["repeat"] == 4
+    assert schema["more_states"] == "Yes"
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"activation": "high"}
+        result["flow_id"], user_input={"activation": "high", "more_states": "No"}
     )
     assert result["type"] == "form"
     assert result["step_id"] == "options_misc"

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -124,7 +124,7 @@ async def test_config_schema(hass):
         }
     }
 
-    # check pin to zone
+    # check pin to zone and multiple output
     config = {
         konnected.DOMAIN: {
             konnected.CONF_ACCESS_TOKEN: "abcdefgh",
@@ -134,6 +134,22 @@ async def test_config_schema(hass):
                     "binary_sensors": [
                         {"pin": 2, "type": "door"},
                         {"zone": 1, "type": "door"},
+                    ],
+                    "switches": [
+                        {
+                            "zone": 3,
+                            "name": "Beep Beep",
+                            "momentary": 65,
+                            "pause": 55,
+                            "repeat": 4,
+                        },
+                        {
+                            "zone": 3,
+                            "name": "Warning",
+                            "momentary": 100,
+                            "pause": 100,
+                            "repeat": -1,
+                        },
                     ],
                 }
             ],
@@ -153,7 +169,7 @@ async def test_config_schema(hass):
                             "11": "Disabled",
                             "12": "Disabled",
                             "2": "Binary Sensor",
-                            "3": "Disabled",
+                            "3": "Switchable Output",
                             "4": "Disabled",
                             "5": "Disabled",
                             "6": "Disabled",
@@ -168,6 +184,24 @@ async def test_config_schema(hass):
                         "binary_sensors": [
                             {"inverse": False, "type": "door", "zone": "2"},
                             {"inverse": False, "type": "door", "zone": "1"},
+                        ],
+                        "switches": [
+                            {
+                                "zone": "3",
+                                "activation": "high",
+                                "name": "Beep Beep",
+                                "momentary": 65,
+                                "pause": 55,
+                                "repeat": 4,
+                            },
+                            {
+                                "zone": "3",
+                                "activation": "high",
+                                "name": "Warning",
+                                "momentary": 100,
+                                "pause": 100,
+                                "repeat": -1,
+                            },
                         ],
                     },
                     "id": "aabbccddeeff",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for configuring multiple output states for each Konnected Alarm Panel Zone or Pin.  This functionality previously existed and was broken when adding Config Flow support in 0.106.

When configuring the output behavior for a Konnected Alarm Panel zone via config options we now include a field for indicating whether to configure additional output states for the zone.  Selecting "Yes" will result in the flow returning config options for an additional output state associated with that zone.  Selecting "No" will continue the flow to configure options for the next zone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32339
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12543

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
