### PR TITLE
Fix powerwall units (kW)

### DIFF
--- a/homeassistant/components/powerwall/binary_sensor.py
+++ b/homeassistant/components/powerwall/binary_sensor.py
@@ -129,7 +129,7 @@ class PowerWallGridStatusSensor(PowerWallEntity, BinarySensorDevice):
 
     @property
     def is_on(self):
-        """Get the current value in kWh."""
+        """Grid is online."""
         return (
             self._coordinator.data[POWERWALL_API_GRID_STATUS] == POWERWALL_GRID_ONLINE
         )

--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -2,12 +2,10 @@
 
 DOMAIN = "powerwall"
 
-POWERWALL_SITE_NAME = "site_name"
-
 POWERWALL_OBJECT = "powerwall"
 POWERWALL_COORDINATOR = "coordinator"
 
-UPDATE_INTERVAL = 60
+UPDATE_INTERVAL = 30
 
 ATTR_REGION = "region"
 ATTR_GRID_CODE = "grid_code"
@@ -46,3 +44,5 @@ POWERWALL_RUNNING_KEY = "running"
 
 MODEL = "PowerWall 2"
 MANUFACTURER = "Tesla"
+
+ENERGY_KILO_WATT = "kW"

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -4,7 +4,6 @@ import logging
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_POWER,
-    ENERGY_KILO_WATT_HOUR,
     UNIT_PERCENTAGE,
 )
 
@@ -14,6 +13,7 @@ from .const import (
     ATTR_FREQUENCY,
     ATTR_INSTANT_AVERAGE_VOLTAGE,
     DOMAIN,
+    ENERGY_KILO_WATT,
     POWERWALL_API_CHARGE,
     POWERWALL_API_DEVICE_TYPE,
     POWERWALL_API_METERS,
@@ -87,7 +87,7 @@ class PowerWallEnergySensor(PowerWallEntity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
+        return ENERGY_KILO_WATT
 
     @property
     def name(self):
@@ -106,7 +106,7 @@ class PowerWallEnergySensor(PowerWallEntity):
 
     @property
     def state(self):
-        """Get the current value in kWh."""
+        """Get the current value in kW."""
         meter = self._coordinator.data[POWERWALL_API_METERS][self._meter]
         return round(float(meter.instant_power / 1000), 3)
 

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -39,13 +39,14 @@ async def test_sensors(hass):
         "energy_exported": 10429451.9916853,
         "energy_imported": 4824191.60668611,
         "instant_average_voltage": 120.650001525879,
-        "unit_of_measurement": "kWh",
+        "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Site Now",
         "device_class": "power",
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
-    assert all(item in state.attributes.items() for item in expected_attributes.items())
+    for key, value in expected_attributes.items():
+        assert state.attributes[key] == value
 
     state = hass.states.get("sensor.powerwall_load_now")
     assert state.state == "1.971"
@@ -54,13 +55,14 @@ async def test_sensors(hass):
         "energy_exported": 1056797.48917483,
         "energy_imported": 4692987.91889705,
         "instant_average_voltage": 120.650001525879,
-        "unit_of_measurement": "kWh",
+        "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Load Now",
         "device_class": "power",
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
-    assert all(item in state.attributes.items() for item in expected_attributes.items())
+    for key, value in expected_attributes.items():
+        assert state.attributes[key] == value
 
     state = hass.states.get("sensor.powerwall_battery_now")
     assert state.state == "-8.55"
@@ -69,13 +71,14 @@ async def test_sensors(hass):
         "energy_exported": 3620010,
         "energy_imported": 4216170,
         "instant_average_voltage": 240.56,
-        "unit_of_measurement": "kWh",
+        "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Battery Now",
         "device_class": "power",
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
-    assert all(item in state.attributes.items() for item in expected_attributes.items())
+    for key, value in expected_attributes.items():
+        assert state.attributes[key] == value
 
     state = hass.states.get("sensor.powerwall_solar_now")
     assert state.state == "10.49"
@@ -84,13 +87,14 @@ async def test_sensors(hass):
         "energy_exported": 9864205.82222448,
         "energy_imported": 28177.5358355867,
         "instant_average_voltage": 120.685001373291,
-        "unit_of_measurement": "kWh",
+        "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Solar Now",
         "device_class": "power",
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
-    assert all(item in state.attributes.items() for item in expected_attributes.items())
+    for key, value in expected_attributes.items():
+        assert state.attributes[key] == value
 
     state = hass.states.get("sensor.powerwall_charge")
     assert state.state == "47.32"
@@ -101,4 +105,5 @@ async def test_sensors(hass):
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
-    assert all(item in state.attributes.items() for item in expected_attributes.items())
+    for key, value in expected_attributes.items():
+        assert state.attributes[key] == value


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix powerwall units (kW)

The scan interval was too low to detect power outages in a storm.

Minor cleanups to code (docstring, dupe const, etc)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33943
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
