### PR TITLE
Add last_beacon to APRS tracker

### DIFF
--- a/homeassistant/components/aprs/device_tracker.py
+++ b/homeassistant/components/aprs/device_tracker.py
@@ -181,7 +181,9 @@ class AprsListenerThread(threading.Thread):
                     )
             if ATTR_TIMESTAMP in msg:
                 timestamp = dt_util.utc_from_timestamp(msg[ATTR_TIMESTAMP])
-                if not timestamp:
+                if timestamp:
+                    attrs[ATTR_LAST_BEACON] = timestamp
+                else:
                     _LOGGER.warning(
                         "APRS message contained invalid last_beacon timestamp: %s",
                         str(timestamp),

--- a/homeassistant/components/aprs/device_tracker.py
+++ b/homeassistant/components/aprs/device_tracker.py
@@ -180,12 +180,11 @@ class AprsListenerThread(threading.Thread):
                         "APRS message contained invalid posambiguity: %s", str(pos_amb)
                     )
             if ATTR_TIMESTAMP in msg:
-                timestamp = msg[ATTR_LAST_BEACON]
-                try:
-                    attrs[ATTR_LAST_BEACON] = dt_util.parse_datetime(timestamp)
-                except ValueError:
+                timestamp = dt_util.utc_from_timestamp(msg[ATTR_TIMESTAMP])
+                if not timestamp:
                     _LOGGER.warning(
-                        "APRS message contained invalid last_beacon timestamp: %s", str(timestamp)
+                        "APRS message contained invalid last_beacon timestamp: %s",
+                        str(timestamp),
                     )
                     """Set the last_beacon to now if invalid dt_util parse."""
                     attrs[ATTR_LAST_BEACON] = dt_util.utcnow()

--- a/homeassistant/components/aprs/device_tracker.py
+++ b/homeassistant/components/aprs/device_tracker.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import slugify
+import homeassistant.util.dt as dt_util
 
 DOMAIN = "aprs"
 
@@ -179,5 +180,6 @@ class AprsListenerThread(threading.Thread):
             for attr in [ATTR_ALTITUDE, ATTR_COMMENT, ATTR_COURSE, ATTR_SPEED]:
                 if attr in msg:
                     attrs[attr] = msg[attr]
+                    attrs["last_beacon"] = dt_util.utcnow()
 
             self.see(dev_id=dev_id, gps=(lat, lon), attributes=attrs)

--- a/homeassistant/components/aprs/device_tracker.py
+++ b/homeassistant/components/aprs/device_tracker.py
@@ -180,18 +180,18 @@ class AprsListenerThread(threading.Thread):
                         "APRS message contained invalid posambiguity: %s", str(pos_amb)
                     )
             if ATTR_TIMESTAMP in msg:
-                timestamp = dt_util.utc_from_timestamp(msg[ATTR_TIMESTAMP])
-                if timestamp:
-                    attrs[ATTR_LAST_BEACON] = timestamp
-                else:
+                try:
+                    timestamp = dt_util.utc_from_timestamp(int(msg[ATTR_TIMESTAMP]))
+                except ValueError:
                     _LOGGER.warning(
-                        "APRS message contained invalid last_beacon timestamp: %s",
-                        str(timestamp),
+                        "APRS message contained invalid timestamp: %s",
+                        str(msg[ATTR_TIMESTAMP]),
                     )
-                    """Set the last_beacon to now if invalid dt_util parse."""
-                    attrs[ATTR_LAST_BEACON] = dt_util.utcnow()
+                    timestamp = dt_util.utcnow()
+
+                attrs[ATTR_LAST_BEACON] = timestamp
             else:
-                """APRS message did not contain a last_beacon field."""
+                """ APRS message didn't contain a timestamp. """
                 attrs[ATTR_LAST_BEACON] = dt_util.utcnow()
 
             for attr in [ATTR_ALTITUDE, ATTR_COMMENT, ATTR_COURSE, ATTR_SPEED]:

--- a/tests/components/aprs/test_device_tracker.py
+++ b/tests/components/aprs/test_device_tracker.py
@@ -430,3 +430,37 @@ def test_aprs_listener_rx_msg_no_timestamp():
         assert listener.start_success
         assert listener.start_message == "Connected to testhost with callsign testcall."
         assert type(see.call_args[1]["attributes"]["last_beacon"]) == datetime.datetime
+
+
+def test_aprs_listener_rx_msg_invalid_timestamp():
+    """Test rx_msg with an invalid timestamp."""
+    with patch("aprslib.IS"):
+        callsign = TEST_CALLSIGN
+        password = TEST_PASSWORD
+        host = TEST_HOST
+        server_filter = TEST_FILTER
+        see = Mock()
+
+        sample_msg = {
+            device_tracker.ATTR_FORMAT: "uncompressed",
+            device_tracker.ATTR_FROM: "ZZ0FOOBAR-1",
+            device_tracker.ATTR_LATITUDE: 0.0,
+            device_tracker.ATTR_LONGITUDE: 0.0,
+            device_tracker.ATTR_TIMESTAMP: "Tuesday back in 1969",
+        }
+
+        listener = device_tracker.AprsListenerThread(
+            callsign, password, host, server_filter, see
+        )
+        listener.run()
+
+        listener.rx_msg(sample_msg)
+
+        assert listener.callsign == callsign
+        assert listener.host == host
+        assert listener.server_filter == server_filter
+        assert listener.see == see
+        assert listener.start_event.is_set()
+        assert listener.start_success
+        assert listener.start_message == "Connected to testhost with callsign testcall."
+        assert type(see.call_args[1]["attributes"]["last_beacon"]) == datetime.datetime

--- a/tests/components/aprs/test_device_tracker.py
+++ b/tests/components/aprs/test_device_tracker.py
@@ -429,4 +429,4 @@ def test_aprs_listener_rx_msg_no_timestamp():
         assert listener.start_event.is_set()
         assert listener.start_success
         assert listener.start_message == "Connected to testhost with callsign testcall."
-        assert "last_beacon" in str(see.call_args)
+        assert type(see.call_args[1]["attributes"]["last_beacon"]) == datetime.datetime


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current APRS device tracker has no sense of time. Because APRS is a beaconing service even if the last beacon was over a day old the position will remain at the last beaconed location. I have added a "last_beacon" attribute that will help automations better determine if the APRS postition is stale or not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
**Unchanged**
```yaml
# Example configuration.yaml
device_tracker:
  - platform: aprs
    username: FO0BAR  # or FO0BAR-1 to FO0BAR-15
    callsigns:
      - 'XX0FOO*'
      - 'YY0BAR-1'

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
