### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -1,5 +1,5 @@
 """Allows to configure custom shell commands to turn a value for a sensor."""
-import collections
+from collections.abc import Mapping
 from datetime import timedelta
 import json
 import logging
@@ -106,7 +106,7 @@ class CommandSensor(Entity):
             if value:
                 try:
                     json_dict = json.loads(value)
-                    if isinstance(json_dict, collections.Mapping):
+                    if isinstance(json_dict, Mapping):
                         self._attributes = {
                             k: json_dict[k]
                             for k in self._json_attributes

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import collections
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -677,7 +678,7 @@ async def websocket_unbind_devices(hass, connection, msg):
 
 def is_cluster_binding(value: Any) -> ClusterBinding:
     """Validate and transform a cluster binding."""
-    if not isinstance(value, collections.Mapping):
+    if not isinstance(value, Mapping):
         raise vol.Invalid("Not a cluster binding")
     try:
         cluster_binding = ClusterBinding(


### PR DESCRIPTION
## Proposed change

Use collections.abc for ABC import

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Import ABC from collections.abc instead of collections for Python 3 compatibility

- This PR fixes or closes issue: fixes #34076 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
