### PR TITLE
Clean up ZHA channel reporting configuration

### DIFF
--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -20,9 +20,6 @@ from ..const import (
     ATTR_UNIQUE_ID,
     ATTR_VALUE,
     CHANNEL_ZDO,
-    REPORT_CONFIG_MAX_INT,
-    REPORT_CONFIG_MIN_INT,
-    REPORT_CONFIG_RPT_CHANGE,
     SIGNAL_ATTR_UPDATED,
 )
 from ..helpers import LogMixin, safe_read
@@ -149,57 +146,47 @@ class ZigbeeChannel(LogMixin):
                 "Failed to bind '%s' cluster: %s", self.cluster.ep_attribute, str(ex)
             )
 
-    async def configure_reporting(
-        self,
-        attr,
-        report_config=(
-            REPORT_CONFIG_MIN_INT,
-            REPORT_CONFIG_MAX_INT,
-            REPORT_CONFIG_RPT_CHANGE,
-        ),
-    ):
+    async def configure_reporting(self) -> None:
         """Configure attribute reporting for a cluster.
 
         This also swallows DeliveryError exceptions that are thrown when
         devices are unreachable.
         """
-        attr_name = self.cluster.attributes.get(attr, [attr])[0]
-
         kwargs = {}
         if self.cluster.cluster_id >= 0xFC00 and self._ch_pool.manufacturer_code:
             kwargs["manufacturer"] = self._ch_pool.manufacturer_code
 
-        min_report_int, max_report_int, reportable_change = report_config
-        try:
-            res = await self.cluster.configure_reporting(
-                attr, min_report_int, max_report_int, reportable_change, **kwargs
-            )
-            self.debug(
-                "reporting '%s' attr on '%s' cluster: %d/%d/%d: Result: '%s'",
-                attr_name,
-                self.cluster.ep_attribute,
-                min_report_int,
-                max_report_int,
-                reportable_change,
-                res,
-            )
-        except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
-            self.debug(
-                "failed to set reporting for '%s' attr on '%s' cluster: %s",
-                attr_name,
-                self.cluster.ep_attribute,
-                str(ex),
-            )
+        for report in self._report_config:
+            attr = report["attr"]
+            attr_name = self.cluster.attributes.get(attr, [attr])[0]
+            min_report_int, max_report_int, reportable_change = report["config"]
+            try:
+                res = await self.cluster.configure_reporting(
+                    attr, min_report_int, max_report_int, reportable_change, **kwargs
+                )
+                self.debug(
+                    "reporting '%s' attr on '%s' cluster: %d/%d/%d: Result: '%s'",
+                    attr_name,
+                    self.cluster.ep_attribute,
+                    min_report_int,
+                    max_report_int,
+                    reportable_change,
+                    res,
+                )
+            except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
+                self.debug(
+                    "failed to set reporting for '%s' attr on '%s' cluster: %s",
+                    attr_name,
+                    self.cluster.ep_attribute,
+                    str(ex),
+                )
 
     async def async_configure(self):
         """Set cluster binding and attribute reporting."""
         if not self._ch_pool.skip_configuration:
             await self.bind()
             if self.cluster.is_server:
-                for report_config in self._report_config:
-                    await self.configure_reporting(
-                        report_config["attr"], report_config["config"]
-                    )
+                await self.configure_reporting()
             self.debug("finished channel configuration")
         else:
             self.debug("skipping channel configuration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nope

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A minor cleanup of ZHA channel Zigbee attribute reporting configuration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
