### PR TITLE
Remove global variable from mochad

### DIFF
--- a/homeassistant/components/mochad/__init__.py
+++ b/homeassistant/components/mochad/__init__.py
@@ -15,8 +15,6 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-CONTROLLER = None
-
 CONF_COMM_TYPE = "comm_type"
 
 DOMAIN = "mochad"
@@ -42,22 +40,22 @@ def setup(hass, config):
     host = conf.get(CONF_HOST)
     port = conf.get(CONF_PORT)
 
-    global CONTROLLER  # pylint: disable=global-statement
     try:
-        CONTROLLER = MochadCtrl(host, port)
+        mochad_controller = MochadCtrl(host, port)
     except exceptions.ConfigurationError:
         _LOGGER.exception()
         return False
 
     def stop_mochad(event):
         """Stop the Mochad service."""
-        CONTROLLER.disconnect()
+        mochad_controller.disconnect()
 
     def start_mochad(event):
         """Start the Mochad service."""
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_mochad)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_mochad)
+    hass.data[DOMAIN] = mochad_controller
 
     return True
 

--- a/homeassistant/components/mochad/light.py
+++ b/homeassistant/components/mochad/light.py
@@ -13,7 +13,7 @@ from homeassistant.components.light import (
 from homeassistant.const import CONF_ADDRESS, CONF_DEVICES, CONF_NAME, CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 
-from . import CONF_COMM_TYPE, CONTROLLER, DOMAIN, REQ_LOCK
+from . import CONF_COMM_TYPE, DOMAIN, REQ_LOCK
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,8 +38,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up X10 dimmers over a mochad controller."""
+    mochad_controller = hass.data[DOMAIN]
     devs = config.get(CONF_DEVICES)
-    add_entities([MochadLight(hass, CONTROLLER.ctrl, dev) for dev in devs])
+    add_entities([MochadLight(hass, mochad_controller.ctrl, dev) for dev in devs])
     return True
 
 

--- a/homeassistant/components/mochad/switch.py
+++ b/homeassistant/components/mochad/switch.py
@@ -9,7 +9,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import CONF_ADDRESS, CONF_DEVICES, CONF_NAME, CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 
-from . import CONF_COMM_TYPE, CONTROLLER, DOMAIN, REQ_LOCK
+from . import CONF_COMM_TYPE, DOMAIN, REQ_LOCK
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,8 +30,9 @@ PLATFORM_SCHEMA = vol.Schema(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up X10 switches over a mochad controller."""
+    mochad_controller = hass.data[DOMAIN]
     devs = config.get(CONF_DEVICES)
-    add_entities([MochadSwitch(hass, CONTROLLER.ctrl, dev) for dev in devs])
+    add_entities([MochadSwitch(hass, mochad_controller.ctrl, dev) for dev in devs])
     return True
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes any global variables from the integration mochad.
Followup to enabling pylint global-statement: #33641

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to PR: #33641 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
