### PR TITLE
Remove MQTT state vacuum value_template support.

### DIFF
--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -36,12 +36,7 @@ from homeassistant.components.vacuum import (
     SUPPORT_STOP,
     StateVacuumDevice,
 )
-from homeassistant.const import (
-    ATTR_SUPPORTED_FEATURES,
-    CONF_DEVICE,
-    CONF_NAME,
-    CONF_VALUE_TEMPLATE,
-)
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_DEVICE, CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
@@ -103,7 +98,6 @@ CONF_PAYLOAD_CLEAN_SPOT = "payload_clean_spot"
 CONF_PAYLOAD_LOCATE = "payload_locate"
 CONF_PAYLOAD_START = "payload_start"
 CONF_PAYLOAD_PAUSE = "payload_pause"
-CONF_STATE_TEMPLATE = "state_template"
 CONF_SET_FAN_SPEED_TOPIC = "set_fan_speed_topic"
 CONF_FAN_SPEED_LIST = "fan_speed_list"
 CONF_SEND_COMMAND_TOPIC = "send_command_topic"
@@ -140,7 +134,6 @@ PLATFORM_SCHEMA_STATE = (
             vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): cv.string,
             vol.Optional(CONF_SEND_COMMAND_TOPIC): mqtt.valid_publish_topic,
             vol.Optional(CONF_SET_FAN_SPEED_TOPIC): mqtt.valid_publish_topic,
-            vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_STATE_TOPIC): mqtt.valid_publish_topic,
             vol.Optional(
                 CONF_SUPPORTED_FEATURES, default=DEFAULT_SERVICE_STRINGS
@@ -240,18 +233,12 @@ class MqttStateVacuum(
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
-        template = self._config.get(CONF_VALUE_TEMPLATE)
-        if template is not None:
-            template.hass = self.hass
         topics = {}
 
         @callback
         def state_message_received(msg):
             """Handle state MQTT message."""
-            payload = msg.payload
-            if template is not None:
-                payload = template.async_render_with_possible_json_value(payload)
-            payload = json.loads(payload)
+            payload = json.loads(msg.payload)
             if STATE in payload and payload[STATE] in POSSIBLE_STATES:
                 self._state = POSSIBLE_STATES[payload[STATE]]
                 del payload[STATE]

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -251,8 +251,7 @@ class MqttStateVacuum(
             payload = msg.payload
             if template is not None:
                 payload = template.async_render_with_possible_json_value(payload)
-            else:
-                payload = json.loads(payload)
+            payload = json.loads(payload)
             if STATE in payload and payload[STATE] in POSSIBLE_STATES:
                 self._state = POSSIBLE_STATES[payload[STATE]]
                 del payload[STATE]

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -248,48 +248,6 @@ async def test_status(hass, mqtt_mock):
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == ["min", "medium", "high", "max"]
 
 
-async def test_status_with_template(hass, mqtt_mock):
-    """Test status updates from the vacuum."""
-    config = deepcopy(DEFAULT_CONFIG)
-    config[mqttvacuum.CONF_VALUE_TEMPLATE] = "{{ value_json['vacuum1'] | tojson }}"
-    config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
-        mqttvacuum.ALL_SERVICES, SERVICE_TO_STRING
-    )
-
-    assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
-
-    message = """{
-        "vacuum1": {
-          "battery_level": 54,
-          "state": "cleaning",
-          "fan_speed": "max"
-        }
-    }"""
-
-    async_fire_mqtt_message(hass, "vacuum/state", message)
-    state = hass.states.get("vacuum.mqtttest")
-    assert state.state == STATE_CLEANING
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) == 54
-    assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-50"
-    assert state.attributes.get(ATTR_FAN_SPEED) == "max"
-
-    message = """{
-        "vacuum1": {
-          "battery_level": 61,
-          "state": "docked",
-          "fan_speed": "min"
-        }
-    }"""
-
-    async_fire_mqtt_message(hass, "vacuum/state", message)
-    state = hass.states.get("vacuum.mqtttest")
-    assert state.state == STATE_DOCKED
-    assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-charging-60"
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) == 61
-    assert state.attributes.get(ATTR_FAN_SPEED) == "min"
-    assert state.attributes.get(ATTR_FAN_SPEED_LIST) == ["min", "medium", "high", "max"]
-
-
 async def test_no_fan_vacuum(hass, mqtt_mock):
     """Test status updates from the vacuum when fan is not supported."""
     config = deepcopy(DEFAULT_CONFIG)


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove MQTT state vacuum `value_template` support.
The implementation is not working, so this can not be considered a breaking change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
