### PR TITLE
Use dict literals

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -137,7 +137,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ADB_SERVER_IP): cv.string,
         vol.Optional(CONF_ADB_SERVER_PORT, default=DEFAULT_ADB_SERVER_PORT): cv.port,
         vol.Optional(CONF_GET_SOURCES, default=DEFAULT_GET_SOURCES): cv.boolean,
-        vol.Optional(CONF_APPS, default=dict()): vol.Schema(
+        vol.Optional(CONF_APPS, default={}): vol.Schema(
             {cv.string: vol.Any(cv.string, None)}
         ),
         vol.Optional(CONF_TURN_ON_COMMAND): cv.string,
@@ -327,7 +327,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             target_device.adb_push(local_path, device_path)
 
     hass.services.register(
-        ANDROIDTV_DOMAIN, SERVICE_UPLOAD, service_upload, schema=SERVICE_UPLOAD_SCHEMA,
+        ANDROIDTV_DOMAIN, SERVICE_UPLOAD, service_upload, schema=SERVICE_UPLOAD_SCHEMA
     )
 
 

--- a/homeassistant/components/config/scene.py
+++ b/homeassistant/components/config/scene.py
@@ -58,7 +58,7 @@ class EditSceneConfigView(EditIdBasedConfigView):
             elif cur_value[CONF_ID] == config_key:
                 break
         else:
-            cur_value = dict()
+            cur_value = {}
             cur_value[CONF_ID] = config_key
             index = len(data)
             data.append(cur_value)

--- a/homeassistant/components/device_tracker/setup.py
+++ b/homeassistant/components/device_tracker/setup.py
@@ -170,7 +170,7 @@ def async_setup_scanner_platform(
             try:
                 extra_attributes = await scanner.async_get_extra_attributes(mac)
             except NotImplementedError:
-                extra_attributes = dict()
+                extra_attributes = {}
 
             kwargs = {
                 "mac": mac,

--- a/homeassistant/components/dht/sensor.py
+++ b/homeassistant/components/dht/sensor.py
@@ -165,7 +165,7 @@ class DHTClient:
         self.adafruit_dht = adafruit_dht
         self.sensor = sensor
         self.pin = pin
-        self.data = dict()
+        self.data = {}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -184,7 +184,7 @@ class EcobeeWeather(WeatherEntity):
 
 def _process_forecast(json):
     """Process a single ecobee API forecast to return expected values."""
-    forecast = dict()
+    forecast = {}
     try:
         forecast[ATTR_FORECAST_TIME] = datetime.strptime(
             json["dateTime"], "%Y-%m-%d %H:%M:%S"

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -228,7 +228,7 @@ class Config:
 
         self.entities = conf.get(CONF_ENTITIES, {})
 
-        self._entities_with_hidden_attr_in_config = dict()
+        self._entities_with_hidden_attr_in_config = {}
         for entity_id in self.entities:
             hidden_value = self.entities[entity_id].get(CONF_ENTITY_HIDDEN, None)
             if hidden_value is not None:

--- a/homeassistant/components/fail2ban/sensor.py
+++ b/homeassistant/components/fail2ban/sensor.py
@@ -108,7 +108,7 @@ class BanLogParser:
         """Initialize the parser."""
         self.log_file = log_file
         self.data = list()
-        self.ip_regex = dict()
+        self.ip_regex = {}
 
     def read_log(self, jail):
         """Read the fail2ban log and find entries for jail."""

--- a/homeassistant/components/ifttt/__init__.py
+++ b/homeassistant/components/ifttt/__init__.py
@@ -64,7 +64,7 @@ async def async_setup(hass, config):
         value2 = call.data.get(ATTR_VALUE2)
         value3 = call.data.get(ATTR_VALUE3)
 
-        target_keys = dict()
+        target_keys = {}
         for target in targets:
             if target not in api_keys:
                 _LOGGER.error("No IFTTT api key for %s", target)

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -171,7 +171,7 @@ def _check_deprecated_turn_off(hass, turn_off_action):
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Kodi platform."""
     if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = dict()
+        hass.data[DOMAIN] = {}
 
     unique_id = None
     # Is this a manual configuration?

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -119,7 +119,7 @@ class MeteoFranceWeather(WeatherEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        data = dict()
+        data = {}
         if self._data and "next_rain" in self._data:
             data["next_rain"] = self._data["next_rain"]
         return data

--- a/homeassistant/components/mhz19/sensor.py
+++ b/homeassistant/components/mhz19/sensor.py
@@ -124,7 +124,7 @@ class MHZClient:
         """Initialize the sensor."""
         self.co2sensor = co2sens
         self._serial = serial
-        self.data = dict()
+        self.data = {}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/mpchc/media_player.py
+++ b/homeassistant/components/mpchc/media_player.py
@@ -68,7 +68,7 @@ class MpcHcDevice(MediaPlayerDevice):
         """Initialize the MPC-HC device."""
         self._name = name
         self._url = url
-        self._player_variables = dict()
+        self._player_variables = {}
         self._available = False
 
     def update(self):
@@ -83,7 +83,7 @@ class MpcHcDevice(MediaPlayerDevice):
             self._available = True
         except requests.exceptions.RequestException:
             _LOGGER.error("Could not connect to MPC-HC at: %s", self._url)
-            self._player_variables = dict()
+            self._player_variables = {}
             self._available = False
 
     def _send_command(self, command_id):

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -57,7 +57,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Nanoleaf light."""
 
     if DATA_NANOLEAF not in hass.data:
-        hass.data[DATA_NANOLEAF] = dict()
+        hass.data[DATA_NANOLEAF] = {}
 
     token = ""
     if discovery_info is not None:

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -161,9 +161,9 @@ class Plant(Entity):
     def __init__(self, name, config):
         """Initialize the Plant component."""
         self._config = config
-        self._sensormap = dict()
-        self._readingmap = dict()
-        self._unit_of_measurement = dict()
+        self._sensormap = {}
+        self._readingmap = {}
+        self._unit_of_measurement = {}
         for reading, entity_id in config["sensors"].items():
             self._sensormap[entity_id] = reading
             self._readingmap[reading] = entity_id
@@ -371,7 +371,7 @@ class DailyHistory:
         """Create new DailyHistory with a maximum length of the history."""
         self.max_length = max_length
         self._days = None
-        self._max_dict = dict()
+        self._max_dict = {}
         self.max = None
 
     def add_measurement(self, value, timestamp=None):

--- a/homeassistant/components/remember_the_milk/__init__.py
+++ b/homeassistant/components/remember_the_milk/__init__.py
@@ -157,7 +157,7 @@ class RememberTheMilkConfiguration:
         """Create new instance of configuration."""
         self._config_file_path = hass.config.path(CONFIG_FILE_NAME)
         if not os.path.isfile(self._config_file_path):
-            self._config = dict()
+            self._config = {}
             return
         try:
             _LOGGER.debug("Loading configuration from file: %s", self._config_file_path)
@@ -168,7 +168,7 @@ class RememberTheMilkConfiguration:
                 "Failed to load configuration file, creating a new one: %s",
                 self._config_file_path,
             )
-            self._config = dict()
+            self._config = {}
 
     def save_config(self):
         """Write the configuration to a file."""
@@ -198,9 +198,9 @@ class RememberTheMilkConfiguration:
     def _initialize_profile(self, profile_name):
         """Initialize the data structures for a profile."""
         if profile_name not in self._config:
-            self._config[profile_name] = dict()
+            self._config[profile_name] = {}
         if CONF_ID_MAP not in self._config[profile_name]:
-            self._config[profile_name][CONF_ID_MAP] = dict()
+            self._config[profile_name][CONF_ID_MAP] = {}
 
     def get_rtm_id(self, profile_name, hass_id):
         """Get the RTM ids for a Home Assistant task ID.

--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -184,7 +184,7 @@ class SpeechToTextView(HomeAssistantView):
             return None
 
         # Convert Header data
-        args = dict()
+        args = {}
         for value in data:
             value = value.strip()
             args[value.partition("=")[0]] = value.partition("=")[2]

--- a/homeassistant/components/ted5000/sensor.py
+++ b/homeassistant/components/ted5000/sensor.py
@@ -90,7 +90,7 @@ class Ted5000Gateway:
     def __init__(self, url):
         """Initialize the data object."""
         self.url = url
-        self.data = dict()
+        self.data = {}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 def initialise_templates(hass, templates, attribute_templates=None):
     """Initialise templates and attribute templates."""
     if attribute_templates is None:
-        attribute_templates = dict()
+        attribute_templates = {}
     for template in chain(templates.values(), attribute_templates.values()):
         if template is None:
             continue
@@ -23,7 +23,7 @@ def extract_entities(
 ):
     """Extract entity ids from templates and attribute templates."""
     if attribute_templates is None:
-        attribute_templates = dict()
+        attribute_templates = {}
     entity_ids = set()
     if manual_entity_ids is None:
         invalid_templates = []

--- a/homeassistant/components/ubus/device_tracker.py
+++ b/homeassistant/components/ubus/device_tracker.py
@@ -94,7 +94,7 @@ class UbusDeviceScanner(DeviceScanner):
 
     def _generate_mac2name(self):
         """Return empty MAC to name dict. Overridden if DHCP server is set."""
-        self.mac2name = dict()
+        self.mac2name = {}
 
     @_refresh_on_access_denied
     def get_device_name(self, device):
@@ -170,7 +170,7 @@ class DnsmasqUbusDeviceScanner(UbusDeviceScanner):
             self.url, self.session_id, "call", "file", "read", path=self.leasefile
         )
         if result:
-            self.mac2name = dict()
+            self.mac2name = {}
             for line in result["data"].splitlines():
                 hosts = line.split(" ")
                 self.mac2name[hosts[1].upper()] = hosts[3]
@@ -185,7 +185,7 @@ class OdhcpdUbusDeviceScanner(UbusDeviceScanner):
     def _generate_mac2name(self):
         result = _req_json_rpc(self.url, self.session_id, "call", "dhcp", "ipv4leases")
         if result:
-            self.mac2name = dict()
+            self.mac2name = {}
             for device in result["device"].values():
                 for lease in device["leases"]:
                     mac = lease["mac"]  # mac = aabbccddeeff

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -79,7 +79,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Volumio platform."""
     if DATA_VOLUMIO not in hass.data:
-        hass.data[DATA_VOLUMIO] = dict()
+        hass.data[DATA_VOLUMIO] = {}
 
     # This is a manual configuration?
     if discovery_info is None:

--- a/tests/components/google_wifi/test_sensor.py
+++ b/tests/components/google_wifi/test_sensor.py
@@ -106,7 +106,7 @@ class TestGoogleWifiSensor(unittest.TestCase):
             conditions = google_wifi.MONITORED_CONDITIONS.keys()
             self.api = google_wifi.GoogleWifiAPI("localhost", conditions)
         self.name = NAME
-        self.sensor_dict = dict()
+        self.sensor_dict = {}
         for condition, cond_list in google_wifi.MONITORED_CONDITIONS.items():
             sensor = google_wifi.GoogleWifiSensor(self.api, self.name, condition)
             name = f"{self.name}_{condition}"

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -144,7 +144,7 @@ async def test_template_position(hass, calls):
     await hass.async_block_till_done()
 
     entity = hass.states.get("cover.test")
-    attrs = dict()
+    attrs = {}
     attrs["position"] = 42
     hass.states.async_set(entity.entity_id, entity.state, attributes=attrs)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes occurrences of using the `dict()` function to create an empty dictionary. Replaced with a dictionary literal `{}` (literals are faster and should be used in general).
Followup to #33654


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to PR: #33654
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
