### PR TITLE
Exclude access token from host info updates in Konnected config flow

### DIFF
--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -283,11 +283,6 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # build config info and wait for user confirmation
             self.data[CONF_HOST] = user_input[CONF_HOST]
             self.data[CONF_PORT] = user_input[CONF_PORT]
-            self.data[CONF_ACCESS_TOKEN] = self.hass.data.get(DOMAIN, {}).get(
-                CONF_ACCESS_TOKEN
-            ) or "".join(
-                random.choices(f"{string.ascii_uppercase}{string.digits}", k=20)
-            )
 
             # brief delay to allow processing of recent status req
             await asyncio.sleep(0.1)
@@ -343,8 +338,12 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        # Attach default options and create entry
+        # Create access token, attach default options and create entry
         self.data[CONF_DEFAULT_OPTIONS] = self.options
+        self.data[CONF_ACCESS_TOKEN] = self.hass.data.get(DOMAIN, {}).get(
+            CONF_ACCESS_TOKEN
+        ) or "".join(random.choices(f"{string.ascii_uppercase}{string.digits}", k=20))
+
         return self.async_create_entry(
             title=KONN_PANEL_MODEL_NAMES[self.data[CONF_MODEL]], data=self.data,
         )

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -494,6 +494,7 @@ async def test_import_existing_config_entry(hass, mock_panel):
         data={
             "host": "0.0.0.0",
             "port": 1111,
+            "access_token": "ORIGINALTOKEN",
             "id": "112233445566",
             "extra": "something",
         },
@@ -546,14 +547,14 @@ async def test_import_existing_config_entry(hass, mock_panel):
 
     assert result["type"] == "abort"
 
-    # We should have updated the entry
+    # We should have updated the host info but not the access token
     assert len(hass.config_entries.async_entries("konnected")) == 1
     assert hass.config_entries.async_entries("konnected")[0].data == {
         "host": "1.2.3.4",
         "port": 1234,
+        "access_token": "ORIGINALTOKEN",
         "id": "112233445566",
         "model": "Konnected Pro",
-        "access_token": "SUPERSECRETTOKEN",
         "extra": "something",
     }
 

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -362,10 +362,11 @@ async def test_ssdp_host_update(hass, mock_panel):
     )
     assert result["type"] == "abort"
 
-    # confirm the host value was updated
+    # confirm the host value was updated, access_token was not
     entry = hass.config_entries.async_entries(config_flow.DOMAIN)[0]
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["port"] == 1234
+    assert entry.data["access_token"] == "11223344556677889900"
 
 
 async def test_import_existing_config(hass, mock_panel):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the Konnected config flow we want to automatically update the host info for a konnected config entry if SSDP indicates it changed.  When updating host info we were also including a randomly generated access token in the self.data object passed to `self._abort_if_unique_id_configured(updates=self.data)`. This was causing config entry updates even though the host info did not change.

In most cases this is fine as the config entry gets reloaded and the new access token is sent to the panel.  However a race condition can occur where the reload is called after the konnected component is loaded, but before it's platforms are not yet loaded.  Causing this error

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 295, in async_unload
    hass, self
  File "/usr/src/homeassistant/homeassistant/components/binary_sensor/__init__.py", line 138, in async_unload_entry
    return await hass.data[DOMAIN].async_unload_entry(entry)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 180, in async_unload_entry
    raise ValueError("Config entry was never loaded!")
ValueError: Config entry was never loaded!
```

When this happens the reload fails such that the panel is using the old access token but the config_entry contains the new access token.  This effectively blocks any updates from the panel until the config_entry is reloaded (via a restart or manually via the integrations UI) and sends the updated settings to the panel.

This PR defers creation of the access_token during the konnected config flow so that it is not included as part of the host info changes.  This prevents the panels from being orphaned if host info changes and also prevents the unnecessary config entry updates stemming from the changed access token.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33905 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
