### PR TITLE
Wake on LAN for UI-configured Samsung TVs

### DIFF
--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Samsung TV."""
+from functools import partial
 import socket
 from urllib.parse import urlparse
 
@@ -200,7 +201,12 @@ class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
             current_mac = self.config_entry.options[CONF_MAC]
         else:
             hostname = self.config_entry.data[CONF_HOST]
-            current_mac = get_mac_address(hostname=hostname)
+            try:
+                current_mac = await self.hass.async_add_executor_job(
+                    partial(get_mac_address, **{"hostname": hostname})
+                )
+            except socket.gaierror:
+                current_mac = None
 
         schema = {vol.Optional(CONF_MAC, default=current_mac): str}
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -207,7 +207,8 @@ class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
                 current_mac = await self.hass.async_add_executor_job(
                     partial(get_mac_address, **{"hostname": hostname})
                 )
-            except socket.gaierror:
+            except OSError:
+                LOGGER.info("Could not find mac address for %s", hostname)
                 current_mac = ""
 
         schema = {vol.Optional(CONF_MAC, default=current_mac): str}

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant import config_entries, core
 from homeassistant.components.ssdp import (
     ATTR_SSDP_LOCATION,
     ATTR_UPNP_MANUFACTURER,
@@ -174,3 +174,17 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {"model": self._title}
 
         return await self.async_step_confirm()
+
+    @staticmethod
+    @core.callback
+    def async_get_options_flow(config_entry):
+        """Define the config flow to handle options."""
+        return SamsungTVOptionsFlowHandler(config_entry)
+
+
+class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a SamsungTV options flow."""
+
+    def __init__(self, config_entry):
+        """Initialize."""
+        self.config_entry = config_entry

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -2,6 +2,7 @@
 import socket
 from urllib.parse import urlparse
 
+from getmac import get_mac_address
 import voluptuous as vol
 
 from homeassistant import config_entries, core
@@ -15,6 +16,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_ID,
     CONF_IP_ADDRESS,
+    CONF_MAC,
     CONF_METHOD,
     CONF_NAME,
     CONF_PORT,
@@ -188,3 +190,17 @@ class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
         """Initialize."""
         self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        if CONF_MAC in self.config_entry.options:
+            current_mac = self.config_entry.options[CONF_MAC]
+        else:
+            hostname = self.config_entry.data[CONF_HOST]
+            current_mac = get_mac_address(hostname=hostname)
+
+        schema = {vol.Optional(CONF_MAC, default=current_mac): str}
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -195,6 +195,8 @@ class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         if user_input is not None:
+            if user_input[CONF_MAC].strip() == "":
+                user_input.pop(CONF_MAC, None)
             return self.async_create_entry(title="", data=user_input)
 
         if CONF_MAC in self.config_entry.options:
@@ -206,7 +208,7 @@ class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
                     partial(get_mac_address, **{"hostname": hostname})
                 )
             except socket.gaierror:
-                current_mac = None
+                current_mac = ""
 
         schema = {vol.Optional(CONF_MAC, default=current_mac): str}
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -195,7 +195,7 @@ class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         if user_input is not None:
-            if user_input[CONF_MAC].strip() == "":
+            if CONF_MAC not in user_input or user_input[CONF_MAC].strip() == "":
                 user_input.pop(CONF_MAC, None)
             return self.async_create_entry(title="", data=user_input)
 
@@ -211,5 +211,7 @@ class SamsungTVOptionsFlowHandler(config_entries.OptionsFlow):
                 LOGGER.info("Could not find mac address for %s", hostname)
                 current_mac = ""
 
-        schema = {vol.Optional(CONF_MAC, default=current_mac): str}
+        schema = {
+            vol.Optional(CONF_MAC, description={"suggested_value": current_mac}): str
+        }
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -5,7 +5,7 @@
   "requirements": [
     "samsungctl[websocket]==0.7.1",
     "samsungtvws[websocket]==1.4.0",
-    "getmac==0.8.1"
+    "getmac==0.8.2"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -4,7 +4,8 @@
   "documentation": "https://www.home-assistant.io/integrations/samsungtv",
   "requirements": [
     "samsungctl[websocket]==0.7.1",
-    "samsungtvws[websocket]==1.4.0"
+    "samsungtvws[websocket]==1.4.0",
+    "getmac==0.8.1"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant import core
 from homeassistant.components.media_player import DEVICE_CLASS_TV, MediaPlayerEntity
-
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -22,9 +22,12 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_ID,
     CONF_IP_ADDRESS,
+    CONF_MAC,
     CONF_METHOD,
     CONF_NAME,
     CONF_PORT,
+    CONF_SERVICE,
+    CONF_SERVICE_DATA,
     CONF_TOKEN,
     STATE_OFF,
     STATE_ON,
@@ -56,7 +59,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Samsung TV from a config entry."""
     ip_address = config_entry.data[CONF_IP_ADDRESS]
     on_script = None
-    if (
+
+    if CONF_MAC in config_entry.options:
+        mac = config_entry.options[CONF_MAC]
+        script = cv.SCRIPT_SCHEMA(
+            {
+                CONF_SERVICE: "wake_on_lan.send_magic_packet",
+                CONF_SERVICE_DATA: {CONF_MAC: mac},
+            }
+        )
+        on_script = Script(hass, script)
+    elif (
         DOMAIN in hass.data
         and ip_address in hass.data[DOMAIN]
         and CONF_ON_ACTION in hass.data[DOMAIN][ip_address]

--- a/homeassistant/components/samsungtv/strings.json
+++ b/homeassistant/components/samsungtv/strings.json
@@ -18,5 +18,15 @@
       "not_successful": "Unable to connect to this Samsung TV device.",
       "not_supported": "This Samsung TV device is currently not supported."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure MAC address",
+        "data": {
+          "mac": "MAC address"
+        }
+      }
+    }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -620,6 +620,7 @@ georss_qld_bushfire_alert_client==0.3
 # homeassistant.components.kef
 # homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
+# homeassistant.components.samsungtv
 getmac==0.8.2
 
 # homeassistant.components.gios

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -255,6 +255,7 @@ georss_qld_bushfire_alert_client==0.3
 # homeassistant.components.kef
 # homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
+# homeassistant.components.samsungtv
 getmac==0.8.2
 
 # homeassistant.components.gios

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for Samsung TV config flow."""
 import socket
+
 import pytest
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 from samsungtvws.exceptions import ConnectionFailure
@@ -26,9 +27,8 @@ from homeassistant.const import (
     CONF_TOKEN,
 )
 
-from tests.common import MockConfigEntry
-
 from tests.async_mock import DEFAULT as DEFAULT_MOCK, Mock, PropertyMock, call, patch
+from tests.common import MockConfigEntry
 
 MOCK_USER_DATA = {CONF_HOST: "fake_host", CONF_NAME: "fake_name"}
 MOCK_SSDP_DATA = {
@@ -604,7 +604,7 @@ async def test_options_with_obtained_mac(hass, remote):
     )
 
     assert result["type"] == "create_entry"
-    assert config_entry.options[CONF_MAC] == "11:11:11"
+    assert config_entry.options.get(CONF_MAC) is None
 
     # override the auto-obtained mac address
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
@@ -639,7 +639,6 @@ async def test_options_without_obtained_mac(hass, remote):
     assert result["type"] == "create_entry"
     assert config_entry.options.get(CONF_MAC) is None
 
-    # override the auto-obtained mac address
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
     result = await hass.config_entries.options.async_configure(

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -625,7 +625,7 @@ async def test_options_without_obtained_mac(hass, remote):
     # simulate an error in getting the mac address
     with patch(
         "homeassistant.components.samsungtv.config_flow.get_mac_address",
-        side_effect=socket.gaierror,
+        side_effect=socket.gaierror(),
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
@@ -637,7 +637,7 @@ async def test_options_without_obtained_mac(hass, remote):
     )
 
     assert result["type"] == "create_entry"
-    assert config_entry.options[CONF_MAC] is None
+    assert config_entry.options.get(CONF_MAC) is None
 
     # override the auto-obtained mac address
     result = await hass.config_entries.options.async_init(config_entry.entry_id)

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -647,3 +647,27 @@ async def test_options_without_obtained_mac(hass, remote):
     )
     assert result["type"] == "create_entry"
     assert config_entry.options[CONF_MAC] == "22:22:22"
+
+
+async def test_options_with_empty_mac(hass, remote):
+    """Test the options flow with an empty string for mac."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "hostname"},)
+
+    config_entry.add_to_hass(hass)
+
+    # simulate an error in getting the mac address
+    with patch(
+        "homeassistant.components.samsungtv.config_flow.get_mac_address",
+        return_value="11:11:11",
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_MAC: " "},
+    )
+
+    assert result["type"] == "create_entry"
+    assert config_entry.options.get(CONF_MAC) is None

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -104,6 +104,8 @@ MOCK_CALLS_ENTRY_WS = {
     "token": "abcde",
 }
 
+MOCK_OPTIONS = {"mac": "11:11:11"}
+
 ENTITY_ID_NOTURNON = f"{DOMAIN}.fake_noturnon"
 MOCK_CONFIG_NOTURNON = {
     SAMSUNGTV_DOMAIN: [
@@ -755,3 +757,43 @@ async def test_on_script_from_mac(hass, remote):
     assert len(result.sequence) == 1
     assert result.sequence[0]["service"] == "wake_on_lan.send_magic_packet"
     assert result.sequence[0]["data"] == {"mac": "11:11:11"}
+
+
+async def test_setup_with_options(hass, remote):
+    """Test setup with mac address in options."""
+    entity_id = f"{DOMAIN}.fake"
+    entry = MockConfigEntry(
+        domain=SAMSUNGTV_DOMAIN,
+        data=MOCK_ENTRY_WS,
+        unique_id=entity_id,
+        options=MOCK_OPTIONS,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.samsungtv.media_player.async_get_on_script_from_mac"
+    ) as on_script:
+        await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
+        # await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert on_script.call_count == 1
+        assert on_script.call_args_list == [call(hass, MOCK_OPTIONS["mac"])]
+
+
+async def test_setup_without_options(hass, remote):
+    """Test setup without mac address in options."""
+    entity_id = f"{DOMAIN}.fake"
+    entry = MockConfigEntry(
+        domain=SAMSUNGTV_DOMAIN, data=MOCK_ENTRY_WS, unique_id=entity_id
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.samsungtv.media_player.async_get_on_script_from_mac"
+    ) as on_script:
+        await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
+        # await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert on_script.call_count == 0

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -25,7 +25,10 @@ from homeassistant.components.samsungtv.const import (
     CONF_ON_ACTION,
     DOMAIN as SAMSUNGTV_DOMAIN,
 )
-from homeassistant.components.samsungtv.media_player import SUPPORT_SAMSUNGTV
+from homeassistant.components.samsungtv.media_player import (
+    SUPPORT_SAMSUNGTV,
+    async_get_on_script_from_mac,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -742,3 +745,13 @@ async def test_select_source_invalid_source(hass, remote):
         assert remote.control.call_count == 0
         assert remote.close.call_count == 0
         assert remote.call_count == 1
+
+
+async def test_on_script_from_mac(hass, remote):
+    """Test creation of on-script from mac address."""
+
+    result = async_get_on_script_from_mac(hass, "11:11:11")
+
+    assert len(result.sequence) == 1
+    assert result.sequence[0]["service"] == "wake_on_lan.send_magic_packet"
+    assert result.sequence[0]["data"] == {"mac": "11:11:11"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When configuring a Samsung TV through YAML, you can define an action to turn it on. This configuration is not available through the UI (for either manually initiated or through discovery).
Since I assume that in most cases the turn-on action would be wake on lan (and for more advanced cases one can use a [universal media player](https://www.home-assistant.io/integrations/universal/)), this PR adds the ability to set a MAC address through an options flow, which will be used to turn the TV on through wake on lan.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
