### PR TITLE
Include charging state for powerwall

### DIFF
--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -45,9 +45,9 @@ POWERWALL_RUNNING_KEY = "running"
 POWERWALL_BATTERY_METER = "battery"
 
 # We only declare charging if they are getting
-# at least 12W incoming as measuring the fields
+# at least 40W incoming as measuring the fields
 # is not an exact science because of interference
-CHARGING_MARGIN_OF_ERROR = -12
+CHARGING_MARGIN_OF_ERROR = -40
 
 MODEL = "PowerWall 2"
 MANUFACTURER = "Tesla"

--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -42,6 +42,12 @@ POWERWALL_GRID_ONLINE = "SystemGridConnected"
 POWERWALL_CONNECTED_KEY = "connected_to_tesla"
 POWERWALL_RUNNING_KEY = "running"
 
+POWERWALL_BATTERY_METER = "battery"
+
+# We only declare charging if they are getting
+# at least 12W incoming as measuring the fields
+# is not an exact science because of interference
+CHARGING_MARGIN_OF_ERROR = -12
 
 MODEL = "PowerWall 2"
 MANUFACTURER = "Tesla"

--- a/tests/components/powerwall/test_binary_sensor.py
+++ b/tests/components/powerwall/test_binary_sensor.py
@@ -52,3 +52,13 @@ async def test_sensors(hass):
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
     assert all(item in state.attributes.items() for item in expected_attributes.items())
+
+    state = hass.states.get("binary_sensor.powerwall_charging")
+    assert state.state == STATE_ON
+    expected_attributes = {
+        "friendly_name": "Powerwall Charging",
+        "device_class": "battery_charging",
+    }
+    # Only test for a subset of attributes in case
+    # HA changes the implementation and a new one appears
+    assert all(item in state.attributes.items() for item in expected_attributes.items())


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This allows homekit to show the charging state in the
homekit app when the powerwall is exported as a linked
battery sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
