### PR TITLE
Fix onvif writing to closing transport

### DIFF
--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for ONVIF."""
+import asyncio
 from pprint import pformat
 from typing import List
 from urllib.parse import urlparse
@@ -191,13 +192,12 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.onvif_config[CONF_USERNAME],
             self.onvif_config[CONF_PASSWORD],
         )
-
         await device.update_xaddrs()
-
         try:
             # Get the MAC address to use as the unique ID for the config flow
             if not self.device_id:
                 devicemgmt = device.create_devicemgmt_service()
+                await asyncio.sleep(0.1)
                 network_interfaces = await devicemgmt.GetNetworkInterfaces()
                 for interface in network_interfaces:
                     if interface.Enabled:
@@ -217,6 +217,7 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Verify there is an H264 profile
             media_service = device.create_media_service()
+            await asyncio.sleep(0.1)
             profiles = await media_service.GetProfiles()
             h264 = any(
                 profile.VideoEncoderConfiguration.Encoding == "H264"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
(Probably) cheaper cameras do not seem to close the request quickly enough, resulting in it being closed while the next request is being made. First i saw duplicate code doing the same thing, retrieving profiles unnecessarily. So i made a helper function to retrieve the profile and save it to serve it next time this function gets called.

Then when multiple requests were being made in very quick succession the second request would fail with "Cannot write to closing transport". When i add a wait of 0.1s to this the transport will have been closed and a new one can be created.

Run less unnecessary requests, wait a little longer to allow camera to close the request before opening next request.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml
# Example configuration.yaml
camera:
  - platform: onvif
    host: 192.168.1.111
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33065
- This PR is related to issue: #33007
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
