### PR TITLE
Fix template light returning NULL in color or temperature

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -388,9 +388,15 @@ class LightTemplate(Light):
                     "Received invalid brightness : %s. Expected: 0-255", brightness
                 )
                 self._brightness = None
-        except TemplateError as ex:
-            _LOGGER.error(ex)
-            self._state = None
+        except ValueError:
+            _LOGGER.error(
+                "Template must supply an integer brightness from 0-255, or 'None'",
+                exc_info=True,
+            )
+            self._brightness = None
+        except TemplateError:
+            _LOGGER.error("Invalid template", exc_info=True)
+            self._brightness = None
 
     @callback
     def update_state(self):

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -378,6 +378,9 @@ class LightTemplate(Light):
             return
         try:
             brightness = self._level_template.async_render()
+            if brightness is None or brightness == "None" or brightness == "":
+                self._brightness = None
+                return
             if 0 <= int(brightness) <= 255:
                 self._brightness = int(brightness)
             else:

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -420,6 +420,7 @@ class LightTemplate(Light):
         try:
             render = self._temperature_template.async_render()
             if render in ("None", ""):
+                self._temperature = None
                 return
             temperature = int(render)
             if self.min_mireds <= temperature <= self.max_mireds:
@@ -441,11 +442,10 @@ class LightTemplate(Light):
         if self._color_template is None:
             return
 
-        self._color = None
-
         try:
             render = self._color_template.async_render()
             if render in ("None", ""):
+                self._color = None
                 return
             h_str, s_str = map(
                 float, render.replace("(", "").replace(")", "").split(",", 1)
@@ -463,7 +463,10 @@ class LightTemplate(Light):
                     h_str,
                     s_str,
                 )
+                self._color = None
             else:
                 _LOGGER.error("Received invalid hs_color : (%s)", render)
-        except TemplateError as ex:
-            _LOGGER.error(ex)
+                self._color = None
+        except TemplateError:
+            _LOGGER.error("Cannot evaluate hs_color template", exc_info=True)
+            self._color = None

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -438,6 +438,12 @@ class LightTemplate(Light):
                     self.max_mireds,
                 )
                 self._temperature = None
+        except ValueError:
+            _LOGGER.error(
+                "Template must supply an integer temperature within the range for this light, or 'None'",
+                exc_info=True,
+            )
+            self._temperature = None
         except TemplateError:
             _LOGGER.error("Cannot evaluate temperature template", exc_info=True)
             self._temperature = None

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -415,7 +415,10 @@ class LightTemplate(Light):
         if self._temperature_template is None:
             return
         try:
-            temperature = int(self._temperature_template.async_render())
+            render = self._temperature_template.async_render()
+            if render is None or render == "None" or render == "":
+                return
+            temperature = int(render)
             if self.min_mireds <= temperature <= self.max_mireds:
                 self._temperature = temperature
             else:
@@ -439,6 +442,8 @@ class LightTemplate(Light):
 
         try:
             render = self._color_template.async_render()
+            if render is None or render == "None" or render == "":
+                return
             h_str, s_str = map(
                 float, render.replace("(", "").replace(")", "").split(",", 1)
             )

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -378,7 +378,7 @@ class LightTemplate(Light):
             return
         try:
             brightness = self._level_template.async_render()
-            if brightness == "None" or brightness == "":
+            if brightness in ("None", ""):
                 self._brightness = None
                 return
             if 0 <= int(brightness) <= 255:
@@ -419,7 +419,7 @@ class LightTemplate(Light):
             return
         try:
             render = self._temperature_template.async_render()
-            if render == "None" or render == "":
+            if render in ("None", ""):
                 return
             temperature = int(render)
             if self.min_mireds <= temperature <= self.max_mireds:
@@ -445,7 +445,7 @@ class LightTemplate(Light):
 
         try:
             render = self._color_template.async_render()
-            if render == "None" or render == "":
+            if render in ("None", ""):
                 return
             h_str, s_str = map(
                 float, render.replace("(", "").replace(")", "").split(",", 1)

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -378,7 +378,7 @@ class LightTemplate(Light):
             return
         try:
             brightness = self._level_template.async_render()
-            if brightness is None or brightness == "None" or brightness == "":
+            if brightness == "None" or brightness == "":
                 self._brightness = None
                 return
             if 0 <= int(brightness) <= 255:
@@ -419,7 +419,7 @@ class LightTemplate(Light):
             return
         try:
             render = self._temperature_template.async_render()
-            if render is None or render == "None" or render == "":
+            if render == "None" or render == "":
                 return
             temperature = int(render)
             if self.min_mireds <= temperature <= self.max_mireds:
@@ -445,7 +445,7 @@ class LightTemplate(Light):
 
         try:
             render = self._color_template.async_render()
-            if render is None or render == "None" or render == "":
+            if render == "None" or render == "":
                 return
             h_str, s_str = map(
                 float, render.replace("(", "").replace(")", "").split(",", 1)

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -588,7 +588,14 @@ class TestTemplateLight:
 
     @pytest.mark.parametrize(
         "expected_temp,template",
-        [(500, "{{500}}"), (None, "{{501}}"), (None, "{{x - 12}}")],
+        [
+            (500, "{{500}}"),
+            (None, "{{501}}"),
+            (None, "{{x - 12}}"),
+            (None, "None"),
+            (None, "{{ none }}"),
+            (None, ""),
+        ],
     )
     def test_temperature_template(self, expected_temp, template):
         """Test the template for the temperature."""
@@ -894,6 +901,8 @@ class TestTemplateLight:
             (None, "{{(361, 100)}}"),
             (None, "{{(360, 101)}}"),
             (None, "{{x - 12}}"),
+            (None, ""),
+            (None, "{{ none }}"),
         ],
     )
     def test_color_template(self, expected_hs, template):

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -543,7 +543,13 @@ class TestTemplateLight:
 
     @pytest.mark.parametrize(
         "expected_level,template",
-        [(255, "{{255}}"), (None, "{{256}}"), (None, "{{x - 12}}")],
+        [
+            (255, "{{255}}"),
+            (None, "{{256}}"),
+            (None, "{{x - 12}}"),
+            (None, "{{ none }}"),
+            (None, ""),
+        ],
     )
     def test_level_template(self, expected_level, template):
         """Test the template for the level."""


### PR DESCRIPTION
## Proposed change
Color and/or white temperature lights may sometimes return "None" from their respective `hs_colo`r and `color_temp` attributes. This pull adds support for this, and eliminates exceptions that may have previously been returned when an attribute is, correctly, set to null.

## Type of change
- [ ] Dependency upgrade
- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #33469 


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X ] The code change is tested and works locally.
- [X ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X ] There is no commented out code in this PR.
- [X ] I have followed the [development checklist][dev-checklist]
- [X ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
