### PR TITLE
Improve MQTT debug info for subscriptions with wildcard

### DIFF
--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -21,8 +21,10 @@ def log_messages(hass: HomeAssistantType, entity_id: str) -> MessageCallbackType
     def _log_message(msg):
         """Log message."""
         debug_info = hass.data[DATA_MQTT_DEBUG_INFO]
-        messages = debug_info["entities"][entity_id]["topics"][msg.subscribed_topic]
-        messages.append(msg.payload)
+        messages = debug_info["entities"][entity_id]["subscriptions"][
+            msg.subscribed_topic
+        ]
+        messages.append((msg.payload, msg.topic))
 
     def _decorator(msg_callback: MessageCallbackType):
         @wraps(msg_callback)
@@ -37,24 +39,26 @@ def log_messages(hass: HomeAssistantType, entity_id: str) -> MessageCallbackType
     return _decorator
 
 
-def add_topic(hass, message_callback, topic):
-    """Prepare debug data for topic."""
+def add_subscription(hass, message_callback, subscription):
+    """Prepare debug data for subscription."""
     entity_id = getattr(message_callback, "__entity_id", None)
     if entity_id:
         debug_info = hass.data.setdefault(
             DATA_MQTT_DEBUG_INFO, {"entities": {}, "triggers": {}}
         )
         entity_info = debug_info["entities"].setdefault(
-            entity_id, {"topics": {}, "discovery_data": {}}
+            entity_id, {"subscriptions": {}, "discovery_data": {}}
         )
-        entity_info["topics"][topic] = deque([], STORED_MESSAGES)
+        entity_info["subscriptions"][subscription] = deque([], STORED_MESSAGES)
 
 
-def remove_topic(hass, message_callback, topic):
-    """Remove debug data for topic."""
+def remove_subscription(hass, message_callback, subscription):
+    """Remove debug data for subscription."""
     entity_id = getattr(message_callback, "__entity_id", None)
     if entity_id and entity_id in hass.data[DATA_MQTT_DEBUG_INFO]["entities"]:
-        hass.data[DATA_MQTT_DEBUG_INFO]["entities"][entity_id]["topics"].pop(topic)
+        hass.data[DATA_MQTT_DEBUG_INFO]["entities"][entity_id]["subscriptions"].pop(
+            subscription
+        )
 
 
 def add_entity_discovery_data(hass, discovery_data, entity_id):
@@ -63,7 +67,7 @@ def add_entity_discovery_data(hass, discovery_data, entity_id):
         DATA_MQTT_DEBUG_INFO, {"entities": {}, "triggers": {}}
     )
     entity_info = debug_info["entities"].setdefault(
-        entity_id, {"topics": {}, "discovery_data": {}}
+        entity_id, {"subscriptions": {}, "discovery_data": {}}
     )
     entity_info["discovery_data"] = discovery_data
 
@@ -117,9 +121,14 @@ async def info_for_device(hass, device_id):
             continue
 
         entity_info = mqtt_debug_info["entities"][entry.entity_id]
-        topics = [
-            {"topic": topic, "messages": list(messages)}
-            for topic, messages in entity_info["topics"].items()
+        subscriptions = [
+            {
+                "topic": topic,
+                "messages": [
+                    {"payload": msg[0], "topic": msg[1]} for msg in list(messages)
+                ],
+            }
+            for topic, messages in entity_info["subscriptions"].items()
         ]
         discovery_data = {
             "topic": entity_info["discovery_data"].get(ATTR_DISCOVERY_TOPIC, ""),
@@ -128,7 +137,7 @@ async def info_for_device(hass, device_id):
         mqtt_info["entities"].append(
             {
                 "entity_id": entry.entity_id,
-                "topics": topics,
+                "subscriptions": subscriptions,
                 "discovery_data": discovery_data,
             }
         )

--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -34,14 +34,16 @@ class EntitySubscription:
         if other is not None and other.unsubscribe_callback is not None:
             other.unsubscribe_callback()
             # Clear debug data if it exists
-            debug_info.remove_topic(self.hass, other.message_callback, other.topic)
+            debug_info.remove_subscription(
+                self.hass, other.message_callback, other.topic
+            )
 
         if self.topic is None:
             # We were asked to remove the subscription or not to create it
             return
 
         # Prepare debug data
-        debug_info.add_topic(self.hass, self.message_callback, self.topic)
+        debug_info.add_subscription(self.hass, self.message_callback, self.topic)
 
         self.unsubscribe_callback = await mqtt.async_subscribe(
             hass, self.topic, self.message_callback, self.qos, self.encoding
@@ -96,7 +98,9 @@ async def async_subscribe_topics(
         if remaining.unsubscribe_callback is not None:
             remaining.unsubscribe_callback()
             # Clear debug data if it exists
-            debug_info.remove_topic(hass, remaining.message_callback, remaining.topic)
+            debug_info.remove_subscription(
+                hass, remaining.message_callback, remaining.topic
+            )
 
     return new_state
 

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -551,9 +551,9 @@ async def help_test_entity_debug_info(hass, mqtt_mock, domain, config):
         == f"homeassistant/{domain}/bla/config"
     )
     assert debug_info_data["entities"][0]["discovery_data"]["payload"] == config
-    assert len(debug_info_data["entities"][0]["topics"]) == 1
+    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
     assert {"topic": "test-topic", "messages": []} in debug_info_data["entities"][0][
-        "topics"
+        "subscriptions"
     ]
     assert len(debug_info_data["triggers"]) == 0
 
@@ -581,24 +581,27 @@ async def help_test_entity_debug_info_max_messages(hass, mqtt_mock, domain, conf
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
-    assert len(debug_info_data["entities"][0]["topics"]) == 1
+    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
     assert {"topic": "test-topic", "messages": []} in debug_info_data["entities"][0][
-        "topics"
+        "subscriptions"
     ]
 
     for i in range(0, debug_info.STORED_MESSAGES + 1):
         async_fire_mqtt_message(hass, "test-topic", f"{i}")
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
-    assert len(debug_info_data["entities"][0]["topics"]) == 1
+    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
     assert (
-        len(debug_info_data["entities"][0]["topics"][0]["messages"])
+        len(debug_info_data["entities"][0]["subscriptions"][0]["messages"])
         == debug_info.STORED_MESSAGES
     )
-    messages = [f"{i}" for i in range(1, debug_info.STORED_MESSAGES + 1)]
+    messages = [
+        {"topic": "test-topic", "payload": f"{i}"}
+        for i in range(1, debug_info.STORED_MESSAGES + 1)
+    ]
     assert {"topic": "test-topic", "messages": messages} in debug_info_data["entities"][
         0
-    ]["topics"]
+    ]["subscriptions"]
 
 
 async def help_test_entity_debug_info_message(
@@ -634,16 +637,19 @@ async def help_test_entity_debug_info_message(
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
-    assert len(debug_info_data["entities"][0]["topics"]) >= 1
-    assert {"topic": topic, "messages": []} in debug_info_data["entities"][0]["topics"]
+    assert len(debug_info_data["entities"][0]["subscriptions"]) >= 1
+    assert {"topic": topic, "messages": []} in debug_info_data["entities"][0][
+        "subscriptions"
+    ]
 
     async_fire_mqtt_message(hass, topic, payload)
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
-    assert len(debug_info_data["entities"][0]["topics"]) >= 1
-    assert {"topic": topic, "messages": [payload]} in debug_info_data["entities"][0][
-        "topics"
-    ]
+    assert len(debug_info_data["entities"][0]["subscriptions"]) >= 1
+    assert {
+        "topic": topic,
+        "messages": [{"topic": topic, "payload": payload}],
+    } in debug_info_data["entities"][0]["subscriptions"]
 
 
 async def help_test_entity_debug_info_remove(hass, mqtt_mock, domain, config):
@@ -675,9 +681,9 @@ async def help_test_entity_debug_info_remove(hass, mqtt_mock, domain, config):
         == f"homeassistant/{domain}/bla/config"
     )
     assert debug_info_data["entities"][0]["discovery_data"]["payload"] == config
-    assert len(debug_info_data["entities"][0]["topics"]) == 1
+    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
     assert {"topic": "test-topic", "messages": []} in debug_info_data["entities"][0][
-        "topics"
+        "subscriptions"
     ]
     assert len(debug_info_data["triggers"]) == 0
     assert debug_info_data["entities"][0]["entity_id"] == f"{domain}.test"
@@ -723,9 +729,9 @@ async def help_test_entity_debug_info_update_entity_id(hass, mqtt_mock, domain, 
     )
     assert debug_info_data["entities"][0]["discovery_data"]["payload"] == config
     assert debug_info_data["entities"][0]["entity_id"] == f"{domain}.test"
-    assert len(debug_info_data["entities"][0]["topics"]) == 1
+    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
     assert {"topic": "test-topic", "messages": []} in debug_info_data["entities"][0][
-        "topics"
+        "subscriptions"
     ]
     assert len(debug_info_data["triggers"]) == 0
 
@@ -741,9 +747,9 @@ async def help_test_entity_debug_info_update_entity_id(hass, mqtt_mock, domain, 
     )
     assert debug_info_data["entities"][0]["discovery_data"]["payload"] == config
     assert debug_info_data["entities"][0]["entity_id"] == f"{domain}.milk"
-    assert len(debug_info_data["entities"][0]["topics"]) == 1
+    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
     assert {"topic": "test-topic", "messages": []} in debug_info_data["entities"][0][
-        "topics"
+        "subscriptions"
     ]
     assert len(debug_info_data["triggers"]) == 0
     assert (


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve MQTT debug info for subscriptions with wildcard; now the debug-info lists the topics subscribed to, and each subscription has a list of received messages with topic and payload.
This is a follow-up to #33744.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
