### PR TITLE
Don't write storage to disk while stopping

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -152,7 +152,7 @@ class CoreState(enum.Enum):
     starting = "STARTING"
     running = "RUNNING"
     stopping = "STOPPING"
-    writing_data = "WRITING_DATA"
+    final_write = "FINAL_WRITE"
 
     def __str__(self) -> str:
         """Return the event."""
@@ -414,7 +414,7 @@ class HomeAssistant:
             # regardless of the state of the loop.
             if self.state == CoreState.not_running:  # just ignore
                 return
-            if self.state == CoreState.stopping or self.state == CoreState.writing_data:
+            if self.state == CoreState.stopping or self.state == CoreState.final_write:
                 _LOGGER.info("async_stop called twice: ignored")
                 return
             if self.state == CoreState.starting:
@@ -428,7 +428,7 @@ class HomeAssistant:
         await self.async_block_till_done()
 
         # stage 2
-        self.state = CoreState.writing_data
+        self.state = CoreState.final_write
         self.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
         await self.async_block_till_done()
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -4,10 +4,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any, Awaitable, Dict, List, Optional, Set, cast
 
-from homeassistant.const import (
-    EVENT_HOMEASSISTANT_FINAL_WRITE,
-    EVENT_HOMEASSISTANT_START,
-)
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import (
     CoreState,
     HomeAssistant,
@@ -187,9 +184,7 @@ class RestoreStateData:
         async_track_time_interval(self.hass, _async_dump_states, STATE_DUMP_INTERVAL)
 
         # Dump states when stopping hass
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_FINAL_WRITE, _async_dump_states
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_dump_states)
 
     @callback
     def async_restore_entity_added(self, entity_id: str) -> None:

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -130,6 +130,7 @@ class Store:
             stored = await self._async_migrate_func(data["version"], data["data"])
 
         self._load_task = None
+        self._async_ensure_stop_listener()
         return stored
 
     async def async_save(self, data: Union[Dict, List]) -> None:

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -6,7 +6,7 @@ import os
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, CoreState, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.loader import bind_hass
 from homeassistant.util import json as json_util
@@ -184,6 +184,9 @@ class Store:
 
     async def _async_handle_write_data(self, *_args):
         """Handle writing the config."""
+        if self.hass.state == CoreState.stopping:
+            self._async_ensure_stop_listener()
+            return
         data = self._data
 
         if "data_func" in data:

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -149,12 +149,12 @@ class Store:
         self._async_cleanup_final_write_listener()
 
         if self.hass.state == CoreState.stopping:
-            self._async_ensure_final_write_listener()
             return
 
         self._unsub_delay_listener = async_call_later(
             self.hass, delay, self._async_callback_delayed_write
         )
+        self._async_ensure_final_write_listener()
 
     @callback
     def _async_ensure_final_write_listener(self):

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -149,6 +149,7 @@ class Store:
         self._async_cleanup_final_write_listener()
 
         if self.hass.state == CoreState.stopping:
+            self._async_ensure_final_write_listener()
             return
 
         self._unsub_delay_listener = async_call_later(

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -135,8 +135,7 @@ class Store:
         if self.hass.state == CoreState.stopping:
             self._async_ensure_stop_listener()
             return
-        else:
-            self._async_cleanup_stop_listener()
+        self._async_cleanup_stop_listener()
         await self._async_handle_write_data()
 
     @callback

--- a/tests/common.py
+++ b/tests/common.py
@@ -1017,8 +1017,11 @@ async def flush_store(store):
     if store._data is None:
         return
 
-    store._async_cleanup_stop_listener()
+    store._async_cleanup_final_write_listener()
     store._async_cleanup_delay_listener()
+    if store._unsub_stop_listener is not None:
+        store._unsub_stop_listener()
+        store._unsub_stop_listener = None
     await store._async_handle_write_data()
 
 
@@ -1030,7 +1033,7 @@ async def get_system_health_info(hass, domain):
 def mock_integration(hass, module):
     """Mock an integration."""
     integration = loader.Integration(
-        hass, f"homeassistant.components.{module.DOMAIN}", None, module.mock_manifest(),
+        hass, f"homeassistant.components.{module.DOMAIN}", None, module.mock_manifest()
     )
 
     _LOGGER.info("Adding mock integration: %s", module.DOMAIN)

--- a/tests/common.py
+++ b/tests/common.py
@@ -1019,9 +1019,6 @@ async def flush_store(store):
 
     store._async_cleanup_final_write_listener()
     store._async_cleanup_delay_listener()
-    if store._unsub_stop_listener is not None:
-        store._unsub_stop_listener()
-        store._unsub_stop_listener = None
     await store._async_handle_write_data()
 
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -28,6 +28,7 @@ from tests.common import (
     get_test_home_assistant,
     mock_coro,
     mock_registry,
+    mock_storage,
 )
 from tests.mock.zwave import MockEntityValues, MockNetwork, MockNode, MockValue
 
@@ -827,6 +828,8 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
+        self.mock_storage = mock_storage()
+        self.mock_storage.__enter__()
         self.hass.start()
         self.registry = mock_registry(self.hass)
 
@@ -862,6 +865,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
         self.hass.stop()
+        self.mock_storage.__exit__(None, None, None)
 
     @patch.object(zwave, "import_module")
     @patch.object(zwave, "discovery")
@@ -1194,6 +1198,8 @@ class TestZWaveServices(unittest.TestCase):
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
+        self.mock_storage = mock_storage()
+        self.mock_storage.__enter__()
         self.hass.start()
 
         # Initialize zwave
@@ -1209,6 +1215,7 @@ class TestZWaveServices(unittest.TestCase):
         self.hass.services.call("zwave", "stop_network", {})
         self.hass.block_till_done()
         self.hass.stop()
+        self.mock_storage.__exit__(None, None, None)
 
     def test_add_node(self):
         """Test zwave add_node service."""

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -6,7 +6,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_FINAL_WRITE,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.core import CoreState
 from homeassistant.helpers import storage
 from homeassistant.util import dt
@@ -83,7 +86,14 @@ async def test_saving_with_delay(hass, store, hass_storage):
 async def test_saving_on_final_write(hass, hass_storage):
     """Test delayed saves trigger when we quit Home Assistant."""
     store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
-    store.async_delay_save(lambda: MOCK_DATA, 1)
+    store.async_delay_save(lambda: MOCK_DATA, 5)
+    assert store.key not in hass_storage
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
     assert store.key not in hass_storage
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
@@ -96,8 +106,10 @@ async def test_saving_on_final_write(hass, hass_storage):
 
 
 async def test_not_delayed_saving_while_stopping(hass, hass_storage):
-    """Test delayed saves don't write when stopping Home Assistant."""
+    """Test delayed saves don't write after the stop event has fired."""
     store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
     hass.state = CoreState.stopping
 
     store.async_delay_save(lambda: MOCK_DATA, 1)
@@ -105,15 +117,20 @@ async def test_not_delayed_saving_while_stopping(hass, hass_storage):
     await hass.async_block_till_done()
     assert store.key not in hass_storage
 
-    hass.state = CoreState.final_write
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
-    await hass.async_block_till_done()
 
-    assert hass_storage[store.key] == {
-        "version": MOCK_VERSION,
-        "key": MOCK_KEY,
-        "data": MOCK_DATA,
-    }
+async def test_not_delayed_saving_after_stopping(hass, hass_storage):
+    """Test delayed saves don't write after stop if issued before stopping Home Assistant."""
+    store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
+    store.async_delay_save(lambda: MOCK_DATA, 10)
+    assert store.key not in hass_storage
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+    assert store.key not in hass_storage
+
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=15))
+    await hass.async_block_till_done()
+    assert store.key not in hass_storage
 
 
 async def test_not_saving_while_stopping(hass, hass_storage):
@@ -122,16 +139,6 @@ async def test_not_saving_while_stopping(hass, hass_storage):
     hass.state = CoreState.stopping
     await store.async_save(MOCK_DATA)
     assert store.key not in hass_storage
-
-    hass.state = CoreState.final_write
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
-    await hass.async_block_till_done()
-
-    assert hass_storage[store.key] == {
-        "version": MOCK_VERSION,
-        "key": MOCK_KEY,
-        "data": MOCK_DATA,
-    }
 
 
 async def test_loading_while_delay(hass, store, hass_storage):

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -90,6 +90,7 @@ async def test_saving_on_final_write(hass, hass_storage):
     assert store.key not in hass_storage
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    hass.state = CoreState.stopping
     await hass.async_block_till_done()
 
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=10))
@@ -125,6 +126,7 @@ async def test_not_delayed_saving_after_stopping(hass, hass_storage):
     assert store.key not in hass_storage
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    hass.state = CoreState.stopping
     await hass.async_block_till_done()
     assert store.key not in hass_storage
 

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -93,3 +93,42 @@ IGNORE_UNCAUGHT_EXCEPTIONS = [
     ("tests.components.yr.test_sensor", "test_forecast_setup"),
     ("tests.components.zwave.test_init", "test_power_schemes"),
 ]
+
+IGNORE_UNCAUGHT_JSON_EXCEPTIONS = [
+    ("tests.components.spotify.test_config_flow", "test_full_flow"),
+    ("tests.components.smartthings.test_init", "test_config_entry_loads_platforms"),
+    (
+        "tests.components.smartthings.test_init",
+        "test_scenes_unauthorized_loads_platforms",
+    ),
+    (
+        "tests.components.smartthings.test_init",
+        "test_config_entry_loads_unconnected_cloud",
+    ),
+    ("tests.components.samsungtv.test_config_flow", "test_ssdp"),
+    ("tests.components.samsungtv.test_config_flow", "test_user_websocket"),
+    ("tests.components.samsungtv.test_config_flow", "test_user_already_configured"),
+    ("tests.components.samsungtv.test_config_flow", "test_autodetect_websocket"),
+    ("tests.components.samsungtv.test_config_flow", "test_autodetect_websocket_ssl"),
+    ("tests.components.samsungtv.test_config_flow", "test_ssdp_already_configured"),
+    ("tests.components.samsungtv.test_config_flow", "test_ssdp_noprefix"),
+    ("tests.components.samsungtv.test_config_flow", "test_user_legacy"),
+    ("tests.components.samsungtv.test_config_flow", "test_autodetect_legacy"),
+    (
+        "tests.components.samsungtv.test_media_player",
+        "test_select_source_invalid_source",
+    ),
+    (
+        "tests.components.samsungtv.test_media_player",
+        "test_play_media_channel_as_string",
+    ),
+    (
+        "tests.components.samsungtv.test_media_player",
+        "test_play_media_channel_as_non_positive",
+    ),
+    ("tests.components.samsungtv.test_media_player", "test_turn_off_websocket"),
+    ("tests.components.samsungtv.test_media_player", "test_play_media_invalid_type"),
+    ("tests.components.harmony.test_config_flow", "test_form_import"),
+    ("tests.components.harmony.test_config_flow", "test_form_ssdp"),
+    ("tests.components.harmony.test_config_flow", "test_user_form"),
+]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is a follow up to #33358 specifically this comment: https://github.com/home-assistant/core/pull/33358#issuecomment-605759395. The PR prevents storage from being written to disk while the HA state is `CoreState.stopping`. The changes account for 3 scenarios:

1. A delayed save is issued before HA stop event has fired and subsequently HA is stopped before the delay kicks in to issue the write
2. A delayed save is issued after HA stop event has fired
3. A save is issued after HA stop event has fired

In all of these scenarios the data is held in memory and written when HA is in the final_write state. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #33358
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
