### PR TITLE
Remove redundant open modes

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -167,7 +167,7 @@ def daemonize() -> None:
         sys.exit(0)
 
     # redirect standard file descriptors to devnull
-    infd = open(os.devnull, "r")
+    infd = open(os.devnull)
     outfd = open(os.devnull, "a+")
     sys.stdout.flush()
     sys.stderr.flush()
@@ -180,7 +180,7 @@ def check_pid(pid_file: str) -> None:
     """Check that Home Assistant is not already running."""
     # Check pid file
     try:
-        with open(pid_file, "r") as file:
+        with open(pid_file) as file:
             pid = int(file.readline())
     except OSError:
         # PID File does not exist

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -61,7 +61,7 @@ class ZWaveLogView(HomeAssistantView):
     def _get_log(self, hass, lines):
         """Retrieve the logfile content."""
         logfilepath = hass.config.path(OZW_LOG_FILENAME)
-        with open(logfilepath, "r") as logfile:
+        with open(logfilepath) as logfile:
             data = (line.rstrip() for line in logfile)
             if lines == 0:
                 loglines = list(data)

--- a/homeassistant/components/fail2ban/sensor.py
+++ b/homeassistant/components/fail2ban/sensor.py
@@ -114,7 +114,7 @@ class BanLogParser:
         """Read the fail2ban log and find entries for jail."""
         self.data = list()
         try:
-            with open(self.log_file, "r", encoding="utf-8") as file_data:
+            with open(self.log_file, encoding="utf-8") as file_data:
                 self.data = self.ip_regex[jail].findall(file_data.read())
 
         except (IndexError, FileNotFoundError, IsADirectoryError, UnboundLocalError):

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -77,7 +77,7 @@ class FileSensor(Entity):
     def update(self):
         """Get the latest entry from a file and updates the state."""
         try:
-            with open(self._file_path, "r", encoding="utf-8") as file_data:
+            with open(self._file_path, encoding="utf-8") as file_data:
                 for line in file_data:
                     data = line
                 data = data.strip()

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -221,7 +221,7 @@ def setup(hass, config):
 
 def check_correct_scopes(token_file):
     """Check for the correct scopes in file."""
-    tokenfile = open(token_file, "r").read()
+    tokenfile = open(token_file).read()
     if "readonly" in tokenfile:
         _LOGGER.warning("Please re-authenticate with Google.")
         return False

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -176,7 +176,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # We have an owfs mounted
     else:
         for family_file_path in glob(os.path.join(base_dir, "*", "family")):
-            with open(family_file_path, "r") as family_file:
+            with open(family_file_path) as family_file:
                 family = family_file.read()
             if "EF" in family:
                 continue
@@ -218,7 +218,7 @@ class OneWire(Entity):
 
     def _read_value_raw(self):
         """Read the value as it is returned by the sensor."""
-        with open(self._device_file, "r") as ds_device_file:
+        with open(self._device_file) as ds_device_file:
             lines = ds_device_file.readlines()
         return lines
 

--- a/homeassistant/components/remember_the_milk/__init__.py
+++ b/homeassistant/components/remember_the_milk/__init__.py
@@ -161,7 +161,7 @@ class RememberTheMilkConfiguration:
             return
         try:
             _LOGGER.debug("Loading configuration from file: %s", self._config_file_path)
-            with open(self._config_file_path, "r") as config_file:
+            with open(self._config_file_path) as config_file:
                 self._config = json.load(config_file)
         except ValueError:
             _LOGGER.error(

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -339,7 +339,7 @@ def process_ha_config_upgrade(hass: HomeAssistant) -> None:
     version_path = hass.config.path(VERSION_FILE)
 
     try:
-        with open(version_path, "rt") as inp:
+        with open(version_path) as inp:
             conf_version = inp.readline().strip()
     except FileNotFoundError:
         # Last version to not have this file
@@ -364,7 +364,7 @@ def process_ha_config_upgrade(hass: HomeAssistant) -> None:
         # 0.92 moved google/tts.py to google_translate/tts.py
         config_path = hass.config.path(YAML_CONFIG_FILE)
 
-        with open(config_path, "rt", encoding="utf-8") as config_file:
+        with open(config_path, encoding="utf-8") as config_file:
             config_raw = config_file.read()
 
         if TTS_PRE_92 in config_raw:

--- a/homeassistant/scripts/macos/__init__.py
+++ b/homeassistant/scripts/macos/__init__.py
@@ -15,7 +15,7 @@ def install_osx():
 
     template_path = os.path.join(os.path.dirname(__file__), "launchd.plist")
 
-    with open(template_path, "r", encoding="utf-8") as inp:
+    with open(template_path, encoding="utf-8") as inp:
         plist = inp.read()
 
     plist = plist.replace("$HASS_PATH$", hass_path)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR removes redundant `open()` modes. The default mode is `rt`.
`t` is also defaulted when just `r` mode is passed.

See: <https://docs.python.org/3/library/functions.html#open>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
