### PR TITLE
Replace OSError aliases with OSError

### DIFF
--- a/homeassistant/components/anel_pwrctrl/switch.py
+++ b/homeassistant/components/anel_pwrctrl/switch.py
@@ -1,7 +1,6 @@
 """Support for ANEL PwrCtrl switches."""
 from datetime import timedelta
 import logging
-import socket
 
 from anel_pwrctrl import DeviceMaster
 import voluptuous as vol
@@ -45,7 +44,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             write_port=port_recv,
         )
         master.query(ip_addr=host)
-    except socket.error as ex:
+    except OSError as ex:
         _LOGGER.error("Unable to discover PwrCtrl device: %s", str(ex))
         return False
 

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 from ipaddress import ip_address
 from itertools import product
 import logging
-import socket
 
 import broadlink
 import voluptuous as vol
@@ -103,7 +102,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         connected, loaded = await asyncio.gather(
             hass.async_add_executor_job(api.auth), remote.async_load_storage_files()
         )
-    except socket.error:
+    except OSError:
         pass
     if not connected:
         hass.data[DOMAIN][COMPONENT].remove(unique_id)
@@ -327,7 +326,7 @@ class BroadlinkRemote(RemoteDevice):
                 continue
             try:
                 await self.hass.async_add_executor_job(function, *args)
-            except socket.error:
+            except OSError:
                 continue
             return
         raise ConnectionError
@@ -336,7 +335,7 @@ class BroadlinkRemote(RemoteDevice):
         """Connect to the remote."""
         try:
             auth = await self.hass.async_add_executor_job(self._api.auth)
-        except socket.error:
+        except OSError:
             auth = False
         if auth and not self._available:
             _LOGGER.warning("Connected to the remote")

--- a/homeassistant/components/ebusd/__init__.py
+++ b/homeassistant/components/ebusd/__init__.py
@@ -82,7 +82,7 @@ def setup(hass, config):
 
         _LOGGER.debug("Ebusd integration setup completed")
         return True
-    except (socket.timeout, socket.error):
+    except (socket.timeout, OSError):
         return False
 
 

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -123,7 +123,7 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
                 else:
                     # most likely the timeout, so check for interrupt
                     continue
-            except socket.error as ex:
+            except OSError as ex:
                 if self._interrupted:
                     clean_socket_close(ssdp_socket)
                     return

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -1,7 +1,6 @@
 """Support for Flux lights."""
 import logging
 import random
-import socket
 
 from flux_led import BulbScanner, WifiLedBulb
 import voluptuous as vol
@@ -363,7 +362,7 @@ class FluxLight(Light):
             try:
                 self._connect()
                 self._error_reported = False
-            except socket.error:
+            except OSError:
                 self._disconnect()
                 if not self._error_reported:
                     _LOGGER.warning(

--- a/homeassistant/components/fritzbox_callmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_callmonitor/sensor.py
@@ -63,7 +63,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # Try to resolve a hostname; if it is already an IP, it will be returned as-is
     try:
         host = socket.gethostbyname(host)
-    except socket.error:
+    except OSError:
         _LOGGER.error("Could not resolve hostname %s", host)
         return
     port = config.get(CONF_PORT)
@@ -170,7 +170,7 @@ class FritzBoxCallMonitor:
         try:
             self.sock.connect((self.host, self.port))
             threading.Thread(target=self._listen).start()
-        except socket.error as err:
+        except OSError as err:
             self.sock = None
             _LOGGER.error(
                 "Cannot connect to %s on port %s: %s", self.host, self.port, err

--- a/homeassistant/components/gpsd/sensor.py
+++ b/homeassistant/components/gpsd/sensor.py
@@ -58,7 +58,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         sock.connect((host, port))
         sock.shutdown(2)
         _LOGGER.debug("Connection to GPSD possible")
-    except socket.error:
+    except OSError:
         _LOGGER.error("Not able to connect to GPSD")
         return False
 

--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -51,7 +51,7 @@ def setup(hass, config):
         sock.connect((host, port))
         sock.shutdown(2)
         _LOGGER.debug("Connection to Graphite possible")
-    except socket.error:
+    except OSError:
         _LOGGER.error("Not able to connect to Graphite")
         return False
 
@@ -128,7 +128,7 @@ class GraphiteFeeder(threading.Thread):
             self._send_to_graphite("\n".join(lines))
         except socket.gaierror:
             _LOGGER.error("Unable to connect to host %s", self._host)
-        except socket.error:
+        except OSError:
             _LOGGER.exception("Failed to send data to graphite")
 
     def run(self):

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -444,7 +444,7 @@ class HarmonyRemote(remote.RemoteDevice):
         try:
             with open(self._config_path, "w+", encoding="utf-8") as file_out:
                 json.dump(self._client.json_config, file_out, sort_keys=True, indent=4)
-        except IOError as exc:
+        except OSError as exc:
             _LOGGER.error(
                 "%s: Unable to write HUB configuration to %s: %s",
                 self.name,

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -355,7 +355,7 @@ class InfluxThread(threading.Thread):
             except (
                 exceptions.InfluxDBClientError,
                 exceptions.InfluxDBServerError,
-                IOError,
+                OSError,
             ) as err:
                 if retry < self.max_tries:
                     time.sleep(RETRY_DELAY)

--- a/homeassistant/components/lannouncer/notify.py
+++ b/homeassistant/components/lannouncer/notify.py
@@ -80,5 +80,5 @@ class LannouncerNotificationService(BaseNotificationService):
             sock.close()
         except socket.gaierror:
             _LOGGER.error("Unable to connect to host %s", self._host)
-        except socket.error:
+        except OSError:
             _LOGGER.exception("Failed to send data to Lannnouncer")

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -122,7 +122,7 @@ class MaxCubeClimate(ClimateDevice):
         with self._cubehandle.mutex:
             try:
                 cube.set_target_temperature(device, target_temperature)
-            except (socket.timeout, socket.error):
+            except (socket.timeout, OSError):
                 _LOGGER.error("Setting target temperature failed")
                 return False
 
@@ -145,7 +145,7 @@ class MaxCubeClimate(ClimateDevice):
         with self._cubehandle.mutex:
             try:
                 self._cubehandle.cube.set_mode(device, mode)
-            except (socket.timeout, socket.error):
+            except (socket.timeout, OSError):
                 _LOGGER.error("Setting operation mode failed")
                 return False
 

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -184,7 +184,7 @@ class MikrotikData:
             # get new hub firmware version if updated
             self.firmware = self.get_info(ATTR_FIRMWARE)
 
-        except (CannotConnect, socket.timeout, socket.error):
+        except (CannotConnect, socket.timeout, OSError):
             self.available = False
             return
 
@@ -249,7 +249,7 @@ class MikrotikData:
                 response = list(self.api(cmd=cmd))
         except (
             librouteros.exceptions.ConnectionClosed,
-            socket.error,
+            OSError,
             socket.timeout,
         ) as api_error:
             _LOGGER.error("Mikrotik %s connection error %s", self._host, api_error)
@@ -407,7 +407,7 @@ def get_api(hass, entry):
         return api
     except (
         librouteros.exceptions.LibRouterosError,
-        socket.error,
+        OSError,
         socket.timeout,
     ) as api_error:
         _LOGGER.error("Mikrotik %s error: %s", entry[CONF_HOST], api_error)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -7,7 +7,6 @@ import json
 import logging
 from operator import attrgetter
 import os
-import socket
 import ssl
 import sys
 import time
@@ -996,7 +995,7 @@ class MQTT:
                     self.connected = True
                     _LOGGER.info("Successfully reconnected to the MQTT server")
                     break
-            except socket.error:
+            except OSError:
                 pass
 
             wait_time = min(2 ** tries, MAX_RECONNECT_WAIT)

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -1,7 +1,6 @@
 """Support for Nest devices."""
 from datetime import datetime, timedelta
 import logging
-import socket
 import threading
 
 from nest import Nest
@@ -294,7 +293,7 @@ class NestDevice:
             if self.local_structure is None:
                 self.local_structure = structure_names
 
-        except (AuthorizationError, APIError, socket.error) as err:
+        except (AuthorizationError, APIError, OSError) as err:
             _LOGGER.error("Connection error while access Nest web service: %s", err)
             return False
         return True
@@ -312,7 +311,7 @@ class NestDevice:
                     continue
                 yield structure
 
-        except (AuthorizationError, APIError, socket.error) as err:
+        except (AuthorizationError, APIError, OSError) as err:
             _LOGGER.error("Connection error while access Nest web service: %s", err)
 
     def thermostats(self):
@@ -354,7 +353,7 @@ class NestDevice:
                         continue
                     yield (structure, device)
 
-        except (AuthorizationError, APIError, socket.error) as err:
+        except (AuthorizationError, APIError, OSError) as err:
             _LOGGER.error("Connection error while access Nest web service: %s", err)
 
 

--- a/homeassistant/components/osramlightify/light.py
+++ b/homeassistant/components/osramlightify/light.py
@@ -1,7 +1,6 @@
 """Support for Osram Lightify."""
 import logging
 import random
-import socket
 
 from lightify import Lightify
 import voluptuous as vol
@@ -74,7 +73,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     host = config[CONF_HOST]
     try:
         bridge = Lightify(host, log_level=logging.NOTSET)
-    except socket.error as err:
+    except OSError as err:
         msg = "Error connecting to bridge: {} due to: {}".format(host, str(err))
         _LOGGER.exception(msg)
         return

--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -67,7 +67,7 @@ def setup(hass, config):
 
     try:
         pilight_client = pilight.Client(host=host, port=port)
-    except (socket.error, socket.timeout) as err:
+    except (OSError, socket.timeout) as err:
         _LOGGER.error("Unable to connect to %s on port %s: %s", host, port, err)
         return False
 

--- a/homeassistant/components/tcp/sensor.py
+++ b/homeassistant/components/tcp/sensor.py
@@ -99,7 +99,7 @@ class TcpSensor(Entity):
             sock.settimeout(self._config[CONF_TIMEOUT])
             try:
                 sock.connect((self._config[CONF_HOST], self._config[CONF_PORT]))
-            except socket.error as err:
+            except OSError as err:
                 _LOGGER.error(
                     "Unable to connect to %s on port %s: %s",
                     self._config[CONF_HOST],
@@ -110,7 +110,7 @@ class TcpSensor(Entity):
 
             try:
                 sock.send(self._config[CONF_PAYLOAD].encode())
-            except socket.error as err:
+            except OSError as err:
                 _LOGGER.error(
                     "Unable to send payload %r to %s on port %s: %s",
                     self._config[CONF_PAYLOAD],

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -1,6 +1,5 @@
 """Support for Ubiquiti's UVC cameras."""
 import logging
-import socket
 
 import requests
 from uvcclient import camera as uvc_camera, nvr
@@ -154,7 +153,7 @@ class UnifiVideoCamera(Camera):
                 )
                 self._connect_addr = addr
                 break
-            except socket.error:
+            except OSError:
                 pass
             except uvc_camera.CameraConnectError:
                 pass

--- a/homeassistant/components/watson_iot/__init__.py
+++ b/homeassistant/components/watson_iot/__init__.py
@@ -208,7 +208,7 @@ class WatsonIOTThread(threading.Thread):
                         _LOGGER.error("Failed to publish message to Watson IoT")
                         continue
                     break
-                except (MissingMessageEncoderException, IOError):
+                except (MissingMessageEncoderException, OSError):
                     if retry < MAX_TRIES:
                         time.sleep(RETRY_DELAY)
                     else:

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -53,7 +53,7 @@ def setup(hass, config):
 
     try:
         host_ip_pton = socket.inet_pton(socket.AF_INET, host_ip)
-    except socket.error:
+    except OSError:
         host_ip_pton = socket.inet_pton(socket.AF_INET6, host_ip)
 
     info = ServiceInfo(

--- a/homeassistant/components/ziggo_mediabox_xl/media_player.py
+++ b/homeassistant/components/ziggo_mediabox_xl/media_player.py
@@ -85,7 +85,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     ZiggoMediaboxXLDevice(mediabox, host, name, connection_successful)
                 )
                 known_devices.add(ip_addr)
-        except socket.error as error:
+        except OSError as error:
             _LOGGER.error("Can't connect to %s: %s", host, error)
     else:
         _LOGGER.info("Ignoring duplicate Ziggo Mediabox XL %s", host)
@@ -115,7 +115,7 @@ class ZiggoMediaboxXLDevice(MediaPlayerDevice):
                 self._available = True
             else:
                 self._available = False
-        except socket.error:
+        except OSError:
             _LOGGER.error("Couldn't fetch state from %s", self._host)
             self._available = False
 
@@ -123,7 +123,7 @@ class ZiggoMediaboxXLDevice(MediaPlayerDevice):
         """Send keys to the device and handle exceptions."""
         try:
             self._mediabox.send_keys(keys)
-        except socket.error:
+        except OSError:
             _LOGGER.error("Couldn't send keys to %s", self._host)
 
     @property

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -101,7 +101,7 @@ def get_local_ip() -> str:
         sock.connect(("8.8.8.8", 80))
 
         return sock.getsockname()[0]  # type: ignore
-    except socket.error:
+    except OSError:
         try:
             return socket.gethostbyname(socket.gethostname())
         except socket.gaierror:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In Python 3.3 the exception hierarchy was changed around operating system errors.

Most of those were merged into a single `OSError`. All others where kept for backward compatibility reasons.

> You don’t have to worry anymore about choosing the appropriate exception type between `OSError`, `IOError`, `EnvironmentError`, `WindowsError`, `mmap.error`, `socket.error` or `select.error`. All these exception types are now only one: OSError. The other names are kept as aliases for compatibility reasons.

<https://python.readthedocs.io/en/stable/whatsnew/3.3.html#pep-3151-reworking-the-os-and-io-exception-hierarchy>

Which was a result of [PEP 3151](https://www.python.org/dev/peps/pep-3151/#built-in-exceptions).

This PR removes the use of all those `OSError` aliases and uses `OSError` directly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
