### PR TITLE
Don't reinvent callback handler removal logic in several integrations

### DIFF
--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -95,7 +95,6 @@ class AirVisualSensor(Entity):
     def __init__(self, airvisual, kind, name, icon, unit, locale, geography_id):
         """Initialize."""
         self._airvisual = airvisual
-        self._async_unsub_dispatcher_connects = []
         self._geography_id = geography_id
         self._icon = icon
         self._kind = kind
@@ -159,9 +158,7 @@ class AirVisualSensor(Entity):
             """Update the state."""
             self.async_schedule_update_ha_state(True)
 
-        self._async_unsub_dispatcher_connects.append(
-            async_dispatcher_connect(self.hass, TOPIC_UPDATE, update)
-        )
+        self.async_on_remove(async_dispatcher_connect(self.hass, TOPIC_UPDATE, update))
 
     async def async_update(self):
         """Update the sensor."""
@@ -206,9 +203,3 @@ class AirVisualSensor(Entity):
                 self._attrs["long"] = self._airvisual.geography_data[CONF_LONGITUDE]
                 self._attrs.pop(ATTR_LATITUDE, None)
                 self._attrs.pop(ATTR_LONGITUDE, None)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect dispatcher listener when removed."""
-        for cancel in self._async_unsub_dispatcher_connects:
-            cancel()
-        self._async_unsub_dispatcher_connects = []

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -437,7 +437,6 @@ class AmbientWeatherEntity(Entity):
         """Initialize the sensor."""
         self._ambient = ambient
         self._device_class = device_class
-        self._async_unsub_dispatcher_connect = None
         self._mac_address = mac_address
         self._sensor_name = sensor_name
         self._sensor_type = sensor_type
@@ -503,17 +502,13 @@ class AmbientWeatherEntity(Entity):
             self.update_from_latest_data()
             self.async_write_ha_state()
 
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, f"ambient_station_data_update_{self._mac_address}", update
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, f"ambient_station_data_update_{self._mac_address}", update
+            )
         )
 
         self.update_from_latest_data()
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
-            self._async_unsub_dispatcher_connect = None
 
     @callback
     def update_from_latest_data(self):

--- a/homeassistant/components/flunearyou/sensor.py
+++ b/homeassistant/components/flunearyou/sensor.py
@@ -56,7 +56,6 @@ class FluNearYouSensor(Entity):
 
     def __init__(self, fny, sensor_type, name, category, icon, unit):
         """Initialize the sensor."""
-        self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._category = category
         self._fny = fny
@@ -110,20 +109,12 @@ class FluNearYouSensor(Entity):
             self.update_from_latest_data()
             self.async_write_ha_state()
 
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, TOPIC_UPDATE, update
-        )
-
+        self.async_on_remove(async_dispatcher_connect(self.hass, TOPIC_UPDATE, update))
         await self._fny.async_register_api_interest(self._sensor_type)
-
         self.update_from_latest_data()
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
-            self._async_unsub_dispatcher_connect = None
-
         self._fny.async_deregister_api_interest(self._sensor_type)
 
     @callback

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -239,7 +239,6 @@ class IQVIAEntity(Entity):
 
     def __init__(self, iqvia, sensor_type, name, icon, zip_code):
         """Initialize the sensor."""
-        self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._icon = icon
         self._iqvia = iqvia
@@ -301,8 +300,8 @@ class IQVIAEntity(Entity):
             self.update_from_latest_data()
             self.async_write_ha_state()
 
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, TOPIC_DATA_UPDATE, update
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, TOPIC_DATA_UPDATE, update)
         )
 
         await self._iqvia.async_register_api_interest(self._type)
@@ -315,10 +314,6 @@ class IQVIAEntity(Entity):
 
     async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
-            self._async_unsub_dispatcher_connect = None
-
         self._iqvia.async_deregister_api_interest(self._type)
         if self._type == TYPE_ALLERGY_FORECAST:
             # Entities that lose interest in allergy forecast data should also lose

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -211,7 +211,6 @@ class NotionEntity(Entity):
         self, notion, task_id, sensor_id, bridge_id, system_id, name, device_class
     ):
         """Initialize the entity."""
-        self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._bridge_id = bridge_id
         self._device_class = device_class
@@ -309,17 +308,11 @@ class NotionEntity(Entity):
             self.update_from_latest_data()
             self.async_write_ha_state()
 
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, TOPIC_DATA_UPDATE, update
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, TOPIC_DATA_UPDATE, update)
         )
 
         self.update_from_latest_data()
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
-            self._async_unsub_dispatcher_connect = None
 
     @callback
     def update_from_latest_data(self):

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -233,7 +233,6 @@ class OpenUvEntity(Entity):
 
     def __init__(self, openuv):
         """Initialize."""
-        self._async_unsub_dispatcher_connect = None
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._available = True
         self._name = None
@@ -263,17 +262,9 @@ class OpenUvEntity(Entity):
             self.update_from_latest_data()
             self.async_write_ha_state()
 
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, TOPIC_UPDATE, update
-        )
+        self.async_on_remove(async_dispatcher_connect(self.hass, TOPIC_UPDATE, update))
 
         self.update_from_latest_data()
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
-            self._async_unsub_dispatcher_connect = None
 
     def update_from_latest_data(self):
         """Update the sensor using the latest data."""

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -410,7 +410,6 @@ class RainMachineEntity(Entity):
         """Initialize."""
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._device_class = None
-        self._dispatcher_handlers = []
         self._name = None
         self.rainmachine = rainmachine
 
@@ -453,12 +452,6 @@ class RainMachineEntity(Entity):
         """Update the state."""
         self.update_from_latest_data()
         self.async_write_ha_state()
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        for handler in self._dispatcher_handlers:
-            handler()
-        self._dispatcher_handlers = []
 
     @callback
     def update_from_latest_data(self):

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -126,7 +126,7 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._dispatcher_handlers.append(
+        self.async_on_remove(
             async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, self._update_state)
         )
         await self.rainmachine.async_register_sensor_api_interest(self._api_category)

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -143,7 +143,7 @@ class RainMachineSensor(RainMachineEntity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._dispatcher_handlers.append(
+        self.async_on_remove(
             async_dispatcher_connect(self.hass, SENSOR_UPDATE_TOPIC, self._update_state)
         )
         await self.rainmachine.async_register_sensor_api_interest(self._api_category)

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -188,7 +188,7 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._dispatcher_handlers.append(
+        self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, PROGRAM_UPDATE_TOPIC, self._update_state
             )
@@ -248,12 +248,12 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._dispatcher_handlers.append(
+        self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, PROGRAM_UPDATE_TOPIC, self._update_state
             )
         )
-        self._dispatcher_handlers.append(
+        self.async_on_remove(
             async_dispatcher_connect(self.hass, ZONE_UPDATE_TOPIC, self._update_state)
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
@balloob helped me realize [here](https://github.com/home-assistant/core/pull/33706#discussion_r403765023) that the `async_on_remove` entity helper exists. I was re-implementing this logic in most of my integrations, so this PR cleans things up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
