### PR TITLE
Add new Econet attributes

### DIFF
--- a/homeassistant/components/econet/water_heater.py
+++ b/homeassistant/components/econet/water_heater.py
@@ -40,6 +40,11 @@ ATTR_IN_USE = "in_use"
 ATTR_START_DATE = "start_date"
 ATTR_END_DATE = "end_date"
 
+ATTR_LOWER_TEMP = "lower_temp"
+ATTR_UPPER_TEMP = "upper_temp"
+ATTR_AMBIENT_TEMP = "ambient_temp"
+ATTR_IS_ENABLED = "is_enabled"
+
 SUPPORT_FLAGS_HEATER = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
 
 ADD_VACATION_SCHEMA = vol.Schema(
@@ -163,6 +168,15 @@ class EcoNetWaterHeater(WaterHeaterDevice):
         if todays_usage:
             data[ATTR_TODAYS_ENERGY_USAGE] = todays_usage
         data[ATTR_IN_USE] = self.water_heater.in_use
+
+        if self.water_heater.lower_temp is not None:
+            data[ATTR_LOWER_TEMP] = round(self.water_heater.lower_temp, 2)
+        if self.water_heater.upper_temp is not None:
+            data[ATTR_UPPER_TEMP] = round(self.water_heater.upper_temp, 2)
+        if self.water_heater.ambient_temp is not None:
+            data[ATTR_AMBIENT_TEMP] = round(self.water_heater.ambient_temp, 2)
+        if self.water_heater.is_enabled is not None:
+            data[ATTR_IS_ENABLED] = self.water_heater.is_enabled
 
         return data
 

--- a/homeassistant/components/econet/water_heater.py
+++ b/homeassistant/components/econet/water_heater.py
@@ -42,7 +42,6 @@ ATTR_END_DATE = "end_date"
 
 ATTR_LOWER_TEMP = "lower_temp"
 ATTR_UPPER_TEMP = "upper_temp"
-ATTR_AMBIENT_TEMP = "ambient_temp"
 ATTR_IS_ENABLED = "is_enabled"
 
 SUPPORT_FLAGS_HEATER = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
@@ -173,8 +172,6 @@ class EcoNetWaterHeater(WaterHeaterDevice):
             data[ATTR_LOWER_TEMP] = round(self.water_heater.lower_temp, 2)
         if self.water_heater.upper_temp is not None:
             data[ATTR_UPPER_TEMP] = round(self.water_heater.upper_temp, 2)
-        if self.water_heater.ambient_temp is not None:
-            data[ATTR_AMBIENT_TEMP] = round(self.water_heater.ambient_temp, 2)
         if self.water_heater.is_enabled is not None:
             data[ATTR_IS_ENABLED] = self.water_heater.is_enabled
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
My new Rheem heat pump water heater has two temperature sensors in it. This means it no longer reports back using the old "current_temperature" attribute but now has two new attributes called "lower_temp" and "upper_temp" (yes, it has one temperature sensor at the bottom of the tank and another at the top). The reading I am getting from "current_temperature" is null which is obviously quite useless to me.

There are also two other useful pieces of information that I would like access to. Those are "ambient_temp" and "is_enabled". The former allows me to see what the temperature in my garage is and the latter allows me to see if the heat pump is actively heating.

The purpose of my change is simply to expose these 4 attributes to homeassistant. pyeconet, the underlying library that homeassistant uses to call into Rheem's Econet service, already supports, reads and propagates all four of these attributes. So I'm just tying it all neatly together into homeassistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue:  N/A
- Link to documentation pull request: N/A (existing documentation does not document attributes like these)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.
-> I don't feel this is necessary. Just passing through some attributes and I have validated this using my own hot water heater and it works. Not likely to be easily broken by future code changes.

If user exposed functionality or configuration variables are added/changed: N/A (the library that communicates with the third party service (pyeconet) has not been changed)

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
-> Again, existing docs don't document attributes like these. It appears as though attributes like these aren't normally documented.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
