### PR TITLE
Fix exceptions in tests for samsung_tv

### DIFF
--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -76,6 +76,7 @@ def remote_fixture():
         remote_class.return_value = remote
         socket = mock.Mock()
         socket_class.return_value = socket
+        socket_class.gethostbyname.return_value = "FAKE_IP_ADDRESS"
         yield remote
 
 
@@ -91,8 +92,10 @@ def remotews_fixture():
         remotews.__enter__ = mock.Mock()
         remotews.__exit__ = mock.Mock()
         remotews_class.return_value = remotews
+        remotews_class().__enter__().token = "FAKE_TOKEN"
         socket = mock.Mock()
         socket_class.return_value = socket
+        socket_class.gethostbyname.return_value = "FAKE_IP_ADDRESS"
         yield remotews
 
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -143,6 +143,7 @@ def remotews_fixture():
         remote.__enter__ = mock.Mock()
         remote.__exit__ = mock.Mock()
         remote_class.return_value = remote
+        remote_class().__enter__().token = "FAKE_TOKEN"
         socket1.gethostbyname.return_value = "FAKE_IP_ADDRESS"
         socket2.gethostbyname.return_value = "FAKE_IP_ADDRESS"
         yield remote
@@ -648,9 +649,7 @@ async def test_play_media(hass, remote):
 
 async def test_play_media_invalid_type(hass, remote):
     """Test for play_media with invalid media type."""
-    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote, patch(
-        "homeassistant.components.samsungtv.config_flow.socket"
-    ):
+    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
         await setup_samsungtv(hass, MOCK_CONFIG)
         remote.reset_mock()
@@ -672,9 +671,7 @@ async def test_play_media_invalid_type(hass, remote):
 
 async def test_play_media_channel_as_string(hass, remote):
     """Test for play_media with invalid channel as string."""
-    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote, patch(
-        "homeassistant.components.samsungtv.config_flow.socket"
-    ):
+    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
         await setup_samsungtv(hass, MOCK_CONFIG)
         remote.reset_mock()
@@ -696,9 +693,7 @@ async def test_play_media_channel_as_string(hass, remote):
 
 async def test_play_media_channel_as_non_positive(hass, remote):
     """Test for play_media with invalid channel as non positive integer."""
-    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote, patch(
-        "homeassistant.components.samsungtv.config_flow.socket"
-    ):
+    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)
         remote.reset_mock()
         assert await hass.services.async_call(
@@ -735,9 +730,7 @@ async def test_select_source(hass, remote):
 
 async def test_select_source_invalid_source(hass, remote):
     """Test for select_source with invalid source."""
-    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote, patch(
-        "homeassistant.components.samsungtv.config_flow.socket"
-    ):
+    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)
         remote.reset_mock()
         assert await hass.services.async_call(

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -44,7 +44,6 @@ IGNORE_UNCAUGHT_EXCEPTIONS = [
     ("tests.components.qwikswitch.test_init", "test_binary_sensor_device"),
     ("tests.components.qwikswitch.test_init", "test_sensor_device"),
     ("tests.components.rflink.test_init", "test_send_command_invalid_arguments"),
-    ("tests.components.samsungtv.test_media_player", "test_update_connection_failure"),
     ("tests.components.unifi_direct.test_device_tracker", "test_get_scanner"),
 ]
 
@@ -59,29 +58,6 @@ IGNORE_UNCAUGHT_JSON_EXCEPTIONS = [
         "tests.components.smartthings.test_init",
         "test_config_entry_loads_unconnected_cloud",
     ),
-    ("tests.components.samsungtv.test_config_flow", "test_ssdp"),
-    ("tests.components.samsungtv.test_config_flow", "test_user_websocket"),
-    ("tests.components.samsungtv.test_config_flow", "test_user_already_configured"),
-    ("tests.components.samsungtv.test_config_flow", "test_autodetect_websocket"),
-    ("tests.components.samsungtv.test_config_flow", "test_autodetect_websocket_ssl"),
-    ("tests.components.samsungtv.test_config_flow", "test_ssdp_already_configured"),
-    ("tests.components.samsungtv.test_config_flow", "test_ssdp_noprefix"),
-    ("tests.components.samsungtv.test_config_flow", "test_user_legacy"),
-    ("tests.components.samsungtv.test_config_flow", "test_autodetect_legacy"),
-    (
-        "tests.components.samsungtv.test_media_player",
-        "test_select_source_invalid_source",
-    ),
-    (
-        "tests.components.samsungtv.test_media_player",
-        "test_play_media_channel_as_string",
-    ),
-    (
-        "tests.components.samsungtv.test_media_player",
-        "test_play_media_channel_as_non_positive",
-    ),
-    ("tests.components.samsungtv.test_media_player", "test_turn_off_websocket"),
-    ("tests.components.samsungtv.test_media_player", "test_play_media_invalid_type"),
     ("tests.components.harmony.test_config_flow", "test_form_import"),
     ("tests.components.harmony.test_config_flow", "test_form_ssdp"),
     ("tests.components.harmony.test_config_flow", "test_user_form"),


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33340
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
