### PR TITLE
Report unserializable data in websocket

### DIFF
--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -11,6 +11,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_call_later
+from homeassistant.util.json import find_paths_unserializable_data
 
 from .auth import AuthPhase, auth_required_message
 from .const import (
@@ -74,14 +75,17 @@ class WebSocketHandler:
 
                 try:
                     dumped = JSON_DUMP(message)
-                except (ValueError, TypeError) as err:
-                    self._logger.error(
-                        "Unable to serialize to JSON: %s\n%s", err, message
-                    )
+                except (ValueError, TypeError):
                     await self.wsock.send_json(
                         error_message(
                             message["id"], ERR_UNKNOWN_ERROR, "Invalid JSON in response"
                         )
+                    )
+                    self._logger.error(
+                        "Unable to serialize to JSON. Bad data found at %s",
+                        ", ".join(
+                            find_paths_unserializable_data(message, dump=JSON_DUMP)
+                        ),
                     )
                     continue
 

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -11,7 +11,10 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.util.json import find_paths_unserializable_data
+from homeassistant.util.json import (
+    find_paths_unserializable_data,
+    format_unserializable_data,
+)
 
 from .auth import AuthPhase, auth_required_message
 from .const import (
@@ -83,7 +86,7 @@ class WebSocketHandler:
                     )
                     self._logger.error(
                         "Unable to serialize to JSON. Bad data found at %s",
-                        ", ".join(
+                        format_unserializable_data(
                             find_paths_unserializable_data(message, dump=JSON_DUMP)
                         ),
                     )

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import tempfile
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError
@@ -86,7 +86,9 @@ def save_json(
                 _LOGGER.error("JSON replacement cleanup failed: %s", err)
 
 
-def find_paths_unserializable_data(bad_data: Any, *, dump=json.dumps) -> List[str]:
+def find_paths_unserializable_data(
+    bad_data: Any, *, dump: Callable[[Any], str] = json.dumps
+) -> List[str]:
     """Find the paths to unserializable data.
 
     This method is slow! Only use for error handling.

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -64,3 +64,18 @@ async def test_pending_msg_peak(hass, mock_low_peak, hass_ws_client, caplog):
     assert msg.type == WSMsgType.close
 
     assert "Client unable to keep up with pending messages" in caplog.text
+
+
+async def test_non_json_message(hass, websocket_client, caplog):
+    """Test trying to serialze non JSON objects."""
+    hass.states.async_set("test_domain.entity", "testing", {"bad": object()})
+    await websocket_client.send_json({"id": 5, "type": "get_states"})
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert not msg["success"]
+    assert (
+        "Unable to serialize to JSON. Bad data found at $.result[0](test_domain.entity).attributes.bad"
+        in caplog.text
+    )

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -76,6 +76,6 @@ async def test_non_json_message(hass, websocket_client, caplog):
     assert msg["type"] == const.TYPE_RESULT
     assert not msg["success"]
     assert (
-        "Unable to serialize to JSON. Bad data found at $.result[0](test_domain.entity).attributes.bad"
+        "Unable to serialize to JSON. Bad data found at $.result[0](state: test_domain.entity).attributes.bad"
         in caplog.text
     )

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -68,7 +68,8 @@ async def test_pending_msg_peak(hass, mock_low_peak, hass_ws_client, caplog):
 
 async def test_non_json_message(hass, websocket_client, caplog):
     """Test trying to serialze non JSON objects."""
-    hass.states.async_set("test_domain.entity", "testing", {"bad": object()})
+    bad_data = object()
+    hass.states.async_set("test_domain.entity", "testing", {"bad": bad_data})
     await websocket_client.send_json({"id": 5, "type": "get_states"})
 
     msg = await websocket_client.receive_json()
@@ -76,6 +77,6 @@ async def test_non_json_message(hass, websocket_client, caplog):
     assert msg["type"] == const.TYPE_RESULT
     assert not msg["success"]
     assert (
-        "Unable to serialize to JSON. Bad data found at $.result[0](state: test_domain.entity).attributes.bad"
+        f"Unable to serialize to JSON. Bad data found at $.result[0](state: test_domain.entity).attributes.bad={bad_data}(<class 'object'>"
         in caplog.text
     )

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from functools import partial
 from json import JSONEncoder, dumps
+import math
 import os
 import sys
 from tempfile import mkdtemp
@@ -80,8 +81,9 @@ def test_save_bad_data():
     with pytest.raises(SerializationError) as excinfo:
         save_json("test4", {"hello": set()})
 
-    assert "Failed to serialize to JSON: test4. Bad data found at $.hello" in str(
-        excinfo.value
+    assert (
+        "Failed to serialize to JSON: test4. Bad data at $.hello=set()(<class 'set'>"
+        in str(excinfo.value)
     )
 
 
@@ -112,22 +114,26 @@ def test_custom_encoder():
 
 def test_find_unserializable_data():
     """Find unserializeable data."""
-    assert find_paths_unserializable_data(1) == []
-    assert find_paths_unserializable_data([1, 2]) == []
-    assert find_paths_unserializable_data({"something": "yo"}) == []
+    assert find_paths_unserializable_data(1) == {}
+    assert find_paths_unserializable_data([1, 2]) == {}
+    assert find_paths_unserializable_data({"something": "yo"}) == {}
 
-    assert find_paths_unserializable_data({"something": set()}) == ["$.something"]
-    assert find_paths_unserializable_data({"something": [1, set()]}) == [
-        "$.something[1]"
-    ]
-    assert find_paths_unserializable_data([1, {"bla": set(), "blub": set()}]) == [
-        "$[1].bla",
-        "$[1].blub",
-    ]
-    assert find_paths_unserializable_data({("A",): 1}) == ["$<key: ('A',)>"]
-    assert find_paths_unserializable_data(
-        float("nan"), dump=partial(dumps, allow_nan=False)
-    ) == ["$"]
+    assert find_paths_unserializable_data({"something": set()}) == {
+        "$.something": set()
+    }
+    assert find_paths_unserializable_data({"something": [1, set()]}) == {
+        "$.something[1]": set()
+    }
+    assert find_paths_unserializable_data([1, {"bla": set(), "blub": set()}]) == {
+        "$[1].bla": set(),
+        "$[1].blub": set(),
+    }
+    assert find_paths_unserializable_data({("A",): 1}) == {"$<key: ('A',)>": ("A",)}
+    assert math.isnan(
+        find_paths_unserializable_data(
+            float("nan"), dump=partial(dumps, allow_nan=False)
+        )["$"]
+    )
 
     # Test custom encoder + State support.
 
@@ -140,12 +146,14 @@ def test_find_unserializable_data():
                 return o.isoformat()
             return super().default(o)
 
-    assert find_paths_unserializable_data(
-        [State("mock_domain.mock_entity", "on", {"bad": object()})],
-        dump=partial(dumps, cls=MockJSONEncoder),
-    ) == ["$[0](state: mock_domain.mock_entity).attributes.bad"]
+    bad_data = object()
 
     assert find_paths_unserializable_data(
-        [Event("bad_event", {"bad_attribute": object()})],
+        [State("mock_domain.mock_entity", "on", {"bad": bad_data})],
         dump=partial(dumps, cls=MockJSONEncoder),
-    ) == ["$[0](event: bad_event).data.bad_attribute"]
+    ) == {"$[0](state: mock_domain.mock_entity).attributes.bad": bad_data}
+
+    assert find_paths_unserializable_data(
+        [Event("bad_event", {"bad_attribute": bad_data})],
+        dump=partial(dumps, cls=MockJSONEncoder),
+    ) == {"$[0](event: bad_event).data.bad_attribute": bad_data}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make the websocket API call out the bad state that is breaking the `get_states` command.

Also updated the find data we can't serialize to JSON to call out the entity if it encounters a state.

This will help with better finding the causes for #33952 and https://github.com/home-assistant/core/issues/33929

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
