### PR TITLE
Manage Melcloud Horizontal and Vertical Swing Modes from UI

### DIFF
--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -178,17 +178,13 @@ class AtaDeviceClimate(MelCloudClimate):
         vane_horizontal = self._device.vane_horizontal
         if vane_horizontal:
             attr.update(
-                {
-                    ATTR_VANE_HORIZONTAL: HVAC_HVANE_LOOKUP.get(vane_horizontal, None),
-                }
+                {ATTR_VANE_HORIZONTAL: HVAC_HVANE_LOOKUP.get(vane_horizontal, None),}
             )
 
         vane_vertical = self._device.vane_vertical
         if vane_vertical:
             attr.update(
-                {
-                    ATTR_VANE_VERTICAL: HVAC_VVANE_LOOKUP.get(vane_vertical, None),
-                }
+                {ATTR_VANE_VERTICAL: HVAC_VVANE_LOOKUP.get(vane_vertical, None),}
             )
         return attr
 
@@ -261,7 +257,10 @@ class AtaDeviceClimate(MelCloudClimate):
         """Set horizontal vane position."""
         operation_mode = HVAC_HVANE_REVERSE_LOOKUP.get(position, "")
         if operation_mode not in self._device.vane_horizontal_positions:
-            valid_pos = [HVAC_HVANE_LOOKUP.get(mode) for mode in self._device.vane_horizontal_positions]
+            valid_pos = [
+                HVAC_HVANE_LOOKUP.get(mode) 
+                for mode in self._device.vane_horizontal_positions
+            ]
             raise ValueError(
                 f"Invalid horizontal vane position [{position}]. Valid positions: {valid_pos}."
             )
@@ -271,7 +270,10 @@ class AtaDeviceClimate(MelCloudClimate):
         """Set vertical vane position."""
         operation_mode = HVAC_VVANE_REVERSE_LOOKUP.get(position, "")
         if operation_mode not in self._device.vane_vertical_positions:
-            valid_pos = [HVAC_VVANE_LOOKUP.get(mode) for mode in self._device.vane_vertical_positions]
+            valid_pos = [
+                HVAC_VVANE_LOOKUP.get(mode) 
+                for mode in self._device.vane_vertical_positions
+            ]
             raise ValueError(
                 f"Invalid vertical vane position [{position}]. Valid positions: {valid_pos}."
             )
@@ -291,7 +293,7 @@ class AtaDeviceClimate(MelCloudClimate):
                 swing = HVAC_VVANE_LOOKUP.get(mode)
 
         if swing is None:
-            return 'Auto'
+            return "Auto"
 
         return swing
 
@@ -323,7 +325,9 @@ class AtaDeviceClimate(MelCloudClimate):
     @property
     def swing_modes(self) -> Optional[List[str]]:
         """Return the list of available swing modes."""
-        list_modes = [HVAC_VVANE_LOOKUP.get(mode) for mode in self._device.vane_vertical_positions]
+        list_modes = [
+            HVAC_VVANE_LOOKUP.get(mode) for mode in self._device.vane_vertical_positions
+        ]
         for mode in self._device.vane_horizontal_positions:
             list_modes.append(HVAC_HVANE_LOOKUP.get(mode))
 

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -326,7 +326,8 @@ class AtaDeviceClimate(MelCloudClimate):
     def swing_modes(self) -> Optional[List[str]]:
         """Return the list of available swing modes."""
         list_modes = [
-            ATA_HVAC_VVANE_LOOKUP.get(mode) for mode in self._device.vane_vertical_positions
+            ATA_HVAC_VVANE_LOOKUP.get(mode)
+            for mode in self._device.vane_vertical_positions
         ]
         for mode in self._device.vane_horizontal_positions:
             list_modes.append(ATA_HVAC_HVANE_LOOKUP.get(mode))

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -178,13 +178,13 @@ class AtaDeviceClimate(MelCloudClimate):
         vane_horizontal = self._device.vane_horizontal
         if vane_horizontal:
             attr.update(
-                {ATTR_VANE_HORIZONTAL: HVAC_HVANE_LOOKUP.get(vane_horizontal, None),}
+                {ATTR_VANE_HORIZONTAL: HVAC_HVANE_LOOKUP.get(vane_horizontal, None), }
             )
 
         vane_vertical = self._device.vane_vertical
         if vane_vertical:
             attr.update(
-                {ATTR_VANE_VERTICAL: HVAC_VVANE_LOOKUP.get(vane_vertical, None),}
+                {ATTR_VANE_VERTICAL: HVAC_VVANE_LOOKUP.get(vane_vertical, None), }
             )
         return attr
 
@@ -258,7 +258,7 @@ class AtaDeviceClimate(MelCloudClimate):
         operation_mode = HVAC_HVANE_REVERSE_LOOKUP.get(position, "")
         if operation_mode not in self._device.vane_horizontal_positions:
             valid_pos = [
-                HVAC_HVANE_LOOKUP.get(mode) 
+                HVAC_HVANE_LOOKUP.get(mode)
                 for mode in self._device.vane_horizontal_positions
             ]
             raise ValueError(
@@ -271,7 +271,7 @@ class AtaDeviceClimate(MelCloudClimate):
         operation_mode = HVAC_VVANE_REVERSE_LOOKUP.get(position, "")
         if operation_mode not in self._device.vane_vertical_positions:
             valid_pos = [
-                HVAC_VVANE_LOOKUP.get(mode) 
+                HVAC_VVANE_LOOKUP.get(mode)
                 for mode in self._device.vane_vertical_positions
             ]
             raise ValueError(

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -178,13 +178,13 @@ class AtaDeviceClimate(MelCloudClimate):
         vane_horizontal = self._device.vane_horizontal
         if vane_horizontal:
             attr.update(
-                {ATTR_VANE_HORIZONTAL: HVAC_HVANE_LOOKUP.get(vane_horizontal, None), }
+                {ATTR_VANE_HORIZONTAL: HVAC_HVANE_LOOKUP.get(vane_horizontal, None)}
             )
 
         vane_vertical = self._device.vane_vertical
         if vane_vertical:
             attr.update(
-                {ATTR_VANE_VERTICAL: HVAC_VVANE_LOOKUP.get(vane_vertical, None), }
+                {ATTR_VANE_VERTICAL: HVAC_VVANE_LOOKUP.get(vane_vertical, None)}
             )
         return attr
 

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -305,22 +305,22 @@ class AtaDeviceClimate(MelCloudClimate):
             operation_mode = HVAC_HVANE_REVERSE_LOOKUP.get(swing_mode)
             if operation_mode is None:
                 raise ValueError(f"Invalid swing_mode [{swing_mode}].")
-            else:
-                is_hor_swing = True
-                curr_mode = self._device.vane_horizontal
-                valid_swing_modes = self._device.vane_horizontal_positions
-                props = {ata.PROPERTY_VANE_HORIZONTAL: operation_mode}
+
+            is_hor_swing = True
+            curr_mode = self._device.vane_horizontal
+            valid_swing_modes = self._device.vane_horizontal_positions
+            props = {ata.PROPERTY_VANE_HORIZONTAL: operation_mode}
         else:
             curr_mode = self._device.vane_vertical
             valid_swing_modes = self._device.vane_vertical_positions
             props = {ata.PROPERTY_VANE_VERTICAL: operation_mode}
 
-        if operation_mode in valid_swing_modes:
-            self._set_hor_swing = is_hor_swing
-            if curr_mode != operation_mode:
-                await self._device.set(props)
-        else:
+        if operation_mode not in valid_swing_modes:
             raise ValueError(f"Invalid swing_mode [{swing_mode}].")
+
+        self._set_hor_swing = is_hor_swing
+        if curr_mode != operation_mode:
+            await self._device.set(props)
 
     @property
     def swing_modes(self) -> Optional[List[str]]:

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -40,10 +40,10 @@ from .const import (
     ATTR_VANE_VERTICAL,
     CONF_POSITION,
     DOMAIN,
-    HorSwingModes,
     SERVICE_SET_VANE_HORIZONTAL,
     SERVICE_SET_VANE_VERTICAL,
     TEMP_UNIT_LOOKUP,
+    HorSwingModes,
     VertSwingModes,
 )
 

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -62,7 +62,7 @@ ATA_HVAC_MODE_LOOKUP = {
 ATA_HVAC_MODE_REVERSE_LOOKUP = {v: k for k, v in ATA_HVAC_MODE_LOOKUP.items()}
 
 
-HVAC_HVANE_LOOKUP = {
+ATA_HVAC_HVANE_LOOKUP = {
     ata.H_VANE_POSITION_AUTO: HorSwingModes.Auto,
     ata.H_VANE_POSITION_1: HorSwingModes.Left,
     ata.H_VANE_POSITION_2: HorSwingModes.MiddleLeft,
@@ -72,10 +72,10 @@ HVAC_HVANE_LOOKUP = {
     ata.H_VANE_POSITION_SPLIT: HorSwingModes.Split,
     ata.H_VANE_POSITION_SWING: HorSwingModes.Swing,
 }
-HVAC_HVANE_REVERSE_LOOKUP = {v: k for k, v in HVAC_HVANE_LOOKUP.items()}
+ATA_HVAC_HVANE_REVERSE_LOOKUP = {v: k for k, v in ATA_HVAC_HVANE_LOOKUP.items()}
 
 
-HVAC_VVANE_LOOKUP = {
+ATA_HVAC_VVANE_LOOKUP = {
     ata.V_VANE_POSITION_AUTO: VertSwingModes.Auto,
     ata.V_VANE_POSITION_1: VertSwingModes.Top,
     ata.V_VANE_POSITION_2: VertSwingModes.MiddleTop,
@@ -84,7 +84,7 @@ HVAC_VVANE_LOOKUP = {
     ata.V_VANE_POSITION_5: VertSwingModes.Bottom,
     ata.V_VANE_POSITION_SWING: VertSwingModes.Swing,
 }
-HVAC_VVANE_REVERSE_LOOKUP = {v: k for k, v in HVAC_VVANE_LOOKUP.items()}
+ATA_HVAC_VVANE_REVERSE_LOOKUP = {v: k for k, v in ATA_HVAC_VVANE_LOOKUP.items()}
 
 
 ATW_ZONE_HVAC_MODE_LOOKUP = {
@@ -178,13 +178,13 @@ class AtaDeviceClimate(MelCloudClimate):
         vane_horizontal = self._device.vane_horizontal
         if vane_horizontal:
             attr.update(
-                {ATTR_VANE_HORIZONTAL: HVAC_HVANE_LOOKUP.get(vane_horizontal, None)}
+                {ATTR_VANE_HORIZONTAL: ATA_HVAC_HVANE_LOOKUP.get(vane_horizontal, None)}
             )
 
         vane_vertical = self._device.vane_vertical
         if vane_vertical:
             attr.update(
-                {ATTR_VANE_VERTICAL: HVAC_VVANE_LOOKUP.get(vane_vertical, None)}
+                {ATTR_VANE_VERTICAL: ATA_HVAC_VVANE_LOOKUP.get(vane_vertical, None)}
             )
         return attr
 
@@ -255,10 +255,10 @@ class AtaDeviceClimate(MelCloudClimate):
 
     async def async_set_vane_horizontal(self, position: str) -> None:
         """Set horizontal vane position."""
-        operation_mode = HVAC_HVANE_REVERSE_LOOKUP.get(position, "")
+        operation_mode = ATA_HVAC_HVANE_REVERSE_LOOKUP.get(position, "")
         if operation_mode not in self._device.vane_horizontal_positions:
             valid_pos = [
-                HVAC_HVANE_LOOKUP.get(mode)
+                ATA_HVAC_HVANE_LOOKUP.get(mode)
                 for mode in self._device.vane_horizontal_positions
             ]
             raise ValueError(
@@ -268,10 +268,10 @@ class AtaDeviceClimate(MelCloudClimate):
 
     async def async_set_vane_vertical(self, position: str) -> None:
         """Set vertical vane position."""
-        operation_mode = HVAC_VVANE_REVERSE_LOOKUP.get(position, "")
+        operation_mode = ATA_HVAC_VVANE_REVERSE_LOOKUP.get(position, "")
         if operation_mode not in self._device.vane_vertical_positions:
             valid_pos = [
-                HVAC_VVANE_LOOKUP.get(mode)
+                ATA_HVAC_VVANE_LOOKUP.get(mode)
                 for mode in self._device.vane_vertical_positions
             ]
             raise ValueError(
@@ -286,11 +286,11 @@ class AtaDeviceClimate(MelCloudClimate):
         if self._set_hor_swing and self._support_hor_swing:
             mode = self._device.vane_horizontal
             if mode is not None:
-                swing = HVAC_HVANE_LOOKUP.get(mode)
+                swing = ATA_HVAC_HVANE_LOOKUP.get(mode)
         elif self._support_ver_swing:
             mode = self._device.vane_vertical
             if mode is not None:
-                swing = HVAC_VVANE_LOOKUP.get(mode)
+                swing = ATA_HVAC_VVANE_LOOKUP.get(mode)
 
         if swing is None:
             return "Auto"
@@ -300,9 +300,9 @@ class AtaDeviceClimate(MelCloudClimate):
     async def async_set_swing_mode(self, swing_mode) -> None:
         """Set new target swing mode."""
         is_hor_swing = False
-        operation_mode = HVAC_VVANE_REVERSE_LOOKUP.get(swing_mode)
+        operation_mode = ATA_HVAC_VVANE_REVERSE_LOOKUP.get(swing_mode)
         if operation_mode is None:
-            operation_mode = HVAC_HVANE_REVERSE_LOOKUP.get(swing_mode)
+            operation_mode = ATA_HVAC_HVANE_REVERSE_LOOKUP.get(swing_mode)
             if operation_mode is None:
                 raise ValueError(f"Invalid swing_mode [{swing_mode}].")
 
@@ -326,10 +326,10 @@ class AtaDeviceClimate(MelCloudClimate):
     def swing_modes(self) -> Optional[List[str]]:
         """Return the list of available swing modes."""
         list_modes = [
-            HVAC_VVANE_LOOKUP.get(mode) for mode in self._device.vane_vertical_positions
+            ATA_HVAC_VVANE_LOOKUP.get(mode) for mode in self._device.vane_vertical_positions
         ]
         for mode in self._device.vane_horizontal_positions:
-            list_modes.append(HVAC_HVANE_LOOKUP.get(mode))
+            list_modes.append(ATA_HVAC_HVANE_LOOKUP.get(mode))
 
         return list_modes
 

--- a/homeassistant/components/melcloud/const.py
+++ b/homeassistant/components/melcloud/const.py
@@ -20,21 +20,25 @@ TEMP_UNIT_LOOKUP = {
 }
 TEMP_UNIT_REVERSE_LOOKUP = {v: k for k, v in TEMP_UNIT_LOOKUP.items()}
 
+
 class HorSwingModes:
-    Auto = 'HorizontalAuto' 
+    """Horizontal swing modes names."""
+    Auto = 'HorizontalAuto'
     Left = 'HorizontalLeft'
-    MiddleLeft = 'HorizontalMiddleLeft' 
+    MiddleLeft = 'HorizontalMiddleLeft'
     Middle = 'HorizontalMiddle'
-    MiddleRight = 'HorizontalMiddleRight' 
+    MiddleRight = 'HorizontalMiddleRight'
     Right = 'HorizontalRight'
     Split = 'HorizontalSplit'
     Swing = 'HorizontalSwing'
 
+
 class VertSwingModes:
-    Auto = 'VerticalAuto' 
+    """Vertical swing modes names."""
+    Auto = 'VerticalAuto'
     Top = 'VerticalTop'
-    MiddleTop = 'VerticalMiddleTop' 
+    MiddleTop = 'VerticalMiddleTop'
     Middle = 'VerticalMiddle'
-    MiddleBottom = 'VerticalMiddleBottom' 
+    MiddleBottom = 'VerticalMiddleBottom'
     Bottom = 'VerticalBottom'
     Swing = 'VerticalSwing'

--- a/homeassistant/components/melcloud/const.py
+++ b/homeassistant/components/melcloud/const.py
@@ -9,9 +9,7 @@ CONF_POSITION = "position"
 
 ATTR_STATUS = "status"
 ATTR_VANE_HORIZONTAL = "vane_horizontal"
-ATTR_VANE_HORIZONTAL_POSITIONS = "vane_horizontal_positions"
 ATTR_VANE_VERTICAL = "vane_vertical"
-ATTR_VANE_VERTICAL_POSITIONS = "vane_vertical_positions"
 
 SERVICE_SET_VANE_HORIZONTAL = "set_vane_horizontal"
 SERVICE_SET_VANE_VERTICAL = "set_vane_vertical"
@@ -21,3 +19,22 @@ TEMP_UNIT_LOOKUP = {
     UNIT_TEMP_FAHRENHEIT: TEMP_FAHRENHEIT,
 }
 TEMP_UNIT_REVERSE_LOOKUP = {v: k for k, v in TEMP_UNIT_LOOKUP.items()}
+
+class HorSwingModes:
+    Auto = 'HorizontalAuto' 
+    Left = 'HorizontalLeft'
+    MiddleLeft = 'HorizontalMiddleLeft' 
+    Middle = 'HorizontalMiddle'
+    MiddleRight = 'HorizontalMiddleRight' 
+    Right = 'HorizontalRight'
+    Split = 'HorizontalSplit'
+    Swing = 'HorizontalSwing'
+
+class VertSwingModes:
+    Auto = 'VerticalAuto' 
+    Top = 'VerticalTop'
+    MiddleTop = 'VerticalMiddleTop' 
+    Middle = 'VerticalMiddle'
+    MiddleBottom = 'VerticalMiddleBottom' 
+    Bottom = 'VerticalBottom'
+    Swing = 'VerticalSwing'

--- a/homeassistant/components/melcloud/const.py
+++ b/homeassistant/components/melcloud/const.py
@@ -24,23 +24,23 @@ TEMP_UNIT_REVERSE_LOOKUP = {v: k for k, v in TEMP_UNIT_LOOKUP.items()}
 class HorSwingModes:
     """Horizontal swing modes names."""
 
-    Auto = 'HorizontalAuto'
-    Left = 'HorizontalLeft'
-    MiddleLeft = 'HorizontalMiddleLeft'
-    Middle = 'HorizontalMiddle'
-    MiddleRight = 'HorizontalMiddleRight'
-    Right = 'HorizontalRight'
-    Split = 'HorizontalSplit'
-    Swing = 'HorizontalSwing'
+    Auto = "HorizontalAuto"
+    Left = "HorizontalLeft"
+    MiddleLeft = "HorizontalMiddleLeft"
+    Middle = "HorizontalMiddle"
+    MiddleRight = "HorizontalMiddleRight"
+    Right = "HorizontalRight"
+    Split = "HorizontalSplit"
+    Swing = "HorizontalSwing"
 
 
 class VertSwingModes:
     """Vertical swing modes names."""
 
-    Auto = 'VerticalAuto'
-    Top = 'VerticalTop'
-    MiddleTop = 'VerticalMiddleTop'
-    Middle = 'VerticalMiddle'
-    MiddleBottom = 'VerticalMiddleBottom'
-    Bottom = 'VerticalBottom'
-    Swing = 'VerticalSwing'
+    Auto = "VerticalAuto"
+    Top = "VerticalTop"
+    MiddleTop = "VerticalMiddleTop"
+    Middle = "VerticalMiddle"
+    MiddleBottom = "VerticalMiddleBottom"
+    Bottom = "VerticalBottom"
+    Swing = "VerticalSwing"

--- a/homeassistant/components/melcloud/const.py
+++ b/homeassistant/components/melcloud/const.py
@@ -23,6 +23,7 @@ TEMP_UNIT_REVERSE_LOOKUP = {v: k for k, v in TEMP_UNIT_LOOKUP.items()}
 
 class HorSwingModes:
     """Horizontal swing modes names."""
+
     Auto = 'HorizontalAuto'
     Left = 'HorizontalLeft'
     MiddleLeft = 'HorizontalMiddleLeft'
@@ -35,6 +36,7 @@ class HorSwingModes:
 
 class VertSwingModes:
     """Vertical swing modes names."""
+
     Auto = 'VerticalAuto'
     Top = 'VerticalTop'
     MiddleTop = 'VerticalMiddleTop'


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

 As anticipated on PR #33008, let me propose an alternativa solution for swing modes in Melcloud component, This will provide control of both Horizontal and Vertical swing modes from UI and more "Human Readable" list of states.
This will change the names of the available swing modes. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to PR: #33008
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
