### PR TITLE
Fix uncaught exceptions in ios

### DIFF
--- a/tests/components/ios/test_init.py
+++ b/tests/components/ios/test_init.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import bootstrap, config_entries, data_entry_flow
 from homeassistant.components import ios
 from homeassistant.setup import async_setup_component
 
@@ -26,6 +26,8 @@ def mock_dependencies(hass):
 
 async def test_creating_entry_sets_up_sensor(hass):
     """Test setting up iOS loads the sensor component."""
+    # so it will not have an empty config
+    await bootstrap.async_from_config_dict({"foo": "bar"}, hass)
     with patch(
         "homeassistant.components.ios.sensor.async_setup_entry",
         return_value=mock_coro(True),
@@ -61,7 +63,7 @@ async def test_not_configuring_ios_not_creates_entry(hass):
     with patch(
         "homeassistant.components.ios.async_setup_entry", return_value=mock_coro(True)
     ) as mock_setup:
-        await async_setup_component(hass, ios.DOMAIN, {})
+        await async_setup_component(hass, ios.DOMAIN, {"foo": "bar"})
         await hass.async_block_till_done()
 
     assert len(mock_setup.mock_calls) == 0

--- a/tests/components/ios/test_init.py
+++ b/tests/components/ios/test_init.py
@@ -3,11 +3,10 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import bootstrap
 from homeassistant.components import ios
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, mock_component, mock_coro
+from tests.common import mock_component, mock_coro
 
 
 @pytest.fixture(autouse=True)
@@ -26,9 +25,6 @@ def mock_dependencies(hass):
 
 async def test_creating_entry_sets_up_sensor(hass):
     """Test setting up iOS loads the sensor component."""
-    # so it will not have an empty config
-    entry = MockConfigEntry(domain=ios.DOMAIN, data={},)
-    entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.ios.sensor.async_setup_entry",
         return_value=mock_coro(True),

--- a/tests/components/ios/test_init.py
+++ b/tests/components/ios/test_init.py
@@ -27,7 +27,6 @@ def mock_dependencies(hass):
 async def test_creating_entry_sets_up_sensor(hass):
     """Test setting up iOS loads the sensor component."""
     # so it will not have an empty config
-    await bootstrap.async_from_config_dict({"foo": "bar"}, hass)
     entry = MockConfigEntry(domain=ios.DOMAIN, data={},)
     entry.add_to_hass(hass)
     with patch(

--- a/tests/components/ios/test_init.py
+++ b/tests/components/ios/test_init.py
@@ -34,7 +34,7 @@ async def test_creating_entry_sets_up_sensor(hass):
         "homeassistant.components.ios.sensor.async_setup_entry",
         return_value=mock_coro(True),
     ) as mock_setup:
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await async_setup_component(hass, ios.DOMAIN, {ios.DOMAIN: {}})
         await hass.async_block_till_done()
 
     assert len(mock_setup.mock_calls) == 1

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -1,7 +1,5 @@
 """List of modules that have uncaught exceptions today. Will be shrunk over time."""
 IGNORE_UNCAUGHT_EXCEPTIONS = [
-    ("tests.components.ios.test_init", "test_creating_entry_sets_up_sensor"),
-    ("tests.components.ios.test_init", "test_not_configuring_ios_not_creates_entry"),
     ("tests.components.local_file.test_camera", "test_file_not_readable"),
 ]
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
not breaking

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
moved the dependency on notify to manifest.json
it was throwing an exception of empty config and i suspect that it
would also happen in real life, so dependency seems a better way


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33332 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
