### PR TITLE
Cloud do checks during setup

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
     CONF_MODE,
     CONF_NAME,
     CONF_REGION,
-    EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import callback
@@ -191,11 +190,7 @@ async def async_setup(hass, config):
     client = CloudClient(hass, prefs, websession, alexa_conf, google_conf)
     cloud = hass.data[DOMAIN] = Cloud(client, **kwargs)
 
-    async def _startup(event):
-        """Startup event."""
-        await cloud.start()
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _startup)
+    await cloud.start()
 
     async def _shutdown(event):
         """Shutdown event."""
@@ -230,17 +225,11 @@ async def async_setup(hass, config):
             return
         loaded = True
 
-        hass.async_create_task(
-            hass.helpers.discovery.async_load_platform(
-                "binary_sensor", DOMAIN, {}, config
-            )
+        await hass.helpers.discovery.async_load_platform(
+            "binary_sensor", DOMAIN, {}, config
         )
-        hass.async_create_task(
-            hass.helpers.discovery.async_load_platform("stt", DOMAIN, {}, config)
-        )
-        hass.async_create_task(
-            hass.helpers.discovery.async_load_platform("tts", DOMAIN, {}, config)
-        )
+        await hass.helpers.discovery.async_load_platform("stt", DOMAIN, {}, config)
+        await hass.helpers.discovery.async_load_platform("tts", DOMAIN, {}, config)
 
     cloud.iot.register_on_connect(_on_connect)
 

--- a/homeassistant/components/cloud/binary_sensor.py
+++ b/homeassistant/components/cloud/binary_sensor.py
@@ -62,7 +62,7 @@ class CloudRemoteBinary(BinarySensorDevice):
         async def async_state_update(data):
             """Update callback."""
             await asyncio.sleep(WAIT_UNTIL_CHANGE)
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         self._unsub_dispatcher = async_dispatcher_connect(
             self.hass, DISPATCHER_REMOTE_UPDATE, async_state_update

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cloud",
   "name": "Home Assistant Cloud",
   "documentation": "https://www.home-assistant.io/integrations/cloud",
-  "requirements": ["hass-nabucasa==0.32.2"],
+  "requirements": ["hass-nabucasa==0.33.0"],
   "dependencies": ["http", "webhook", "alexa"],
   "after_dependencies": ["google_assistant"],
   "codeowners": ["@home-assistant/cloud"]

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,7 +11,7 @@ ciso8601==2.1.3
 cryptography==2.8
 defusedxml==0.6.0
 distro==1.4.0
-hass-nabucasa==0.32.2
+hass-nabucasa==0.33.0
 home-assistant-frontend==20200401.0
 importlib-metadata==1.5.0
 jinja2>=2.11.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -674,7 +674,7 @@ habitipy==0.2.0
 hangups==0.4.9
 
 # homeassistant.components.cloud
-hass-nabucasa==0.32.2
+hass-nabucasa==0.33.0
 
 # homeassistant.components.mqtt
 hbmqtt==0.9.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -264,7 +264,7 @@ ha-ffmpeg==2.0
 hangups==0.4.9
 
 # homeassistant.components.cloud
-hass-nabucasa==0.32.2
+hass-nabucasa==0.33.0
 
 # homeassistant.components.mqtt
 hbmqtt==0.9.5

--- a/tests/components/cloud/test_binary_sensor.py
+++ b/tests/components/cloud/test_binary_sensor.py
@@ -1,24 +1,23 @@
 """Tests for the cloud binary sensor."""
 from unittest.mock import Mock
 
+from asynctest import patch
+
 from homeassistant.components.cloud.const import DISPATCHER_REMOTE_UPDATE
 from homeassistant.setup import async_setup_component
 
 
 async def test_remote_connection_sensor(hass):
     """Test the remote connection sensor."""
-    from homeassistant.components.cloud import binary_sensor as bin_sensor
-
-    bin_sensor.WAIT_UNTIL_CHANGE = 0
-
     assert await async_setup_component(hass, "cloud", {"cloud": {}})
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.remote_ui") is None
 
     # Fake connection/discovery
-    org_cloud = hass.data["cloud"]
-    await org_cloud.iot._on_connect[-1]()
+    await hass.helpers.discovery.async_load_platform(
+        "binary_sensor", "cloud", {}, {"cloud": {}}
+    )
 
     # Mock test env
     cloud = hass.data["cloud"] = Mock()
@@ -29,17 +28,18 @@ async def test_remote_connection_sensor(hass):
     assert state is not None
     assert state.state == "unavailable"
 
-    cloud.remote.is_connected = False
-    cloud.remote.certificate = object()
-    hass.helpers.dispatcher.async_dispatcher_send(DISPATCHER_REMOTE_UPDATE, {})
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.cloud.binary_sensor.WAIT_UNTIL_CHANGE", 0):
+        cloud.remote.is_connected = False
+        cloud.remote.certificate = object()
+        hass.helpers.dispatcher.async_dispatcher_send(DISPATCHER_REMOTE_UPDATE, {})
+        await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.remote_ui")
-    assert state.state == "off"
+        state = hass.states.get("binary_sensor.remote_ui")
+        assert state.state == "off"
 
-    cloud.remote.is_connected = True
-    hass.helpers.dispatcher.async_dispatcher_send(DISPATCHER_REMOTE_UPDATE, {})
-    await hass.async_block_till_done()
+        cloud.remote.is_connected = True
+        hass.helpers.dispatcher.async_dispatcher_send(DISPATCHER_REMOTE_UPDATE, {})
+        await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.remote_ui")
-    assert state.state == "on"
+        state = hass.states.get("binary_sensor.remote_ui")
+        assert state.state == "on"

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.components import cloud
 from homeassistant.components.cloud.const import DOMAIN
 from homeassistant.components.cloud.prefs import STORAGE_KEY
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Context
 from homeassistant.exceptions import Unauthorized
 from homeassistant.setup import async_setup_component
@@ -103,12 +103,6 @@ async def test_remote_services(hass, mock_cloud_fixture, hass_read_only_user):
 
 async def test_startup_shutdown_events(hass, mock_cloud_fixture):
     """Test if the cloud will start on startup event."""
-    with patch("hass_nabucasa.Cloud.start", return_value=mock_coro()) as mock_start:
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        await hass.async_block_till_done()
-
-    assert mock_start.called
-
     with patch("hass_nabucasa.Cloud.stop", return_value=mock_coro()) as mock_stop:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Home Assistant Cloud now loads domain info during `async_setup`, so when you depend on cloud, you can rely on the fact that we know the remote url.

Cloud integration loads now in 1.2s on my mac.

Requires https://github.com/NabuCasa/hass-nabucasa/pull/140 to be released as 0.33.

CC @frenck @cgtobi 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
