### PR TITLE
Bump up zha dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,12 +4,12 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
-    "bellows-homeassistant==0.14.0",
-    "zha-quirks==0.0.37",
+    "bellows-homeassistant==0.15.1",
+    "zha-quirks==0.0.38",
     "zigpy-cc==0.3.1",
-    "zigpy-deconz==0.7.0",
-    "zigpy-homeassistant==0.16.0",
-    "zigpy-xbee-homeassistant==0.10.0",
+    "zigpy-deconz==0.8.0",
+    "zigpy-homeassistant==0.18.0",
+    "zigpy-xbee-homeassistant==0.11.0",
     "zigpy-zigate==0.5.1"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -317,7 +317,7 @@ beautifulsoup4==4.8.2
 beewi_smartclim==0.0.7
 
 # homeassistant.components.zha
-bellows-homeassistant==0.14.0
+bellows-homeassistant==0.15.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.7.1
@@ -2176,7 +2176,7 @@ zengge==0.2
 zeroconf==0.24.5
 
 # homeassistant.components.zha
-zha-quirks==0.0.37
+zha-quirks==0.0.38
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9
@@ -2188,13 +2188,13 @@ ziggo-mediabox-xl==1.1.0
 zigpy-cc==0.3.1
 
 # homeassistant.components.zha
-zigpy-deconz==0.7.0
+zigpy-deconz==0.8.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.16.0
+zigpy-homeassistant==0.18.0
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.10.0
+zigpy-xbee-homeassistant==0.11.0
 
 # homeassistant.components.zha
 zigpy-zigate==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,7 +131,7 @@ av==6.1.2
 axis==25
 
 # homeassistant.components.zha
-bellows-homeassistant==0.14.0
+bellows-homeassistant==0.15.1
 
 # homeassistant.components.bom
 bomradarloop==0.1.4
@@ -798,19 +798,19 @@ yahooweather==0.10
 zeroconf==0.24.5
 
 # homeassistant.components.zha
-zha-quirks==0.0.37
+zha-quirks==0.0.38
 
 # homeassistant.components.zha
 zigpy-cc==0.3.1
 
 # homeassistant.components.zha
-zigpy-deconz==0.7.0
+zigpy-deconz==0.8.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.16.0
+zigpy-homeassistant==0.18.0
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.10.0
+zigpy-xbee-homeassistant==0.11.0
 
 # homeassistant.components.zha
 zigpy-zigate==0.5.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nope

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump up ZHA dependencies. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
