### PR TITLE
Perform some small Flu Near You cleanup

### DIFF
--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
@@ -90,13 +89,7 @@ async def async_setup_entry(hass, config_entry):
         config_entry.data.get(CONF_LATITUDE, hass.config.latitude),
         config_entry.data.get(CONF_LONGITUDE, hass.config.longitude),
     )
-
-    try:
-        await fny.async_update()
-    except FluNearYouError as err:
-        LOGGER.error("Error while setting up integration: %s", err)
-        raise ConfigEntryNotReady
-
+    await fny.async_update()
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = fny
 
     hass.async_create_task(

--- a/homeassistant/components/flunearyou/config_flow.py
+++ b/homeassistant/components/flunearyou/config_flow.py
@@ -52,7 +52,7 @@ class FluNearYouFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE]
             )
         except FluNearYouError as err:
-            LOGGER.error("Error while setting up integration: %s", err)
+            LOGGER.error("Error while configuring integration: %s", err)
             return self.async_show_form(
                 step_id="user", errors={"base": "general_error"}
             )

--- a/homeassistant/components/flunearyou/const.py
+++ b/homeassistant/components/flunearyou/const.py
@@ -2,7 +2,7 @@
 import logging
 
 DOMAIN = "flunearyou"
-LOGGER = logging.getLogger("homeassistant.components.flunearyou")
+LOGGER = logging.getLogger(__package__)
 
 DATA_CLIENT = "client"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on @MartinHjelmare's comments in https://github.com/home-assistant/core/pull/32858, this PR does some small code cleanup to the Flu Near You integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
flunearyou:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x]  The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
