### PR TITLE
Separate august keypads into their own device

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -259,6 +259,13 @@ class AugustData(AugustSubscriberMixin):
                 await self._async_update_device_detail(
                     self._locks_by_id[device_id], self._api.async_get_lock_detail
                 )
+                # keypads are always attached to locks
+                if (
+                    device_id in self._device_detail_by_id
+                    and self._device_detail_by_id[device_id].keypad is not None
+                ):
+                    keypad = self._device_detail_by_id[device_id].keypad
+                    self._device_detail_by_id[keypad.device_id] = keypad
             elif device_id in self._doorbells_by_id:
                 await self._async_update_device_detail(
                     self._doorbells_by_id[device_id],

--- a/tests/components/august/test_sensor.py
+++ b/tests/components/august/test_sensor.py
@@ -71,21 +71,12 @@ async def test_create_lock_with_linked_keypad(hass):
     assert entry
     assert entry.unique_id == "A6697750D607098BAE8D6BAA11EF8063_device_battery"
 
-    sensor_a6697750d607098bae8d6baa11ef8063_name_keypad_battery = hass.states.get(
-        "sensor.a6697750d607098bae8d6baa11ef8063_name_keypad_battery"
-    )
-    assert sensor_a6697750d607098bae8d6baa11ef8063_name_keypad_battery.state == "60"
-    assert (
-        sensor_a6697750d607098bae8d6baa11ef8063_name_keypad_battery.attributes[
-            "unit_of_measurement"
-        ]
-        == "%"
-    )
-    entry = entity_registry.async_get(
-        "sensor.a6697750d607098bae8d6baa11ef8063_name_keypad_battery"
-    )
+    state = hass.states.get("sensor.front_door_lock_keypad_battery")
+    assert state.state == "60"
+    assert state.attributes["unit_of_measurement"] == "%"
+    entry = entity_registry.async_get("sensor.front_door_lock_keypad_battery")
     assert entry
-    assert entry.unique_id == "A6697750D607098BAE8D6BAA11EF8063_linked_keypad_battery"
+    assert entry.unique_id == "5bc65c24e6ef2a263e1450a8_linked_keypad_battery"
 
 
 async def test_create_lock_with_low_battery_linked_keypad(hass):
@@ -110,21 +101,12 @@ async def test_create_lock_with_low_battery_linked_keypad(hass):
     assert entry
     assert entry.unique_id == "A6697750D607098BAE8D6BAA11EF8063_device_battery"
 
-    sensor_a6697750d607098bae8d6baa11ef8063_name_keypad_battery = hass.states.get(
-        "sensor.a6697750d607098bae8d6baa11ef8063_name_keypad_battery"
-    )
-    assert sensor_a6697750d607098bae8d6baa11ef8063_name_keypad_battery.state == "10"
-    assert (
-        sensor_a6697750d607098bae8d6baa11ef8063_name_keypad_battery.attributes[
-            "unit_of_measurement"
-        ]
-        == "%"
-    )
-    entry = entity_registry.async_get(
-        "sensor.a6697750d607098bae8d6baa11ef8063_name_keypad_battery"
-    )
+    state = hass.states.get("sensor.front_door_lock_keypad_battery")
+    assert state.state == "10"
+    assert state.attributes["unit_of_measurement"] == "%"
+    entry = entity_registry.async_get("sensor.front_door_lock_keypad_battery")
     assert entry
-    assert entry.unique_id == "A6697750D607098BAE8D6BAA11EF8063_linked_keypad_battery"
+    assert entry.unique_id == "5bc65c24e6ef2a263e1450a8_linked_keypad_battery"
 
     # No activity means it will be unavailable until someone unlocks/locks it
     lock_operator_sensor = entity_registry.async_get(


### PR DESCRIPTION



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The keypad has its own unique id so its better
represented as its own device.  This fixes
showing the keypad battery state for the lock
in the UI.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
