### PR TITLE
Ability to mock long poll requests + refactor qwikswitch unit tests

### DIFF
--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -2,30 +2,49 @@
 import asyncio
 import logging
 
-from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
 from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.setup import async_setup_component
 
 _LOGGER = logging.getLogger(__name__)
 
 
-DEVICES = """[
-        {"id":"@000001","name":"Switch 1","type":"rel","val":"OFF",
-        "time":"1522777506","rssi":"51%"},
-        {"id":"@000002","name":"Light 2","type":"rel","val":"ON",
-        "time":"1522777507","rssi":"45%"},
-        {"id":"@000003","name":"Dim 3","type":"dim","val":"280c00",
-        "time":"1522777544","rssi":"62%"}]"""
+DEVICES = [
+    {
+        "id": "@000001",
+        "name": "Switch 1",
+        "type": "rel",
+        "val": "OFF",
+        "time": "1522777506",
+        "rssi": "51%",
+    },
+    {
+        "id": "@000002",
+        "name": "Light 2",
+        "type": "rel",
+        "val": "ON",
+        "time": "1522777507",
+        "rssi": "45%",
+    },
+    {
+        "id": "@000003",
+        "name": "Dim 3",
+        "type": "dim",
+        "val": "280c00",
+        "time": "1522777544",
+        "rssi": "62%",
+    },
+]
 
 
-async def test_binary_sensor_device(hass, aioclient_mock):  # noqa: F811
+async def test_binary_sensor_device(hass, aioclient_mock):
     """Test a binary sensor device."""
     config = {
         "qwikswitch": {
             "sensors": {"name": "s1", "id": "@a00001", "channel": 1, "type": "imod"}
         }
     }
-    aioclient_mock.get("http://127.0.0.1:2020/&device", text=DEVICES)
+    aioclient_mock.get("http://127.0.0.1:2020/&device", json=DEVICES)
     aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
     await async_setup_component(hass, QWIKSWITCH, config)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -55,7 +74,7 @@ async def test_binary_sensor_device(hass, aioclient_mock):  # noqa: F811
     assert state_obj.state == "off"
 
 
-async def test_sensor_device(hass, aioclient_mock):  # noqa: F811
+async def test_sensor_device(hass, aioclient_mock):
     """Test a sensor device."""
     config = {
         "qwikswitch": {
@@ -67,7 +86,7 @@ async def test_sensor_device(hass, aioclient_mock):  # noqa: F811
             }
         }
     }
-    aioclient_mock.get("http://127.0.0.1:2020/&device", text=DEVICES)
+    aioclient_mock.get("http://127.0.0.1:2020/&device", json=DEVICES)
     aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
     await async_setup_component(hass, QWIKSWITCH, config)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -6,6 +6,8 @@ from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 
+from tests.test_util.aiohttp import MockLongPollSideEffect
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -45,7 +47,8 @@ async def test_binary_sensor_device(hass, aioclient_mock):
         }
     }
     aioclient_mock.get("http://127.0.0.1:2020/&device", json=DEVICES)
-    listen_mock = aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
+    listen_mock = MockLongPollSideEffect()
+    aioclient_mock.get("http://127.0.0.1:2020/&listen", side_effect=listen_mock)
     await async_setup_component(hass, QWIKSWITCH, config)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -69,6 +72,8 @@ async def test_binary_sensor_device(hass, aioclient_mock):
     state_obj = hass.states.get("binary_sensor.s1")
     assert state_obj.state == "off"
 
+    listen_mock.stop()
+
 
 async def test_sensor_device(hass, aioclient_mock):
     """Test a sensor device."""
@@ -83,7 +88,8 @@ async def test_sensor_device(hass, aioclient_mock):
         }
     }
     aioclient_mock.get("http://127.0.0.1:2020/&device", json=DEVICES)
-    listen_mock = aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
+    listen_mock = MockLongPollSideEffect()
+    aioclient_mock.get("http://127.0.0.1:2020/&listen", side_effect=listen_mock)
     await async_setup_component(hass, QWIKSWITCH, config)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -98,3 +104,5 @@ async def test_sensor_device(hass, aioclient_mock):
     await hass.async_block_till_done()
     state_obj = hass.states.get("sensor.ss1")
     assert state_obj.state == "416"
+
+    listen_mock.stop()

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -56,7 +56,7 @@ async def test_binary_sensor_device(hass, aioclient_mock):
     aioclient_mock.get(
         "http://127.0.0.1:2020/&listen",
         long_poll=True,
-        text='{"id":"@a00001","cmd":"","data":"4e0e1601","rssi":"61%"}',
+        json={"id": "@a00001", "cmd": "", "data": "4e0e1601", "rssi": "61%"},
     )
     await asyncio.sleep(0.01)
     await hass.async_block_till_done()
@@ -66,7 +66,7 @@ async def test_binary_sensor_device(hass, aioclient_mock):
     aioclient_mock.get(
         "http://127.0.0.1:2020/&listen",
         long_poll=True,
-        text='{"id":"@a00001","cmd":"","data":"4e0e1701","rssi":"61%"}',
+        json={"id": "@a00001", "cmd": "", "data": "4e0e1701", "rssi": "61%"},
     )
     await asyncio.sleep(0.01)
     await hass.async_block_till_done()
@@ -98,7 +98,7 @@ async def test_sensor_device(hass, aioclient_mock):
     aioclient_mock.get(
         "http://127.0.0.1:2020/&listen",
         long_poll=True,
-        text='{"id":"@a00001","name":"ss1","type":"rel",' '"val":"4733800001a00000"}',
+        json={"id": "@a00001", "name": "ss1", "type": "rel", "val": "4733800001a00000"},
     )
     await asyncio.sleep(0.01)
     await hass.async_block_till_done()

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -45,7 +45,7 @@ async def test_binary_sensor_device(hass, aioclient_mock):
         }
     }
     aioclient_mock.get("http://127.0.0.1:2020/&device", json=DEVICES)
-    aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
+    listen_mock = aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
     await async_setup_component(hass, QWIKSWITCH, config)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -53,19 +53,15 @@ async def test_binary_sensor_device(hass, aioclient_mock):
     state_obj = hass.states.get("binary_sensor.s1")
     assert state_obj.state == "off"
 
-    aioclient_mock.get(
-        "http://127.0.0.1:2020/&listen",
-        long_poll=True,
-        json={"id": "@a00001", "cmd": "", "data": "4e0e1601", "rssi": "61%"},
+    listen_mock.queue_response(
+        json={"id": "@a00001", "cmd": "", "data": "4e0e1601", "rssi": "61%"}
     )
     await asyncio.sleep(0.01)
     await hass.async_block_till_done()
     state_obj = hass.states.get("binary_sensor.s1")
     assert state_obj.state == "on"
 
-    aioclient_mock.get(
-        "http://127.0.0.1:2020/&listen",
-        long_poll=True,
+    listen_mock.queue_response(
         json={"id": "@a00001", "cmd": "", "data": "4e0e1701", "rssi": "61%"},
     )
     await asyncio.sleep(0.01)
@@ -87,7 +83,7 @@ async def test_sensor_device(hass, aioclient_mock):
         }
     }
     aioclient_mock.get("http://127.0.0.1:2020/&device", json=DEVICES)
-    aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
+    listen_mock = aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
     await async_setup_component(hass, QWIKSWITCH, config)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -95,9 +91,7 @@ async def test_sensor_device(hass, aioclient_mock):
     state_obj = hass.states.get("sensor.ss1")
     assert state_obj.state == "None"
 
-    aioclient_mock.get(
-        "http://127.0.0.1:2020/&listen",
-        long_poll=True,
+    listen_mock.queue_response(
         json={"id": "@a00001", "name": "ss1", "type": "rel", "val": "4733800001a00000"},
     )
     await asyncio.sleep(0.01)

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -1,60 +1,21 @@
 """Test qwikswitch sensors."""
+import asyncio
 import logging
-
-from aiohttp.client_exceptions import ClientError
-import pytest
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 
-from tests.test_util.aiohttp import mock_aiohttp_client
-
 _LOGGER = logging.getLogger(__name__)
 
 
-class AiohttpClientMockResponseList(list):
-    """Return multiple values for aiohttp Mocker.
-
-    aoihttp mocker uses decode to fetch the next value.
-    """
-
-    def decode(self, _):
-        """Return next item from list."""
-        try:
-            res = list.pop(self, 0)
-            _LOGGER.debug("MockResponseList popped %s: %s", res, self)
-            if isinstance(res, Exception):
-                raise res
-            return res
-        except IndexError:
-            raise AssertionError("MockResponseList empty")
-
-    async def wait_till_empty(self, hass):
-        """Wait until empty."""
-        while self:
-            await hass.async_block_till_done()
-        await hass.async_block_till_done()
-
-
-LISTEN = AiohttpClientMockResponseList()
-
-
-@pytest.fixture
-def aioclient_mock():
-    """HTTP client listen and devices."""
-    devices = """[
+DEVICES = """[
         {"id":"@000001","name":"Switch 1","type":"rel","val":"OFF",
         "time":"1522777506","rssi":"51%"},
         {"id":"@000002","name":"Light 2","type":"rel","val":"ON",
         "time":"1522777507","rssi":"45%"},
         {"id":"@000003","name":"Dim 3","type":"dim","val":"280c00",
         "time":"1522777544","rssi":"62%"}]"""
-
-    with mock_aiohttp_client() as mock_session:
-        mock_session.get("http://127.0.0.1:2020/&listen", content=LISTEN)
-        mock_session.get("http://127.0.0.1:2020/&device", text=devices)
-        yield mock_session
 
 
 async def test_binary_sensor_device(hass, aioclient_mock):  # noqa: F811
@@ -64,24 +25,32 @@ async def test_binary_sensor_device(hass, aioclient_mock):  # noqa: F811
             "sensors": {"name": "s1", "id": "@a00001", "channel": 1, "type": "imod"}
         }
     }
+    aioclient_mock.get("http://127.0.0.1:2020/&device", text=DEVICES)
+    aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
     await async_setup_component(hass, QWIKSWITCH, config)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
 
     state_obj = hass.states.get("binary_sensor.s1")
     assert state_obj.state == "off"
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-
-    LISTEN.append('{"id":"@a00001","cmd":"","data":"4e0e1601","rssi":"61%"}')
-    LISTEN.append(ClientError())  # Will cause a sleep
-
+    aioclient_mock.get(
+        "http://127.0.0.1:2020/&listen",
+        long_poll=True,
+        text='{"id":"@a00001","cmd":"","data":"4e0e1601","rssi":"61%"}',
+    )
+    await asyncio.sleep(0.01)
     await hass.async_block_till_done()
     state_obj = hass.states.get("binary_sensor.s1")
     assert state_obj.state == "on"
 
-    LISTEN.append('{"id":"@a00001","cmd":"","data":"4e0e1701","rssi":"61%"}')
-    hass.data[QWIKSWITCH]._sleep_task.cancel()
-    await LISTEN.wait_till_empty(hass)
+    aioclient_mock.get(
+        "http://127.0.0.1:2020/&listen",
+        long_poll=True,
+        text='{"id":"@a00001","cmd":"","data":"4e0e1701","rssi":"61%"}',
+    )
+    await asyncio.sleep(0.01)
+    await hass.async_block_till_done()
     state_obj = hass.states.get("binary_sensor.s1")
     assert state_obj.state == "off"
 
@@ -98,18 +67,21 @@ async def test_sensor_device(hass, aioclient_mock):  # noqa: F811
             }
         }
     }
+    aioclient_mock.get("http://127.0.0.1:2020/&device", text=DEVICES)
+    aioclient_mock.get("http://127.0.0.1:2020/&listen", long_poll=True)
     await async_setup_component(hass, QWIKSWITCH, config)
-
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
+
     state_obj = hass.states.get("sensor.ss1")
     assert state_obj.state == "None"
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-
-    LISTEN.append(
-        '{"id":"@a00001","name":"ss1","type":"rel",' '"val":"4733800001a00000"}'
+    aioclient_mock.get(
+        "http://127.0.0.1:2020/&listen",
+        long_poll=True,
+        text='{"id":"@a00001","name":"ss1","type":"rel",' '"val":"4733800001a00000"}',
     )
-
+    await asyncio.sleep(0.01)
     await hass.async_block_till_done()
     state_obj = hass.states.get("sensor.ss1")
     assert state_obj.state == "416"

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -79,23 +79,23 @@ class AiohttpClientMocker:
 
     def put(self, *args, **kwargs):
         """Register a mock put request."""
-        self.request("put", *args, **kwargs)
+        return self.request("put", *args, **kwargs)
 
     def post(self, *args, **kwargs):
         """Register a mock post request."""
-        self.request("post", *args, **kwargs)
+        return self.request("post", *args, **kwargs)
 
     def delete(self, *args, **kwargs):
         """Register a mock delete request."""
-        self.request("delete", *args, **kwargs)
+        return self.request("delete", *args, **kwargs)
 
     def options(self, *args, **kwargs):
         """Register a mock options request."""
-        self.request("options", *args, **kwargs)
+        return self.request("options", *args, **kwargs)
 
     def patch(self, *args, **kwargs):
         """Register a mock patch request."""
-        self.request("patch", *args, **kwargs)
+        return self.request("patch", *args, **kwargs)
 
     @property
     def call_count(self):

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -319,4 +319,4 @@ class MockLongPollSideEffect:
     def stop(self):
         """Stop the current request and future ones. Avoids exception if there is someone waiting when exiting test."""
         self.stopping = True
-        self.queue_response(method="", url="", exc=ClientError())
+        self.queue_response(exc=ClientError())

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -56,6 +56,7 @@ class AiohttpClientMocker:
             text = _json.dumps(json)
         if text is not None:
             content = text.encode("utf-8")
+        content_not_empty = content is not None
         if content is None:
             content = b""
 
@@ -67,10 +68,14 @@ class AiohttpClientMocker:
         new_response = AiohttpClientMockResponse(
             method, url, status, content, cookies, exc, headers, long_poll
         )
-        if long_poll and content != b"":
+        if long_poll and content_not_empty:
             for response in self._mocks:
                 if response.long_poll and response.match_request(method, url, params):
                     response.set_long_poll_response(new_response)
+                    return
+            assert (
+                False
+            ), "First call with with long_poll has to be with empty content to set up queue."
         else:
             self._mocks.append(new_response)
 

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -1,4 +1,5 @@
 """Aiohttp test utils."""
+import asyncio
 from contextlib import contextmanager
 import json as _json
 import re


### PR DESCRIPTION
the qwikswitch integration is using a long poll where it sends an HTTP gets that wait until a command is available. Added this ability to mock_aiohttp_client and then refactored with it the 
unit test. However, this can be useful to other integrations as well that support devices that send "push"-like commands via these sockets

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
it adds the options for mock_aiohttp_client to get any of the commands (although it will usually be get) with the optional long_poll boolean. If set to True with an empty response(no content, text, or json), if just registers a response as a handler that sets up a queue. subsequent mock_aiohttp_client.get() commands will fill the queue responses, while if someones tries to get from these, it will pop the responses sequentially or wait if the queue is empty until another command becomes available

the refactoring of the qwikswitch tests came from seeing (https://github.com/home-assistant/core/pull/33737) that there are global variables there and the code was difficult to understand and was only working because of uncaught exceptions. Felt it was better to improve but needed a bit of the additional infrastructure in mock_aiohttp_client 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
