### PR TITLE
Add script to clean up translations

### DIFF
--- a/script/translations_clean.py
+++ b/script/translations_clean.py
@@ -1,0 +1,116 @@
+"""Find translation keys that are in Lokalise but no longer defined in source."""
+import json
+import pathlib
+import sys
+
+import requests
+
+INTEGRATION_DIR = pathlib.Path("homeassistant/components")
+PROJECT_ID = "130246255a974bd3b5e8a1.51616605"
+
+
+class Lokalise:
+    """Lokalise API."""
+
+    def __init__(self, project_id, token):
+        """Initialize Lokalise API."""
+        self.project_id = project_id
+        self.token = token
+
+    def request(self, method, path, data):
+        """Make a request to the Lokalise API."""
+        method = method.upper()
+        kwargs = {"headers": {"x-api-token": self.token}}
+        if method == "GET":
+            kwargs["params"] = data
+        else:
+            kwargs["json"] = data
+
+        req = requests.request(
+            method,
+            f"https://api.lokalise.com/api2/projects/{self.project_id}/{path}",
+            **kwargs,
+        )
+        req.raise_for_status()
+        return req.json()
+
+    def keys_list(self, params={}):
+        """Fetch key ID from a name.
+
+        https://app.lokalise.com/api2docs/curl/#transition-list-all-keys-get
+        """
+        return self.request("GET", "keys", params)["keys"]
+
+    def keys_delete_multiple(self, key_ids):
+        """Delete multiple keys.
+
+        https://app.lokalise.com/api2docs/curl/#transition-delete-multiple-keys-delete
+        """
+        return self.request("DELETE", "keys", {"keys": key_ids})
+
+
+def find_extra(base, translations, path_prefix, missing_keys):
+    """Find all keys that are in translations but not in base."""
+    for key, value in translations.items():
+        cur_path = f"{path_prefix}::{key}" if path_prefix else key
+
+        # Value is either a dict or a string
+        if isinstance(value, dict):
+            base_search = None if base is None else base.get(key)
+            find_extra(base_search, value, cur_path, missing_keys)
+
+        elif base is None or key not in base:
+            missing_keys.append(cur_path)
+
+
+def find():
+    """Find all missing keys."""
+    missing_keys = []
+
+    for int_dir in INTEGRATION_DIR.iterdir():
+        strings = int_dir / "strings.json"
+
+        if not strings.is_file():
+            continue
+
+        translations = int_dir / ".translations" / "en.json"
+
+        strings_json = json.loads(strings.read_text())
+        translations_json = json.loads(translations.read_text())
+
+        find_extra(
+            strings_json, translations_json, f"component::{int_dir.name}", missing_keys
+        )
+
+    return missing_keys
+
+
+def run():
+    """Clean translations."""
+    missing_keys = find()
+
+    if not missing_keys:
+        print("No missing translations!")
+        return 0
+
+    lokalise = Lokalise(PROJECT_ID, pathlib.Path(".lokalise_token").read_text().strip())
+
+    to_delete = []
+
+    for key in missing_keys:
+        print("Processing", key)
+        key_data = lokalise.keys_list({"filter_keys": key})
+        if len(key_data) != 1:
+            print(
+                f"Lookin up key in Lokalise returns {len(key_data)} results, expected 1"
+            )
+            continue
+        to_delete.append(key_data[0]["key_id"])
+
+    print("Deleting keys:", ", ".join(map(str, to_delete)))
+    print(lokalise.keys_delete_multiple(to_delete))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Over time we change our `strings.json` file and we often forget to update Lokalise to either rename the keys or delete them. This results in us having stale keys in Lokalise, which we then download and include in our releases. These translations are then sent to the frontend too, where they sit in memory.

This script will find all keys that are in the download from Lokalise, which are no longer represented in the base strings file. These keys are removed. 

Here is an output when I just ran it. Note that the first key can no longer be found in Lokalise as I had used that key to test.

We could consider including this in our nightly translations bump, but I rather not, because sometimes we do plan on renaming keys.

@bramkragten this might be useful for the frontend too.

```
› python3 script/translations_clean.py
Processing component::deconz::config::step::hassio_confirm::data::allow_clip_sensor
Lookin up key in Lokalise returns 0 results, expected 1
Processing component::deconz::config::step::hassio_confirm::data::allow_deconz_groups
Processing component::deconz::config::step::options::data::allow_clip_sensor
Processing component::deconz::config::step::options::data::allow_deconz_groups
Processing component::deconz::config::step::options::title
Processing component::deconz::options::step::async_step_deconz_devices::data::allow_clip_sensor
Processing component::deconz::options::step::async_step_deconz_devices::data::allow_deconz_groups
Processing component::deconz::options::step::async_step_deconz_devices::description
Processing component::ambient_station::config::error::identifier_exists
Processing component::geonetnz_quakes::config::error::identifier_exists
Processing component::vizio::config::abort::already_in_progress
Processing component::vizio::config::abort::already_setup_with_diff_host_and_name
Processing component::vizio::config::abort::host_exists
Processing component::vizio::config::abort::name_exists
Processing component::vizio::config::abort::updated_options
Processing component::vizio::config::abort::updated_volume_step
Processing component::vizio::config::error::tv_needs_token
Processing component::vizio::config::step::tv_apps::data::apps_to_include_or_exclude
Processing component::vizio::config::step::tv_apps::data::include_or_exclude
Processing component::vizio::config::step::tv_apps::description
Processing component::vizio::config::step::tv_apps::title
Processing component::vizio::config::step::user_tv::data::apps_to_include_or_exclude
Processing component::vizio::config::step::user_tv::data::include_or_exclude
Processing component::vizio::config::step::user_tv::description
Processing component::vizio::config::step::user_tv::title
Processing component::vizio::options::step::init::data::timeout
Processing component::cert_expiry::config::abort::host_port_exists
Processing component::cert_expiry::config::error::certificate_error
Processing component::cert_expiry::config::error::certificate_fetch_failed
Processing component::cert_expiry::config::error::host_port_exists
Processing component::cert_expiry::config::error::wrong_host
Processing component::simplisafe::config::step::user::data::code
Processing component::withings::config::abort::no_flows
Processing component::withings::config::step::user::data::profile
Processing component::withings::config::step::user::description
Processing component::withings::config::step::user::title
Processing component::harmony::config::error::invalid_auth
Processing component::wwlln::config::abort::window_too_small
Processing component::wwlln::config::error::identifier_exists
Processing component::samsungtv::config::abort::not_found
Processing component::binary_sensor::device_automation::trigger_type::closed
Processing component::binary_sensor::device_automation::trigger_type::moist§
Processing component::notion::config::error::identifier_exists
Processing component::airvisual::config::step::user::data::show_on_map
Processing component::opentherm_gw::config::step::init::data::floor_temperature
Processing component::opentherm_gw::config::step::init::data::precision
Processing component::axis::config::abort::updated_configuration
Processing component::minecraft_server::config::step::user::data::port
Processing component::switch::device_automation::condition_type::turn_off
Processing component::switch::device_automation::condition_type::turn_on
Processing component::airly::config::error::name_exists
Processing component::plex::config::abort::discovery_no_file
Processing component::plex::config::error::no_token
Processing component::plex::config::step::manual_setup::data::host
Processing component::plex::config::step::manual_setup::data::port
Processing component::plex::config::step::manual_setup::data::ssl
Processing component::plex::config::step::manual_setup::data::token
Processing component::plex::config::step::manual_setup::data::verify_ssl
Processing component::plex::config::step::manual_setup::title
Processing component::plex::config::step::user::data::manual_setup
Processing component::plex::config::step::user::data::token
Processing component::plex::config::step::user::description
Processing component::plex::config::step::user::title
Processing component::plex::options::step::plex_mp_settings::data::show_all_controls
Processing component::transmission::config::abort::one_instance_allowed
Processing component::transmission::config::step::options::data::scan_interval
Processing component::transmission::config::step::options::title
Processing component::transmission::options::step::init::description
Processing component::roku::config::error::unknown
Processing component::directv::config::error::unknown
Deleting keys: 20415195, 10125943, 10525352, 10125944, 27063585, 27063586, 27063587, 17440810, 27063588, 35122573, 35304772, 35122575, 35122576, 35287929, 35122577, 35122581, 38503717, 38503718, 38503719, 38503720, 38397197, 38397198, 38397199, 38397200, 35287930, 27063575, 29555589, 27063576, 27063578, 29555590, 13713563, 27862136, 27147398, 27147399, 27147400, 39613299, 38331420, 24627498, 34683255, 28043843, 28043850, 24449374, 38073804, 28601769, 28601772, 34386413, 36567775, 27539919, 27539920, 28541840, 28777946, 28044847, 28044848, 28044849, 28044850, 28044851, 28044852, 28044853, 28044854, 27946923, 27946924, 27946925, 28210592, 28210639, 28210642, 28210643, 28210652, 39197497, 38961181
{'project_id': '130246255a974bd3b5e8a1.51616605', 'keys_removed': True, 'keys_locked': 0}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
