### PR TITLE
Use byte literals instead of encode

### DIFF
--- a/homeassistant/components/actiontec/device_tracker.py
+++ b/homeassistant/components/actiontec/device_tracker.py
@@ -99,11 +99,11 @@ class ActiontecDeviceScanner(DeviceScanner):
             telnet.read_until(b"Password: ")
             telnet.write((self.password + "\n").encode("ascii"))
             prompt = telnet.read_until(b"Wireless Broadband Router> ").split(b"\n")[-1]
-            telnet.write("firewall mac_cache_dump\n".encode("ascii"))
-            telnet.write("\n".encode("ascii"))
+            telnet.write(b"firewall mac_cache_dump\n")
+            telnet.write(b"\n")
             telnet.read_until(prompt)
             leases_result = telnet.read_until(prompt).split(b"\n")[1:-1]
-            telnet.write("exit\n".encode("ascii"))
+            telnet.write(b"exit\n")
         except EOFError:
             _LOGGER.exception("Unexpected response from router")
             return

--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -104,7 +104,7 @@ class GraphiteFeeder(threading.Thread):
         sock.settimeout(10)
         sock.connect((self._host, self._port))
         sock.sendall(data.encode("ascii"))
-        sock.send("\n".encode("ascii"))
+        sock.send(b"\n")
         sock.close()
 
     def _report_attributes(self, entity_id, new_state):

--- a/homeassistant/components/lannouncer/notify.py
+++ b/homeassistant/components/lannouncer/notify.py
@@ -69,7 +69,7 @@ class LannouncerNotificationService(BaseNotificationService):
             # Send message
             _LOGGER.debug("Sending message: %s", cmd)
             sock.sendall(cmd.encode())
-            sock.sendall("&@DONE@\n".encode())
+            sock.sendall(b"&@DONE@\n")
 
             # Check response
             buffer = sock.recv(1024)

--- a/homeassistant/components/thomson/device_tracker.py
+++ b/homeassistant/components/thomson/device_tracker.py
@@ -98,9 +98,9 @@ class ThomsonDeviceScanner(DeviceScanner):
             telnet.read_until(b"Password : ")
             telnet.write((self.password + "\r\n").encode("ascii"))
             telnet.read_until(b"=>")
-            telnet.write(("hostmgr list\r\n").encode("ascii"))
+            telnet.write(b"hostmgr list\r\n")
             devices_result = telnet.read_until(b"=>").split(b"\r\n")
-            telnet.write("exit\r\n".encode("ascii"))
+            telnet.write(b"exit\r\n")
         except EOFError:
             _LOGGER.exception("Unexpected response from router")
             return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR replaces occurrences of using `.encode()` to use byte literals instead, when possible.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
