### PR TITLE
Enable pylint global-statement

### DIFF
--- a/homeassistant/components/apcupsd/__init__.py
+++ b/homeassistant/components/apcupsd/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Use config values to set up a function enabling status retrieval."""
-    global DATA
+    global DATA  # pylint: disable=global-statement
     conf = config[DOMAIN]
     host = conf.get(CONF_HOST)
     port = conf.get(CONF_PORT)

--- a/homeassistant/components/aquostv/media_player.py
+++ b/homeassistant/components/aquostv/media_player.py
@@ -126,7 +126,7 @@ class SharpAquosTVDevice(MediaPlayerDevice):
 
     def __init__(self, name, remote, power_on_enabled=False):
         """Initialize the aquos device."""
-        global SUPPORT_SHARPTV
+        global SUPPORT_SHARPTV  # pylint: disable=global-statement
         self._power_on_enabled = power_on_enabled
         if self._power_on_enabled:
             SUPPORT_SHARPTV = SUPPORT_SHARPTV | SUPPORT_TURN_ON

--- a/homeassistant/components/arduino/__init__.py
+++ b/homeassistant/components/arduino/__init__.py
@@ -28,7 +28,7 @@ def setup(hass, config):
 
     port = config[DOMAIN][CONF_PORT]
 
-    global BOARD
+    global BOARD  # pylint: disable=global-statement
     try:
         BOARD = ArduinoBoard(port)
     except (serial.serialutil.SerialException, FileNotFoundError):

--- a/homeassistant/components/bloomsky/__init__.py
+++ b/homeassistant/components/bloomsky/__init__.py
@@ -31,7 +31,7 @@ def setup(hass, config):
     """Set up the BloomSky component."""
     api_key = config[DOMAIN][CONF_API_KEY]
 
-    global BLOOMSKY
+    global BLOOMSKY  # pylint: disable=global-statement
     try:
         BLOOMSKY = BloomSky(api_key, hass.config.units.is_metric)
     except RuntimeError:

--- a/homeassistant/components/mochad/__init__.py
+++ b/homeassistant/components/mochad/__init__.py
@@ -42,7 +42,7 @@ def setup(hass, config):
     host = conf.get(CONF_HOST)
     port = conf.get(CONF_PORT)
 
-    global CONTROLLER
+    global CONTROLLER  # pylint: disable=global-statement
     try:
         CONTROLLER = MochadCtrl(host, port)
     except exceptions.ConfigurationError:

--- a/homeassistant/components/scsgate/__init__.py
+++ b/homeassistant/components/scsgate/__init__.py
@@ -34,7 +34,7 @@ SCSGATE_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the SCSGate component."""
     device = config[DOMAIN][CONF_DEVICE]
-    global SCSGATE
+    global SCSGATE  # pylint: disable=global-statement
 
     try:
         SCSGATE = SCSGate(device=device, logger=_LOGGER)

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -46,7 +46,7 @@ def setup(hass, config):
     Will automatically load sensor components to support
     devices discovered on the account.
     """
-    global DATA
+    global DATA  # pylint: disable=global-statement
 
     username = config[DOMAIN][CONF_USERNAME]
     password = config[DOMAIN][CONF_PASSWORD]

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -75,7 +75,7 @@ DEVICE_SERIAL_SCHEMA = vol.Schema({vol.Required(ATTR_DEVICE_SERIAL): cv.string})
 
 def setup(hass, config):
     """Set up the Verisure component."""
-    global HUB
+    global HUB  # pylint: disable=global-statement
     HUB = VerisureHub(config[DOMAIN])
     HUB.update_overview = Throttle(config[DOMAIN][CONF_SCAN_INTERVAL])(
         HUB.update_overview

--- a/homeassistant/components/zigbee/__init__.py
+++ b/homeassistant/components/zigbee/__init__.py
@@ -71,15 +71,15 @@ PLATFORM_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the connection to the Zigbee device."""
-    global DEVICE
-    global GPIO_DIGITAL_OUTPUT_LOW
-    global GPIO_DIGITAL_OUTPUT_HIGH
-    global ADC_PERCENTAGE
-    global DIGITAL_PINS
-    global ANALOG_PINS
-    global CONVERT_ADC
-    global ZIGBEE_EXCEPTION
-    global ZIGBEE_TX_FAILURE
+    global DEVICE  # pylint: disable=global-statement
+    global GPIO_DIGITAL_OUTPUT_LOW  # pylint: disable=global-statement
+    global GPIO_DIGITAL_OUTPUT_HIGH  # pylint: disable=global-statement
+    global ADC_PERCENTAGE  # pylint: disable=global-statement
+    global DIGITAL_PINS  # pylint: disable=global-statement
+    global ANALOG_PINS  # pylint: disable=global-statement
+    global CONVERT_ADC  # pylint: disable=global-statement
+    global ZIGBEE_EXCEPTION  # pylint: disable=global-statement
+    global ZIGBEE_TX_FAILURE  # pylint: disable=global-statement
 
     GPIO_DIGITAL_OUTPUT_LOW = xb_const.GPIO_DIGITAL_OUTPUT_LOW
     GPIO_DIGITAL_OUTPUT_HIGH = xb_const.GPIO_DIGITAL_OUTPUT_HIGH

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -31,7 +31,7 @@ def set_default_time_zone(time_zone: dt.tzinfo) -> None:
 
     Async friendly.
     """
-    global DEFAULT_TIME_ZONE
+    global DEFAULT_TIME_ZONE  # pylint: disable=global-statement
 
     # NOTE: Remove in the future in favour of typing
     assert isinstance(time_zone, dt.tzinfo)

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -295,7 +295,7 @@ def secret_yaml(loader: SafeLineLoader, node: yaml.nodes.Node) -> JSON_TYPE:
             _LOGGER.debug("Secret %s retrieved from keyring", node.value)
             return pwd
 
-    global credstash  # pylint: disable=invalid-name
+    global credstash  # pylint: disable=invalid-name, global-statement
 
     if credstash:
         # pylint: disable=no-member

--- a/pylintrc
+++ b/pylintrc
@@ -34,7 +34,6 @@ disable=
   abstract-method,
   cyclic-import,
   duplicate-code,
-  global-statement,
   inconsistent-return-statements,
   locally-disabled,
   not-context-manager,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR enables the `global-statement` Pylint rule.

Current occurrences in the codebase are exempted from this rule by disabling the Pylint rule on each occurrence.

This means we accept the legacy, but won't accept new ones.

The reason for this is that I've seen quite a few PRs that brought in globals. By enabling the rule, the CI would catch that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
