### PR TITLE
Cleanup ZHA group entity lifecycle

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -32,6 +32,7 @@ from .core.const import (
     SIGNAL_ADD_ENTITIES,
     RadioType,
 )
+from .core.discovery import GROUP_PROBE
 
 DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({vol.Optional(ha_const.CONF_TYPE): cv.string})
 
@@ -138,6 +139,7 @@ async def async_unload_entry(hass, config_entry):
     """Unload ZHA config entry."""
     await hass.data[DATA_ZHA][DATA_ZHA_GATEWAY].shutdown()
 
+    GROUP_PROBE.cleanup()
     api.async_unload_api(hass)
 
     dispatchers = hass.data[DATA_ZHA].get(DATA_ZHA_DISPATCHERS, [])

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -213,6 +213,7 @@ SIGNAL_SET_LEVEL = "set_level"
 SIGNAL_STATE_ATTR = "update_state_attribute"
 SIGNAL_UPDATE_DEVICE = "{}_zha_update_device"
 SIGNAL_REMOVE_GROUP = "remove_group"
+SIGNAL_GROUP_ENTITY_REMOVED = "group_entity_removed"
 SIGNAL_GROUP_MEMBERSHIP_CHANGE = "group_membership_change"
 
 UNKNOWN = "unknown"

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -561,7 +561,15 @@ class ZHADevice(LogMixin):
 
     async def async_remove_from_group(self, group_id):
         """Remove this device from the provided zigbee group."""
-        await self._zigpy_device.remove_from_group(group_id)
+        try:
+            await self._zigpy_device.remove_from_group(group_id)
+        except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
+            self.debug(
+                "Failed to remove device '%s' from group: 0x%04x ex: %s",
+                self._zigpy_device.ieee,
+                group_id,
+                str(ex),
+            )
 
     async def async_bind_to_group(self, group_id, cluster_bindings):
         """Directly bind this device to a group for the given clusters."""

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -36,7 +36,7 @@ ENTITY_SUFFIX = "entity_suffix"
 RESTART_GRACE_PERIOD = 7200  # 2 hours
 
 
-class BaseZhaEntity(RestoreEntity, LogMixin, entity.Entity):
+class BaseZhaEntity(LogMixin, entity.Entity):
     """A base class for ZHA entities."""
 
     def __init__(self, unique_id: str, zha_device: ZhaDeviceType, **kwargs):
@@ -117,28 +117,11 @@ class BaseZhaEntity(RestoreEntity, LogMixin, entity.Entity):
     def async_set_state(self, attr_id: int, attr_name: str, value: Any) -> None:
         """Set the entity state."""
 
-    async def async_added_to_hass(self) -> None:
-        """Run when about to be added to hass."""
-        await super().async_added_to_hass()
-        self.remove_future = asyncio.Future()
-        await self.async_accept_signal(
-            None,
-            f"{SIGNAL_REMOVE}_{self.zha_device.ieee}",
-            self.async_remove,
-            signal_override=True,
-        )
-
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect entity object when removed."""
         for unsub in self._unsubs[:]:
             unsub()
             self._unsubs.remove(unsub)
-        self.zha_device.gateway.remove_entity_reference(self)
-        self.remove_future.set_result(True)
-
-    @callback
-    def async_restore_last_state(self, last_state) -> None:
-        """Restore previous state."""
 
     async def async_accept_signal(
         self, channel: ChannelType, signal: str, func: CALLABLE_T, signal_override=False
@@ -160,7 +143,7 @@ class BaseZhaEntity(RestoreEntity, LogMixin, entity.Entity):
         _LOGGER.log(level, msg, *args)
 
 
-class ZhaEntity(BaseZhaEntity):
+class ZhaEntity(BaseZhaEntity, RestoreEntity):
     """A base class for non group ZHA entities."""
 
     def __init__(
@@ -183,6 +166,13 @@ class ZhaEntity(BaseZhaEntity):
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
         await super().async_added_to_hass()
+        self.remove_future = asyncio.Future()
+        await self.async_accept_signal(
+            None,
+            f"{SIGNAL_REMOVE}_{self.zha_device.ieee}",
+            self.async_remove,
+            signal_override=True,
+        )
         await self.async_check_recently_seen()
         await self.async_accept_signal(
             None,
@@ -198,6 +188,16 @@ class ZhaEntity(BaseZhaEntity):
             self.device_info,
             self.remove_future,
         )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect entity object when removed."""
+        await super().async_will_remove_from_hass()
+        self.zha_device.gateway.remove_entity_reference(self)
+        self.remove_future.set_result(True)
+
+    @callback
+    def async_restore_last_state(self, last_state) -> None:
+        """Restore previous state."""
 
     async def async_check_recently_seen(self) -> None:
         """Check if the device was seen within the last 2 hours."""

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -8,7 +8,10 @@ from typing import Any, Awaitable, Dict, List, Optional
 from homeassistant.core import CALLBACK_TYPE, State, callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -19,6 +22,7 @@ from .core.const import (
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
     DOMAIN,
+    SIGNAL_GROUP_ENTITY_REMOVED,
     SIGNAL_GROUP_MEMBERSHIP_CHANGE,
     SIGNAL_REMOVE,
     SIGNAL_REMOVE_GROUP,
@@ -244,13 +248,20 @@ class ZhaGroupEntity(BaseZhaEntity):
         await self.async_accept_signal(
             None,
             f"{SIGNAL_GROUP_MEMBERSHIP_CHANGE}_0x{self._group_id:04x}",
-            self._update_group_entities,
+            self.async_remove,
             signal_override=True,
         )
 
         self._async_unsub_state_changed = async_track_state_change(
             self.hass, self._entity_ids, self.async_state_changed_listener
         )
+
+        def send_removed_signal():
+            async_dispatcher_send(
+                self.hass, SIGNAL_GROUP_ENTITY_REMOVED, self._group_id
+            )
+
+        self.async_on_remove(send_removed_signal)
         await self.async_update()
 
     @callback
@@ -259,17 +270,6 @@ class ZhaGroupEntity(BaseZhaEntity):
     ):
         """Handle child updates."""
         self.async_schedule_update_ha_state(True)
-
-    def _update_group_entities(self):
-        """Update tracked entities when membership changes."""
-        group = self.zha_device.gateway.get_group(self._group_id)
-        self._entity_ids = group.get_domain_entity_ids(self.platform.domain)
-        if self._async_unsub_state_changed is not None:
-            self._async_unsub_state_changed()
-
-        self._async_unsub_state_changed = async_track_state_change(
-            self.hass, self._entity_ids, self.async_state_changed_listener
-        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Handle removal from Home Assistant."""

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -539,3 +539,21 @@ async def async_test_zha_group_light_entity(
     await zha_group.async_add_members([device_light_3.ieee])
     await dev3_cluster_on_off.on()
     assert hass.states.get(entity_id).state == STATE_ON
+
+    # make the group have only 1 member and now there should be no entity
+    await zha_group.async_remove_members([device_light_2.ieee, device_light_3.ieee])
+    assert len(zha_group.members) == 1
+    assert hass.states.get(entity_id).state is None
+    # make sure the entity registry entry is still there
+    assert zha_gateway.ha_entity_registry.async_get(entity_id) is not None
+
+    # add a member back and ensure that the group entity was created again
+    await zha_group.async_add_members([device_light_3.ieee])
+    await dev3_cluster_on_off.on()
+    assert hass.states.get(entity_id).state == STATE_ON
+
+    # remove the group and ensure that there is no entity and that the entity registry is cleaned up
+    assert zha_gateway.ha_entity_registry.async_get(entity_id) is not None
+    await zha_gateway.async_remove_zigpy_group(zha_group.group_id)
+    assert hass.states.get(entity_id).state is None
+    assert zha_gateway.ha_entity_registry.async_get(entity_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
No


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR closes some holes in the ZHA group entity lifecycle. The PR does the following:

- Move state restore from the BaseZhaEntity to ZhaEntity because groups shouldn't restore state
- Cleans up the entity registry when a group is removed
- re-probes groups when members are added or removed ensuring that we always add or remove entities as needed 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33920
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
