### PR TITLE
allow overriding host api url in config flow

### DIFF
--- a/homeassistant/components/konnected/.translations/en.json
+++ b/homeassistant/components/konnected/.translations/en.json
@@ -85,9 +85,9 @@
             },
             "options_misc": {
                 "data": {
-                    "api_host": "Override API host url (optional)",
+                    "api_host": "Override API host URL (optional)",
                     "blink": "Blink panel LED on when sending state change",
-                    "override_api_host": "Override default Home Assistant API host panel url"
+                    "override_api_host": "Override default Home Assistant API host panel URL"
                 },
                 "description": "Please select the desired behavior for your panel",
                 "title": "Configure Misc"

--- a/homeassistant/components/konnected/.translations/en.json
+++ b/homeassistant/components/konnected/.translations/en.json
@@ -33,6 +33,9 @@
         "abort": {
             "not_konn_panel": "Not a recognized Konnected.io device"
         },
+        "error": {
+            "bad_host": "Invalid Override API host url"
+        },
         "step": {
             "options_binary": {
                 "data": {
@@ -82,7 +85,9 @@
             },
             "options_misc": {
                 "data": {
-                    "blink": "Blink panel LED on when sending state change"
+                    "api_host": "Override API host url (optional)",
+                    "blink": "Blink panel LED on when sending state change",
+                    "override_api_host": "Override default Home Assistant API host panel uses"
                 },
                 "description": "Please select the desired behavior for your panel",
                 "title": "Configure Misc"

--- a/homeassistant/components/konnected/.translations/en.json
+++ b/homeassistant/components/konnected/.translations/en.json
@@ -87,7 +87,7 @@
                 "data": {
                     "api_host": "Override API host url (optional)",
                     "blink": "Blink panel LED on when sending state change",
-                    "override_api_host": "Override default Home Assistant API host panel uses"
+                    "override_api_host": "Override default Home Assistant API host panel url"
                 },
                 "description": "Please select the desired behavior for your panel",
                 "title": "Configure Misc"

--- a/homeassistant/components/konnected/panel.py
+++ b/homeassistant/components/konnected/panel.py
@@ -294,7 +294,9 @@ class AlarmPanel:
     @callback
     def async_desired_settings_payload(self):
         """Return a dict representing the desired device configuration."""
-        desired_api_host = (
+        # keeping self.hass.data check for backwards compatibility
+        # newly configured integrations store this in the config entry
+        desired_api_host = self.options.get(CONF_API_HOST) or (
             self.hass.data[DOMAIN].get(CONF_API_HOST) or self.hass.config.api.base_url
         )
         desired_api_endpoint = desired_api_host + ENDPOINT_ROOT

--- a/homeassistant/components/konnected/strings.json
+++ b/homeassistant/components/konnected/strings.json
@@ -95,7 +95,7 @@
         "description": "Please select the desired behavior for your panel",
         "data": {
           "blink": "Blink panel LED on when sending state change",
-          "override_api_host": "Override default Home Assistant API host panel uses",
+          "override_api_host": "Override default Home Assistant API host panel url",
           "api_host": "Override API host url (optional)"
         }
       }

--- a/homeassistant/components/konnected/strings.json
+++ b/homeassistant/components/konnected/strings.json
@@ -94,11 +94,15 @@
         "title": "Configure Misc",
         "description": "Please select the desired behavior for your panel",
         "data": {
-          "blink": "Blink panel LED on when sending state change"
+          "blink": "Blink panel LED on when sending state change",
+          "override_api_host": "Override default Home Assistant API host panel uses",
+          "api_host": "Override API host url (optional)"
         }
       }
     },
-    "error": {},
+    "error": {
+      "bad_host": "Invalid Override API host url"
+    },
     "abort": {
       "not_konn_panel": "Not a recognized Konnected.io device"
     }

--- a/homeassistant/components/konnected/strings.json
+++ b/homeassistant/components/konnected/strings.json
@@ -95,8 +95,8 @@
         "description": "Please select the desired behavior for your panel",
         "data": {
           "blink": "Blink panel LED on when sending state change",
-          "override_api_host": "Override default Home Assistant API host panel url",
-          "api_host": "Override API host url (optional)"
+          "override_api_host": "Override default Home Assistant API host panel URL",
+          "api_host": "Override API host URL (optional)"
         }
       }
     },

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -43,6 +43,7 @@ async def test_config_schema(hass):
     """Test that config schema is imported properly."""
     config = {
         konnected.DOMAIN: {
+            konnected.CONF_API_HOST: "http://1.1.1.1:8888",
             konnected.CONF_ACCESS_TOKEN: "abcdefgh",
             konnected.CONF_DEVICES: [{konnected.CONF_ID: "aabbccddeeff"}],
         }
@@ -50,10 +51,12 @@ async def test_config_schema(hass):
     assert konnected.CONFIG_SCHEMA(config) == {
         "konnected": {
             "access_token": "abcdefgh",
+            "api_host": "http://1.1.1.1:8888",
             "devices": [
                 {
                     "default_options": {
                         "blink": True,
+                        "api_host": "http://1.1.1.1:8888",
                         "discovery": True,
                         "io": {
                             "1": "Disabled",
@@ -96,6 +99,7 @@ async def test_config_schema(hass):
                 {
                     "default_options": {
                         "blink": True,
+                        "api_host": "",
                         "discovery": True,
                         "io": {
                             "1": "Disabled",
@@ -162,6 +166,7 @@ async def test_config_schema(hass):
                 {
                     "default_options": {
                         "blink": True,
+                        "api_host": "",
                         "discovery": True,
                         "io": {
                             "1": "Binary Sensor",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The recently added Konnected UI configuration does not provide support for configuring the `api_host` used in panel postbacks.  This PR addresses this oversight by allowing the value to be imported, or configured, for each Konnected panel.  

This change is backward compatible for users who implemented the workaround.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33480 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12595

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
