### PR TITLE
Add 2SA authentication to Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/.translations/en.json
+++ b/homeassistant/components/synology_dsm/.translations/en.json
@@ -5,10 +5,17 @@
         },
         "error": {
             "login": "Login error: please check your username & password",
-            "missing_data": "Missing data: please retry later or an other configuration"
+            "missing_data": "Missing data: please retry later or an other configuration",
+            "otp_failed": "Two-step authentication failed, retry with a new pass code"
         },
         "flow_title": "Synology DSM {name} ({host})",
         "step": {
+            "2sa": {
+                "data": {
+                    "otp_code": "Code"
+                },
+                "title": "Synology DSM: two-step authentication"
+            },
             "link": {
                 "data": {
                     "api_version": "DSM version",

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -71,8 +71,11 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     unit = hass.config.units.temperature_unit
     use_ssl = entry.data[CONF_SSL]
     api_version = entry.data.get(CONF_API_VERSION, DEFAULT_DSM_VERSION)
+    device_token = entry.data.get("device_token")
 
-    api = SynoApi(hass, host, port, username, password, unit, use_ssl, api_version)
+    api = SynoApi(
+        hass, host, port, username, password, unit, use_ssl, device_token, api_version
+    )
 
     await api.async_setup()
 
@@ -105,6 +108,7 @@ class SynoApi:
         password: str,
         temp_unit: str,
         use_ssl: bool,
+        device_token: str,
         api_version: int,
     ):
         """Initialize the API wrapper class."""
@@ -114,6 +118,7 @@ class SynoApi:
         self._username = username
         self._password = password
         self._use_ssl = use_ssl
+        self._device_token = device_token
         self._api_version = api_version
         self.temp_unit = temp_unit
 
@@ -137,6 +142,7 @@ class SynoApi:
             self._username,
             self._password,
             self._use_ssl,
+            device_token=self._device_token,
             dsm_version=self._api_version,
         )
 

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -6,9 +6,9 @@ from homeassistant.const import (
 )
 
 DOMAIN = "synology_dsm"
+BASE_NAME = "Synology"
 
 CONF_VOLUMES = "volumes"
-BASE_NAME = "Synology"
 DEFAULT_SSL = True
 DEFAULT_PORT = 5000
 DEFAULT_PORT_SSL = 5001

--- a/homeassistant/components/synology_dsm/manifest.json
+++ b/homeassistant/components/synology_dsm/manifest.json
@@ -2,7 +2,7 @@
   "domain": "synology_dsm",
   "name": "Synology DSM",
   "documentation": "https://www.home-assistant.io/integrations/synology_dsm",
-  "requirements": ["python-synology==0.5.0"],
+  "requirements": ["python-synology==0.6.0"],
   "codeowners": ["@ProtoThis", "@Quentame"],
   "config_flow": true,
   "ssdp": [

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -13,6 +13,12 @@
           "password": "Password"
         }
       },
+      "2sa": {
+        "title": "Synology DSM: two-step authentication",
+        "data": {
+          "otp_code": "Code"
+        }
+      },
       "link": {
         "title": "Synology DSM",
         "description": "Do you want to setup {name} ({host})?",
@@ -27,7 +33,8 @@
     },
     "error": {
       "login": "Login error: please check your username & password",
-      "missing_data": "Missing data: please retry later or an other configuration"
+      "missing_data": "Missing data: please retry later or an other configuration",
+      "otp_failed": "Two-step authentication failed, retry with a new pass code"
     },
     "abort": { "already_configured": "Host already configured" }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1673,7 +1673,7 @@ python-sochain-api==0.0.2
 python-songpal==0.11.2
 
 # homeassistant.components.synology_dsm
-python-synology==0.5.0
+python-synology==0.6.0
 
 # homeassistant.components.tado
 python-tado==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -637,7 +637,7 @@ python-miio==0.5.0.1
 python-nest==4.1.0
 
 # homeassistant.components.synology_dsm
-python-synology==0.5.0
+python-synology==0.6.0
 
 # homeassistant.components.tado
 python-tado==0.6.0


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add 2SA authentication to Synology DSM

~~Requires ProtoThis/python-synology#29 merge + release~~

Dependency upgrade notes : https://github.com/ProtoThis/python-synology/releases/tag/0.6.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31477 (feature request actually)
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
