### PR TITLE
Fix modbus sync/async issues

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -196,15 +196,16 @@ class ModbusHub:
 
     def _framer(self, method):
         if method == "ascii":
-            return ModbusAsciiFramer(ClientDecoder())
+            framer = ModbusAsciiFramer(ClientDecoder())
         elif method == "rtu":
-            return ModbusRtuFramer(ClientDecoder())
+            framer = ModbusRtuFramer(ClientDecoder())
         elif method == "binary":
-            return ModbusBinaryFramer(ClientDecoder())
+            framer = ModbusBinaryFramer(ClientDecoder())
         elif method == "socket":
-            return ModbusSocketFramer(ClientDecoder())
+            framer = ModbusSocketFramer(ClientDecoder())
         else:
-            return None
+            framer = None
+        return framer
 
     async def create_serial(self):
         """Create serial modbus client and connect."""

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -140,7 +140,7 @@ async def async_setup(hass, config):
     for client in hub_collect.values():
         await client.setup(hass)
 
-    # register function to gracefully stop modbud
+    # register function to gracefully stop modbus
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
 
     # Register services for modbus
@@ -194,6 +194,7 @@ class ModbusHub:
             await asyncio.sleep(self._config_delay)
             self._config_delay = 0
 
+    @staticmethod
     def _framer(self, method):
         if method == "ascii":
             framer = ModbusAsciiFramer(ClientDecoder())
@@ -206,12 +207,6 @@ class ModbusHub:
         else:
             framer = None
         return framer
-
-    async def create_serial(self):
-        """Create serial modbus client and connect."""
-        # pylint: disable = E0633
-        # Client* do deliver loop, client as result but
-        # pylint does not accept that fact
 
     async def setup(self, hass):
         """Set up pymodbus client."""

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -3,13 +3,21 @@ import asyncio
 import logging
 
 from async_timeout import timeout
-from pymodbus.client.asynchronous import schedulers
-from pymodbus.client.asynchronous.serial import AsyncModbusSerialClient as ClientSerial
-from pymodbus.client.asynchronous.tcp import AsyncModbusTCPClient as ClientTCP
-from pymodbus.client.asynchronous.udp import AsyncModbusUDPClient as ClientUDP
+from pymodbus.client.asynchronous.asyncio import (
+    AsyncioModbusSerialClient,
+    ModbusClientProtocol,
+    init_tcp_client,
+    init_udp_client,
+)
 from pymodbus.exceptions import ModbusException
+from pymodbus.factory import ClientDecoder
 from pymodbus.pdu import ExceptionResponse
-from pymodbus.transaction import ModbusRtuFramer
+from pymodbus.transaction import (
+    ModbusAsciiFramer,
+    ModbusBinaryFramer,
+    ModbusRtuFramer,
+    ModbusSocketFramer,
+)
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -105,13 +113,6 @@ async def async_setup(hass, config):
         for client in hub_collect.values():
             del client
 
-    def start_modbus():
-        """Start Modbus service."""
-        for client in hub_collect.values():
-            client.setup()
-
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
-
     async def write_register(service):
         """Write Modbus registers."""
         unit = int(float(service.data[ATTR_UNIT]))
@@ -136,7 +137,11 @@ async def async_setup(hass, config):
         await hub_collect[client_name].write_coil(unit, address, state)
 
     # do not wait for EVENT_HOMEASSISTANT_START, activate pymodbus now
-    await hass.async_add_executor_job(start_modbus)
+    for client in hub_collect.values():
+        await client.setup(hass)
+
+    # register function to gracefully stop modbud
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
 
     # Register services for modbus
     hass.services.async_register(
@@ -189,47 +194,59 @@ class ModbusHub:
             await asyncio.sleep(self._config_delay)
             self._config_delay = 0
 
-    def setup(self):
-        """Set up pymodbus client."""
+    def _framer(self, method):
+        if method == "ascii":
+            return ModbusAsciiFramer(ClientDecoder())
+        elif method == "rtu":
+            return ModbusRtuFramer(ClientDecoder())
+        elif method == "binary":
+            return ModbusBinaryFramer(ClientDecoder())
+        elif method == "socket":
+            return ModbusSocketFramer(ClientDecoder())
+        else:
+            return None
+
+    async def create_serial(self):
+        """Create serial modbus client and connect."""
         # pylint: disable = E0633
         # Client* do deliver loop, client as result but
         # pylint does not accept that fact
 
+    async def setup(self, hass):
+        """Set up pymodbus client."""
         if self._config_type == "serial":
-            _, self._client = ClientSerial(
-                schedulers.ASYNC_IO,
-                method=self._config_method,
-                port=self._config_port,
+            # reconnect ??
+            framer = self._framer(self._config_method)
+
+            # just a class creation no IO or other slow items
+            self._client = AsyncioModbusSerialClient(
+                self._config_port,
+                protocol_class=ModbusClientProtocol,
+                framer=framer,
+                loop=self._loop,
                 baudrate=self._config_baudrate,
-                stopbits=self._config_stopbits,
                 bytesize=self._config_bytesize,
                 parity=self._config_parity,
-                loop=self._loop,
+                stopbits=self._config_stopbits,
             )
+            await self._client.connect()
         elif self._config_type == "rtuovertcp":
-            _, self._client = ClientTCP(
-                schedulers.ASYNC_IO,
-                host=self._config_host,
-                port=self._config_port,
-                framer=ModbusRtuFramer,
-                timeout=self._config_timeout,
-                loop=self._loop,
+            # framer ModbusRtuFramer ??
+            # timeout ??
+            self._client = await init_tcp_client(
+                None, self._loop, self._config_host, self._config_port
             )
         elif self._config_type == "tcp":
-            _, self._client = ClientTCP(
-                schedulers.ASYNC_IO,
-                host=self._config_host,
-                port=self._config_port,
-                timeout=self._config_timeout,
-                loop=self._loop,
+            # framer ??
+            # timeout ??
+            self._client = await init_tcp_client(
+                None, self._loop, self._config_host, self._config_port
             )
         elif self._config_type == "udp":
-            _, self._client = ClientUDP(
-                schedulers.ASYNC_IO,
-                host=self._config_host,
-                port=self._config_port,
-                timeout=self._config_timeout,
-                loop=self._loop,
+            # framer ??
+            # timeout ??
+            self._client = await init_udp_client(
+                None, self._loop, self._config_host, self._config_port
             )
         else:
             assert False

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -194,7 +194,8 @@ class ModbusHub:
             await asyncio.sleep(self._config_delay)
             self._config_delay = 0
 
-    def _framer(self, method):
+    @staticmethod
+    def _framer(method):
         if method == "ascii":
             framer = ModbusAsciiFramer(ClientDecoder())
         elif method == "rtu":

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -194,7 +194,6 @@ class ModbusHub:
             await asyncio.sleep(self._config_delay)
             self._config_delay = 0
 
-    @staticmethod
     def _framer(self, method):
         if method == "ascii":
             framer = ModbusAsciiFramer(ClientDecoder())

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -2,6 +2,7 @@
   "domain": "modbus",
   "name": "Modbus",
   "documentation": "https://www.home-assistant.io/integrations/modbus",
-  "requirements": ["pymodbus==2.3.0"],
+  "requirements": ["pymodbus==2.3.0",
+		   "pyserial-asyncio==0.4.0"],
   "codeowners": ["@adamchengtkc", "@janiversen"]
 }

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -3,6 +3,6 @@
   "name": "Modbus",
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "requirements": ["pymodbus==2.3.0",
-		   "pyserial-asyncio==0.4.0"],
+		   "pyserial-asyncio==0.4"],
   "codeowners": ["@adamchengtkc", "@janiversen"]
 }

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -3,6 +3,6 @@
   "name": "Modbus",
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "requirements": ["pymodbus==2.3.0",
-		   "pyserial-asyncio==0.4"],
+                   "pyserial-asyncio==0.4"],
   "codeowners": ["@adamchengtkc", "@janiversen"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1528,11 +1528,9 @@ pysdcp==1
 # homeassistant.components.sensibo
 pysensibo==1.0.3
 
+# homeassistant.components.modbus
 # homeassistant.components.serial
 pyserial-asyncio==0.4
-
-# homeassistant.components.modbus
-pyserial-asyncio==0.4.0
 
 # homeassistant.components.acer_projector
 pyserial==3.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1531,6 +1531,9 @@ pysensibo==1.0.3
 # homeassistant.components.serial
 pyserial-asyncio==0.4
 
+# homeassistant.components.modbus
+pyserial-asyncio==0.4.0
+
 # homeassistant.components.acer_projector
 pyserial==3.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -597,6 +597,9 @@ pyps4-2ndscreen==1.0.7
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93
 
+# homeassistant.components.modbus
+pyserial-asyncio==0.4.0
+
 # homeassistant.components.signal_messenger
 pysignalclirestapi==0.2.4
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -598,7 +598,8 @@ pyps4-2ndscreen==1.0.7
 pyqwikswitch==0.93
 
 # homeassistant.components.modbus
-pyserial-asyncio==0.4.0
+# homeassistant.components.serial
+pyserial-asyncio==0.4
 
 # homeassistant.components.signal_messenger
 pysignalclirestapi==0.2.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The boiler plates in pymodbus for creating client are a mixture of sync/async, and this causes problems together with HA.

Do not use boiler plates but the lower level init_<type> functions that are defined as async.

The advantage of this change (apart from solving #33872) is to avoid a task creation.

tcp and udp are well tested, but I do not have serial modbus equipment here, so I have only been able to test that the error reported is 

Remark manifest.json is changed, because pymodbus does not include a serial driver (as pr their design, see first commit).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ x] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
No changes. But everybody who have chimed in on #33872 please test with your configurations.

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
fixes #33872
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [x ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
