### PR TITLE
Remove global variable from bloomsky

### DIFF
--- a/homeassistant/components/bloomsky/__init__.py
+++ b/homeassistant/components/bloomsky/__init__.py
@@ -13,7 +13,6 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-BLOOMSKY = None
 BLOOMSKY_TYPE = ["camera", "binary_sensor", "sensor"]
 
 DOMAIN = "bloomsky"
@@ -31,11 +30,13 @@ def setup(hass, config):
     """Set up the BloomSky component."""
     api_key = config[DOMAIN][CONF_API_KEY]
 
-    global BLOOMSKY  # pylint: disable=global-statement
+    bloomsky = None
     try:
-        BLOOMSKY = BloomSky(api_key, hass.config.units.is_metric)
+        bloomsky = BloomSky(api_key, hass.config.units.is_metric)
     except RuntimeError:
         return False
+
+    hass.data[DOMAIN] = bloomsky
 
     for component in BLOOMSKY_TYPE:
         discovery.load_platform(hass, component, DOMAIN, {}, config)

--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensor
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 import homeassistant.helpers.config_validation as cv
 
-from . import BLOOMSKY
+from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,10 +26,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather binary sensors."""
     # Default needed in case of discovery
     sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
+    bloomsky = hass.data[DOMAIN]
 
-    for device in BLOOMSKY.devices.values():
+    for device in bloomsky.devices.values():
         for variable in sensors:
-            add_entities([BloomSkySensor(BLOOMSKY, device, variable)], True)
+            add_entities([BloomSkySensor(bloomsky, device, variable)], True)
 
 
 class BloomSkySensor(BinarySensorDevice):

--- a/homeassistant/components/bloomsky/camera.py
+++ b/homeassistant/components/bloomsky/camera.py
@@ -5,13 +5,15 @@ import requests
 
 from homeassistant.components.camera import Camera
 
-from . import BLOOMSKY
+from . import DOMAIN
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up access to BloomSky cameras."""
-    for device in BLOOMSKY.devices.values():
-        add_entities([BloomSkyCamera(BLOOMSKY, device)])
+    bloomsky = hass.data[DOMAIN]
+
+    for device in bloomsky.devices.values():
+        add_entities([BloomSkyCamera(bloomsky, device)])
 
 
 class BloomSkyCamera(Camera):

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-from . import BLOOMSKY
+from . import DOMAIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -61,10 +61,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather sensors."""
     # Default needed in case of discovery
     sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
+    bloomsky = hass.data[DOMAIN]
 
-    for device in BLOOMSKY.devices.values():
+    for device in bloomsky.devices.values():
         for variable in sensors:
-            add_entities([BloomSkySensor(BLOOMSKY, device, variable)], True)
+            add_entities([BloomSkySensor(bloomsky, device, variable)], True)
 
 
 class BloomSkySensor(Entity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes any global variables from the integration bloomsky.
Followup to enabling pylint global-statement: #33641

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to PR: #33641 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
