### PR TITLE
Fix Onvif Camera that does not have SnapshotUri such as Sricam

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -411,8 +411,11 @@ class ONVIFHassCamera(Camera):
             req = media_service.create_type("GetSnapshotUri")
             req.ProfileToken = profiles[self._profile_index].token
 
-            snapshot_uri = await media_service.GetSnapshotUri(req)
-            self._snapshot = snapshot_uri.Uri
+            try:
+                snapshot_uri = await media_service.GetSnapshotUri(req)
+                self._snapshot = snapshot_uri.Uri
+            except ServerDisconnectedError as err:
+                _LOGGER.debug("Camera does not support GetSnapshotUri: %s", err)
 
             _LOGGER.debug(
                 "ONVIF Camera Using the following URL for %s snapshot: %s",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change allow some ONVIF camera that does not have the GetSnapshotUri to work as in 0.107.7


## Logs I had before this patch :

```
2020-04-09 11:56:41 DEBUG (MainThread) [homeassistant.components.onvif.camera] Retrieving current camera date/time
2020-04-09 11:56:42 WARNING (MainThread) [homeassistant.components.onvif.camera] Couldn't get camera 'JustIN' date/time. Error: None
2020-04-09 11:56:42 DEBUG (MainThread) [homeassistant.components.onvif.camera] Connecting with ONVIF Camera: 192.168.1.52 on port 5000
2020-04-09 11:56:42 DEBUG (MainThread) [homeassistant.components.onvif.camera] Retrieving profiles
2020-04-09 11:56:44 DEBUG (MainThread) [homeassistant.components.onvif.camera] Retrieved '2' profiles
2020-04-09 11:56:44 DEBUG (MainThread) [homeassistant.components.onvif.camera] Using profile index '0'
2020-04-09 11:56:44 DEBUG (MainThread) [homeassistant.components.onvif.camera] Retrieving stream uri
2020-04-09 11:56:46 DEBUG (MainThread) [homeassistant.components.onvif.camera] ONVIF Camera Using the following URL for JustIN: rtsp://<user>:<password>@192.168.1.52:554/onvif1
2020-04-09 11:56:46 DEBUG (MainThread) [homeassistant.components.onvif.camera] Connecting with ONVIF Camera: 192.168.1.52 on port 5000
2020-04-09 11:56:46 DEBUG (MainThread) [homeassistant.components.onvif.camera] Retrieving profiles
2020-04-09 11:56:49 DEBUG (MainThread) [homeassistant.components.onvif.camera] Retrieved '2' profiles
2020-04-09 11:56:49 DEBUG (MainThread) [homeassistant.components.onvif.camera] Using profile index '0'
2020-04-09 11:56:49 DEBUG (MainThread) [homeassistant.components.onvif.camera] Retrieving snapshot uri
2020-04-09 11:56:51 WARNING (MainThread) [homeassistant.components.onvif.camera] Couldn't connect to camera 'JustIN', but will retry later. Error: None
```

I goes in python ClientConnectionError with err value "None".  This error is from the await self.async_obtain_snapshot_uri() that could not retrieve the snapshot uri.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
