### PR TITLE
Fix vizio bug that occurs when CONF_APPS isn't in config entry options

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -126,7 +126,7 @@ class VizioOptionsConfigFlow(config_entries.OptionsFlow):
                 CONF_EXCLUDE
                 if self.config_entry.options
                 and CONF_EXCLUDE in self.config_entry.options.get(CONF_APPS, {})
-                else CONF_EXCLUDE
+                else CONF_INCLUDE
             )
             options.update(
                 {

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -125,7 +125,7 @@ class VizioOptionsConfigFlow(config_entries.OptionsFlow):
             default_include_or_exclude = (
                 CONF_EXCLUDE
                 if self.config_entry.options
-                and CONF_EXCLUDE in self.config_entry.options.get(CONF_APPS)
+                and CONF_EXCLUDE in self.config_entry.options.get(CONF_APPS, {})
                 else CONF_EXCLUDE
             )
             options.update(

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -177,7 +177,7 @@ async def test_tv_options_flow_with_apps(hass: HomeAssistantType) -> None:
 
 
 async def test_tv_options_flow_start_with_volume(hass: HomeAssistantType) -> None:
-    """Test options config flow for TV with providing apps option after providing volume step."""
+    """Test options config flow for TV with providing apps option after providing volume step in initial config."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_USER_VALID_TV_CONFIG,

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_C
 from homeassistant.components.vizio.config_flow import _get_config_schema
 from homeassistant.components.vizio.const import (
     CONF_APPS,
+    CONF_APPS_TO_INCLUDE_OR_EXCLUDE,
     CONF_INCLUDE,
     CONF_VOLUME_STEP,
     DEFAULT_NAME,
@@ -185,7 +186,10 @@ async def test_tv_options_flow_start_with_volume(hass: HomeAssistantType) -> Non
     )
     entry.add_to_hass(hass)
 
-    assert entry.options and entry.options == {CONF_VOLUME_STEP: VOLUME_STEP}
+    assert entry.options
+    assert entry.options == {CONF_VOLUME_STEP: VOLUME_STEP}
+    assert CONF_APPS not in entry.options
+    assert CONF_APPS_TO_INCLUDE_OR_EXCLUDE not in entry.options
 
     result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
 

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -176,6 +176,36 @@ async def test_tv_options_flow_with_apps(hass: HomeAssistantType) -> None:
     assert result["data"][CONF_APPS] == {CONF_INCLUDE: [CURRENT_APP]}
 
 
+async def test_tv_options_flow_start_with_volume(hass: HomeAssistantType) -> None:
+    """Test options config flow for TV with providing apps option after providing volume step."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_USER_VALID_TV_CONFIG,
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
+    )
+    entry.add_to_hass(hass)
+
+    assert entry.options and entry.options == {CONF_VOLUME_STEP: VOLUME_STEP}
+
+    result = await hass.config_entries.options.async_init(entry.entry_id, data=None)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    options = {CONF_VOLUME_STEP: VOLUME_STEP}
+    options.update(MOCK_INCLUDE_APPS)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=options
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == ""
+    assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
+    assert CONF_APPS in result["data"]
+    assert result["data"][CONF_APPS] == {CONF_INCLUDE: [CURRENT_APP]}
+
+
 async def test_user_host_already_configured(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,


### PR DESCRIPTION
## Proposed change
A  user reported an error (#33851) when `CONF_APPS` isn't in the config entry  options that causes the UI for options not to load. This fix sets a default when `CONF_APPS` isn't found (`{}`) which should prevent the error. This should be included in the next minor release that goes out for 0.108. I don't see a need to add a test for this because it's a straightforward bug with a straightforward fix, but I will add one if needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33851

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
