### PR TITLE
Restore ability to change the scan interval in the NUT 

### DIFF
--- a/homeassistant/components/nut/.translations/en.json
+++ b/homeassistant/components/nut/.translations/en.json
@@ -1,50 +1,47 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect, please try again",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "resources": {
-                "data": {
-                    "resources": "Resources"
-                },
-                "title": "Choose the Resources to Monitor"
-            },
-            "ups": {
-                "data": {
-                    "alias": "Alias",
-                    "resources": "Resources"
-                },
-                "title": "Choose the UPS to Monitor"
-            },
-            "user": {
-                "data": {
-                    "alias": "Alias",
-                    "host": "Host",
-                    "name": "Name",
-                    "password": "Password",
-                    "port": "Port",
-                    "resources": "Resources",
-                    "username": "Username"
-                },
-                "description": "If there are multiple UPSs attached to the NUT server, enter the name UPS to query in the 'Alias' field.",
-                "title": "Connect to the NUT server"
-            }
-        },
-        "title": "Network UPS Tools (NUT)"
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "resources": "Resources"
-                },
-                "description": "Choose Sensor Resources."
-            }
+  "config": {
+    "title": "Network UPS Tools (NUT)",
+    "step": {
+      "user": {
+        "title": "Connect to the NUT server",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "username": "Username",
+          "password": "Password"
         }
+      },
+      "ups": {
+        "title": "Choose the UPS to Monitor",
+        "data": {
+          "alias": "Alias",
+          "resources": "Resources"
+        }
+      },
+      "resources": {
+        "title": "Choose the Resources to Monitor",
+        "data": {
+          "resources": "Resources"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Choose Sensor Resources.",
+        "data": {
+          "resources": "Resources",
+          "scan_interval": "Scan Interval (seconds)"
+        }
+      }
+    }
+  }
 }

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
     CONF_RESOURCES,
+    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
@@ -21,6 +22,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     COORDINATOR,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     PLATFORMS,
     PYNUT_DATA,
@@ -52,6 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     alias = config.get(CONF_ALIAS)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
+    scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
     data = PyNUTData(host, port, alias, username, password)
 
@@ -65,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER,
         name="NUT resource status",
         update_method=async_update_data,
-        update_interval=timedelta(seconds=60),
+        update_interval=timedelta(seconds=scan_interval),
     )
 
     # Fetch initial data so we have data when entities subscribe

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -30,7 +30,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 SENSOR_DICT = {
-    sensor_id: SENSOR_TYPES[sensor_id][SENSOR_NAME] for sensor_id in SENSOR_TYPES
+    sensor_id: sensor_spec[SENSOR_NAME]
+    for sensor_id, sensor_spec in SENSOR_TYPES.items()
 }
 
 DATA_SCHEMA = vol.Schema(

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -10,19 +10,28 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
     CONF_RESOURCES,
+    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from . import PyNUTData, find_resources_in_config_entry
-from .const import DEFAULT_HOST, DEFAULT_PORT, SENSOR_TYPES
+from .const import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    SENSOR_NAME,
+    SENSOR_TYPES,
+)
 from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
 
-SENSOR_DICT = {sensor_id: SENSOR_TYPES[sensor_id][0] for sensor_id in SENSOR_TYPES}
+SENSOR_DICT = {
+    sensor_id: SENSOR_TYPES[sensor_id][SENSOR_NAME] for sensor_id in SENSOR_TYPES
+}
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -34,22 +43,20 @@ DATA_SCHEMA = vol.Schema(
 )
 
 
-def _resource_schema(available_resources, selected_resources):
+def _resource_schema_base(available_resources, selected_resources):
     """Resource selection schema."""
 
     known_available_resources = {
-        sensor_id: sensor[0]
+        sensor_id: sensor[SENSOR_NAME]
         for sensor_id, sensor in SENSOR_TYPES.items()
         if sensor_id in available_resources
     }
 
-    return vol.Schema(
-        {
-            vol.Required(CONF_RESOURCES, default=selected_resources): cv.multi_select(
-                known_available_resources
-            )
-        }
-    )
+    return {
+        vol.Required(CONF_RESOURCES, default=selected_resources): cv.multi_select(
+            known_available_resources
+        )
+    }
 
 
 def _ups_schema(ups_list):
@@ -160,7 +167,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(
                 step_id="resources",
-                data_schema=_resource_schema(self.available_resources, []),
+                data_schema=vol.Schema(
+                    _resource_schema_base(self.available_resources, [])
+                ),
             )
 
         self.nut_config.update(user_input)
@@ -207,12 +216,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         resources = find_resources_in_config_entry(self.config_entry)
+        scan_interval = self.config_entry.options.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
 
         info = await validate_input(self.hass, self.config_entry.data)
 
+        base_schema = _resource_schema_base(info["available_resources"], resources)
+        base_schema[
+            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval)
+        ] = cv.positive_int
+
         return self.async_show_form(
-            step_id="init",
-            data_schema=_resource_schema(info["available_resources"], resources),
+            step_id="init", data_schema=vol.Schema(base_schema),
         )
 
 

--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -26,6 +26,7 @@ KEY_STATUS = "ups.status"
 KEY_STATUS_DISPLAY = "ups.status.display"
 
 COORDINATOR = "coordinator"
+DEFAULT_SCAN_INTERVAL = 60
 
 PYNUT_DATA = "data"
 PYNUT_UNIQUE_ID = "unique_id"

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -38,7 +38,8 @@
       "init": {
         "description": "Choose Sensor Resources.",
         "data": {
-          "resources": "Resources"
+          "resources": "Resources",
+          "scan_interval": "Scan Interval (seconds)"
         }
       }
     }


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Now configurable in the options flow instead.

PR #31167 had originally added an option to change this but it got lost in the transition to config flow since the PR went in while I was already working on NUT and somehow it didn't conflict.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33956
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
