### PR TITLE
Fix uncaught exceptions for qwikswitch

### DIFF
--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -21,14 +21,11 @@ class AiohttpClientMockResponseList(list):
 
     def decode(self, _):
         """Return next item from list."""
-        try:
-            res = list.pop(self, 0)
-            _LOGGER.debug("MockResponseList popped %s: %s", res, self)
-            if isinstance(res, Exception):
-                raise res
-            return res
-        except IndexError:
-            raise AssertionError("MockResponseList empty")
+        res = list.pop(self, 0)
+        _LOGGER.debug("MockResponseList popped %s: %s", res, self)
+        if isinstance(res, Exception):
+            raise res
+        return res
 
     async def wait_till_empty(self, hass):
         """Wait until empty."""
@@ -80,6 +77,7 @@ async def test_binary_sensor_device(hass, aioclient_mock):  # noqa: F811
     assert state_obj.state == "on"
 
     LISTEN.append('{"id":"@a00001","cmd":"","data":"4e0e1701","rssi":"61%"}')
+    LISTEN.append(ClientError())  # Will cause a sleep
     hass.data[QWIKSWITCH]._sleep_task.cancel()
     await LISTEN.wait_till_empty(hass)
     state_obj = hass.states.get("binary_sensor.s1")
@@ -109,6 +107,7 @@ async def test_sensor_device(hass, aioclient_mock):  # noqa: F811
     LISTEN.append(
         '{"id":"@a00001","name":"ss1","type":"rel",' '"val":"4733800001a00000"}'
     )
+    LISTEN.append(ClientError())  # Will cause a sleep
 
     await hass.async_block_till_done()
     state_obj = hass.states.get("sensor.ss1")

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -39,8 +39,6 @@ IGNORE_UNCAUGHT_EXCEPTIONS = [
     ("tests.components.ios.test_init", "test_creating_entry_sets_up_sensor"),
     ("tests.components.ios.test_init", "test_not_configuring_ios_not_creates_entry"),
     ("tests.components.local_file.test_camera", "test_file_not_readable"),
-    ("tests.components.qwikswitch.test_init", "test_binary_sensor_device"),
-    ("tests.components.qwikswitch.test_init", "test_sensor_device"),
     ("tests.components.rflink.test_init", "test_send_command_invalid_arguments"),
     ("tests.components.unifi_direct.test_device_tracker", "test_get_scanner"),
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33338 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
