### PR TITLE
Remove MAC lookup for minecraft server

### DIFF
--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -1,8 +1,4 @@
 """Config flow for Minecraft Server integration."""
-from functools import partial
-import ipaddress
-
-import getmac
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -69,9 +65,7 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                     unique_id = ""
                     title = f"{host}:{port}"
                     # Check if 'host' is a valid SRV record.
-                    srv_record = await helpers.async_check_srv_record(
-                        self.hass, host
-                    )
+                    srv_record = await helpers.async_check_srv_record(self.hass, host)
                     if srv_record is not None:
                         # Use only SRV host name in unique_id (does not change).
                         unique_id = f"{host}-srv"

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -41,9 +41,6 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                 except ValueError:
                     pass  # 'port' is already set to default value.
 
-            # Remove '[' and ']' in case of an IPv6 address.
-            host = host.strip("[]")
-
             # Validate port configuration (limit to user and dynamic port range).
             if (port < 1024) or (port > 65535):
                 errors["base"] = "invalid_port"

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -90,17 +90,6 @@ async def test_show_config_form(hass: HomeAssistantType) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_invalid_ip(hass: HomeAssistantType) -> None:
-    """Test error in case of an invalid IP address."""
-    with patch("getmac.get_mac_address", return_value=None):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV4
-        )
-
-        assert result["type"] == RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "invalid_ip"}
-
-
 async def test_same_host(hass: HomeAssistantType) -> None:
     """Test abort in case of same host name."""
     with patch(
@@ -209,39 +198,33 @@ async def test_connection_succeeded_with_host(hass: HomeAssistantType) -> None:
 
 async def test_connection_succeeded_with_ip4(hass: HomeAssistantType) -> None:
     """Test config entry in case of a successful connection with an IPv4 address."""
-    with patch("getmac.get_mac_address", return_value="01:23:45:67:89:ab"):
+    with patch("aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError):
         with patch(
-            "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
+            "mcstatus.server.MinecraftServer.status",
+            return_value=PingResponse(STATUS_RESPONSE_RAW),
         ):
-            with patch(
-                "mcstatus.server.MinecraftServer.status",
-                return_value=PingResponse(STATUS_RESPONSE_RAW),
-            ):
-                result = await hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV4
-                )
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV4
+            )
 
-                assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-                assert result["title"] == USER_INPUT_IPV4[CONF_HOST]
-                assert result["data"][CONF_NAME] == USER_INPUT_IPV4[CONF_NAME]
-                assert result["data"][CONF_HOST] == "1.1.1.1"
+            assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == USER_INPUT_IPV4[CONF_HOST]
+            assert result["data"][CONF_NAME] == USER_INPUT_IPV4[CONF_NAME]
+            assert result["data"][CONF_HOST] == "1.1.1.1"
 
 
 async def test_connection_succeeded_with_ip6(hass: HomeAssistantType) -> None:
     """Test config entry in case of a successful connection with an IPv6 address."""
-    with patch("getmac.get_mac_address", return_value="01:23:45:67:89:ab"):
+    with patch("aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError):
         with patch(
-            "aiodns.DNSResolver.query", side_effect=aiodns.error.DNSError,
+            "mcstatus.server.MinecraftServer.status",
+            return_value=PingResponse(STATUS_RESPONSE_RAW),
         ):
-            with patch(
-                "mcstatus.server.MinecraftServer.status",
-                return_value=PingResponse(STATUS_RESPONSE_RAW),
-            ):
-                result = await hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV6
-                )
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV6
+            )
 
-                assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-                assert result["title"] == USER_INPUT_IPV6[CONF_HOST]
-                assert result["data"][CONF_NAME] == USER_INPUT_IPV6[CONF_NAME]
-                assert result["data"][CONF_HOST] == "::ffff:0101:0101"
+            assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+            assert result["title"] == USER_INPUT_IPV6[CONF_HOST]
+            assert result["data"][CONF_NAME] == USER_INPUT_IPV6[CONF_NAME]
+            assert result["data"][CONF_HOST] == "::ffff:0101:0101"

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -227,4 +227,4 @@ async def test_connection_succeeded_with_ip6(hass: HomeAssistantType) -> None:
             assert result["type"] == RESULT_TYPE_CREATE_ENTRY
             assert result["title"] == "[::ffff:0101:0101]:25565"
             assert result["data"][CONF_NAME] == USER_INPUT_IPV6[CONF_NAME]
-            assert result["data"][CONF_HOST] == "::ffff:0101:0101"
+            assert result["data"][CONF_HOST] == "[::ffff:0101:0101]"

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -225,6 +225,6 @@ async def test_connection_succeeded_with_ip6(hass: HomeAssistantType) -> None:
             )
 
             assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-            assert result["title"] == USER_INPUT_IPV6[CONF_HOST]
+            assert result["title"] == "[::ffff:0101:0101]:25565"
             assert result["data"][CONF_NAME] == USER_INPUT_IPV6[CONF_NAME]
             assert result["data"][CONF_HOST] == "::ffff:0101:0101"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Minecraft servers no longer rely on the MAC address of the server as a unique identifier when using an IP address to access the host.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding a Minecraft server will fail if the server uses an IP address but is not on the same layer 2 network. Local addresses and DNS names work fine, this functionality has not changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33955
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
