### PR TITLE
Fix netatmo device unavailable and services

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -259,7 +259,7 @@ class NetatmoThermostat(ClimateDevice):
         if hvac_mode == HVAC_MODE_OFF:
             self.turn_off()
         elif hvac_mode == HVAC_MODE_AUTO:
-            if self.hvac_mode == STATE_OFF:
+            if self.hvac_mode == HVAC_MODE_OFF:
                 self.turn_on()
             self.set_preset_mode(PRESET_SCHEDULE)
         elif hvac_mode == HVAC_MODE_HEAT:
@@ -337,9 +337,9 @@ class NetatmoThermostat(ClimateDevice):
                 STATE_NETATMO_MANUAL,
                 DEFAULT_MIN_TEMP,
             )
-        elif self.hvac_mode != STATE_OFF:
+        elif self.hvac_mode != HVAC_MODE_OFF:
             self._data.homestatus.setroomThermpoint(
-                self._data.home_id, self._room_id, HVAC_MODE_OFF
+                self._data.home_id, self._room_id, STATE_NETATMO_OFF
             )
         self.update_without_throttle = True
         self.schedule_update_ha_state()
@@ -355,7 +355,7 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def available(self) -> bool:
         """If the device hasn't been able to connect, mark as unavailable."""
-        return self._connected or self._connected is None
+        return self._connected or self._connected is not None
 
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -355,7 +355,7 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def available(self) -> bool:
         """If the device hasn't been able to connect, mark as unavailable."""
-        return self._connected or self._connected is not None
+        return self._connected or self._connected is None
 
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""
@@ -391,7 +391,7 @@ class NetatmoThermostat(ClimateDevice):
                 self._room_name,
                 err,
             )
-            self._connected = None
+            self._connected = False
         self._away = self._hvac_mode == HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
 
 

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -260,7 +260,6 @@ class NetatmoThermostat(ClimateDevice):
             self.turn_off()
         elif hvac_mode == HVAC_MODE_AUTO:
             if self.hvac_mode == STATE_OFF:
-                _LOGGER.debug("Turning on first")
                 self.turn_on()
             self.set_preset_mode(PRESET_SCHEDULE)
         elif hvac_mode == HVAC_MODE_HEAT:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -355,7 +355,7 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def available(self) -> bool:
         """If the device hasn't been able to connect, mark as unavailable."""
-        return self._connected or self._connected is None
+        return bool(self._connected)
 
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
+    DEFAULT_MIN_TEMP,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
@@ -331,13 +332,18 @@ class NetatmoThermostat(ClimateDevice):
     def turn_off(self):
         """Turn the entity off."""
         if self._module_type == NA_VALVE:
-            _LOGGER.info("Valves do not support being turned off")
+            self._data.homestatus.setroomThermpoint(
+                self._data.home_id,
+                self._room_id,
+                STATE_NETATMO_MANUAL,
+                DEFAULT_MIN_TEMP,
+            )
         elif self.hvac_mode != STATE_OFF:
             self._data.homestatus.setroomThermpoint(
                 self._data.home_id, self._room_id, HVAC_MODE_OFF
             )
-            self.update_without_throttle = True
-            self.schedule_update_ha_state()
+        self.update_without_throttle = True
+        self.schedule_update_ha_state()
 
     def turn_on(self):
         """Turn the entity on."""

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -11,7 +11,6 @@ from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
-    DEFAULT_MIN_TEMP,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
@@ -56,6 +55,7 @@ STATE_NETATMO_MAX = "max"
 STATE_NETATMO_AWAY = PRESET_AWAY
 STATE_NETATMO_OFF = STATE_OFF
 STATE_NETATMO_MANUAL = "manual"
+STATE_NETATMO_HOME = "home"
 
 PRESET_MAP_NETATMO = {
     PRESET_FROST_GUARD: STATE_NETATMO_HG,
@@ -173,8 +173,11 @@ class NetatmoThermostat(ClimateDevice):
         self._support_flags = SUPPORT_FLAGS
         self._hvac_mode = None
         self._battery_level = None
+        self._connected = None
         self.update_without_throttle = False
-        self._module_type = self._data.room_status.get(room_id, {}).get("module_type")
+        self._module_type = self._data.room_status.get(room_id, {}).get(
+            "module_type", NA_VALVE
+        )
 
         if self._module_type == NA_THERM:
             self._operation_list.append(HVAC_MODE_OFF)
@@ -252,25 +255,23 @@ class NetatmoThermostat(ClimateDevice):
 
     def set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
-        mode = None
-
+        _LOGGER.debug("set hvac mode: %s", hvac_mode)
         if hvac_mode == HVAC_MODE_OFF:
-            mode = STATE_NETATMO_OFF
+            self.turn_off()
         elif hvac_mode == HVAC_MODE_AUTO:
-            mode = PRESET_SCHEDULE
+            if self.hvac_mode == STATE_OFF:
+                _LOGGER.debug("Turning on first")
+                self.turn_on()
+            self.set_preset_mode(PRESET_SCHEDULE)
         elif hvac_mode == HVAC_MODE_HEAT:
-            mode = PRESET_BOOST
-
-        self.set_preset_mode(mode)
+            self.set_preset_mode(PRESET_BOOST)
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
+        _LOGGER.debug("set preset mode: %s", preset_mode)
         if self.target_temperature == 0:
             self._data.homestatus.setroomThermpoint(
-                self._data.home_id,
-                self._room_id,
-                STATE_NETATMO_MANUAL,
-                DEFAULT_MIN_TEMP,
+                self._data.home_id, self._room_id, STATE_NETATMO_HOME,
             )
 
         if (
@@ -283,7 +284,7 @@ class NetatmoThermostat(ClimateDevice):
                 STATE_NETATMO_MANUAL,
                 DEFAULT_MAX_TEMP,
             )
-        elif preset_mode in [PRESET_BOOST, STATE_NETATMO_MAX, STATE_NETATMO_OFF]:
+        elif preset_mode in [PRESET_BOOST, STATE_NETATMO_MAX]:
             self._data.homestatus.setroomThermpoint(
                 self._data.home_id, self._room_id, PRESET_MAP_NETATMO[preset_mode]
             )
@@ -293,6 +294,7 @@ class NetatmoThermostat(ClimateDevice):
             )
         else:
             _LOGGER.error("Preset mode '%s' not available", preset_mode)
+
         self.update_without_throttle = True
         self.schedule_update_ha_state()
 
@@ -328,6 +330,31 @@ class NetatmoThermostat(ClimateDevice):
 
         return attr
 
+    def turn_off(self):
+        """Turn the entity off."""
+        _LOGGER.debug("Turn off home: %s room: %s", self._data.home_id, self._room_id)
+        if self._module_type != NA_VALVE:
+            _LOGGER.info("Valves do not support being turned off")
+        elif self.hvac_mode != STATE_OFF:
+            self._data.homestatus.setroomThermpoint(
+                self._data.home_id, self._room_id, HVAC_MODE_OFF
+            )
+            self.update_without_throttle = True
+            self.schedule_update_ha_state()
+
+    def turn_on(self):
+        """Turn the entity on."""
+        self._data.homestatus.setroomThermpoint(
+            self._data.home_id, self._room_id, STATE_NETATMO_HOME
+        )
+        self.update_without_throttle = True
+        self.schedule_update_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """If the device hasn't been able to connect, mark as unavailable."""
+        return self._connected or self._connected is None
+
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""
         try:
@@ -356,11 +383,12 @@ class NetatmoThermostat(ClimateDevice):
                 "battery_level"
             )
         except KeyError as err:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "The thermostat in room %s seems to be out of reach. (%s)",
                 self._room_name,
                 err,
             )
+            self._connected = None
         self._away = self._hvac_mode == HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
 
 

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -255,7 +255,6 @@ class NetatmoThermostat(ClimateDevice):
 
     def set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
-        _LOGGER.debug("set hvac mode: %s", hvac_mode)
         if hvac_mode == HVAC_MODE_OFF:
             self.turn_off()
         elif hvac_mode == HVAC_MODE_AUTO:
@@ -268,7 +267,6 @@ class NetatmoThermostat(ClimateDevice):
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        _LOGGER.debug("set preset mode: %s", preset_mode)
         if self.target_temperature == 0:
             self._data.homestatus.setroomThermpoint(
                 self._data.home_id, self._room_id, STATE_NETATMO_HOME,
@@ -332,8 +330,7 @@ class NetatmoThermostat(ClimateDevice):
 
     def turn_off(self):
         """Turn the entity off."""
-        _LOGGER.debug("Turn off home: %s room: %s", self._data.home_id, self._room_id)
-        if self._module_type != NA_VALVE:
+        if self._module_type == NA_VALVE:
             _LOGGER.info("Valves do not support being turned off")
         elif self.hvac_mode != STATE_OFF:
             self._data.homestatus.setroomThermpoint(

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -384,6 +384,7 @@ class NetatmoThermostat(ClimateDevice):
             self._battery_level = self._data.room_status[self._room_id].get(
                 "battery_level"
             )
+            self._connected = True
         except KeyError as err:
             _LOGGER.debug(
                 "The thermostat in room %s seems to be out of reach. (%s)",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will set the entity as unavailable when errors occur that imply that the device is out of reach or its batteries died.
It also fixes an issue with turn_on/off services not working correctly. Since valves can't be turned off they will be set to the lowest setting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33428 and fixes #32229
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
