### PR TITLE
Use UNIT_UV_INDEX constant

### DIFF
--- a/homeassistant/components/metoffice/sensor.py
+++ b/homeassistant/components/metoffice/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     SPEED_MILES_PER_HOUR,
     TEMP_CELSIUS,
     UNIT_PERCENTAGE,
+    UNIT_UV_INDEX,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -72,7 +73,7 @@ SENSOR_TYPES = {
     "wind_gust": ["Wind Gust", SPEED_MILES_PER_HOUR],
     "visibility": ["Visibility", None],
     "visibility_distance": ["Visibility Distance", LENGTH_KILOMETERS],
-    "uv": ["UV", None],
+    "uv": ["UV", UNIT_UV_INDEX],
     "precipitation": ["Probability of Precipitation", UNIT_PERCENTAGE],
     "humidity": ["Humidity", UNIT_PERCENTAGE],
 }

--- a/homeassistant/components/openuv/sensor.py
+++ b/homeassistant/components/openuv/sensor.py
@@ -1,7 +1,7 @@
 """Support for OpenUV sensors."""
 import logging
 
-from homeassistant.const import TIME_MINUTES
+from homeassistant.const import TIME_MINUTES, UNIT_UV_INDEX
 from homeassistant.core import callback
 from homeassistant.util.dt import as_local, parse_datetime
 
@@ -43,9 +43,9 @@ UV_LEVEL_LOW = "Low"
 
 SENSORS = {
     TYPE_CURRENT_OZONE_LEVEL: ("Current Ozone Level", "mdi:vector-triangle", "du"),
-    TYPE_CURRENT_UV_INDEX: ("Current UV Index", "mdi:weather-sunny", "index"),
+    TYPE_CURRENT_UV_INDEX: ("Current UV Index", "mdi:weather-sunny", UNIT_UV_INDEX),
     TYPE_CURRENT_UV_LEVEL: ("Current UV Level", "mdi:weather-sunny", None),
-    TYPE_MAX_UV_INDEX: ("Max UV Index", "mdi:weather-sunny", "index"),
+    TYPE_MAX_UV_INDEX: ("Max UV Index", "mdi:weather-sunny", UNIT_UV_INDEX),
     TYPE_SAFE_EXPOSURE_TIME_1: (
         "Skin Type 1 Safe Exposure Time",
         "mdi:timer",

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     POWER_WATT,
     TEMP_CELSIUS,
     UNIT_PERCENTAGE,
+    UNIT_UV_INDEX,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -57,7 +58,7 @@ DATA_TYPES = OrderedDict(
         ("Sound", ""),
         ("Sensor Status", ""),
         ("Counter value", ""),
-        ("UV", "uv"),
+        ("UV", UNIT_UV_INDEX),
         ("Humidity status", ""),
         ("Forecast", ""),
         ("Forecast numeric", ""),

--- a/homeassistant/components/tellduslive/sensor.py
+++ b/homeassistant/components/tellduslive/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TIME_HOURS,
     UNIT_PERCENTAGE,
+    UNIT_UV_INDEX,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -44,7 +45,7 @@ SENSOR_TYPES = {
     SENSOR_TYPE_WINDDIRECTION: ["Wind direction", "", "", None],
     SENSOR_TYPE_WINDAVERAGE: ["Wind average", SPEED_METERS_PER_SECOND, "", None],
     SENSOR_TYPE_WINDGUST: ["Wind gust", SPEED_METERS_PER_SECOND, "", None],
-    SENSOR_TYPE_UV: ["UV", "UV", "", None],
+    SENSOR_TYPE_UV: ["UV", UNIT_UV_INDEX, "", None],
     SENSOR_TYPE_WATT: ["Power", POWER_WATT, "", None],
     SENSOR_TYPE_LUMINANCE: ["Luminance", "lx", None, DEVICE_CLASS_ILLUMINANCE],
     SENSOR_TYPE_DEW_POINT: ["Dew Point", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Some UV sensors in the integrations `Metoffice`, `OpenUV`, `Rfxtrx` and `Tellduslive` did not have generalized unit of measurement. However, after this change these sensors now have the unit of measurment `UV index`. Please consider this change as it can be a breaking change for people who display this kind of sensor in external systems, for example, influxdb.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add and use `UNIT_UV_INDEX` constant by replacing the string occurrence in the code base.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
