### PR TITLE
Fix unhandled exceptions for config, default_config, harmony

### DIFF
--- a/homeassistant/components/harmony/util.py
+++ b/homeassistant/components/harmony/util.py
@@ -11,7 +11,7 @@ def find_unique_id_for_remote(harmony: HarmonyAPI):
     """Find the unique id for both websocket and xmpp clients."""
     websocket_unique_id = harmony.hub_config.info.get("activeRemoteId")
     if websocket_unique_id is not None:
-        return websocket_unique_id
+        return str(websocket_unique_id)
 
     # fallback to the xmpp unique id if websocket is not available
     return harmony.config["global"]["timeStampHash"].split(";")[-1]

--- a/tests/components/config/test_group.py
+++ b/tests/components/config/test_group.py
@@ -1,6 +1,8 @@
 """Test Group config panel."""
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
+
+from asynctest import CoroutineMock
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
@@ -50,7 +52,7 @@ async def test_update_device_config(hass, hass_client):
         """Mock writing data."""
         written.append(data)
 
-    mock_call = MagicMock()
+    mock_call = CoroutineMock()
 
     with patch("homeassistant.components.config._read", mock_read), patch(
         "homeassistant.components.config._write", mock_write

--- a/tests/components/default_config/test_init.py
+++ b/tests/components/default_config/test_init.py
@@ -15,4 +15,4 @@ def recorder_url_mock():
 
 async def test_setup(hass):
     """Test setup."""
-    assert await async_setup_component(hass, "default_config", {})
+    assert await async_setup_component(hass, "default_config", {"foo": "bar"})

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -4,7 +4,6 @@ IGNORE_UNCAUGHT_EXCEPTIONS = [
     ("tests.components.cast.test_media_player", "test_entry_setup_single_config"),
     ("tests.components.cast.test_media_player", "test_entry_setup_list_config"),
     ("tests.components.cast.test_media_player", "test_entry_setup_platform_not_ready"),
-    ("tests.components.config.test_group", "test_update_device_config"),
     ("tests.components.default_config.test_init", "test_setup"),
     ("tests.components.demo.test_init", "test_setting_up_demo"),
     ("tests.components.discovery.test_init", "test_discover_config_flow"),

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -57,7 +57,4 @@ IGNORE_UNCAUGHT_JSON_EXCEPTIONS = [
         "tests.components.smartthings.test_init",
         "test_config_entry_loads_unconnected_cloud",
     ),
-    ("tests.components.harmony.test_config_flow", "test_form_import"),
-    ("tests.components.harmony.test_config_flow", "test_form_ssdp"),
-    ("tests.components.harmony.test_config_flow", "test_user_form"),
 ]

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -4,7 +4,6 @@ IGNORE_UNCAUGHT_EXCEPTIONS = [
     ("tests.components.cast.test_media_player", "test_entry_setup_single_config"),
     ("tests.components.cast.test_media_player", "test_entry_setup_list_config"),
     ("tests.components.cast.test_media_player", "test_entry_setup_platform_not_ready"),
-    ("tests.components.default_config.test_init", "test_setup"),
     ("tests.components.demo.test_init", "test_setting_up_demo"),
     ("tests.components.discovery.test_init", "test_discover_config_flow"),
     ("tests.components.dyson.test_air_quality", "test_purecool_aiq_attributes"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

did one PR for all three since they are tiny and i got tired of opening too many PRs...
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33322 , fixes #33320
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
