### PR TITLE
Handle float values for homekit lightning

### DIFF
--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -149,7 +149,7 @@ class Light(HomeAccessory):
         # Handle Brightness
         if CHAR_BRIGHTNESS in self.chars:
             brightness = new_state.attributes.get(ATTR_BRIGHTNESS)
-            if isinstance(brightness, int):
+            if isinstance(brightness, (int, float)):
                 brightness = round(brightness / 255 * 100, 0)
                 # The homeassistant component might report its brightness as 0 but is
                 # not off. But 0 is a special value in homekit. When you turn on a
@@ -169,22 +169,18 @@ class Light(HomeAccessory):
         # Handle color temperature
         if CHAR_COLOR_TEMPERATURE in self.chars:
             color_temperature = new_state.attributes.get(ATTR_COLOR_TEMP)
-            if (
-                isinstance(color_temperature, int)
-                and self.char_color_temperature.value != color_temperature
-            ):
-                self.char_color_temperature.set_value(color_temperature)
+            if isinstance(color_temperature, (int, float)):
+                color_temperature = round(color_temperature, 0)
+                if self.char_color_temperature.value != color_temperature:
+                    self.char_color_temperature.set_value(color_temperature)
 
         # Handle Color
         if CHAR_SATURATION in self.chars and CHAR_HUE in self.chars:
             hue, saturation = new_state.attributes.get(ATTR_HS_COLOR, (None, None))
-            if (
-                isinstance(hue, (int, float))
-                and isinstance(saturation, (int, float))
-                and (
-                    hue != self.char_hue.value
-                    or saturation != self.char_saturation.value
-                )
-            ):
-                self.char_hue.set_value(hue)
-                self.char_saturation.set_value(saturation)
+            if isinstance(hue, (int, float)) and isinstance(saturation, (int, float)):
+                hue = round(hue, 0)
+                saturation = round(saturation, 0)
+                if hue != self.char_hue.value:
+                    self.char_hue.set_value(hue)
+                if saturation != self.char_saturation.value:
+                    self.char_saturation.set_value(saturation)

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -235,6 +235,17 @@ async def test_light_brightness(hass, hk_driver, cls, events, driver):
     await hass.async_block_till_done()
     assert acc.char_brightness.value == 1
 
+    # Ensure floats are handled
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_BRIGHTNESS: 55.66})
+    await hass.async_block_till_done()
+    assert acc.char_brightness.value == 22
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_BRIGHTNESS: 108.4})
+    await hass.async_block_till_done()
+    assert acc.char_brightness.value == 43
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_BRIGHTNESS: 0.0})
+    await hass.async_block_till_done()
+    assert acc.char_brightness.value == 1
+
 
 async def test_light_color_temperature(hass, hk_driver, cls, events, driver):
     """Test light with color temperature."""
@@ -417,6 +428,11 @@ async def test_light_set_brightness_and_color(hass, hk_driver, cls, events, driv
     await hass.async_block_till_done()
     assert acc.char_brightness.value == 40
 
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_HS_COLOR: (4.5, 9.2)})
+    await hass.async_block_till_done()
+    assert acc.char_hue.value == 4
+    assert acc.char_saturation.value == 9
+
     # Set from HomeKit
     call_turn_on = async_mock_service(hass, DOMAIN, "turn_on")
 
@@ -488,6 +504,10 @@ async def test_light_set_brightness_and_color_temp(
     hass.states.async_set(entity_id, STATE_ON, {ATTR_BRIGHTNESS: 102})
     await hass.async_block_till_done()
     assert acc.char_brightness.value == 40
+
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_COLOR_TEMP: (224.14)})
+    await hass.async_block_till_done()
+    assert acc.char_color_temperature.value == 224
 
     # Set from HomeKit
     call_turn_on = async_mock_service(hass, DOMAIN, "turn_on")


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix HomeKit light not updating brightness value when changed from HomeAssistant

The `homekit` integration would ignore brightness that was a float value in state changes.

The `homekit` integration would accept Hue/sat/color float values for state changes but would not round them which are invalid values for Homekit Accessory Protocol since the step size is 1. (floats are ok as long as its .0)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33640
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
