### PR TITLE
Fix Doorbird yaml import aborted if discovery finds it first

### DIFF
--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -127,6 +127,73 @@ async def test_form_import(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_form_import_with_zeroconf_already_discovered(hass):
+    """Test we get the form with import source."""
+    await hass.async_add_executor_job(
+        init_recorder_component, hass
+    )  # force in memory db
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    # Running the zeroconf init will make the unique id
+    # in progress
+    zero_conf = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data={
+            "properties": {"macaddress": "1CCAE3DOORBIRD"},
+            "name": "Doorstation - abc123._axis-video._tcp.local.",
+            "host": "192.168.1.5",
+        },
+    )
+    assert zero_conf["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert zero_conf["step_id"] == "user"
+    assert zero_conf["errors"] == {}
+
+    import_config = VALID_CONFIG.copy()
+    import_config[CONF_EVENTS] = ["event1", "event2", "event3"]
+    import_config[CONF_TOKEN] = "imported_token"
+    import_config[
+        CONF_CUSTOM_URL
+    ] = "http://legacy.custom.url/should/only/come/in/from/yaml"
+
+    doorbirdapi = _get_mock_doorbirdapi_return_values(
+        ready=[True], info={"WIFI_MAC_ADDR": "1CCAE3DOORBIRD"}
+    )
+    with patch(
+        "homeassistant.components.doorbird.config_flow.DoorBird",
+        return_value=doorbirdapi,
+    ), patch("homeassistant.components.logbook.async_setup", return_value=True), patch(
+        "homeassistant.components.doorbird.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.doorbird.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=import_config,
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "1.2.3.4"
+    assert result["data"] == {
+        "host": "1.2.3.4",
+        "name": "mydoorbird",
+        "password": "password",
+        "username": "friend",
+        "events": ["event1", "event2", "event3"],
+        "token": "imported_token",
+        # This will go away once we convert to cloud hooks
+        "hass_url_override": "http://legacy.custom.url/should/only/come/in/from/yaml",
+    }
+    # It is not possible to import options at this time
+    # so they end up in the config entry data and are
+    # used a fallback when they are not in options
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_form_zeroconf_wrong_oui(hass):
     """Test we abort when we get the wrong OUI via zeroconf."""
     await hass.async_add_executor_job(


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There is a race condition in the config flow where discovery would find the doorbird before the import happened which would abort the import as the unique id was already set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33837
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
