### PR TITLE
Rename domain import in modbus

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -35,7 +35,7 @@ from .const import (
     CONF_PARITY,
     CONF_STOPBITS,
     DEFAULT_HUB,
-    MODBUS_DOMAIN,
+    MODBUS_DOMAIN as DOMAIN,
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
 )
@@ -68,7 +68,7 @@ ETHERNET_SCHEMA = BASE_SCHEMA.extend(
 )
 
 CONFIG_SCHEMA = vol.Schema(
-    {MODBUS_DOMAIN: vol.All(cv.ensure_list, [vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)])},
+    {DOMAIN: vol.All(cv.ensure_list, [vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)])},
     extra=vol.ALLOW_EXTRA,
 )
 
@@ -95,9 +95,9 @@ SERVICE_WRITE_COIL_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up Modbus component."""
-    hass.data[MODBUS_DOMAIN] = hub_collect = {}
+    hass.data[DOMAIN] = hub_collect = {}
 
-    for client_config in config[MODBUS_DOMAIN]:
+    for client_config in config[DOMAIN]:
         hub_collect[client_config[CONF_NAME]] = ModbusHub(client_config, hass.loop)
 
     def stop_modbus(event):
@@ -140,13 +140,13 @@ async def async_setup(hass, config):
 
     # Register services for modbus
     hass.services.async_register(
-        MODBUS_DOMAIN,
+        DOMAIN,
         SERVICE_WRITE_REGISTER,
         write_register,
         schema=SERVICE_WRITE_REGISTER_SCHEMA,
     )
     hass.services.async_register(
-        MODBUS_DOMAIN, SERVICE_WRITE_COIL, write_coil, schema=SERVICE_WRITE_COIL_SCHEMA,
+        DOMAIN, SERVICE_WRITE_COIL, write_coil, schema=SERVICE_WRITE_COIL_SCHEMA,
     )
     return True
 
@@ -204,7 +204,6 @@ class ModbusHub:
                 stopbits=self._config_stopbits,
                 bytesize=self._config_bytesize,
                 parity=self._config_parity,
-                timeout=self._config_timeout,
                 loop=self._loop,
             )
         elif self._config_type == "rtuovertcp":

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -11,7 +11,7 @@ from homeassistant.components.modbus.const import (
     CONF_REGISTER_TYPE,
     CONF_REGISTERS,
     DEFAULT_HUB,
-    MODBUS_DOMAIN,
+    DOMAIN,
 )
 from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_SCAN_INTERVAL
 from homeassistant.setup import async_setup_component
@@ -25,10 +25,10 @@ _LOGGER = logging.getLogger(__name__)
 @pytest.fixture()
 def mock_hub(hass):
     """Mock hub."""
-    mock_integration(hass, MockModule(MODBUS_DOMAIN))
+    mock_integration(hass, MockModule(DOMAIN))
     hub = mock.MagicMock()
     hub.name = "hub"
-    hass.data[MODBUS_DOMAIN] = {DEFAULT_HUB: hub}
+    hass.data[DOMAIN] = {DEFAULT_HUB: hub}
     return hub
 
 

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -11,7 +11,7 @@ from homeassistant.components.modbus.const import (
     CONF_REGISTER_TYPE,
     CONF_REGISTERS,
     DEFAULT_HUB,
-    DOMAIN,
+    MODBUS_DOMAIN as DOMAIN,
 )
 from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_SCAN_INTERVAL
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changed MODBUS_DOMAIN to DOMAIN,
the constant need to be named DOMAIN because homeassistant/config.py check for that name

This was identified when using packages and a double hub configuration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
A special thank to polcape, for helping pinning this bug down.

- This PR fixes or closes issue: fixes #
fixes #33873
- This PR is related to issue: 
#33872
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [x ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
