### PR TITLE
Fix slide open/close percentage

### DIFF
--- a/homeassistant/components/slide/__init__.py
+++ b/homeassistant/components/slide/__init__.py
@@ -1,4 +1,4 @@
-"""Component for the Go Slide API."""
+"""Component for the Slide API."""
 
 from datetime import timedelta
 import logging
@@ -19,7 +19,15 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 
-from .const import API, COMPONENT, DEFAULT_RETRY, DOMAIN, SLIDES
+from .const import (
+    API,
+    COMPONENT,
+    CONF_INVERT_POSITION,
+    DEFAULT_OFFSET,
+    DEFAULT_RETRY,
+    DOMAIN,
+    SLIDES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +42,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): cv.time_period,
+                vol.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
             }
         )
     },
@@ -43,6 +52,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the Slide platform."""
+    # pylint: disable=unused-argument
 
     async def update_slides(now=None):
         """Update slide information."""
@@ -60,7 +70,7 @@ async def async_setup(hass, config):
         for slide in result:
             if "device_id" not in slide:
                 _LOGGER.error(
-                    "Found invalid Slide entry, device_id is missing. Entry=%s", slide,
+                    "Found invalid Slide entry, device_id is missing. Entry=%s", slide
                 )
                 continue
 
@@ -73,6 +83,7 @@ async def async_setup(hass, config):
             oldpos = slidenew.get("pos")
             slidenew["pos"] = None
             slidenew["online"] = False
+            slidenew["invert"] = config[DOMAIN][CONF_INVERT_POSITION]
 
             if "device_info" not in slide:
                 _LOGGER.error(
@@ -91,15 +102,21 @@ async def async_setup(hass, config):
 
                 if oldpos is None or oldpos == slidenew["pos"]:
                     slidenew["state"] = (
-                        STATE_CLOSED if slidenew["pos"] > 0.95 else STATE_OPEN
+                        STATE_CLOSED
+                        if slidenew["pos"] > (1 - DEFAULT_OFFSET)
+                        else STATE_OPEN
                     )
                 elif oldpos < slidenew["pos"]:
                     slidenew["state"] = (
-                        STATE_CLOSED if slidenew["pos"] >= 0.95 else STATE_CLOSING
+                        STATE_CLOSED
+                        if slidenew["pos"] >= (1 - DEFAULT_OFFSET)
+                        else STATE_CLOSING
                     )
                 else:
                     slidenew["state"] = (
-                        STATE_OPEN if slidenew["pos"] <= 0.05 else STATE_OPENING
+                        STATE_OPEN
+                        if slidenew["pos"] <= DEFAULT_OFFSET
+                        else STATE_OPENING
                     )
             elif "code" in slide["device_info"]:
                 _LOGGER.warning(

--- a/homeassistant/components/slide/__init__.py
+++ b/homeassistant/components/slide/__init__.py
@@ -52,7 +52,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the Slide platform."""
-    # pylint: disable=unused-argument
 
     async def update_slides(now=None):
         """Update slide information."""

--- a/homeassistant/components/slide/__init__.py
+++ b/homeassistant/components/slide/__init__.py
@@ -152,7 +152,7 @@ async def async_setup(hass, config):
         result = await hass.data[DOMAIN][API].login()
     except (goslideapi.ClientConnectionError, goslideapi.ClientTimeoutError) as err:
         _LOGGER.error(
-            "Error connecting to Slide Cloud: %s, going to retry in %s seconds",
+            "Error connecting to Slide Cloud: %s, going to retry in %s second(s)",
             err,
             DEFAULT_RETRY,
         )

--- a/homeassistant/components/slide/const.py
+++ b/homeassistant/components/slide/const.py
@@ -1,7 +1,9 @@
-"""Define constants for the Go Slide component."""
+"""Define constants for the Slide component."""
 
 API = "api"
 COMPONENT = "cover"
+CONF_INVERT_POSITION = "invert_position"
 DOMAIN = "slide"
 SLIDES = "slides"
+DEFAULT_OFFSET = 0.15
 DEFAULT_RETRY = 120

--- a/homeassistant/components/slide/cover.py
+++ b/homeassistant/components/slide/cover.py
@@ -19,7 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up cover(s) for Slide platform."""
-    # pylint: disable=unused-argument
 
     if discovery_info is None:
         return

--- a/homeassistant/components/slide/cover.py
+++ b/homeassistant/components/slide/cover.py
@@ -1,4 +1,4 @@
-"""Support for Go Slide slides."""
+"""Support for Slide slides."""
 
 import logging
 
@@ -12,13 +12,14 @@ from homeassistant.components.cover import (
 )
 from homeassistant.const import ATTR_ID
 
-from .const import API, DOMAIN, SLIDES
+from .const import API, DEFAULT_OFFSET, DOMAIN, SLIDES
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up cover(s) for Go Slide platform."""
+    """Set up cover(s) for Slide platform."""
+    # pylint: disable=unused-argument
 
     if discovery_info is None:
         return
@@ -33,7 +34,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 class SlideCover(CoverDevice):
-    """Representation of a Go Slide cover."""
+    """Representation of a Slide cover."""
 
     def __init__(self, api, slide):
         """Initialize the cover."""
@@ -42,6 +43,7 @@ class SlideCover(CoverDevice):
         self._id = slide["id"]
         self._unique_id = slide["mac"]
         self._name = slide["name"]
+        self._invert = slide["invert"]
 
     @property
     def unique_id(self):
@@ -95,6 +97,10 @@ class SlideCover(CoverDevice):
         """Return the current position of cover shutter."""
         pos = self._slide["pos"]
         if pos is not None:
+            if (1 - pos) <= DEFAULT_OFFSET or pos <= DEFAULT_OFFSET:
+                pos = round(pos)
+            if not self._invert:
+                pos = 1 - pos
             pos = int(pos * 100)
         return pos
 
@@ -115,6 +121,8 @@ class SlideCover(CoverDevice):
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION] / 100
+        if not self._invert:
+            position = 1 - position
 
         if self._slide["pos"] is not None:
             if position > self._slide["pos"]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
This integration was previously using the (wrong) inverted percentage of open/close. Now we are according to the Home Assistant standards, which makes HomeKit working out of the box.

## Proposed change
Fix the inverted percentage of open/close, as fallback a new option "invert_position" has been introduced. The offset of 5% to round it off as open/close has been extended to 15%.
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
slide:
  username: YOUR_SLIDE_APP_USERNAME
  password: YOUR_SLIDE_APP_PASSWORD
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31752, #32896 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12720

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
