### PR TITLE
Add notify function for BMW Connected Drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: {cv.string: ACCOUNT_SCHEMA}}, extra=vol.ALLO
 SERVICE_SCHEMA = vol.Schema({vol.Required(ATTR_VIN): cv.string})
 
 
-BMW_COMPONENTS = ["binary_sensor", "device_tracker", "lock", "sensor"]
+BMW_COMPONENTS = ["binary_sensor", "device_tracker", "lock", "notify", "sensor"]
 UPDATE_INTERVAL = 5  # in minutes
 
 SERVICE_UPDATE_STATE = "update_state"

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -2,6 +2,7 @@
   "domain": "bmw_connected_drive",
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
-  "requirements": ["bimmer_connected==0.7.1"],
+  "requirements": ["bimmer_connected==0.7.5"],
+  "dependencies": [],
   "codeowners": ["@gerard33"]
 }

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -25,15 +25,20 @@ def get_service(hass, config, discovery_info=None):
     """Get the BMW notification service."""
     accounts = hass.data[BMW_DOMAIN]
     _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
-    return BMWNotificationService(accounts)
+    svc = BMWNotificationService()
+    svc.setup(accounts)
+    return svc
 
 
 class BMWNotificationService(BaseNotificationService):
     """Send Notifications to BMW."""
 
-    def __init__(self, accounts):
+    def __init__(self):
         """Set up the notification service."""
         self.targets = {}
+
+    def setup(self, accounts):
+        """Get the BMW vehicle(s) for the account(s)."""
         for account in accounts:
             self.targets.update({v.name: v for v in account.account.vehicles})
 

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -1,0 +1,69 @@
+"""Support for BMW notifications."""
+import logging
+
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    ATTR_TARGET,
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    BaseNotificationService,
+)
+from homeassistant.const import ATTR_LATITUDE, ATTR_LOCATION, ATTR_LONGITUDE, ATTR_NAME
+
+from . import DOMAIN as BMW_DOMAIN
+
+ATTR_LAT = "lat"
+ATTR_LOCATION_ATTRIBUTES = ["street", "city", "postal_code", "country"]
+ATTR_LON = "lon"
+ATTR_SUBJECT = "subject"
+ATTR_TEXT = "text"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the BMW notification service."""
+    accounts = hass.data[BMW_DOMAIN]
+    _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
+    return BMWNotificationService(accounts)
+
+
+class BMWNotificationService(BaseNotificationService):
+    """Send Notifications to BMW."""
+
+    def __init__(self, accounts):
+        """Set up the notification service."""
+        self.targets = {}
+        for account in accounts:
+            self.targets.update({v.name: v for v in account.account.vehicles})
+
+    def send_message(self, message="", **kwargs):
+        """Send a message or POI to the car."""
+        for _vehicle in kwargs[ATTR_TARGET]:
+            _LOGGER.debug("Sending message to %s", _vehicle.name)
+
+            # Extract params from data dict
+            title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+            data = kwargs.get(ATTR_DATA)
+
+            # Check if message is a POI
+            if data is not None and ATTR_LOCATION in data:
+                location_dict = {
+                    ATTR_LAT: data[ATTR_LOCATION][ATTR_LATITUDE],
+                    ATTR_LON: data[ATTR_LOCATION][ATTR_LONGITUDE],
+                    ATTR_NAME: message,
+                }
+                # Update dictionary with additional attributes if available
+                location_dict.update(
+                    {
+                        k: v
+                        for k, v in data[ATTR_LOCATION].items()
+                        if k in ATTR_LOCATION_ATTRIBUTES
+                    }
+                )
+
+                _vehicle.remote_services.trigger_send_poi(location_dict)
+            else:
+                _vehicle.remote_services.trigger_send_message(
+                    {ATTR_TEXT: message, ATTR_SUBJECT: title}
+                )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -320,7 +320,7 @@ beewi_smartclim==0.0.7
 bellows-homeassistant==0.15.2
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.7.1
+bimmer_connected==0.7.5
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1


### PR DESCRIPTION
## Breaking change
n/a

## Proposed change
Add the notify function for BMW Connected Drive which makes it possible to send messages or Points of Interest (which can be used to navigate to) to your BMW vehicle from Home Assistant.

A big thanks to @rikroe for updating the library to support this functionality and reviewing and improving the notify code.

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
bmw_connected_drive:
  name_of_car:
    username: USERNAME_BMW_CONNECTED_DRIVE
    password: PASSWORD_BMW_CONNECTED_DRIVE
    region: one of "north_america", "china" , "rest_of_world"
```

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12622

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
