### PR TITLE
Ensure harmony hub is ready before importing

### DIFF
--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -24,6 +24,7 @@ from homeassistant.components.remote import (
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -33,6 +34,13 @@ from .const import (
     HARMONY_OPTIONS_UPDATE,
     SERVICE_CHANGE_CHANNEL,
     SERVICE_SYNC,
+    UNIQUE_ID,
+)
+from .util import (
+    find_best_name_for_remote,
+    find_matching_config_entries_for_host,
+    find_unique_id_for_remote,
+    get_harmony_client_if_available,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,6 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     extra=vol.ALLOW_EXTRA,
 )
 
+
 HARMONY_SYNC_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids})
 
 HARMONY_CHANGE_CHANNEL_SCHEMA = vol.Schema(
@@ -68,9 +77,25 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         # Now handled by ssdp in the config flow
         return
 
+    if find_matching_config_entries_for_host(hass, config[CONF_HOST]):
+        return
+
+    # We do the validation to verify we can connect
+    # so we can raise PlatformNotReady to force
+    # a retry so we can avoid a scenario where the config
+    # entry cannot be created via import because hub
+    # is not yet ready.
+    harmony = await get_harmony_client_if_available(config[CONF_HOST])
+    if not harmony:
+        raise PlatformNotReady
+
+    validated_config = config.copy()
+    validated_config[UNIQUE_ID] = find_unique_id_for_remote(harmony)
+    validated_config[CONF_NAME] = find_best_name_for_remote(config, harmony)
+
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=validated_config
         )
     )
 

--- a/homeassistant/components/harmony/util.py
+++ b/homeassistant/components/harmony/util.py
@@ -1,8 +1,13 @@
 """The Logitech Harmony Hub integration utils."""
-from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
+import aioharmony.exceptions as harmony_exceptions
+from aioharmony.harmonyapi import HarmonyAPI
+
+from homeassistant.const import CONF_HOST, CONF_NAME
+
+from .const import DOMAIN
 
 
-def find_unique_id_for_remote(harmony: HarmonyClient):
+def find_unique_id_for_remote(harmony: HarmonyAPI):
     """Find the unique id for both websocket and xmpp clients."""
     websocket_unique_id = harmony.hub_config.info.get("activeRemoteId")
     if websocket_unique_id is not None:
@@ -10,3 +15,38 @@ def find_unique_id_for_remote(harmony: HarmonyClient):
 
     # fallback to the xmpp unique id if websocket is not available
     return harmony.config["global"]["timeStampHash"].split(";")[-1]
+
+
+def find_best_name_for_remote(data: dict, harmony: HarmonyAPI):
+    """Find the best name from config or fallback to the remote."""
+    # As a last resort we get the name from the harmony client
+    # in the event a name was not provided.  harmony.name is
+    # usually the ip address but it can be an empty string.
+    if CONF_NAME not in data or data[CONF_NAME] is None or data[CONF_NAME] == "":
+        return harmony.name
+
+    return data[CONF_NAME]
+
+
+async def get_harmony_client_if_available(ip_address: str):
+    """Connect to a harmony hub and fetch info."""
+    harmony = HarmonyAPI(ip_address=ip_address)
+
+    try:
+        if not await harmony.connect():
+            await harmony.close()
+            return None
+    except harmony_exceptions.TimeOut:
+        return None
+
+    await harmony.close()
+
+    return harmony
+
+
+def find_matching_config_entries_for_host(hass, host):
+    """Search existing config entries for one matching the host."""
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.data[CONF_HOST] == host:
+            return entry
+    return None

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -25,8 +25,7 @@ async def test_user_form(hass):
 
     harmonyapi = _get_mock_harmonyapi(connect=True)
     with patch(
-        "homeassistant.components.harmony.config_flow.HarmonyAPI",
-        return_value=harmonyapi,
+        "homeassistant.components.harmony.util.HarmonyAPI", return_value=harmonyapi,
     ), patch(
         "homeassistant.components.harmony.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -53,8 +52,7 @@ async def test_form_import(hass):
 
     harmonyapi = _get_mock_harmonyapi(connect=True)
     with patch(
-        "homeassistant.components.harmony.config_flow.HarmonyAPI",
-        return_value=harmonyapi,
+        "homeassistant.components.harmony.util.HarmonyAPI", return_value=harmonyapi,
     ), patch(
         "homeassistant.components.harmony.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -68,9 +66,11 @@ async def test_form_import(hass):
                 "name": "friend",
                 "activity": "Watch TV",
                 "delay_secs": 0.9,
+                "unique_id": "555234534543",
             },
         )
 
+    assert result["result"].unique_id == "555234534543"
     assert result["type"] == "create_entry"
     assert result["title"] == "friend"
     assert result["data"] == {
@@ -94,8 +94,7 @@ async def test_form_ssdp(hass):
     harmonyapi = _get_mock_harmonyapi(connect=True)
 
     with patch(
-        "homeassistant.components.harmony.config_flow.HarmonyAPI",
-        return_value=harmonyapi,
+        "homeassistant.components.harmony.util.HarmonyAPI", return_value=harmonyapi,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -114,8 +113,7 @@ async def test_form_ssdp(hass):
     }
 
     with patch(
-        "homeassistant.components.harmony.config_flow.HarmonyAPI",
-        return_value=harmonyapi,
+        "homeassistant.components.harmony.util.HarmonyAPI", return_value=harmonyapi,
     ), patch(
         "homeassistant.components.harmony.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -141,8 +139,7 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.harmony.config_flow.HarmonyAPI",
-        side_effect=CannotConnect,
+        "homeassistant.components.harmony.util.HarmonyAPI", side_effect=CannotConnect,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the harmony hub was not ready for connection or
was busy when importing from yaml, the import validation
would fail would not be retried.

To mitigate this scenario we now do the validation in
async_setup_platform which allows us to raise
PlatformNotReady so we can retry later.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33521
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
