### PR TITLE
Skip parsing Plex session if incomplete

### DIFF
--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -105,6 +105,7 @@ class PlexSensor(Entity):
         """Update method for Plex sensor."""
         _LOGGER.debug("Refreshing sensor [%s]", self.unique_id)
 
+        @callback
         def update_plex(_):
             async_dispatcher_send(
                 self.hass,

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -104,6 +104,9 @@ class PlexSensor(Entity):
             if sess.TYPE == "photo":
                 _LOGGER.debug("Photo session detected, skipping: %s", sess)
                 continue
+            if not sess.usernames:
+                _LOGGER.debug("Session temporarily incomplete, skipping: %s", sess)
+                continue
             user = sess.usernames[0]
             device = sess.players[0].title
             now_playing_user = f"{user} - {device}"

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -2,10 +2,7 @@
 import logging
 
 from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_call_later
 
@@ -60,11 +57,67 @@ class PlexSensor(Entity):
         )
         self.hass.data[PLEX_DOMAIN][DISPATCHERS][server_id].append(unsub)
 
-    @callback
-    def async_refresh_sensor(self, sessions):
+    async def async_refresh_sensor(self, sessions):
         """Set instance object and trigger an entity state update."""
+        _LOGGER.debug("Refreshing sensor [%s]", self.unique_id)
+
         self.sessions = sessions
-        self.async_schedule_update_ha_state(True)
+
+        @callback
+        def update_plex(_):
+            dispatcher_send(
+                self.hass,
+                PLEX_UPDATE_PLATFORMS_SIGNAL.format(self._server.machine_identifier),
+            )
+
+        now_playing = []
+        for sess in self.sessions:
+            if sess.TYPE == "photo":
+                _LOGGER.debug("Photo session detected, skipping: %s", sess)
+                continue
+            if not sess.usernames:
+                _LOGGER.debug(
+                    "Session temporarily incomplete, will try again: %s", sess
+                )
+                async_call_later(self.hass, 5, update_plex)
+                return
+            user = sess.usernames[0]
+            device = sess.players[0].title
+            now_playing_user = f"{user} - {device}"
+            now_playing_title = ""
+
+            if sess.TYPE in ["clip", "episode"]:
+                # example:
+                # "Supernatural (2005) - s01e13 - Route 666"
+                season_title = sess.grandparentTitle
+                show = await self.hass.async_add_executor_job(sess.show)
+                if show.year is not None:
+                    season_title += f" ({show.year!s})"
+                season_episode = sess.seasonEpisode
+                episode_title = sess.title
+                now_playing_title = (
+                    f"{season_title} - {season_episode} - {episode_title}"
+                )
+            elif sess.TYPE == "track":
+                # example:
+                # "Billy Talent - Afraid of Heights - Afraid of Heights"
+                track_artist = sess.grandparentTitle
+                track_album = sess.parentTitle
+                track_title = sess.title
+                now_playing_title = f"{track_artist} - {track_album} - {track_title}"
+            else:
+                # example:
+                # "picture_of_last_summer_camp (2015)"
+                # "The Incredible Hulk (2008)"
+                now_playing_title = sess.title
+                if sess.year is not None:
+                    now_playing_title += f" ({sess.year})"
+
+            now_playing.append((now_playing_user, now_playing_title))
+        self._state = len(self.sessions)
+        self._now_playing = now_playing
+
+        self.async_write_ha_state()
 
     @property
     def name(self):
@@ -100,63 +153,6 @@ class PlexSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {content[0]: content[1] for content in self._now_playing}
-
-    def update(self):
-        """Update method for Plex sensor."""
-        _LOGGER.debug("Refreshing sensor [%s]", self.unique_id)
-
-        @callback
-        def update_plex(_):
-            async_dispatcher_send(
-                self.hass,
-                PLEX_UPDATE_PLATFORMS_SIGNAL.format(self._server.machine_identifier),
-            )
-
-        now_playing = []
-        for sess in self.sessions:
-            if sess.TYPE == "photo":
-                _LOGGER.debug("Photo session detected, skipping: %s", sess)
-                continue
-            if not sess.usernames:
-                _LOGGER.debug(
-                    "Session temporarily incomplete, will try again: %s", sess
-                )
-                async_call_later(self.hass, 5, update_plex)
-                continue
-            user = sess.usernames[0]
-            device = sess.players[0].title
-            now_playing_user = f"{user} - {device}"
-            now_playing_title = ""
-
-            if sess.TYPE in ["clip", "episode"]:
-                # example:
-                # "Supernatural (2005) - s01e13 - Route 666"
-                season_title = sess.grandparentTitle
-                if sess.show().year is not None:
-                    season_title += f" ({sess.show().year!s})"
-                season_episode = sess.seasonEpisode
-                episode_title = sess.title
-                now_playing_title = (
-                    f"{season_title} - {season_episode} - {episode_title}"
-                )
-            elif sess.TYPE == "track":
-                # example:
-                # "Billy Talent - Afraid of Heights - Afraid of Heights"
-                track_artist = sess.grandparentTitle
-                track_album = sess.parentTitle
-                track_title = sess.title
-                now_playing_title = f"{track_artist} - {track_album} - {track_title}"
-            else:
-                # example:
-                # "picture_of_last_summer_camp (2015)"
-                # "The Incredible Hulk (2008)"
-                now_playing_title = sess.title
-                if sess.year is not None:
-                    now_playing_title += f" ({sess.year})"
-
-            now_playing.append((now_playing_user, now_playing_title))
-        self._state = len(self.sessions)
-        self._now_playing = now_playing
 
     @property
     def device_info(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes incomplete data is returned for an actively playing session. Not much we can do besides skip it and try again later.

In this case the session details will be unavailable, but the session will still be counted in the total number of known sessions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33523
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
