### PR TITLE
Fix nws platform setup and data update.

### DIFF
--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -78,7 +78,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
         for component in PLATFORMS:
             hass.async_create_task(
-                discovery.async_load_platform(hass, component, DOMAIN, {}, config)
+                discovery.async_load_platform(hass, component, DOMAIN, entry, config)
             )
 
     return True

--- a/homeassistant/components/nws/weather.py
+++ b/homeassistant/components/nws/weather.py
@@ -77,9 +77,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the NWS weather platform."""
     if discovery_info is None:
         return
-    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
-    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    station = config.get(CONF_STATION)
+    latitude = discovery_info.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = discovery_info.get(CONF_LONGITUDE, hass.config.longitude)
+    station = discovery_info.get(CONF_STATION)
 
     nws_data = hass.data[DOMAIN][base_unique_id(latitude, longitude)]
 

--- a/homeassistant/components/nws/weather.py
+++ b/homeassistant/components/nws/weather.py
@@ -73,8 +73,10 @@ def convert_condition(time, weather):
     return cond, max(prec_probs)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the NWS weather platform."""
+    if discovery_info is None:
+        return
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
     station = config.get(CONF_STATION)
@@ -134,7 +136,7 @@ class NWSWeather(WeatherEntity):
         else:
             self._forecast = self.nws.forecast_hourly
 
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def should_poll(self) -> bool:

--- a/tests/components/nws/test_init.py
+++ b/tests/components/nws/test_init.py
@@ -31,7 +31,7 @@ DUPLICATE_CONFIG = {
 async def test_no_config(hass, mock_simple_nws):
     """Test that nws does not setup with no config."""
     with assert_setup_component(0):
-        assert await async_setup_component(hass, DOMAIN, {}) is True
+        assert await async_setup_component(hass, DOMAIN, {})
         assert DOMAIN not in hass.data
 
 
@@ -40,7 +40,7 @@ async def test_successful_minimal_config(hass, mock_simple_nws):
     hass.config.latitude = 40.0
     hass.config.longitude = -75.0
     with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, MINIMAL_CONFIG) is True
+        assert await async_setup_component(hass, DOMAIN, MINIMAL_CONFIG)
         assert DOMAIN in hass.data
         assert nws.base_unique_id(40.0, -75.0) in hass.data[DOMAIN]
 
@@ -48,7 +48,7 @@ async def test_successful_minimal_config(hass, mock_simple_nws):
 async def test_successful_latlon_config(hass, mock_simple_nws):
     """Test that nws setup with latlon config."""
     with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, LATLON_CONFIG) is True
+        assert await async_setup_component(hass, DOMAIN, LATLON_CONFIG)
         assert DOMAIN in hass.data
         assert nws.base_unique_id(45.0, -75.0) in hass.data[DOMAIN]
 
@@ -56,12 +56,12 @@ async def test_successful_latlon_config(hass, mock_simple_nws):
 async def test_successful_full_config(hass, mock_simple_nws):
     """Test that nws setup with full config."""
     with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, FULL_CONFIG) is True
+        assert await async_setup_component(hass, DOMAIN, FULL_CONFIG)
         assert DOMAIN in hass.data
         assert nws.base_unique_id(45.0, -75.0) in hass.data[DOMAIN]
 
 
 async def test_unsuccessful_duplicate_config(hass, mock_simple_nws):
     """Test that nws setup with duplicate config."""
-    assert await async_setup_component(hass, DOMAIN, DUPLICATE_CONFIG) is True
+    assert await async_setup_component(hass, DOMAIN, DUPLICATE_CONFIG)
     assert len(hass.data[DOMAIN]) == 1

--- a/tests/components/nws/test_init.py
+++ b/tests/components/nws/test_init.py
@@ -32,6 +32,11 @@ async def test_no_config(hass, mock_simple_nws):
     """Test that nws does not setup with no config."""
     with assert_setup_component(0):
         assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        assert len(entity_registry.entities) == 0
+
         assert DOMAIN not in hass.data
 
 
@@ -39,24 +44,39 @@ async def test_successful_minimal_config(hass, mock_simple_nws):
     """Test that nws setup with minimal config."""
     hass.config.latitude = 40.0
     hass.config.longitude = -75.0
-    with assert_setup_component(1):
+    with assert_setup_component(1, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, MINIMAL_CONFIG)
+        await hass.async_block_till_done()
+
+        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        assert len(entity_registry.entities) == 2
+
         assert DOMAIN in hass.data
         assert nws.base_unique_id(40.0, -75.0) in hass.data[DOMAIN]
 
 
 async def test_successful_latlon_config(hass, mock_simple_nws):
     """Test that nws setup with latlon config."""
-    with assert_setup_component(1):
+    with assert_setup_component(1, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, LATLON_CONFIG)
+        await hass.async_block_till_done()
+
+        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        assert len(entity_registry.entities) == 2
+
         assert DOMAIN in hass.data
         assert nws.base_unique_id(45.0, -75.0) in hass.data[DOMAIN]
 
 
 async def test_successful_full_config(hass, mock_simple_nws):
     """Test that nws setup with full config."""
-    with assert_setup_component(1):
+    with assert_setup_component(1, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, FULL_CONFIG)
+        await hass.async_block_till_done()
+
+        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        assert len(entity_registry.entities) == 2
+
         assert DOMAIN in hass.data
         assert nws.base_unique_id(45.0, -75.0) in hass.data[DOMAIN]
 
@@ -64,4 +84,9 @@ async def test_successful_full_config(hass, mock_simple_nws):
 async def test_unsuccessful_duplicate_config(hass, mock_simple_nws):
     """Test that nws setup with duplicate config."""
     assert await async_setup_component(hass, DOMAIN, DUPLICATE_CONFIG)
+    await hass.async_block_till_done()
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    assert len(entity_registry.entities) == 2
+
     assert len(hass.data[DOMAIN]) == 1

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -40,7 +40,7 @@ HOURLY_CONFIG = {
     ],
 )
 async def test_imperial_metric(
-    hass, units, result_observation, result_forecast, mock_simple_nws
+    hass, units, result_observation, result_forecast, mock_simple_nws, caplog
 ):
     """Test with imperial and metric units."""
     hass.config.units = units
@@ -72,6 +72,9 @@ async def test_imperial_metric(
     forecast = data.get(ATTR_FORECAST)
     for key, value in result_forecast.items():
         assert forecast[0].get(key) == value
+
+    assert "Error updating observation" not in caplog.text
+    assert "Success updating observation" not in caplog.text
 
 
 async def test_none_values(hass, mock_simple_nws):
@@ -136,14 +139,18 @@ async def test_error_observation(hass, mock_simple_nws, caplog):
     assert await async_setup_component(hass, nws.DOMAIN, MINIMAL_CONFIG)
     await hass.async_block_till_done()
 
+    assert "Error updating observation for station ABC" in caplog.text
+    assert "Success updating observation for station ABC" not in caplog.text
+    caplog.clear()
+
     instance.update_observation.side_effect = None
 
     future_time = dt_util.utcnow() + timedelta(minutes=15)
     async_fire_time_changed(hass, future_time)
     await hass.async_block_till_done()
 
-    assert "Error updating observation" in caplog.text
-    assert "Success updating observation" in caplog.text
+    assert "Error updating observation for station ABC" not in caplog.text
+    assert "Success updating observation for station ABC" in caplog.text
 
 
 async def test_error_forecast(hass, caplog, mock_simple_nws):
@@ -154,14 +161,18 @@ async def test_error_forecast(hass, caplog, mock_simple_nws):
     assert await async_setup_component(hass, nws.DOMAIN, MINIMAL_CONFIG)
     await hass.async_block_till_done()
 
+    assert "Error updating forecast for station ABC" in caplog.text
+    assert "Success updating forecast for station ABC" not in caplog.text
+    caplog.clear()
+
     instance.update_forecast.side_effect = None
 
     future_time = dt_util.utcnow() + timedelta(minutes=15)
     async_fire_time_changed(hass, future_time)
     await hass.async_block_till_done()
 
-    assert "Error updating forecast" in caplog.text
-    assert "Success updating forecast" in caplog.text
+    assert "Error updating forecast for station ABC" not in caplog.text
+    assert "Success updating forecast for station ABC" in caplog.text
 
 
 async def test_error_forecast_hourly(hass, caplog, mock_simple_nws):
@@ -172,11 +183,15 @@ async def test_error_forecast_hourly(hass, caplog, mock_simple_nws):
     assert await async_setup_component(hass, nws.DOMAIN, MINIMAL_CONFIG)
     await hass.async_block_till_done()
 
+    assert "Error updating forecast_hourly for station ABC" in caplog.text
+    assert "Success updating forecast_hourly for station ABC" not in caplog.text
+    caplog.clear()
+
     instance.update_forecast_hourly.side_effect = None
 
     future_time = dt_util.utcnow() + timedelta(minutes=15)
     async_fire_time_changed(hass, future_time)
     await hass.async_block_till_done()
 
-    assert "Error updating forecast_hourly" in caplog.text
-    assert "Success updating forecast_hourly" in caplog.text
+    assert "Error updating forecast_hourly for station ABC" not in caplog.text
+    assert "Success updating forecast_hourly for station ABC" in caplog.text

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -21,16 +21,6 @@ from tests.components.nws.const import (
     NONE_OBSERVATION,
 )
 
-HOURLY_CONFIG = {
-    "weather": {
-        "platform": "nws",
-        "api_key": "x@example.com",
-        "latitude": 40.0,
-        "longitude": -85.0,
-        "mode": "hourly",
-    }
-}
-
 
 @pytest.mark.parametrize(
     "units,result_observation,result_forecast",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fixes platform setup.  Current behavior didn't pass anything to platform setup!  Oops.  This was caught after adding guard clause to catch no `discovery_info` based on [comments](https://github.com/home-assistant/core/pull/31398#pullrequestreview-390097363).

Also fixes logging for data updates.  Current behavior logs every successful update, and more importantly never reported back a failed update correctly.  I plan to switch to using a DataUpdateCoordinator object for each API call, but this will come later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
nws:
  - api_key: MY_API_KEY
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
