### PR TITLE
Discover manually added casts

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -55,7 +55,7 @@ from .const import (
     SIGNAL_CAST_REMOVED,
     SIGNAL_HASS_CAST_SHOW_VIEW,
 )
-from .discovery import discover_chromecast, setup_internal_discovery
+from .discovery import setup_internal_discovery
 from .helpers import (
     CastStatusListener,
     ChromecastInfo,
@@ -178,20 +178,7 @@ async def _async_setup_platform(
     for chromecast in list(hass.data[KNOWN_CHROMECAST_INFO_KEY]):
         async_cast_discovered(chromecast)
 
-    if info is None or info.is_audio_group:
-        # If we were a) explicitly told to enable discovery or
-        # b) have an audio group cast device, we need internal discovery.
-        hass.async_add_executor_job(setup_internal_discovery, hass)
-    else:
-        info = await hass.async_add_executor_job(info.fill_out_missing_chromecast_info)
-        if info.friendly_name is None:
-            _LOGGER.debug(
-                "Cannot retrieve detail information for chromecast"
-                " %s, the device may not be online",
-                info,
-            )
-
-        hass.async_add_executor_job(discover_chromecast, hass, info)
+    hass.async_add_executor_job(setup_internal_discovery, hass)
 
 
 class CastDevice(MediaPlayerDevice):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Connecting to Cast devices now depends on mDNS even when IP
addresses of the Cast Devices are manually entered.

There are some trouble shooting hints in the [discovery docs](https://www.home-assistant.io/integrations/discovery/#mdns-and-upnp) in case mDNS is not working.

Not relying on mDNS had the following issues:

- Broken behavior if a cast device added by its IP was not available when HA started (this PR)
- Multiple code paths for adding cast devices
- Google has made changes to the local API recently which means mDNS is needed to get device information such as model name

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix bugs where manually added casts which are down when HA is started would not have unique_id set.
Instead of trying to connect to the manually added cast using `setup/eureka_info` to get UUID, wait for mdns discovery of the manually added cast.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28128

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
