### PR TITLE
Load integrations with requirements in device_automation

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -13,7 +13,8 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_registry import async_entries_for_device
-from homeassistant.loader import IntegrationNotFound, async_get_integration
+from homeassistant.loader import IntegrationNotFound
+from homeassistant.requirements import async_get_integration_with_requirements
 
 from .exceptions import DeviceNotFound, InvalidDeviceAutomationConfig
 
@@ -80,7 +81,7 @@ async def async_get_device_automation_platform(
     """
     platform_name = TYPES[automation_type][0]
     try:
-        integration = await async_get_integration(hass, domain)
+        integration = await async_get_integration_with_requirements(hass, domain)
         platform = integration.get_platform(platform_name)
     except IntegrationNotFound:
         raise InvalidDeviceAutomationConfig(f"Integration '{domain}' not found")

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -15,7 +15,6 @@ from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
     Dict,
     List,
@@ -285,26 +284,13 @@ class Integration:
         return f"<Integration {self.domain}: {self.pkg_path}>"
 
 
-async def async_get_integration_with_cache(
-    hass: "HomeAssistant",
-    domain: str,
-    cache_key: str,
-    loader: Callable[
-        ["HomeAssistant", str, Dict[str, Any], asyncio.Event, Optional[Dict[str, Any]]],
-        Awaitable[Integration],
-    ],
-    loader_args: Optional[Dict[str, Any]] = None,
-) -> Integration:
-    """Load an integration using a cache.
-
-    Return the cached resource if available, otherwise call the passed in
-    loader to load the integration.
-    """
-    cache = hass.data.get(cache_key)
+async def async_get_integration(hass: "HomeAssistant", domain: str) -> Integration:
+    """Get an integration."""
+    cache = hass.data.get(DATA_INTEGRATIONS)
     if cache is None:
         if not _async_mount_config_dir(hass):
             raise IntegrationNotFound(domain)
-        cache = hass.data[cache_key] = {}
+        cache = hass.data[DATA_INTEGRATIONS] = {}
 
     int_or_evt: Union[Integration, asyncio.Event, None] = cache.get(domain, _UNDEF)
 
@@ -323,20 +309,6 @@ async def async_get_integration_with_cache(
 
     event = cache[domain] = asyncio.Event()
 
-    return await loader(hass, domain, cache, event, loader_args)
-
-
-async def _async_get_integration(
-    hass: "HomeAssistant",
-    domain: str,
-    cache: Dict[str, Any],
-    event: asyncio.Event,
-    args: Optional[Dict[str, Any]],
-) -> Integration:
-    """Get an integration.
-
-    Update the passed in cache and resolve the load event.
-    """
     # Instead of using resolve_from_root we use the cache of custom
     # components to find the integration.
     integration = (await async_get_custom_components(hass)).get(domain)
@@ -370,13 +342,6 @@ async def _async_get_integration(
         raise IntegrationNotFound(domain)
 
     return integration
-
-
-async def async_get_integration(hass: "HomeAssistant", domain: str) -> Integration:
-    """Get an integration."""
-    return await async_get_integration_with_cache(
-        hass, domain, DATA_INTEGRATIONS, _async_get_integration
-    )
 
 
 class LoaderError(Exception):

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -59,8 +59,6 @@ async def async_get_integration_with_requirements(
 
     cache = hass.data.get(DATA_INTEGRATIONS_WITH_REQS)
     if cache is None:
-        if not _async_mount_config_dir(hass):
-            raise IntegrationNotFound(domain)
         cache = hass.data[DATA_INTEGRATIONS_WITH_REQS] = {}
 
     int_or_evt: Union[Integration, asyncio.Event, None] = cache.get(domain, _UNDEF)


### PR DESCRIPTION
- Split cached loader behavior out of `async_get_integration` and use it for both `async_get_integration` and `async_get_integration_with_requirements`
- Use `async_get_integration_with_requirements` for device_automation

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR resolves #33104 by using `async_get_integration_with_requirements` in `device_automation/__init__.py`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33104 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

Note that some local tests are failing, but the same local tests are failing on the dev branch (at least on my system), so I don't believe the issues are related to this PR.

No new tests were added since the existing tests already verify that the modified functions work. 

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
