### PR TITLE
deCONZ - Always allow manual input of gateway

### DIFF
--- a/homeassistant/components/deconz/.translations/en.json
+++ b/homeassistant/components/deconz/.translations/en.json
@@ -17,16 +17,23 @@
                 "description": "Do you want to configure Home Assistant to connect to the deCONZ gateway provided by the Hass.io add-on {addon}?",
                 "title": "deCONZ Zigbee gateway via Hass.io add-on"
             },
-            "init": {
+            "user": {
                 "data": {
-                    "host": "Host",
-                    "port": "Port"
+                    "host": "Select discovered deCONZ gateway",
+                    "manual_input": "Configure deCONZ gateway manually"
                 },
-                "title": "Define deCONZ gateway"
+                "title": "Select deCONZ gateway"
             },
             "link": {
                 "description": "Unlock your deCONZ gateway to register with Home Assistant.\n\n1. Go to deCONZ Settings -> Gateway -> Advanced\n2. Press \"Authenticate app\" button",
                 "title": "Link with deCONZ"
+            },
+            "manual_input": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "title": "Configure deCONZ gateway"
             }
         }
     },

--- a/homeassistant/components/deconz/.translations/en.json
+++ b/homeassistant/components/deconz/.translations/en.json
@@ -19,8 +19,7 @@
             },
             "user": {
                 "data": {
-                    "host": "Select discovered deCONZ gateway",
-                    "manual_input": "Configure deCONZ gateway manually"
+                    "host": "Select discovered deCONZ gateway"
                 },
                 "title": "Select deCONZ gateway"
             },

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -32,7 +32,7 @@ from .const import (
 
 DECONZ_MANUFACTURERURL = "http://www.dresden-elektronik.de"
 CONF_SERIAL = "serial"
-CONF_MANUAL_INPUT = "manual_input"
+CONF_MANUAL_INPUT = "Manually define gateway"
 
 
 @callback
@@ -71,18 +71,17 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """
         if user_input is not None:
 
-            if user_input.get(CONF_MANUAL_INPUT):
+            if CONF_MANUAL_INPUT == user_input[CONF_HOST]:
                 return await self.async_step_manual_input()
 
-            if CONF_HOST in user_input:
-                for bridge in self.bridges:
-                    if bridge[CONF_HOST] == user_input[CONF_HOST]:
-                        self.bridge_id = bridge[CONF_BRIDGE_ID]
-                        self.deconz_config = {
-                            CONF_HOST: bridge[CONF_HOST],
-                            CONF_PORT: bridge[CONF_PORT],
-                        }
-                        return await self.async_step_link()
+            for bridge in self.bridges:
+                if bridge[CONF_HOST] == user_input[CONF_HOST]:
+                    self.bridge_id = bridge[CONF_BRIDGE_ID]
+                    self.deconz_config = {
+                        CONF_HOST: bridge[CONF_HOST],
+                        CONF_PORT: bridge[CONF_PORT],
+                    }
+                    return await self.async_step_link()
 
         session = aiohttp_client.async_get_clientsession(self.hass)
 
@@ -101,14 +100,11 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             for bridge in self.bridges:
                 hosts.append(bridge[CONF_HOST])
 
+            hosts.append(CONF_MANUAL_INPUT)
+
             return self.async_show_form(
                 step_id="user",
-                data_schema=vol.Schema(
-                    {
-                        vol.Optional(CONF_HOST): vol.In(hosts),
-                        vol.Optional(CONF_MANUAL_INPUT): bool,
-                    }
-                ),
+                data_schema=vol.Schema({vol.Optional(CONF_HOST): vol.In(hosts)}),
             )
 
         return await self.async_step_manual_input()

--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -2,9 +2,18 @@
   "config": {
     "flow_title": "deCONZ Zigbee gateway ({host})",
     "step": {
-      "init": {
-        "title": "Define deCONZ gateway",
-        "data": { "host": "Host", "port": "Port" }
+      "user": {
+        "title": "Select deCONZ gateway",
+        "data": {
+          "host": "Select discovered deCONZ gateway"
+        }
+      },
+      "manual_input": {
+        "title": "Configure deCONZ gateway",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
       },
       "link": {
         "title": "Link with deCONZ",

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -7,6 +7,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components import ssdp
 from homeassistant.components.deconz import config_flow
 from homeassistant.components.deconz.config_flow import (
+    CONF_MANUAL_INPUT,
     CONF_SERIAL,
     DECONZ_MANUFACTURERURL,
 )
@@ -21,16 +22,26 @@ from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from .test_gateway import API_KEY, BRIDGEID, setup_deconz_integration
 
 
-async def test_flow_1_discovered_bridge(hass, aioclient_mock):
-    """Test that config flow for one discovered bridge works."""
+async def test_flow_discovered_bridges(hass, aioclient_mock):
+    """Test that config flow works for discovered bridges."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
-        json=[{"id": BRIDGEID, "internalipaddress": "1.2.3.4", "internalport": 80}],
+        json=[
+            {"id": BRIDGEID, "internalipaddress": "1.2.3.4", "internalport": 80},
+            {"id": "1234E567890A", "internalipaddress": "5.6.7.8", "internalport": 80},
+        ],
         headers={"content-type": "application/json"},
     )
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: "1.2.3.4"}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -55,14 +66,11 @@ async def test_flow_1_discovered_bridge(hass, aioclient_mock):
     }
 
 
-async def test_flow_2_discovered_bridges(hass, aioclient_mock):
-    """Test that config flow works for multiple discovered bridges."""
+async def test_flow_manual_configuration_decision(hass, aioclient_mock):
+    """Test that config flow for one discovered bridge works."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
-        json=[
-            {"id": BRIDGEID, "internalipaddress": "1.2.3.4", "internalport": 80},
-            {"id": "1234E567890A", "internalipaddress": "5.6.7.8", "internalport": 80},
-        ],
+        json=[{"id": BRIDGEID, "internalipaddress": "1.2.3.4", "internalport": 80}],
         headers={"content-type": "application/json"},
     )
 
@@ -70,11 +78,15 @@ async def test_flow_2_discovered_bridges(hass, aioclient_mock):
         DOMAIN, context={"source": "user"}
     )
 
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_MANUAL_INPUT: True}
+    )
+
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_HOST: "1.2.3.4"}
+        result["flow_id"], user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -83,6 +95,12 @@ async def test_flow_2_discovered_bridges(hass, aioclient_mock):
     aioclient_mock.post(
         "http://1.2.3.4:80/api",
         json=[{"success": {"username": API_KEY}}],
+        headers={"content-type": "application/json"},
+    )
+
+    aioclient_mock.get(
+        f"http://1.2.3.4:80/api/{API_KEY}/config",
+        json={"bridgeid": BRIDGEID},
         headers={"content-type": "application/json"},
     )
 
@@ -112,7 +130,7 @@ async def test_flow_manual_configuration(hass, aioclient_mock):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
@@ -155,7 +173,7 @@ async def test_manual_configuration_after_discovery_timeout(hass, aioclient_mock
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "manual_input"
     assert not hass.config_entries.flow._progress[result["flow_id"]].bridges
 
 
@@ -168,7 +186,7 @@ async def test_manual_configuration_after_discovery_ResponseError(hass, aioclien
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "manual_input"
     assert not hass.config_entries.flow._progress[result["flow_id"]].bridges
 
 
@@ -187,7 +205,7 @@ async def test_manual_configuration_update_configuration(hass, aioclient_mock):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "2.3.4.5", CONF_PORT: 80},
@@ -232,7 +250,7 @@ async def test_manual_configuration_dont_update_configuration(hass, aioclient_mo
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
@@ -274,7 +292,7 @@ async def test_manual_configuration_timeout_get_bridge(hass, aioclient_mock):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "manual_input"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "1.2.3.4", CONF_PORT: 80},
@@ -311,6 +329,10 @@ async def test_link_get_api_key_ResponseError(hass, aioclient_mock):
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: "1.2.3.4"}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -79,7 +79,7 @@ async def test_flow_manual_configuration_decision(hass, aioclient_mock):
     )
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_MANUAL_INPUT: True}
+        result["flow_id"], user_input={CONF_HOST: CONF_MANUAL_INPUT}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow manual configuration of gateway regardless of presence of other discovered bridges
This removes step_init which was previously used to keep translations available. With this PR the strings are changed anyway so need new translations and thus can step_init be removed. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33886
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
