### PR TITLE
Debounce calls to Plex server

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -9,6 +9,7 @@ DEFAULT_PORT = 32400
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
+DEBOUNCE_TIMEOUT = 0.5
 DISPATCHERS = "dispatchers"
 PLATFORMS = frozenset(["media_player", "sensor"])
 PLATFORMS_COMPLETED = "platforms_completed"

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -9,7 +9,7 @@ DEFAULT_PORT = 32400
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
-DEBOUNCE_TIMEOUT = 0.5
+DEBOUNCE_TIMEOUT = 1
 DISPATCHERS = "dispatchers"
 PLATFORMS = frozenset(["media_player", "sensor"])
 PLATFORMS_COMPLETED = "platforms_completed"

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -58,6 +58,7 @@ def debounce(func):
         """Schedule async callback."""
         nonlocal unsub
         if unsub:
+            _LOGGER.debug("Throttling update of %s", self._plex_server.friendlyName)
             unsub()  # pylint: disable=not-callable
         unsub = async_call_later(
             self.hass, DEBOUNCE_TIMEOUT, partial(call_later_listener, self),

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -58,7 +58,7 @@ def debounce(func):
         """Schedule async callback."""
         nonlocal unsub
         if unsub:
-            _LOGGER.debug("Throttling update of %s", self._plex_server.friendlyName)
+            _LOGGER.debug("Throttling update of %s", self.friendly_name)
             unsub()  # pylint: disable=not-callable
         unsub = async_call_later(
             self.hass, DEBOUNCE_TIMEOUT, partial(call_later_listener, self),

--- a/tests/components/plex/common.py
+++ b/tests/components/plex/common.py
@@ -1,13 +1,20 @@
 """Common fixtures and functions for Plex tests."""
 from datetime import timedelta
 
-from homeassistant.components.plex.const import DEBOUNCE_TIMEOUT
+from homeassistant.components.plex.const import (
+    DEBOUNCE_TIMEOUT,
+    PLEX_UPDATE_PLATFORMS_SIGNAL,
+)
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 
 
-def tick_debounce_timeout(hass):
-    """Advance test clock by debounce timeout."""
+async def trigger_plex_update(hass, server_id):
+    """Update Plex by sending signal and jumping ahead by debounce timeout."""
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
     next_update = dt_util.utcnow() + timedelta(seconds=DEBOUNCE_TIMEOUT)
     async_fire_time_changed(hass, next_update)
+    await hass.async_block_till_done()

--- a/tests/components/plex/common.py
+++ b/tests/components/plex/common.py
@@ -1,0 +1,13 @@
+"""Common fixtures and functions for Plex tests."""
+from datetime import timedelta
+
+from homeassistant.components.plex.const import DEBOUNCE_TIMEOUT
+import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed
+
+
+def tick_debounce_timeout(hass):
+    """Advance test clock by debounce timeout."""
+    next_update = dt_util.utcnow() + timedelta(seconds=DEBOUNCE_TIMEOUT)
+    async_fire_time_changed(hass, next_update)

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -15,15 +15,13 @@ from homeassistant.components.plex.const import (
     CONF_USE_EPISODE_ART,
     DOMAIN,
     PLEX_SERVER_CONFIG,
-    PLEX_UPDATE_PLATFORMS_SIGNAL,
     SERVERS,
 )
 from homeassistant.config_entries import ENTRY_STATE_LOADED
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_URL
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
-from .common import tick_debounce_timeout
+from .common import trigger_plex_update
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
 from .mock_classes import MockPlexAccount, MockPlexServer
 
@@ -417,9 +415,7 @@ async def test_option_flow_new_users_available(hass, caplog):
 
     server_id = mock_plex_server.machineIdentifier
 
-    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
 

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_URL
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
+from .common import tick_debounce_timeout
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
 from .mock_classes import MockPlexAccount, MockPlexServer
 
@@ -417,6 +418,7 @@ async def test_option_flow_new_users_available(hass, caplog):
     server_id = mock_plex_server.machineIdentifier
 
     async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -23,11 +23,10 @@ from homeassistant.const import (
     CONF_URL,
     CONF_VERIFY_SSL,
 )
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from .common import tick_debounce_timeout
+from .common import trigger_plex_update
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
 from .mock_classes import MockPlexAccount, MockPlexServer
 
@@ -75,7 +74,7 @@ async def test_setup_with_config(hass):
     )
 
 
-async def test_setup_with_config_entry(hass):
+async def test_setup_with_config_entry(hass, caplog):
     """Test setup component with config."""
 
     mock_plex_server = MockPlexServer()
@@ -110,34 +109,31 @@ async def test_setup_with_config_entry(hass):
         hass.data[const.DOMAIN][const.PLATFORMS_COMPLETED][server_id] == const.PLATFORMS
     )
 
-    async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     sensor = hass.states.get("sensor.plex_plex_server_1")
     assert sensor.state == str(len(mock_plex_server.accounts))
 
-    async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     with patch.object(
         mock_plex_server, "clients", side_effect=plexapi.exceptions.BadRequest
-    ):
-        async_dispatcher_send(
-            hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id)
-        )
-        tick_debounce_timeout(hass)
-        await hass.async_block_till_done()
+    ) as patched_clients_bad_request:
+        await trigger_plex_update(hass, server_id)
+
+    assert patched_clients_bad_request.called
+    assert "Error requesting Plex client data from server" in caplog.text
 
     with patch.object(
         mock_plex_server, "clients", side_effect=requests.exceptions.RequestException
-    ):
-        async_dispatcher_send(
-            hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id)
-        )
-        tick_debounce_timeout(hass)
-        await hass.async_block_till_done()
+    ) as patched_clients_requests_exception:
+        await trigger_plex_update(hass, server_id)
+
+    assert patched_clients_requests_exception.called
+    assert (
+        f"Could not connect to Plex server: {mock_plex_server.friendlyName}"
+        in caplog.text
+    )
 
 
 async def test_set_config_entry_unique_id(hass):
@@ -299,9 +295,7 @@ async def test_setup_with_photo_session(hass):
 
     server_id = mock_plex_server.machineIdentifier
 
-    async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     media_player = hass.states.get("media_player.plex_product_title")
     assert media_player.state == "idle"

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from .common import tick_debounce_timeout
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
 from .mock_classes import MockPlexAccount, MockPlexServer
 
@@ -110,12 +111,14 @@ async def test_setup_with_config_entry(hass):
     )
 
     async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     sensor = hass.states.get("sensor.plex_plex_server_1")
     assert sensor.state == str(len(mock_plex_server.accounts))
 
     async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     with patch.object(
@@ -124,6 +127,7 @@ async def test_setup_with_config_entry(hass):
         async_dispatcher_send(
             hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id)
         )
+        tick_debounce_timeout(hass)
         await hass.async_block_till_done()
 
     with patch.object(
@@ -132,6 +136,7 @@ async def test_setup_with_config_entry(hass):
         async_dispatcher_send(
             hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id)
         )
+        tick_debounce_timeout(hass)
         await hass.async_block_till_done()
 
 
@@ -295,6 +300,7 @@ async def test_setup_with_photo_session(hass):
     server_id = mock_plex_server.machineIdentifier
 
     async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     media_player = hass.states.get("media_player.plex_product_title")

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -13,6 +13,7 @@ from homeassistant.components.plex.const import (
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
+from .common import tick_debounce_timeout
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .mock_classes import MockPlexServer
 
@@ -45,6 +46,7 @@ async def test_new_users_available(hass):
     server_id = mock_plex_server.machineIdentifier
 
     async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
@@ -84,6 +86,7 @@ async def test_new_ignored_users_available(hass, caplog):
     server_id = mock_plex_server.machineIdentifier
 
     async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
@@ -119,6 +122,7 @@ async def test_mark_sessions_idle(hass):
     server_id = mock_plex_server.machineIdentifier
 
     async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     sensor = hass.states.get("sensor.plex_plex_server_1")
@@ -128,6 +132,7 @@ async def test_mark_sessions_idle(hass):
     mock_plex_server.clear_sessions()
 
     async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    tick_debounce_timeout(hass)
     await hass.async_block_till_done()
 
     sensor = hass.states.get("sensor.plex_plex_server_1")

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -1,5 +1,6 @@
 """Tests for Plex server."""
 import copy
+from datetime import timedelta
 
 from asynctest import patch
 
@@ -7,17 +8,19 @@ from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.plex.const import (
     CONF_IGNORE_NEW_SHARED_USERS,
     CONF_MONITORED_USERS,
+    DEBOUNCE_TIMEOUT,
     DOMAIN,
     PLEX_UPDATE_PLATFORMS_SIGNAL,
     SERVERS,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+import homeassistant.util.dt as dt_util
 
-from .common import tick_debounce_timeout
+from .common import trigger_plex_update
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .mock_classes import MockPlexServer
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_new_users_available(hass):
@@ -45,9 +48,7 @@ async def test_new_users_available(hass):
 
     server_id = mock_plex_server.machineIdentifier
 
-    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
 
@@ -85,9 +86,7 @@ async def test_new_ignored_users_available(hass, caplog):
 
     server_id = mock_plex_server.machineIdentifier
 
-    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
 
@@ -121,9 +120,7 @@ async def test_mark_sessions_idle(hass):
 
     server_id = mock_plex_server.machineIdentifier
 
-    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     sensor = hass.states.get("sensor.plex_plex_server_1")
     assert sensor.state == str(len(mock_plex_server.accounts))
@@ -131,9 +128,44 @@ async def test_mark_sessions_idle(hass):
     mock_plex_server.clear_clients()
     mock_plex_server.clear_sessions()
 
-    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-    tick_debounce_timeout(hass)
-    await hass.async_block_till_done()
+    await trigger_plex_update(hass, server_id)
 
     sensor = hass.states.get("sensor.plex_plex_server_1")
     assert sensor.state == "0"
+
+
+async def test_debouncer(hass, caplog):
+    """Test debouncer decorator logic."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=DEFAULT_DATA,
+        options=DEFAULT_OPTIONS,
+        unique_id=DEFAULT_DATA["server_id"],
+    )
+
+    mock_plex_server = MockPlexServer(config_entry=entry)
+
+    with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
+        "homeassistant.components.plex.PlexWebsocket.listen"
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    server_id = mock_plex_server.machineIdentifier
+
+    # First two updates are skipped
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
+
+    next_update = dt_util.utcnow() + timedelta(seconds=DEBOUNCE_TIMEOUT)
+    async_fire_time_changed(hass, next_update)
+    await hass.async_block_till_done()
+
+    assert (
+        caplog.text.count(f"Throttling update of {mock_plex_server.friendlyName}") == 2
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates for Plex `media_player` and `sensor` entities are triggered whenever a callback is received on a websocket listener. Sometimes these can come in rapid succession and it appears they can cause race conditions where objects are updated while they're being used. It's important to throttle the updates but also not "lose" the last request to update as updates can arrive very infrequently.

A different approach to #33534 which I believe is addressing a symptom instead of the root cause.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
