### PR TITLE
Use ZigbeeException instead of DeliveryError in ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -263,7 +263,7 @@ class ZigbeeChannel(LogMixin):
                 only_cache=from_cache,
                 manufacturer=manufacturer,
             )
-            results = result
+            return result
         except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
             self.debug(
                 "failed to get attributes '%s' on '%s' cluster: %s",
@@ -271,8 +271,7 @@ class ZigbeeChannel(LogMixin):
                 self.cluster.ep_attribute,
                 str(ex),
             )
-            results = {}
-        return results
+            return {}
 
     def log(self, level, msg, *args):
         """Log a message."""

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -56,7 +56,7 @@ def decorate_command(channel, command):
             )
             return result
 
-        except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
+        except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as ex:
             channel.debug("command failed: %s exception: %s", command.__name__, str(ex))
             return ex
 
@@ -135,13 +135,13 @@ class ZigbeeChannel(LogMixin):
     async def bind(self):
         """Bind a zigbee cluster.
 
-        This also swallows DeliveryError exceptions that are thrown when
+        This also swallows ZigbeeException exceptions that are thrown when
         devices are unreachable.
         """
         try:
             res = await self.cluster.bind()
             self.debug("bound '%s' cluster: %s", self.cluster.ep_attribute, res[0])
-        except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
+        except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as ex:
             self.debug(
                 "Failed to bind '%s' cluster: %s", self.cluster.ep_attribute, str(ex)
             )
@@ -149,7 +149,7 @@ class ZigbeeChannel(LogMixin):
     async def configure_reporting(self) -> None:
         """Configure attribute reporting for a cluster.
 
-        This also swallows DeliveryError exceptions that are thrown when
+        This also swallows ZigbeeException exceptions that are thrown when
         devices are unreachable.
         """
         kwargs = {}
@@ -173,7 +173,7 @@ class ZigbeeChannel(LogMixin):
                     reportable_change,
                     res,
                 )
-            except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
+            except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as ex:
                 self.debug(
                     "failed to set reporting for '%s' attr on '%s' cluster: %s",
                     attr_name,
@@ -263,12 +263,8 @@ class ZigbeeChannel(LogMixin):
                 only_cache=from_cache,
                 manufacturer=manufacturer,
             )
-            results = {
-                attribute: result.get(attribute)
-                for attribute in attributes
-                if result.get(attribute) is not None
-            }
-        except (asyncio.TimeoutError, zigpy.exceptions.DeliveryError) as ex:
+            results = result
+        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
             self.debug(
                 "failed to get attributes '%s' on '%s' cluster: %s",
                 attributes,

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -1,7 +1,7 @@
 """HVAC channels module for Zigbee Home Automation."""
 import logging
 
-from zigpy.exceptions import DeliveryError
+from zigpy.exceptions import ZigbeeException
 import zigpy.zcl.clusters.hvac as hvac
 
 from homeassistant.core import callback
@@ -31,7 +31,7 @@ class FanChannel(ZigbeeChannel):
 
         try:
             await self.cluster.write_attributes({"fan_mode": value})
-        except DeliveryError as ex:
+        except ZigbeeException as ex:
             self.error("Could not set speed: %s", ex)
             return
 

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -7,7 +7,7 @@ https://home-assistant.io/integrations/zha/
 import asyncio
 import logging
 
-from zigpy.exceptions import DeliveryError
+from zigpy.exceptions import ZigbeeException
 import zigpy.zcl.clusters.security as security
 
 from homeassistant.core import callback
@@ -151,7 +151,7 @@ class IASZoneChannel(ZigbeeChannel):
                 self._cluster.ep_attribute,
                 res[0],
             )
-        except DeliveryError as ex:
+        except ZigbeeException as ex:
             self.debug(
                 "Failed to write cie_addr: %s to '%s' cluster: %s",
                 str(ieee),

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -511,7 +511,7 @@ class ZHADevice(LogMixin):
                 response,
             )
             return response
-        except zigpy.exceptions.DeliveryError as exc:
+        except zigpy.exceptions.ZigbeeException as exc:
             self.debug(
                 "failed to set attribute: %s %s %s %s %s",
                 f"{ATTR_VALUE}: {value}",
@@ -563,7 +563,7 @@ class ZHADevice(LogMixin):
         """Remove this device from the provided zigbee group."""
         try:
             await self._zigpy_device.remove_from_group(group_id)
-        except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
+        except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as ex:
             self.debug(
                 "Failed to remove device '%s' from group: 0x%04x ex: %s",
                 self._zigpy_device.ieee,

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -3,7 +3,7 @@ import functools
 import logging
 from typing import List
 
-from zigpy.exceptions import DeliveryError
+from zigpy.exceptions import ZigbeeException
 import zigpy.zcl.clusters.hvac as hvac
 
 from homeassistant.components.fan import (
@@ -177,7 +177,7 @@ class FanGroup(BaseFan, ZhaGroupEntity):
             """Set the speed of the fan."""
             try:
                 await self._fan_channel.write_attributes({"fan_mode": value})
-            except DeliveryError as ex:
+            except ZigbeeException as ex:
                 self.error("Could not set speed: %s", ex)
                 return
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In an earlier PR there was a comment made about DeliveryError: https://github.com/home-assistant/core/pull/33977#discussion_r406906728 we discussed and decided that ZigbeeException should be used across the board in these cases. This PR makes the changes. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
