### PR TITLE
Add a config flow for flume

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -121,7 +121,7 @@ homeassistant/components/filter/* @dgomes
 homeassistant/components/fitbit/* @robbiet480
 homeassistant/components/fixer/* @fabaff
 homeassistant/components/flock/* @fabaff
-homeassistant/components/flume/* @ChrisMandich
+homeassistant/components/flume/* @ChrisMandich @bdraco
 homeassistant/components/flunearyou/* @bachya
 homeassistant/components/fortigate/* @kifeo
 homeassistant/components/fortios/* @kimfrellsen

--- a/homeassistant/components/flume/.translations/en.json
+++ b/homeassistant/components/flume/.translations/en.json
@@ -1,0 +1,25 @@
+{
+   "config" : {
+      "error" : {
+         "unknown" : "Unexpected error",
+         "invalid_auth" : "Invalid authentication",
+         "cannot_connect" : "Failed to connect, please try again"
+      },
+      "step" : {
+         "user" : {
+            "description" : "In order to access the Flume Personal API, you will need to request a 'Client ID' and 'Client Secret' at https://portal.flumetech.com/settings#token",
+            "title" : "Connect to your Flume Account",
+            "data" : {
+               "username" : "Username",
+               "client_secret" : "Client Secret",
+               "client_id" : "Client ID",
+               "password" : "Password"
+            }
+         }
+      },
+      "abort" : {
+         "already_configured" : "This account is already configured"
+      },
+      "title" : "Flume"
+   }
+}

--- a/homeassistant/components/flume/__init__.py
+++ b/homeassistant/components/flume/__init__.py
@@ -45,16 +45,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     http_session = Session()
 
-    flume_auth = FlumeAuth(
-        username,
-        password,
-        client_id,
-        client_secret,
-        flume_token_file=flume_token_full_path,
-        http_session=http_session,
-    )
-
     try:
+        flume_auth = await hass.async_add_executor_job(
+            partial(
+                FlumeAuth,
+                username,
+                password,
+                client_id,
+                client_secret,
+                flume_token_file=flume_token_full_path,
+                http_session=http_session,
+            )
+        )
         flume_devices = await hass.async_add_executor_job(
             partial(FlumeDeviceList, flume_auth, http_session=http_session,)
         )

--- a/homeassistant/components/flume/__init__.py
+++ b/homeassistant/components/flume/__init__.py
@@ -1,1 +1,93 @@
-"""The Flume component."""
+"""The flume integration."""
+import asyncio
+from functools import partial
+import logging
+
+from pyflume import FlumeDeviceList
+from requests import Session
+from requests.exceptions import RequestException
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import (
+    BASE_TOKEN_FILENAME,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    DOMAIN,
+    FLUME_DEVICES,
+    FLUME_HTTP_SESSION,
+    FLUME_TOKEN_FULL_PATH,
+    PLATFORMS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the flume component."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up flume from a config entry."""
+
+    config = entry.data
+
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    client_id = config[CONF_CLIENT_ID]
+    client_secret = config[CONF_CLIENT_SECRET]
+    flume_token_full_path = hass.config.path(f"{BASE_TOKEN_FILENAME}-{username}")
+
+    http_session = Session()
+
+    try:
+        flume_devices = await hass.async_add_executor_job(
+            partial(
+                FlumeDeviceList,
+                username,
+                password,
+                client_id,
+                client_secret,
+                flume_token_full_path,
+                http_session=http_session,
+            )
+        )
+    except RequestException:
+        raise ConfigEntryNotReady
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOGGER.error("Invalid credentials for flume: %s", ex)
+        return False
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        FLUME_DEVICES: flume_devices,
+        FLUME_TOKEN_FULL_PATH: flume_token_full_path,
+        FLUME_HTTP_SESSION: http_session,
+    }
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/flume/config_flow.py
+++ b/homeassistant/components/flume/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for flume integration."""
+from functools import partial
 import logging
 
 from pyflume import FlumeAuth, FlumeDeviceList
@@ -38,14 +39,18 @@ async def validate_input(hass: core.HomeAssistant, data):
     client_id = data[CONF_CLIENT_ID]
     client_secret = data[CONF_CLIENT_SECRET]
     flume_token_full_path = hass.config.path(f"{BASE_TOKEN_FILENAME}-{username}")
-    flume_auth = FlumeAuth(
-        username,
-        password,
-        client_id,
-        client_secret,
-        flume_token_file=flume_token_full_path,
-    )
+
     try:
+        flume_auth = await hass.async_add_executor_job(
+            partial(
+                FlumeAuth,
+                username,
+                password,
+                client_id,
+                client_secret,
+                flume_token_file=flume_token_full_path,
+            )
+        )
         flume_devices = await hass.async_add_executor_job(FlumeDeviceList, flume_auth)
     except RequestException:
         raise CannotConnect

--- a/homeassistant/components/flume/config_flow.py
+++ b/homeassistant/components/flume/config_flow.py
@@ -1,8 +1,7 @@
 """Config flow for flume integration."""
-from functools import partial
 import logging
 
-from pyflume import FlumeDeviceList
+from pyflume import FlumeAuth, FlumeDeviceList
 from requests.exceptions import RequestException
 import voluptuous as vol
 
@@ -39,17 +38,15 @@ async def validate_input(hass: core.HomeAssistant, data):
     client_id = data[CONF_CLIENT_ID]
     client_secret = data[CONF_CLIENT_SECRET]
     flume_token_full_path = hass.config.path(f"{BASE_TOKEN_FILENAME}-{username}")
+    flume_auth = FlumeAuth(
+        username,
+        password,
+        client_id,
+        client_secret,
+        flume_token_file=flume_token_full_path,
+    )
     try:
-        flume_devices = await hass.async_add_executor_job(
-            partial(
-                FlumeDeviceList,
-                username,
-                password,
-                client_id,
-                client_secret,
-                flume_token_full_path,
-            )
-        )
+        flume_devices = await hass.async_add_executor_job(FlumeDeviceList, flume_auth)
     except RequestException:
         raise CannotConnect
     except Exception:  # pylint: disable=broad-except

--- a/homeassistant/components/flume/config_flow.py
+++ b/homeassistant/components/flume/config_flow.py
@@ -1,0 +1,102 @@
+"""Config flow for flume integration."""
+from functools import partial
+import logging
+
+from pyflume import FlumeDeviceList
+from requests.exceptions import RequestException
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from .const import BASE_TOKEN_FILENAME, CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+# If flume ever implements a login page for oauth
+# we can use the oauth2 support built into Home Assistant.
+#
+# Currently they only implement the token endpoint
+#
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_CLIENT_ID): str,
+        vol.Required(CONF_CLIENT_SECRET): str,
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    username = data[CONF_USERNAME]
+    password = data[CONF_PASSWORD]
+    client_id = data[CONF_CLIENT_ID]
+    client_secret = data[CONF_CLIENT_SECRET]
+    flume_token_full_path = hass.config.path(f"{BASE_TOKEN_FILENAME}-{username}")
+    try:
+        flume_devices = await hass.async_add_executor_job(
+            partial(
+                FlumeDeviceList,
+                username,
+                password,
+                client_id,
+                client_secret,
+                flume_token_full_path,
+            )
+        )
+    except RequestException:
+        raise CannotConnect
+    except Exception:  # pylint: disable=broad-except
+        raise InvalidAuth
+    if not flume_devices or not flume_devices.device_list:
+        raise CannotConnect
+
+    # Return info that you want to store in the config entry.
+    return {"title": username}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for flume."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_USERNAME])
+            self._abort_if_unique_id_configured()
+
+            try:
+                info = await validate_input(self.hass, user_input)
+                return self.async_create_entry(title=info["title"], data=user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, user_input):
+        """Handle import."""
+        return await self.async_step_user(user_input)
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/flume/const.py
+++ b/homeassistant/components/flume/const.py
@@ -9,10 +9,16 @@ CONF_CLIENT_ID = "client_id"
 CONF_CLIENT_SECRET = "client_secret"
 FLUME_TYPE_SENSOR = 2
 
-FLUME_TOKEN_FULL_PATH = "token_full_path"
+FLUME_AUTH = "flume_auth"
 FLUME_HTTP_SESSION = "http_session"
 FLUME_DEVICES = "devices"
 
 
 CONF_TOKEN_FILE = "token_filename"
 BASE_TOKEN_FILENAME = "FLUME_TOKEN_FILE"
+
+
+KEY_DEVICE_TYPE = "type"
+KEY_DEVICE_ID = "id"
+KEY_DEVICE_LOCATION = "location"
+KEY_DEVICE_LOCATION_NAME = "name"

--- a/homeassistant/components/flume/const.py
+++ b/homeassistant/components/flume/const.py
@@ -1,0 +1,18 @@
+"""The Flume component."""
+DOMAIN = "flume"
+
+PLATFORMS = ["sensor"]
+
+DEFAULT_NAME = "Flume Sensor"
+
+CONF_CLIENT_ID = "client_id"
+CONF_CLIENT_SECRET = "client_secret"
+FLUME_TYPE_SENSOR = 2
+
+FLUME_TOKEN_FULL_PATH = "token_full_path"
+FLUME_HTTP_SESSION = "http_session"
+FLUME_DEVICES = "devices"
+
+
+CONF_TOKEN_FILE = "token_filename"
+BASE_TOKEN_FILENAME = "FLUME_TOKEN_FILE"

--- a/homeassistant/components/flume/manifest.json
+++ b/homeassistant/components/flume/manifest.json
@@ -3,7 +3,7 @@
   "name": "flume",
   "documentation": "https://www.home-assistant.io/integrations/flume/",
   "requirements": [
-    "pyflume==0.3.0"
+    "pyflume==0.4.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/flume/manifest.json
+++ b/homeassistant/components/flume/manifest.json
@@ -2,6 +2,13 @@
   "domain": "flume",
   "name": "flume",
   "documentation": "https://www.home-assistant.io/integrations/flume/",
-  "requirements": ["pyflume==0.3.0"],
-  "codeowners": ["@ChrisMandich"]
+  "requirements": [
+    "pyflume==0.3.0"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@ChrisMandich",
+    "@bdraco"
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/flume/sensor.py
+++ b/homeassistant/components/flume/sensor.py
@@ -85,7 +85,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     if flume_entity_list:
-        async_add_entities(flume_entity_list, True)
+        async_add_entities(flume_entity_list)
 
 
 class FlumeSensor(Entity):
@@ -150,3 +150,9 @@ class FlumeSensor(Entity):
         _LOGGER.debug("Successful update of flume sensor: %s", self._name)
         self._state = self._flume_device.value
         self._available = True
+
+    async def async_added_to_hass(self):
+        """Request an update when added."""
+        # We do ask for an update with async_add_entities()
+        # because it will update disabled entities
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/flume/strings.json
+++ b/homeassistant/components/flume/strings.json
@@ -1,0 +1,25 @@
+{
+   "config" : {
+      "error" : {
+         "unknown" : "Unexpected error",
+         "invalid_auth" : "Invalid authentication",
+         "cannot_connect" : "Failed to connect, please try again"
+      },
+      "step" : {
+         "user" : {
+            "description" : "In order to access the Flume Personal API, you will need to request a 'Client ID' and 'Client Secret' at https://portal.flumetech.com/settings#token",
+            "title" : "Connect to your Flume Account",
+            "data" : {
+               "username" : "Username",
+               "client_secret" : "Client Secret",
+               "client_id" : "Client ID",
+               "password" : "Password"
+            }
+         }
+      },
+      "abort" : {
+         "already_configured" : "This account is already configured"
+      },
+      "title" : "Flume"
+   }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -31,6 +31,7 @@ FLOWS = [
     "elkm1",
     "emulated_roku",
     "esphome",
+    "flume",
     "flunearyou",
     "freebox",
     "garmin_connect",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1283,7 +1283,7 @@ pyflexit==0.3
 pyflic-homeassistant==0.4.dev0
 
 # homeassistant.components.flume
-pyflume==0.3.0
+pyflume==0.4.0
 
 # homeassistant.components.flunearyou
 pyflunearyou==1.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -495,11 +495,11 @@ pyeverlights==0.1.0
 # homeassistant.components.fido
 pyfido==2.1.1
 
-# homeassistant.components.flunearyou
-pyflunearyou==1.0.7
-
 # homeassistant.components.flume
 pyflume==0.4.0
+
+# homeassistant.components.flunearyou
+pyflunearyou==1.0.7
 
 # homeassistant.components.fritzbox
 pyfritzhome==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -499,7 +499,7 @@ pyfido==2.1.1
 pyflunearyou==1.0.7
 
 # homeassistant.components.flume
-pyflume==0.3.0
+pyflume==0.4.0
 
 # homeassistant.components.fritzbox
 pyfritzhome==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -498,6 +498,9 @@ pyfido==2.1.1
 # homeassistant.components.flunearyou
 pyflunearyou==1.0.7
 
+# homeassistant.components.flume
+pyflume==0.3.0
+
 # homeassistant.components.fritzbox
 pyfritzhome==0.4.0
 

--- a/tests/components/flume/__init__.py
+++ b/tests/components/flume/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the flume integration."""

--- a/tests/components/flume/test_config_flow.py
+++ b/tests/components/flume/test_config_flow.py
@@ -1,0 +1,138 @@
+"""Test the flume config flow."""
+from asynctest import MagicMock, patch
+import requests.exceptions
+
+from homeassistant import config_entries, setup
+from homeassistant.components.flume.const import DOMAIN
+
+
+def _get_mocked_flume_device_list():
+    flume_device_list_mock = MagicMock()
+    type(flume_device_list_mock).device_list = ["mock"]
+    return flume_device_list_mock
+
+
+async def test_form(hass):
+    """Test we get the form and can setup from user input."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    mock_flume_device_list = _get_mocked_flume_device_list()
+
+    with patch(
+        "homeassistant.components.flume.config_flow.FlumeDeviceList",
+        return_value=mock_flume_device_list,
+    ), patch(
+        "homeassistant.components.flume.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.flume.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "test-username"
+    assert result2["data"] == {
+        "username": "test-username",
+        "password": "test-password",
+        "client_id": "client_id",
+        "client_secret": "client_secret",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_import(hass):
+    """Test we can import the sensor platform config."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    mock_flume_device_list = _get_mocked_flume_device_list()
+
+    with patch(
+        "homeassistant.components.flume.config_flow.FlumeDeviceList",
+        return_value=mock_flume_device_list,
+    ), patch(
+        "homeassistant.components.flume.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.flume.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "username": "test-username",
+                "password": "test-password",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "test-username"
+    assert result["data"] == {
+        "username": "test-username",
+        "password": "test-password",
+        "client_id": "client_id",
+        "client_secret": "client_secret",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.flume.config_flow.FlumeDeviceList",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "homeassistant.components.flume.config_flow.FlumeDeviceList",
+        side_effect=requests.exceptions.ConnectionError(),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/flume/test_config_flow.py
+++ b/tests/components/flume/test_config_flow.py
@@ -24,6 +24,8 @@ async def test_form(hass):
     mock_flume_device_list = _get_mocked_flume_device_list()
 
     with patch(
+        "homeassistant.components.flume.config_flow.FlumeAuth", return_value=True,
+    ), patch(
         "homeassistant.components.flume.config_flow.FlumeDeviceList",
         return_value=mock_flume_device_list,
     ), patch(
@@ -60,6 +62,8 @@ async def test_form_import(hass):
     mock_flume_device_list = _get_mocked_flume_device_list()
 
     with patch(
+        "homeassistant.components.flume.config_flow.FlumeAuth", return_value=True,
+    ), patch(
         "homeassistant.components.flume.config_flow.FlumeDeviceList",
         return_value=mock_flume_device_list,
     ), patch(
@@ -98,6 +102,8 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
+        "homeassistant.components.flume.config_flow.FlumeAuth", return_value=True,
+    ), patch(
         "homeassistant.components.flume.config_flow.FlumeDeviceList",
         side_effect=Exception,
     ):
@@ -121,6 +127,8 @@ async def test_form_cannot_connect(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     with patch(
+        "homeassistant.components.flume.config_flow.FlumeAuth", return_value=True,
+    ), patch(
         "homeassistant.components.flume.config_flow.FlumeDeviceList",
         side_effect=requests.exceptions.ConnectionError(),
     ):


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

* Sensors no longer block Home Assistant startup
since the flume api can take > 60s to respond on
the first poll

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12546

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
