### PR TITLE
Properly demarcate websocket and REST API callbacks in SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -636,10 +636,7 @@ class SimpliSafeEntity(Entity):
 
     @callback
     def _async_internal_update_from_websocket_event(self, event):
-        """Perform some internal websocket handling.
-
-        Should not be called directly.
-        """
+        """Perform internal websocket handling prior to handing off."""
         if self._async_should_ignore_websocket_event(event):
             return
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -541,7 +541,6 @@ class SimpliSafeEntity(Entity):
 
     def __init__(self, simplisafe, system, name, *, serial=None):
         """Initialize."""
-        self._async_unsub_dispatcher_connects = []
         self._name = name
         self._online = True
         self._simplisafe = simplisafe
@@ -647,7 +646,7 @@ class SimpliSafeEntity(Entity):
             self.async_update_from_rest_api()
             self.async_write_ha_state()
 
-        self._async_unsub_dispatcher_connects.append(
+        self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
                 TOPIC_UPDATE_REST_API.format(self._system.system_id),
@@ -677,7 +676,7 @@ class SimpliSafeEntity(Entity):
             self._async_internal_update_from_websocket_event(event)
             self.async_write_ha_state()
 
-        self._async_unsub_dispatcher_connects.append(
+        self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
                 TOPIC_UPDATE_WEBSOCKET.format(self._system.system_id),
@@ -696,9 +695,3 @@ class SimpliSafeEntity(Entity):
     def async_update_from_websocket_event(self, event):
         """Update the entity with the provided websocket event."""
         raise NotImplementedError()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect dispatcher listener when removed."""
-        for dispatcher_callback in self._async_unsub_dispatcher_connects:
-            dispatcher_callback()
-        self._async_unsub_dispatcher_connects = []

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -63,7 +63,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ACCOUNTS = "accounts"
 
 DATA_LISTENER = "listener"
-TOPIC_UPDATE = "simplisafe_update_data_{0}"
+TOPIC_UPDATE_REST_API = "simplisafe_update_rest_api_{0}"
+TOPIC_UPDATE_WEBSOCKET = "simplisafe_update_websocket_{0}"
 
 EVENT_SIMPLISAFE_EVENT = "SIMPLISAFE_EVENT"
 EVENT_SIMPLISAFE_NOTIFICATION = "SIMPLISAFE_NOTIFICATION"
@@ -354,7 +355,6 @@ class SimpliSafeWebsocket:
         """Initialize."""
         self._hass = hass
         self._websocket = websocket
-        self.last_events = {}
 
     @staticmethod
     def _on_connect():
@@ -369,8 +369,9 @@ class SimpliSafeWebsocket:
     def _on_event(self, event):
         """Define a handler to fire when a new SimpliSafe event arrives."""
         _LOGGER.debug("New websocket event: %s", event)
-        self.last_events[event.system_id] = event
-        async_dispatcher_send(self._hass, TOPIC_UPDATE.format(event.system_id))
+        async_dispatcher_send(
+            self._hass, TOPIC_UPDATE_WEBSOCKET.format(event.system_id), event
+        )
 
         if event.event_type not in WEBSOCKET_EVENTS_TO_TRIGGER_HASS_EVENT:
             return
@@ -491,7 +492,9 @@ class SimpliSafe:
             await system.update()
             self._async_process_new_notifications(system)
             _LOGGER.debug('Updated REST API data for "%s"', system.address)
-            async_dispatcher_send(self._hass, TOPIC_UPDATE.format(system.system_id))
+            async_dispatcher_send(
+                self._hass, TOPIC_UPDATE_REST_API.format(system.system_id)
+            )
 
         tasks = [update_system(system) for system in self.systems.values()]
 
@@ -538,8 +541,7 @@ class SimpliSafeEntity(Entity):
 
     def __init__(self, simplisafe, system, name, *, serial=None):
         """Initialize."""
-        self._async_unsub_dispatcher_connect = None
-        self._last_processed_websocket_event = None
+        self._async_unsub_dispatcher_connects = []
         self._name = name
         self._online = True
         self._simplisafe = simplisafe
@@ -614,10 +616,6 @@ class SimpliSafeEntity(Entity):
         a particular entity, like a lock – because some events (like arming the system
         from a keypad _or_ from the website) should impact the same entity.
         """
-        # We've already processed this event:
-        if self._last_processed_websocket_event == event:
-            return True
-
         # This is an event for a system other than the one this entity belongs to:
         if event.system_id != self._system.system_id:
             return True
@@ -636,60 +634,15 @@ class SimpliSafeEntity(Entity):
 
         return False
 
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-
-        @callback
-        def update():
-            """Update the state."""
-            self.update_from_latest_data()
-            self.async_write_ha_state()
-
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, TOPIC_UPDATE.format(self._system.system_id), update
-        )
-
-        self.update_from_latest_data()
-
-    @callback
-    def update_from_latest_data(self):
-        """Update the entity."""
-        self.async_update_from_rest_api()
-
-        last_websocket_event = self._simplisafe.websocket.last_events.get(
-            self._system.system_id
-        )
-
-        if self._async_should_ignore_websocket_event(last_websocket_event):
-            return
-
-        self._last_processed_websocket_event = last_websocket_event
-
-        if last_websocket_event.sensor_type:
-            sensor_type = last_websocket_event.sensor_type.name
-        else:
-            sensor_type = None
-
-        self._attrs.update(
-            {
-                ATTR_LAST_EVENT_INFO: last_websocket_event.info,
-                ATTR_LAST_EVENT_SENSOR_NAME: last_websocket_event.sensor_name,
-                ATTR_LAST_EVENT_SENSOR_TYPE: sensor_type,
-                ATTR_LAST_EVENT_TIMESTAMP: last_websocket_event.timestamp,
-            }
-        )
-        self._async_internal_update_from_websocket_event(last_websocket_event)
-
-    @callback
-    def async_update_from_rest_api(self):
-        """Update the entity with the provided REST API data."""
-
     @callback
     def _async_internal_update_from_websocket_event(self, event):
-        """Check for connection events and set offline appropriately.
+        """Perform some internal websocket handling.
 
         Should not be called directly.
         """
+        if self._async_should_ignore_websocket_event(event):
+            return
+
         if event.event_type == EVENT_CONNECTION_LOST:
             self._online = False
         elif event.event_type == EVENT_CONNECTION_RESTORED:
@@ -701,13 +654,67 @@ class SimpliSafeEntity(Entity):
         if not self._online:
             return
 
+        if event.sensor_type:
+            sensor_type = event.sensor_type.name
+        else:
+            sensor_type = None
+
+        self._attrs.update(
+            {
+                ATTR_LAST_EVENT_INFO: event.info,
+                ATTR_LAST_EVENT_SENSOR_NAME: event.sensor_name,
+                ATTR_LAST_EVENT_SENSOR_TYPE: sensor_type,
+                ATTR_LAST_EVENT_TIMESTAMP: event.timestamp,
+            }
+        )
+
         self.async_update_from_websocket_event(event)
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+
+        @callback
+        def update_from_rest_api():
+            """Update the entity with new REST API data."""
+            self.async_update_from_rest_api()
+            self.async_write_ha_state()
+
+        @callback
+        def update_from_websocket(event):
+            """Update the entity with new websocket data."""
+            self._async_internal_update_from_websocket_event(event)
+            self.async_write_ha_state()
+
+        self._async_unsub_dispatcher_connects.append(
+            async_dispatcher_connect(
+                self.hass,
+                TOPIC_UPDATE_REST_API.format(self._system.system_id),
+                update_from_rest_api,
+            )
+        )
+
+        self._async_unsub_dispatcher_connects.append(
+            async_dispatcher_connect(
+                self.hass,
+                TOPIC_UPDATE_WEBSOCKET.format(self._system.system_id),
+                update_from_websocket,
+            )
+        )
+
+        self.async_update_from_rest_api()
+
+    @callback
+    def async_update_from_rest_api(self):
+        """Update the entity with the provided REST API data."""
+        raise NotImplementedError()
 
     @callback
     def async_update_from_websocket_event(self, event):
-        """Update the entity with the provided websocket API data."""
+        """Update the entity with the provided websocket event."""
+        raise NotImplementedError()
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
+        for dispatcher_callback in self._async_unsub_dispatcher_connects:
+            dispatcher_callback()
+        self._async_unsub_dispatcher_connects = []

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -676,12 +676,6 @@ class SimpliSafeEntity(Entity):
             self.async_update_from_rest_api()
             self.async_write_ha_state()
 
-        @callback
-        def websocket_update(event):
-            """Update the entity with new websocket data."""
-            self._async_internal_update_from_websocket_event(event)
-            self.async_write_ha_state()
-
         self._async_unsub_dispatcher_connects.append(
             async_dispatcher_connect(
                 self.hass,
@@ -689,6 +683,12 @@ class SimpliSafeEntity(Entity):
                 rest_api_update,
             )
         )
+
+        @callback
+        def websocket_update(event):
+            """Update the entity with new websocket data."""
+            self._async_internal_update_from_websocket_event(event)
+            self.async_write_ha_state()
 
         self._async_unsub_dispatcher_connects.append(
             async_dispatcher_connect(

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -671,13 +671,13 @@ class SimpliSafeEntity(Entity):
         """Register callbacks."""
 
         @callback
-        def update_from_rest_api():
+        def rest_api_update():
             """Update the entity with new REST API data."""
             self.async_update_from_rest_api()
             self.async_write_ha_state()
 
         @callback
-        def update_from_websocket(event):
+        def websocket_update(event):
             """Update the entity with new websocket data."""
             self._async_internal_update_from_websocket_event(event)
             self.async_write_ha_state()
@@ -686,7 +686,7 @@ class SimpliSafeEntity(Entity):
             async_dispatcher_connect(
                 self.hass,
                 TOPIC_UPDATE_REST_API.format(self._system.system_id),
-                update_from_rest_api,
+                rest_api_update,
             )
         )
 
@@ -694,7 +694,7 @@ class SimpliSafeEntity(Entity):
             async_dispatcher_connect(
                 self.hass,
                 TOPIC_UPDATE_WEBSOCKET.format(self._system.system_id),
-                update_from_websocket,
+                websocket_update,
             )
         )
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -666,8 +666,8 @@ class SimpliSafeEntity(Entity):
             if event.event_type not in self.websocket_events_to_listen_for:
                 return
 
-            # Ignore this event if it belongs to a entity with a different serial:
-            # from this one's:
+            # Ignore this event if it belongs to a entity with a different serial
+            # number from this one's:
             if (
                 event.event_type in WEBSOCKET_EVENTS_REQUIRING_SERIAL
                 and event.sensor_serial != self._serial

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -195,7 +195,6 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
     @callback
     def async_update_from_rest_api(self):
         """Update the entity with the provided REST API data."""
-        _LOGGER.error("REST API")
         if self._system.version == 3:
             self._attrs.update(
                 {
@@ -235,7 +234,6 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
     @callback
     def async_update_from_websocket_event(self, event):
         """Update the entity with the provided websocket API event data."""
-        _LOGGER.error("Websocket")
         if event.event_type in (
             EVENT_ALARM_CANCELED,
             EVENT_DISARMED_BY_MASTER_PIN,

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -195,6 +195,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
     @callback
     def async_update_from_rest_api(self):
         """Update the entity with the provided REST API data."""
+        _LOGGER.error("REST API")
         if self._system.version == 3:
             self._attrs.update(
                 {
@@ -234,6 +235,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanel):
     @callback
     def async_update_from_websocket_event(self, event):
         """Update the entity with the provided websocket API event data."""
+        _LOGGER.error("Websocket")
         if event.event_type in (
             EVENT_ALARM_CANCELED,
             EVENT_DISARMED_BY_MASTER_PIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously, the SimpliSafe integration's handling of REST API and websocket updates was too intertwined; data from, say, the REST API would trigger logic tied to the websocket (and vice versa), requiring all sorts of maneuvers to ensure that data didn't collide. This PR unwinds the two and ensures that each type of data update only triggers the appropriate callback.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_email
      password: !secret simplisafe_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
