### PR TITLE
Allow async_setup changes to config entry data be taken into account

### DIFF
--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from .const import (
     CONF_CITY,
     CONF_COUNTRY,
+    CONF_GEOGRAPHIES,
     DATA_CLIENT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -33,8 +34,6 @@ _LOGGER = logging.getLogger(__name__)
 DATA_LISTENER = "listener"
 
 DEFAULT_OPTIONS = {CONF_SHOW_ON_MAP: True}
-
-CONF_GEOGRAPHIES = "geographies"
 
 GEOGRAPHY_COORDINATES_SCHEMA = vol.Schema(
     {
@@ -158,8 +157,7 @@ async def async_migrate_entry(hass, config_entry):
 
         # Update the config entry to only include the first geography (there is always
         # guaranteed to be at least one):
-        data = {**config_entry.data}
-        geographies = data.pop(CONF_GEOGRAPHIES)
+        geographies = list(config_entry.data[CONF_GEOGRAPHIES])
         first_geography = geographies.pop(0)
         first_id = async_get_geography_id(first_geography)
 

--- a/homeassistant/components/airvisual/const.py
+++ b/homeassistant/components/airvisual/const.py
@@ -5,6 +5,7 @@ DOMAIN = "airvisual"
 
 CONF_CITY = "city"
 CONF_COUNTRY = "country"
+CONF_GEOGRAPHIES = "geographies"
 
 DATA_CLIENT = "client"
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -1,5 +1,6 @@
 """Classes to help gather user submissions."""
 import abc
+import asyncio
 import logging
 from typing import Any, Dict, List, Optional, cast
 import uuid
@@ -53,7 +54,17 @@ class FlowManager(abc.ABC):
     def __init__(self, hass: HomeAssistant,) -> None:
         """Initialize the flow manager."""
         self.hass = hass
+        self._initializing: Dict[str, List[asyncio.Future]] = {}
         self._progress: Dict[str, Any] = {}
+
+    async def async_wait_init_flow_finish(self, handler: str) -> None:
+        """Wait till all flows in progress are initialized."""
+        current = self._initializing.get(handler)
+
+        if not current:
+            return
+
+        await asyncio.wait(current)
 
     @abc.abstractmethod
     async def async_create_flow(
@@ -94,16 +105,25 @@ class FlowManager(abc.ABC):
         """Start a configuration flow."""
         if context is None:
             context = {}
-        flow = await self.async_create_flow(handler, context=context, data=data)
-        if not flow:
-            raise UnknownFlow("Flow was not created")
-        flow.hass = self.hass
-        flow.handler = handler
-        flow.flow_id = uuid.uuid4().hex
-        flow.context = context
-        self._progress[flow.flow_id] = flow
 
-        result = await self._async_handle_step(flow, flow.init_step, data)
+        try:
+            init_done: asyncio.Future = asyncio.Future()
+            self._initializing.setdefault(handler, []).append(init_done)
+
+            flow = await self.async_create_flow(handler, context=context, data=data)
+            if not flow:
+                raise UnknownFlow("Flow was not created")
+            flow.hass = self.hass
+            flow.handler = handler
+            flow.flow_id = uuid.uuid4().hex
+            flow.context = context
+            self._progress[flow.flow_id] = flow
+
+            result = await self._async_handle_step(
+                flow, flow.init_step, data, init_done
+            )
+        finally:
+            self._initializing[handler].remove(init_done)
 
         if result["type"] != RESULT_TYPE_ABORT:
             await self.async_post_init(flow, result)
@@ -154,13 +174,19 @@ class FlowManager(abc.ABC):
             raise UnknownFlow
 
     async def _async_handle_step(
-        self, flow: Any, step_id: str, user_input: Optional[Dict]
+        self,
+        flow: Any,
+        step_id: str,
+        user_input: Optional[Dict],
+        step_done: Optional[asyncio.Future] = None,
     ) -> Dict:
         """Handle a step of a flow."""
         method = f"async_step_{step_id}"
 
         if not hasattr(flow, method):
             self._progress.pop(flow.flow_id)
+            if step_done:
+                step_done.set_result(None)
             raise UnknownStep(
                 f"Handler {flow.__class__.__name__} doesn't support step {step_id}"
             )
@@ -171,6 +197,13 @@ class FlowManager(abc.ABC):
             result = _create_abort_data(
                 flow.flow_id, flow.handler, err.reason, err.description_placeholders
             )
+
+        # Mark the step as done.
+        # We do this before calling async_finish_flow because config entries will hit a
+        # circular dependency where async_finish_flow sets up new entry, which needs the
+        # integration to be set up, which is waiting for init to be done.
+        if step_done:
+            step_done.set_result(None)
 
         if result["type"] not in (
             RESULT_TYPE_FORM,

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -197,9 +197,12 @@ async def _async_setup_component(
         )
         return False
 
-    if hass.config_entries:
-        for entry in hass.config_entries.async_entries(domain):
-            await entry.async_setup(hass, integration=integration)
+    # Flush out async_setup calling create_task. Fragile but covered by test.
+    await asyncio.sleep(0)
+    await hass.config_entries.flow.async_wait_init_flow_finish(domain)
+
+    for entry in hass.config_entries.async_entries(domain):
+        await entry.async_setup(hass, integration=integration)
 
     hass.config.components.add(domain)
 

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -9,19 +9,6 @@ from .test_device import MAC, setup_axis_integration
 from tests.common import MockConfigEntry, mock_coro
 
 
-async def test_setup_device_already_configured(hass):
-    """Test already configured device does not configure a second."""
-    with patch.object(hass, "config_entries") as mock_config_entries:
-
-        assert await async_setup_component(
-            hass,
-            axis.DOMAIN,
-            {axis.DOMAIN: {"device_name": {axis.CONF_HOST: "1.2.3.4"}}},
-        )
-
-    assert not mock_config_entries.flow.mock_calls
-
-
 async def test_setup_no_config(hass):
     """Test setup without configuration."""
     assert await async_setup_component(hass, axis.DOMAIN, {})

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -230,7 +230,7 @@ async def test_setup_with_no_config(hass):
     assert konnected.YAML_CONFIGS not in hass.data[konnected.DOMAIN]
 
 
-async def test_setup_defined_hosts_known_auth(hass):
+async def test_setup_defined_hosts_known_auth(hass, mock_panel):
     """Test we don't initiate a config entry if configured panel is known."""
     MockConfigEntry(
         domain="konnected",

--- a/tests/components/luftdaten/test_init.py
+++ b/tests/components/luftdaten/test_init.py
@@ -15,7 +15,9 @@ async def test_config_with_sensor_passed_to_config_entry(hass):
         CONF_SCAN_INTERVAL: 600,
     }
 
-    with patch.object(hass, "config_entries") as mock_config_entries, patch.object(
+    with patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_entries, patch.object(
         luftdaten, "configured_sensors", return_value=[]
     ):
         assert await async_setup_component(hass, DOMAIN, conf) is True
@@ -27,7 +29,9 @@ async def test_config_already_registered_not_passed_to_config_entry(hass):
     """Test that an already registered sensor does not initiate an import."""
     conf = {CONF_SENSOR_ID: "12345abcde"}
 
-    with patch.object(hass, "config_entries") as mock_config_entries, patch.object(
+    with patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_entries, patch.object(
         luftdaten, "configured_sensors", return_value=["12345abcde"]
     ):
         assert await async_setup_component(hass, DOMAIN, conf) is True

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -55,7 +55,9 @@ def get_homekit_info_mock(model):
 
 async def test_setup(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
-    with patch.object(hass.config_entries, "flow") as mock_config_flow, patch.object(
+    with patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
         zeroconf, "ServiceBrowser", side_effect=service_update_mock
     ) as mock_service_browser:
         mock_zeroconf.get_service_info.side_effect = get_service_info_mock
@@ -72,7 +74,9 @@ async def test_homekit_match_partial_space(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
-    ), patch.object(hass.config_entries, "flow") as mock_config_flow, patch.object(
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
         zeroconf, "ServiceBrowser", side_effect=service_update_mock
     ) as mock_service_browser:
         mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock("LIFX bulb")
@@ -87,7 +91,9 @@ async def test_homekit_match_partial_dash(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
-    ), patch.object(hass.config_entries, "flow") as mock_config_flow, patch.object(
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
         zeroconf, "ServiceBrowser", side_effect=service_update_mock
     ) as mock_service_browser:
         mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
@@ -104,7 +110,9 @@ async def test_homekit_match_full(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
-    ), patch.object(hass.config_entries, "flow") as mock_config_flow, patch.object(
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
         zeroconf, "ServiceBrowser", side_effect=service_update_mock
     ) as mock_service_browser:
         mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock("BSB002")

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1477,7 +1477,7 @@ async def test_async_setup_init_entry(hass):
         )
         return True
 
-    async_setup_entry = MagicMock(return_value=mock_coro(True))
+    async_setup_entry = CoroutineMock(return_value=True)
     mock_integration(
         hass,
         MockModule(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1463,3 +1463,97 @@ async def test_partial_flows_hidden(hass, manager):
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_discovery")
         assert state is not None
+
+
+async def test_async_setup_init_entry(hass):
+    """Test a config entry being initialized during integration setup."""
+
+    async def mock_async_setup(hass, config):
+        """Mock setup."""
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                "comp", context={"source": config_entries.SOURCE_IMPORT}, data={},
+            )
+        )
+        return True
+
+    async_setup_entry = MagicMock(return_value=mock_coro(True))
+    mock_integration(
+        hass,
+        MockModule(
+            "comp", async_setup=mock_async_setup, async_setup_entry=async_setup_entry
+        ),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+    await async_setup_component(hass, "persistent_notification", {})
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_import(self, user_input):
+            """Test import step creating entry."""
+            return self.async_create_entry(title="title", data={})
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        assert await async_setup_component(hass, "comp", {})
+
+        await hass.async_block_till_done()
+
+        assert len(async_setup_entry.mock_calls) == 1
+
+        entries = hass.config_entries.async_entries("comp")
+        assert len(entries) == 1
+        assert entries[0].state == config_entries.ENTRY_STATE_LOADED
+
+
+async def test_async_setup_update_entry(hass):
+    """Test a config entry being updated during integration setup."""
+    entry = MockConfigEntry(domain="comp", data={"value": "initial"})
+    entry.add_to_hass(hass)
+
+    async def mock_async_setup(hass, config):
+        """Mock setup."""
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                "comp", context={"source": config_entries.SOURCE_IMPORT}, data={},
+            )
+        )
+        return True
+
+    async def mock_async_setup_entry(hass, entry):
+        """Mock setting up an entry."""
+        assert entry.data["value"] == "updated"
+        return True
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=mock_async_setup,
+            async_setup_entry=mock_async_setup_entry,
+        ),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+    await async_setup_component(hass, "persistent_notification", {})
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_import(self, user_input):
+            """Test import step updating existing entry."""
+            self.hass.config_entries.async_update_entry(
+                entry, data={"value": "updated"}
+            )
+            return self.async_abort(reason="yo")
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        assert await async_setup_component(hass, "comp", {})
+
+        entries = hass.config_entries.async_entries("comp")
+        assert len(entries) == 1
+        assert entries[0].state == config_entries.ENTRY_STATE_LOADED
+        assert entries[0].data == {"value": "updated"}

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from asynctest import CoroutineMock
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, loader


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The setup process of an integration sets up the integration (`async_setup`) and then sets up all config entries (`async_setup_entry`).

If `async_setup` updates a config entry, it does so by starting a config flow with source IMPORT and that config flow might update the entry.

With this PR, the setup process will wait till all config flows are done initializing before setting up the config entries. This gives the config flow the opportunity to update config entry data based on imported data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
