### PR TITLE
Updater fallback to GET if POST fails

### DIFF
--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -175,7 +175,9 @@ async def get_newest_version(hass, huuid, include_components):
         get_fallback = True
     elif req.status != 200:
         _LOGGER.error(
-            "Unexpected status: %s while posting update information", req.status
+            "Unexpected status: %s while posting update information"
+            "Retrying with a get request",
+            req.status,
         )
         get_fallback = True
 
@@ -186,9 +188,9 @@ async def get_newest_version(hass, huuid, include_components):
             raise update_coordinator.UpdateFailed(
                 "Timed out fetching Home Assistant Update information."
             )
-        elif req.status != 200:
+        if req.status != 200:
             raise update_coordinator.UpdateFailed(
-                "Unexpected status: %s while fetching update information.", req.status
+                f"Unexpected status: {req.status} while fetching update information."
             )
 
     try:

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -170,7 +170,7 @@ async def get_newest_version(hass, huuid, include_components):
     if post_cm.expired:
         _LOGGER.error(
             "Timed out while attempt to post update information. "
-            "Retrying with a get request. "
+            "Retrying with a get request"
         )
         get_fallback = True
     elif req.status != 200:

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -175,7 +175,7 @@ async def get_newest_version(hass, huuid, include_components):
         get_fallback = True
     elif req.status != 200:
         _LOGGER.error(
-            "Unexpected status: %s while posting update information.", req.status
+            "Unexpected status: %s while posting update information", req.status
         )
         get_fallback = True
 

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -152,7 +152,7 @@ async def test_error_fetching_new_version_invalid_response(hass, aioclient_mock)
 
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value={"fake": "bla"}),
+        return_value={"fake": "bla"},
     ), pytest.raises(UpdateFailed):
         await updater.get_newest_version(hass, MOCK_HUUID, False)
 

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -177,7 +177,7 @@ async def test_both_post_and_get_fallback_fail(hass, aioclient_mock):
     aioclient_mock.get(updater.UPDATER_URL, status=500)
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value={"fake": "bla"}),
+        return_value={"fake": "bla"},
     ), pytest.raises(UpdateFailed):
         await updater.get_newest_version(hass, MOCK_HUUID, False)
 

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.components import updater
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockDependency, mock_component, mock_coro
+from tests.common import MockDependency, mock_component
 
 NEW_VERSION = "10000.0"
 MOCK_VERSION = "10.0"
@@ -75,7 +75,7 @@ async def test_same_version_shows_entity_false(
 ):
     """Test if sensor is false if no new version is available."""
     mock_get_uuid.return_value = MOCK_HUUID
-    mock_get_newest_version.return_value = mock_coro((MOCK_VERSION, ""))
+    mock_get_newest_version.return_value = (MOCK_VERSION, "")
 
     assert await async_setup_component(hass, updater.DOMAIN, {updater.DOMAIN: {}})
 
@@ -92,7 +92,7 @@ async def test_same_version_shows_entity_false(
 async def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
     """Test we do not gather analytics when disable reporting is active."""
     mock_get_uuid.return_value = MOCK_HUUID
-    mock_get_newest_version.return_value = mock_coro((MOCK_VERSION, ""))
+    mock_get_newest_version.return_value = (MOCK_VERSION, "")
 
     assert await async_setup_component(
         hass, updater.DOMAIN, {updater.DOMAIN: {"reporting": False}}
@@ -123,7 +123,7 @@ async def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
 
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value=mock_coro({"fake": "bla"})),
+        Mock(return_value={"fake": "bla"}),
     ):
         res = await updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res == (MOCK_RESPONSE["version"], MOCK_RESPONSE["release-notes"])
@@ -135,7 +135,7 @@ async def test_error_fetching_new_version_bad_json(hass, aioclient_mock):
 
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value=mock_coro({"fake": "bla"})),
+        Mock(return_value={"fake": "bla"}),
     ), pytest.raises(UpdateFailed):
         await updater.get_newest_version(hass, MOCK_HUUID, False)
 
@@ -152,7 +152,7 @@ async def test_error_fetching_new_version_invalid_response(hass, aioclient_mock)
 
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value=mock_coro({"fake": "bla"})),
+        Mock(return_value={"fake": "bla"}),
     ), pytest.raises(UpdateFailed):
         await updater.get_newest_version(hass, MOCK_HUUID, False)
 
@@ -163,7 +163,7 @@ async def test_fallback_to_get_if_post_fails(hass, aioclient_mock):
     aioclient_mock.get(updater.UPDATER_URL, json=MOCK_RESPONSE)
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value=mock_coro({"fake": "bla"})),
+        Mock(return_value={"fake": "bla"}),
     ):
         assert await updater.get_newest_version(hass, MOCK_HUUID, False) == (
             "0.15",
@@ -177,7 +177,7 @@ async def test_both_post_and_get_fallback_fail(hass, aioclient_mock):
     aioclient_mock.get(updater.UPDATER_URL, status=500)
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value=mock_coro({"fake": "bla"})),
+        Mock(return_value={"fake": "bla"}),
     ), pytest.raises(UpdateFailed):
         await updater.get_newest_version(hass, MOCK_HUUID, False)
 

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -163,7 +163,7 @@ async def test_fallback_to_get_if_post_fails(hass, aioclient_mock):
     aioclient_mock.get(updater.UPDATER_URL, json=MOCK_RESPONSE)
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value={"fake": "bla"}),
+        return_value={"fake": "bla"},
     ):
         assert await updater.get_newest_version(hass, MOCK_HUUID, False) == (
             "0.15",

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -135,7 +135,7 @@ async def test_error_fetching_new_version_bad_json(hass, aioclient_mock):
 
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value={"fake": "bla"}),
+        return_value={"fake": "bla"},
     ), pytest.raises(UpdateFailed):
         await updater.get_newest_version(hass, MOCK_HUUID, False)
 

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -123,7 +123,7 @@ async def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
 
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
-        Mock(return_value={"fake": "bla"}),
+        return_value={"fake": "bla"},
     ):
         res = await updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res == (MOCK_RESPONSE["version"], MOCK_RESPONSE["release-notes"])

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Updater component."""
-from unittest.mock import Mock
 
 from asynctest import patch
 import pytest

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.components import updater
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockDependency, mock_component
+from tests.common import MockDependency, mock_component, mock_coro
 
 NEW_VERSION = "10000.0"
 MOCK_VERSION = "10.0"
@@ -75,7 +75,7 @@ async def test_same_version_shows_entity_false(
 ):
     """Test if sensor is false if no new version is available."""
     mock_get_uuid.return_value = MOCK_HUUID
-    mock_get_newest_version.return_value = (MOCK_VERSION, "")
+    mock_get_newest_version.return_value = mock_coro((MOCK_VERSION, ""))
 
     assert await async_setup_component(hass, updater.DOMAIN, {updater.DOMAIN: {}})
 
@@ -92,7 +92,7 @@ async def test_same_version_shows_entity_false(
 async def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
     """Test we do not gather analytics when disable reporting is active."""
     mock_get_uuid.return_value = MOCK_HUUID
-    mock_get_newest_version.return_value = (MOCK_VERSION, "")
+    mock_get_newest_version.return_value = mock_coro((MOCK_VERSION, ""))
 
     assert await async_setup_component(
         hass, updater.DOMAIN, {updater.DOMAIN: {"reporting": False}}


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updater fallback to GET if POST fails

The CDN can cache a GET but not a POST so
if the POST unable to go though, GET
is usually still working.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33142
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
