### PR TITLE
Temporary transition Docker init

### DIFF
--- a/rootfs/init
+++ b/rootfs/init
@@ -1,0 +1,23 @@
+#!/bin/execlineb -S0
+
+##
+## load default PATH (the same that Docker includes if not provided) if it doesn't exist,
+## then go ahead with stage1.
+## this was motivated due to this issue:
+## - https://github.com/just-containers/s6-overlay/issues/108
+##
+
+/bin/importas -D /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PATH PATH
+export PATH ${PATH}
+
+##
+## Skip further init if the user has a given CMD.
+## This is to prevent Home Assistant from starting twice if the user
+## decided to override/start via the CMD.
+##
+
+ifelse { s6-test $# -ne 0 }
+{
+  $@
+}
+/etc/s6/init/init-stage1 $@


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a small override of the S6 Overlay init.

Currently, we are experiencing users that are having issue with the Docker containers of Home Assistant. This is not an error on our end, but unfortunately, we have to deal with cases where users have made an override of the CMD.

This CMD is now no longer used by us. Passing in the CMD causes our init system to start up Home Assistant, + de CMD to start another instance.

Developer blog: <https://developers.home-assistant.io/blog/2020/04/12/s6-overlay>

A quick search of sample issues reported:
- #34070 
- #33882
- #32992
- #33648
- #33651
- #33917
- #32992
- #33867

There are also quite a bit of reports on external repositories and our community forum.


The proposal is as follows:

- Merge this PR, as it temporarily disables the S6 init when a CMD is given by the user. This makes our images backward compatible for now, while keeping properly upgraded systems working with S6.

- Release it in a patch release.

- Revert this PR for 0.109, and let's make sure we properly educate and inform our users about the change in the release notes for 0.109.


**Note:** I remain that this is **not** a Home Assistant issue, nevertheless, we can help in mitigating the fallout to our users.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
