### PR TITLE
Read min and max mireds from ZHA lights

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -41,6 +41,18 @@ class ColorChannel(ZigbeeChannel):
         """Initialize ColorChannel."""
         super().__init__(cluster, ch_pool)
         self._color_capabilities = None
+        self._min_mireds = None
+        self._max_mireds = None
+
+    @property
+    def min_mireds(self):
+        """Return the coldest color_temp that this channel supports."""
+        return self._min_mireds
+
+    @property
+    def max_mireds(self):
+        """Return the warmest color_temp that this channel supports."""
+        return self._max_mireds
 
     def get_color_capabilities(self):
         """Return the color capabilities."""
@@ -59,9 +71,15 @@ class ColorChannel(ZigbeeChannel):
 
     async def fetch_color_capabilities(self, from_cache):
         """Get the color configuration."""
-        capabilities = await self.get_attribute_value(
-            "color_capabilities", from_cache=from_cache
-        )
+        attributes = [
+            "color_temp_physical_min",
+            "color_temp_physical_max",
+            "color_capabilities",
+        ]
+        results = await self.get_attributes(attributes, from_cache=from_cache)
+        capabilities = results.get("color_capabilities")
+        self._min_mireds = results.get("color_temp_physical_min", 153)
+        self._max_mireds = results.get("color_temp_physical_max", 500)
 
         if capabilities is None:
             # ZCL Version 4 devices don't support the color_capabilities

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -41,8 +41,8 @@ class ColorChannel(ZigbeeChannel):
         """Initialize ColorChannel."""
         super().__init__(cluster, ch_pool)
         self._color_capabilities = None
-        self._min_mireds = None
-        self._max_mireds = None
+        self._min_mireds = 153
+        self._max_mireds = 500
 
     @property
     def min_mireds(self):

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -329,9 +329,6 @@ class Light(BaseLight, ZhaEntity):
         if self._color_channel:
             self._min_mireds: Optional[int] = self._color_channel.min_mireds
             self._max_mireds: Optional[int] = self._color_channel.max_mireds
-        else:
-            self._min_mireds: Optional[int] = 153
-            self._max_mireds: Optional[int] = 500
         self._cancel_refresh_handle = None
         effect_list = []
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -108,7 +108,7 @@ class BaseLight(LogMixin, light.Light):
         self._off_brightness: Optional[int] = None
         self._hs_color: Optional[Tuple[float, float]] = None
         self._color_temp: Optional[int] = None
-        self._min_mireds: Optional[int] = 154
+        self._min_mireds: Optional[int] = 153
         self._max_mireds: Optional[int] = 500
         self._white_value: Optional[int] = None
         self._effect_list: Optional[List[str]] = None
@@ -137,6 +137,16 @@ class BaseLight(LogMixin, light.Light):
     def brightness(self):
         """Return the brightness of this light."""
         return self._brightness
+
+    @property
+    def min_mireds(self):
+        """Return the coldest color_temp that this light supports."""
+        return self._min_mireds
+
+    @property
+    def max_mireds(self):
+        """Return the warmest color_temp that this light supports."""
+        return self._max_mireds
 
     def set_level(self, value):
         """Set the brightness of this light between 0..254.
@@ -316,6 +326,12 @@ class Light(BaseLight, ZhaEntity):
         self._level_channel = self.cluster_channels.get(CHANNEL_LEVEL)
         self._color_channel = self.cluster_channels.get(CHANNEL_COLOR)
         self._identify_channel = self.zha_device.channels.identify_ch
+        if self._color_channel:
+            self._min_mireds: Optional[int] = self._color_channel.min_mireds
+            self._max_mireds: Optional[int] = self._color_channel.max_mireds
+        else:
+            self._min_mireds: Optional[int] = 153
+            self._max_mireds: Optional[int] = 500
         self._cancel_refresh_handle = None
         effect_list = []
 
@@ -501,7 +517,7 @@ class LightGroup(BaseLight, ZhaGroupEntity):
 
         self._color_temp = helpers.reduce_attribute(on_states, ATTR_COLOR_TEMP)
         self._min_mireds = helpers.reduce_attribute(
-            states, ATTR_MIN_MIREDS, default=154, reduce=min
+            states, ATTR_MIN_MIREDS, default=153, reduce=min
         )
         self._max_mireds = helpers.reduce_attribute(
             states, ATTR_MAX_MIREDS, default=500, reduce=max

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -392,3 +392,12 @@ async def test_device_override(hass, zigpy_device_mock, setup_zha, override, ent
     await zha_gateway.async_device_initialized(zigpy_device)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id) is not None
+
+
+async def test_group_probe_cleanup_called(hass, setup_zha, config_entry):
+    """Test cleanup happens when zha is unloaded."""
+    await setup_zha()
+    disc.GROUP_PROBE.cleanup = mock.Mock(wraps=disc.GROUP_PROBE.cleanup)
+    await config_entry.async_unload(hass)
+    await hass.async_block_till_done()
+    disc.GROUP_PROBE.cleanup.assert_called()

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -552,6 +552,15 @@ async def async_test_zha_group_light_entity(
     await dev3_cluster_on_off.on()
     assert hass.states.get(entity_id).state == STATE_ON
 
+    # add a 3rd member and ensure we still have an entity and we track the new one
+    await dev1_cluster_on_off.off()
+    await dev3_cluster_on_off.off()
+    assert hass.states.get(entity_id).state == STATE_OFF
+    # this will test that _reprobe_group is used correctly
+    await zha_group.async_add_members([device_light_2.ieee])
+    await dev2_cluster_on_off.on()
+    assert hass.states.get(entity_id).state == STATE_ON
+
     # remove the group and ensure that there is no entity and that the entity registry is cleaned up
     assert zha_gateway.ha_entity_registry.async_get(entity_id) is not None
     await zha_gateway.async_remove_zigpy_group(zha_group.group_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the ColorControl channel and the light entity so that ZHA lights use the min and max mireds that the bulbs support instead of the HA defaults. We fall back to the default HA values if we can't read the attributes. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
