### PR TITLE
Container for dummy

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -1,0 +1,17 @@
+FROM homeassistant/amd64-homeassistant-base:7.0.1
+
+WORKDIR /usr/src
+
+## Setup Home Assistant
+COPY . homeassistant/
+RUN \
+    pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
+        -r homeassistant/requirements_all.txt -c homeassistant/homeassistant/package_constraints.txt \
+    && pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
+        -e ./homeassistant \
+    && python3 -m compileall homeassistant/homeassistant
+
+WORKDIR /config
+
+ENTRYPOINT ["/bin/ash", "-c"]
+CMD ["python3", "-m", "homeassistant", "--config", "/config"]

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -120,6 +120,16 @@ stages:
           -r https://github.com/home-assistant/hassio-homeassistant \
           -t machine --docker-hub homeassistant
       displayName: 'Build Release'
+  - job: 'ReleaseCore'
+    pool:
+      vmImage: 'ubuntu-latest'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    - script: |
+        docker login -u $(dockerUser) -p $(dockerPassword)
+      displayName: 'Docker hub login'
+    - script: |
+        docker build --tag homeassistant/home-assistant:$(Build.SourceBranch) -f Dockerfile.core .
+        docker push homeassistant/home-assistant:$(Build.SourceBranch)
 
 - stage: 'Publish'
   jobs:
@@ -178,34 +188,34 @@ stages:
           local tag_l=$1
           local tag_r=$2
 
-          docker manifest create homeassistant/home-assistant:${tag_l} \
+          docker manifest create homeassistant/hassio-homeassistant:${tag_l} \
             homeassistant/amd64-homeassistant:${tag_r} \
             homeassistant/i386-homeassistant:${tag_r} \
             homeassistant/armhf-homeassistant:${tag_r} \
             homeassistant/armv7-homeassistant:${tag_r} \
             homeassistant/aarch64-homeassistant:${tag_r}
 
-          docker manifest annotate homeassistant/home-assistant:${tag_l} \
+          docker manifest annotate homeassistant/hassio-homeassistant:${tag_l} \
             homeassistant/amd64-homeassistant:${tag_r} \
             --os linux --arch amd64
 
-          docker manifest annotate homeassistant/home-assistant:${tag_l} \
+          docker manifest annotate homeassistant/hassio-homeassistant:${tag_l} \
             homeassistant/i386-homeassistant:${tag_r} \
             --os linux --arch 386
 
-          docker manifest annotate homeassistant/home-assistant:${tag_l} \
+          docker manifest annotate homeassistant/hassio-homeassistant:${tag_l} \
             homeassistant/armhf-homeassistant:${tag_r} \
             --os linux --arch arm --variant=v6
 
-          docker manifest annotate homeassistant/home-assistant:${tag_l} \
+          docker manifest annotate homeassistant/hassio-homeassistant:${tag_l} \
             homeassistant/armv7-homeassistant:${tag_r} \
             --os linux --arch arm --variant=v7
 
-          docker manifest annotate homeassistant/home-assistant:${tag_l} \
+          docker manifest annotate homeassistant/hassio-homeassistant:${tag_l} \
             homeassistant/aarch64-homeassistant:${tag_r} \
             --os linux --arch arm64 --variant=v8
 
-          docker manifest push --purge homeassistant/home-assistant:${tag_l}
+          docker manifest push --purge homeassistant/hassio-homeassistant:${tag_l}
         }
 
         docker pull homeassistant/amd64-homeassistant:$(homeassistantRelease)


### PR DESCRIPTION
## Proposed change

Fix: #34135 

Too much people run docker from Turtorials and have not the knowlage to maintain it later. This issue revert homeassistant/home-assistant to work like before the move over to use the improvments from Hass.io - So it work like a dummy container for people which just copy past commands from video/turtorials. For people which more knowlage which want use the improvments from Hass.io like jemalloc, can use the new meta image `homeassistant/hassio-homeassistant` which also work als multi arch image.

This make it possible to improve the Hass.io Images without affect the dummy core images but allow people also to use the more complex images. So we never bad affect this 2 worlds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
