### PR TITLE
Add Android TV screen capture option and use library screencap

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,8 +3,8 @@
   "name": "Android TV",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
-    "adb-shell==0.1.1",
-    "androidtv==0.0.39",
+    "adb-shell==0.1.3",
+    "androidtv==0.0.40",
     "pure-python-adb==0.2.2.dev0"
   ],
   "codeowners": ["@JeffLIrion"]

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -1,5 +1,4 @@
 """Support for functionality to interact with Android TV / Fire TV devices."""
-import binascii
 from datetime import datetime
 import functools
 import logging
@@ -89,12 +88,14 @@ CONF_GET_SOURCES = "get_sources"
 CONF_STATE_DETECTION_RULES = "state_detection_rules"
 CONF_TURN_ON_COMMAND = "turn_on_command"
 CONF_TURN_OFF_COMMAND = "turn_off_command"
+CONF_SCREENCAP = "screencap"
 
 DEFAULT_NAME = "Android TV"
 DEFAULT_PORT = 5555
 DEFAULT_ADB_SERVER_PORT = 5037
 DEFAULT_GET_SOURCES = True
 DEFAULT_DEVICE_CLASS = "auto"
+DEFAULT_SCREENCAP = True
 
 DEVICE_ANDROIDTV = "androidtv"
 DEVICE_FIRETV = "firetv"
@@ -146,6 +147,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             {cv.string: ha_state_detection_rules_validator(vol.Invalid)}
         ),
         vol.Optional(CONF_EXCLUDE_UNNAMED_APPS, default=False): cv.boolean,
+        vol.Optional(CONF_SCREENCAP, default=DEFAULT_SCREENCAP): cv.boolean,
     }
 )
 
@@ -239,6 +241,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         config.get(CONF_TURN_ON_COMMAND),
         config.get(CONF_TURN_OFF_COMMAND),
         config[CONF_EXCLUDE_UNNAMED_APPS],
+        config[CONF_SCREENCAP],
     ]
 
     if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
@@ -382,6 +385,7 @@ class ADBDevice(MediaPlayerDevice):
         turn_on_command,
         turn_off_command,
         exclude_unnamed_apps,
+        screencap,
     ):
         """Initialize the Android TV / Fire TV device."""
         self.aftv = aftv
@@ -401,6 +405,7 @@ class ADBDevice(MediaPlayerDevice):
         self.turn_off_command = turn_off_command
 
         self._exclude_unnamed_apps = exclude_unnamed_apps
+        self._screencap = screencap
 
         # ADB exceptions to catch
         if not self.aftv.adb_server_ip:
@@ -479,7 +484,7 @@ class ADBDevice(MediaPlayerDevice):
 
     async def async_get_media_image(self):
         """Fetch current playing image."""
-        if self.state in [STATE_OFF, None] or not self.available:
+        if not self._screencap or self.state in [STATE_OFF, None] or not self.available:
             return None, None
 
         media_data = await self.hass.async_add_executor_job(self.get_raw_media_data)
@@ -490,15 +495,7 @@ class ADBDevice(MediaPlayerDevice):
     @adb_decorator()
     def get_raw_media_data(self):
         """Raw base64 image data."""
-        try:
-            response = self.aftv.adb_shell("screencap -p | base64")
-        except UnicodeDecodeError:
-            return None
-
-        if isinstance(response, str) and response.strip():
-            return binascii.a2b_base64(response.strip().replace("\n", ""))
-
-        return None
+        return self.aftv.adb_screencap()
 
     @property
     def media_image_hash(self):
@@ -613,6 +610,7 @@ class AndroidTVDevice(ADBDevice):
         turn_on_command,
         turn_off_command,
         exclude_unnamed_apps,
+        screencap,
     ):
         """Initialize the Android TV device."""
         super().__init__(
@@ -623,6 +621,7 @@ class AndroidTVDevice(ADBDevice):
             turn_on_command,
             turn_off_command,
             exclude_unnamed_apps,
+            screencap,
         )
 
         self._is_volume_muted = None

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -494,7 +494,7 @@ class ADBDevice(MediaPlayerDevice):
 
     @adb_decorator()
     def get_raw_media_data(self):
-        """Raw base64 image data."""
+        """Raw image data."""
         return self.aftv.adb_screencap()
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -119,7 +119,7 @@ adafruit-circuitpython-bmp280==3.1.1
 adafruit-circuitpython-mcp230xx==2.2.2
 
 # homeassistant.components.androidtv
-adb-shell==0.1.1
+adb-shell==0.1.3
 
 # homeassistant.components.adguard
 adguardhome==0.4.2
@@ -235,7 +235,7 @@ ambiclimate==0.2.1
 amcrest==1.7.0
 
 # homeassistant.components.androidtv
-androidtv==0.0.39
+androidtv==0.0.40
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -29,7 +29,7 @@ YesssSMS==0.4.1
 abodepy==0.19.0
 
 # homeassistant.components.androidtv
-adb-shell==0.1.1
+adb-shell==0.1.3
 
 # homeassistant.components.adguard
 adguardhome==0.4.2
@@ -106,7 +106,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.39
+androidtv==0.0.40
 
 # homeassistant.components.apns
 apns2==0.3.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add attribute option to turn off screen captures for Android TV; for devices that have permanent HDCP (hdmi protection) or slow screen updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
media_player:
  - platform: androidtv
    #Existing options here
    screencap: false
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #34018
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12850

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
