### PR TITLE
Prevent nut from doing I/O in the event loop

### DIFF
--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -253,15 +253,6 @@ class NUTSensor(Entity):
         """Return the sensor attributes."""
         return {ATTR_STATE: self._display_state}
 
-    def _format_display_state(self, status):
-        """Return UPS display state."""
-        if status is None:
-            return STATE_TYPES["OFF"]
-        try:
-            return " ".join(STATE_TYPES[state] for state in status[KEY_STATUS].split())
-        except KeyError:
-            return STATE_UNKNOWN
-
     def update(self):
         """Get the latest status and use it to update our sensor state."""
         status = self._data.status
@@ -271,7 +262,7 @@ class NUTSensor(Entity):
             return
 
         self._available = True
-        self._display_state = self._format_display_state(status)
+        self._display_state = _format_display_state(status)
         # In case of the display status sensor, keep a human-readable form
         # as the sensor state.
         if self.type == KEY_STATUS_DISPLAY:
@@ -280,6 +271,16 @@ class NUTSensor(Entity):
             self._state = None
         else:
             self._state = status[self.type]
+
+
+def _format_display_state(status):
+    """Return UPS display state."""
+    if status is None:
+        return STATE_TYPES["OFF"]
+    try:
+        return " ".join(STATE_TYPES[state] for state in status[KEY_STATUS].split())
+    except KeyError:
+        return STATE_UNKNOWN
 
 
 class PyNUTData:

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -220,6 +220,8 @@ class NUTSensor(Entity):
         self._name = "{} {}".format(name, SENSOR_TYPES[sensor_type][0])
         self._unit = SENSOR_TYPES[sensor_type][1]
         self._state = None
+        self._display_state = None
+        self._available = False
 
     @property
     def name(self):
@@ -242,37 +244,42 @@ class NUTSensor(Entity):
         return self._unit
 
     @property
+    def available(self):
+        """Return if the device is polling successfully."""
+        return self._available
+
+    @property
     def device_state_attributes(self):
         """Return the sensor attributes."""
-        attr = dict()
-        attr[ATTR_STATE] = self.display_state()
-        return attr
+        return {ATTR_STATE: self._display_state}
 
-    def display_state(self):
+    def _format_display_state(self, status):
         """Return UPS display state."""
-        if self._data.status is None:
+        if status is None:
             return STATE_TYPES["OFF"]
         try:
-            return " ".join(
-                STATE_TYPES[state] for state in self._data.status[KEY_STATUS].split()
-            )
+            return " ".join(STATE_TYPES[state] for state in status[KEY_STATUS].split())
         except KeyError:
             return STATE_UNKNOWN
 
     def update(self):
         """Get the latest status and use it to update our sensor state."""
-        if self._data.status is None:
-            self._state = None
+        status = self._data.status
+
+        if status is None:
+            self._available = False
             return
 
+        self._available = True
+        self._display_state = self._format_display_state(status)
         # In case of the display status sensor, keep a human-readable form
         # as the sensor state.
         if self.type == KEY_STATUS_DISPLAY:
-            self._state = self.display_state()
-        elif self.type not in self._data.status:
+            self._state = self._display_state
+        elif self.type not in status:
             self._state = None
         else:
-            self._state = self._data.status[self.type]
+            self._state = status[self.type]
 
 
 class PyNUTData:


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
device_state_attributes would call for an update if the
throttle happened to expire.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33418
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
