### PR TITLE
Remove extraneous parameter from AlarmDecoder services

### DIFF
--- a/homeassistant/components/alarmdecoder/services.yaml
+++ b/homeassistant/components/alarmdecoder/services.yaml
@@ -1,9 +1,6 @@
 alarm_keypress:
   description: Send custom keypresses to the alarm.
   fields:
-    entity_id:
-      description: Name of the alarm control panel to trigger.
-      example: 'alarm_control_panel.downstairs'
     keypress:
       description: 'String to send to the alarm panel.'
       example: '*71'
@@ -11,9 +8,6 @@ alarm_keypress:
 alarm_toggle_chime:
   description: Send the alarm the toggle chime command.
   fields:
-    entity_id:
-      description: Name of the alarm control panel to trigger.
-      example: 'alarm_control_panel.downstairs'
     code:
       description: A required code to toggle the alarm control panel chime with.
       example: 1234


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR removes the `entity_id` field from the `alarm_keypress` and `alarm_toggle_chime` services for AlarmDecoder. The `entity_id` field was not used in either of the [service handlers](https://github.com/home-assistant/core/blob/dev/homeassistant/components/alarmdecoder/alarm_control_panel.py#L52-L74) or [voluptuous schemas](https://github.com/home-assistant/core/blob/dev/homeassistant/components/alarmdecoder/alarm_control_panel.py#L34-L39).

It was causing issues in the _Services_ panel UI below by prefilling fields that didn't exist and triggering a `Failed to call service alarmdecoder/alarm_keypress. extra keys not allowed @ data['entity_id']` error.

![image](https://user-images.githubusercontent.com/7400326/78199171-e79d2100-7458-11ea-8607-bcbba7f122e8.png)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
