### PR TITLE
Fix vizio brand name in strings.json

### DIFF
--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -1,9 +1,9 @@
 {
   "config": {
-    "title": "Vizio SmartCast",
+    "title": "VIZIO SmartCast",
     "step": {
       "user": {
-        "title": "Setup Vizio SmartCast Device",
+        "title": "Setup VIZIO SmartCast Device",
         "description": "An Access Token is only needed for TVs. If you are configuring a TV and do not have an Access Token yet, leave it blank to go through a pairing process.",
         "data": {
           "name": "Name",
@@ -21,16 +21,16 @@
       },
       "pairing_complete": {
         "title": "Pairing Complete",
-        "description": "Your Vizio SmartCast device is now connected to Home Assistant."
+        "description": "Your VIZIO SmartCast device is now connected to Home Assistant."
       },
       "pairing_complete_import": {
         "title": "Pairing Complete",
-        "description": "Your Vizio SmartCast TV is now connected to Home Assistant.\n\nYour Access Token is '**{access_token}**'."
+        "description": "Your VIZIO SmartCast TV is now connected to Home Assistant.\n\nYour Access Token is '**{access_token}**'."
       }
     },
     "error": {
-      "host_exists": "Vizio device with specified host already configured.",
-      "name_exists": "Vizio device with specified name already configured.",
+      "host_exists": "VIZIO device with specified host already configured.",
+      "name_exists": "VIZIO device with specified name already configured.",
       "complete_pairing failed": "Unable to complete pairing. Ensure the PIN you provided is correct and the TV is still powered and connected to the network before resubmitting.",
       "cant_connect": "Could not connect to the device. [Review the docs](https://www.home-assistant.io/integrations/vizio/) and re-verify that:\n- The device is powered on\n- The device is connected to the network\n- The values you filled in are accurate\nbefore attempting to resubmit."
     },
@@ -40,10 +40,10 @@
     }
   },
   "options": {
-    "title": "Update Vizo SmartCast Options",
+    "title": "Update VIZIO SmartCast Options",
     "step": {
       "init": {
-        "title": "Update Vizo SmartCast Options",
+        "title": "Update VIZIO SmartCast Options",
         "description": "If you have a Smart TV, you can optionally filter your source list by choosing which apps to include or exclude in your source list.",
         "data": {
           "volume_step": "Volume Step Size",


### PR DESCRIPTION
## Proposed change
In an earlier PR I updated the brand name for vizio to VIZIO in the manifest to match their brand guidelines. I did not think at the time to update `strings.json` but this PR makes that update. Also fixed two spelling errors


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
