### PR TITLE
Clean up access to config in various integrations v3

### DIFF
--- a/homeassistant/components/bbb_gpio/binary_sensor.py
+++ b/homeassistant/components/bbb_gpio/binary_sensor.py
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Beaglebone Black GPIO devices."""
-    pins = config.get(CONF_PINS)
+    pins = config[CONF_PINS]
 
     binary_sensors = []
 
@@ -50,10 +50,10 @@ class BBBGPIOBinarySensor(BinarySensorDevice):
     def __init__(self, pin, params):
         """Initialize the Beaglebone Black binary sensor."""
         self._pin = pin
-        self._name = params.get(CONF_NAME) or DEVICE_DEFAULT_NAME
-        self._bouncetime = params.get(CONF_BOUNCETIME)
-        self._pull_mode = params.get(CONF_PULL_MODE)
-        self._invert_logic = params.get(CONF_INVERT_LOGIC)
+        self._name = params[CONF_NAME] or DEVICE_DEFAULT_NAME
+        self._bouncetime = params[CONF_BOUNCETIME]
+        self._pull_mode = params[CONF_PULL_MODE]
+        self._invert_logic = params[CONF_INVERT_LOGIC]
 
         bbb_gpio.setup_input(self._pin, self._pull_mode)
         self._state = bbb_gpio.read_input(self._pin)

--- a/homeassistant/components/bbb_gpio/switch.py
+++ b/homeassistant/components/bbb_gpio/switch.py
@@ -30,7 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the BeagleBone Black GPIO devices."""
-    pins = config.get(CONF_PINS)
+    pins = config[CONF_PINS]
 
     switches = []
     for pin, params in pins.items():
@@ -44,9 +44,9 @@ class BBBGPIOSwitch(ToggleEntity):
     def __init__(self, pin, params):
         """Initialize the pin."""
         self._pin = pin
-        self._name = params.get(CONF_NAME) or DEVICE_DEFAULT_NAME
-        self._state = params.get(CONF_INITIAL)
-        self._invert_logic = params.get(CONF_INVERT_LOGIC)
+        self._name = params[CONF_NAME] or DEVICE_DEFAULT_NAME
+        self._state = params[CONF_INITIAL]
+        self._invert_logic = params[CONF_INVERT_LOGIC]
 
         bbb_gpio.setup_output(self._pin)
 

--- a/homeassistant/components/bbox/sensor.py
+++ b/homeassistant/components/bbox/sensor.py
@@ -74,7 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.error(error)
         return False
 
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     sensors = []
     for variable in config[CONF_MONITORED_VARIABLES]:

--- a/homeassistant/components/bh1750/sensor.py
+++ b/homeassistant/components/bh1750/sensor.py
@@ -63,10 +63,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the BH1750 sensor."""
 
-    name = config.get(CONF_NAME)
-    bus_number = config.get(CONF_I2C_BUS)
-    i2c_address = config.get(CONF_I2C_ADDRESS)
-    operation_mode = config.get(CONF_OPERATION_MODE)
+    name = config[CONF_NAME]
+    bus_number = config[CONF_I2C_BUS]
+    i2c_address = config[CONF_I2C_ADDRESS]
+    operation_mode = config[CONF_OPERATION_MODE]
 
     bus = smbus.SMBus(bus_number)
 
@@ -76,8 +76,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             bus,
             i2c_address,
             operation_mode=operation_mode,
-            measurement_delay=config.get(CONF_DELAY),
-            sensitivity=config.get(CONF_SENSITIVITY),
+            measurement_delay=config[CONF_DELAY],
+            sensitivity=config[CONF_SENSITIVITY],
             logger=_LOGGER,
         )
     )
@@ -85,7 +85,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         _LOGGER.error("BH1750 sensor not detected at %s", i2c_address)
         return False
 
-    dev = [BH1750Sensor(sensor, name, SENSOR_UNIT, config.get(CONF_MULTIPLIER))]
+    dev = [BH1750Sensor(sensor, name, SENSOR_UNIT, config[CONF_MULTIPLIER])]
     _LOGGER.info(
         "Setup of BH1750 light sensor at %s in mode %s is complete",
         i2c_address,

--- a/homeassistant/components/bitcoin/sensor.py
+++ b/homeassistant/components/bitcoin/sensor.py
@@ -63,7 +63,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Bitcoin sensors."""
 
-    currency = config.get(CONF_CURRENCY)
+    currency = config[CONF_CURRENCY]
 
     if currency not in exchangerates.get_ticker():
         _LOGGER.warning("Currency %s is not available. Using USD", currency)

--- a/homeassistant/components/bizkaibus/sensor.py
+++ b/homeassistant/components/bizkaibus/sensor.py
@@ -30,7 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Bizkaibus public transport sensor."""
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
     stop = config[CONF_STOP_ID]
     route = config[CONF_ROUTE]
 

--- a/homeassistant/components/blinksticklight/light.py
+++ b/homeassistant/components/blinksticklight/light.py
@@ -35,8 +35,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Blinkstick device specified by serial number."""
 
-    name = config.get(CONF_NAME)
-    serial = config.get(CONF_SERIAL)
+    name = config[CONF_NAME]
+    serial = config[CONF_SERIAL]
 
     stick = blinkstick.find_by_serial(serial)
 

--- a/homeassistant/components/blinkt/light.py
+++ b/homeassistant/components/blinkt/light.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # ensure that the lights are off when exiting
     blinkt.set_clear_on_exit()
 
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     add_entities(
         [BlinktLight(blinkt, name, index) for index in range(blinkt.NUM_PIXELS)]

--- a/homeassistant/components/blockchain/sensor.py
+++ b/homeassistant/components/blockchain/sensor.py
@@ -33,8 +33,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Blockchain.com sensors."""
 
-    addresses = config.get(CONF_ADDRESSES)
-    name = config.get(CONF_NAME)
+    addresses = config[CONF_ADDRESSES]
+    name = config[CONF_NAME]
 
     for address in addresses:
         if not validate_address(address):

--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather binary sensors."""
     # Default needed in case of discovery
-    sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
+    sensors = config[CONF_MONITORED_CONDITIONS]
     bloomsky = hass.data[DOMAIN]
 
     for device in bloomsky.devices.values():

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather sensors."""
     # Default needed in case of discovery
-    sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
+    sensors = config[CONF_MONITORED_CONDITIONS]
     bloomsky = hass.data[DOMAIN]
 
     for device in bloomsky.devices.values():

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -112,7 +112,7 @@ async def async_setup_scanner(
     hass: HomeAssistantType, config: dict, async_see, discovery_info=None
 ):
     """Set up the Bluetooth Scanner."""
-    device_id: int = config.get(CONF_DEVICE_ID)
+    device_id: int = config[CONF_DEVICE_ID]
     interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
     request_rssi = config.get(CONF_REQUEST_RSSI, False)
     update_bluetooth_lock = asyncio.Lock()

--- a/homeassistant/components/bme280/sensor.py
+++ b/homeassistant/components/bme280/sensor.py
@@ -85,22 +85,22 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the BME280 sensor."""
 
     SENSOR_TYPES[SENSOR_TEMP][1] = hass.config.units.temperature_unit
-    name = config.get(CONF_NAME)
-    i2c_address = config.get(CONF_I2C_ADDRESS)
+    name = config[CONF_NAME]
+    i2c_address = config[CONF_I2C_ADDRESS]
 
-    bus = smbus.SMBus(config.get(CONF_I2C_BUS))
+    bus = smbus.SMBus(config[CONF_I2C_BUS])
     sensor = await hass.async_add_job(
         partial(
             BME280,
             bus,
             i2c_address,
-            osrs_t=config.get(CONF_OVERSAMPLING_TEMP),
-            osrs_p=config.get(CONF_OVERSAMPLING_PRES),
-            osrs_h=config.get(CONF_OVERSAMPLING_HUM),
-            mode=config.get(CONF_OPERATION_MODE),
-            t_sb=config.get(CONF_T_STANDBY),
-            filter_mode=config.get(CONF_FILTER_MODE),
-            delta_temp=config.get(CONF_DELTA_TEMP),
+            osrs_t=config[CONF_OVERSAMPLING_TEMP],
+            osrs_p=config[CONF_OVERSAMPLING_PRES],
+            osrs_h=config[CONF_OVERSAMPLING_HUM],
+            mode=config[CONF_OPERATION_MODE],
+            t_sb=config[CONF_T_STANDBY],
+            filter_mode=config[CONF_FILTER_MODE],
+            delta_temp=config[CONF_DELTA_TEMP],
             logger=_LOGGER,
         )
     )

--- a/homeassistant/components/bme680/sensor.py
+++ b/homeassistant/components/bme680/sensor.py
@@ -109,7 +109,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the BME680 sensor."""
     SENSOR_TYPES[SENSOR_TEMP][1] = hass.config.units.temperature_unit
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     sensor_handler = await hass.async_add_job(_setup_bme680, config)
     if sensor_handler is None:
@@ -132,8 +132,8 @@ def _setup_bme680(config):
     sensor = None
     try:
         # pylint: disable=no-member
-        i2c_address = config.get(CONF_I2C_ADDRESS)
-        bus = SMBus(config.get(CONF_I2C_BUS))
+        i2c_address = config[CONF_I2C_ADDRESS]
+        bus = SMBus(config[CONF_I2C_BUS])
         sensor = bme680.BME680(i2c_address, bus)
 
         # Configure Oversampling
@@ -145,10 +145,10 @@ def _setup_bme680(config):
             8: bme680.OS_8X,
             16: bme680.OS_16X,
         }
-        sensor.set_temperature_oversample(os_lookup[config.get(CONF_OVERSAMPLING_TEMP)])
-        sensor.set_temp_offset(config.get(CONF_TEMP_OFFSET))
-        sensor.set_humidity_oversample(os_lookup[config.get(CONF_OVERSAMPLING_HUM)])
-        sensor.set_pressure_oversample(os_lookup[config.get(CONF_OVERSAMPLING_PRES)])
+        sensor.set_temperature_oversample(os_lookup[config[CONF_OVERSAMPLING_TEMP]])
+        sensor.set_temp_offset(config[CONF_TEMP_OFFSET])
+        sensor.set_humidity_oversample(os_lookup[config[CONF_OVERSAMPLING_HUM]])
+        sensor.set_pressure_oversample(os_lookup[config[CONF_OVERSAMPLING_PRES]])
 
         # Configure IIR Filter
         filter_lookup = {
@@ -161,7 +161,7 @@ def _setup_bme680(config):
             63: bme680.FILTER_SIZE_63,
             127: bme680.FILTER_SIZE_127,
         }
-        sensor.set_filter(filter_lookup[config.get(CONF_FILTER_SIZE)])
+        sensor.set_filter(filter_lookup[config[CONF_FILTER_SIZE]])
 
         # Configure the Gas Heater
         if (

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -61,7 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Sony Bravia TV platform."""
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
 
     if host is None:
         return
@@ -74,7 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if host_ip == host:
             pin = host_config["pin"]
             mac = host_config["mac"]
-            name = config.get(CONF_NAME)
+            name = config[CONF_NAME]
             braviarc = BraviaRC(host, mac)
             if not braviarc.connect(pin, CLIENTID_PREFIX, NICKNAME):
                 raise PlatformNotReady
@@ -91,8 +91,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 def setup_bravia(config, pin, hass, add_entities):
     """Set up a Sony Bravia TV based on host parameter."""
-    host = config.get(CONF_HOST)
-    name = config.get(CONF_NAME)
+    host = config[CONF_HOST]
+    name = config[CONF_NAME]
 
     if pin is None:
         request_configuration(config, hass, add_entities)
@@ -128,8 +128,8 @@ def setup_bravia(config, pin, hass, add_entities):
 
 def request_configuration(config, hass, add_entities):
     """Request configuration steps from the user."""
-    host = config.get(CONF_HOST)
-    name = config.get(CONF_NAME)
+    host = config[CONF_HOST]
+    name = config[CONF_NAME]
 
     configurator = hass.components.configurator
 

--- a/homeassistant/components/brottsplatskartan/sensor.py
+++ b/homeassistant/components/brottsplatskartan/sensor.py
@@ -65,7 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     area = config.get(CONF_AREA)
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     # Every Home Assistant instance should have their own unique
     # app parameter: https://brottsplatskartan.se/sida/api


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces incorrect use of `dict.get(key)` for required and optional config keys with a default value with `dict[key]` in various integrations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
