### PR TITLE
Clean up access to config in various integrations v4

### DIFF
--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -194,7 +194,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Inclusive(
             CONF_LONGITUDE, "coordinates", "Latitude and longitude must exist together"
         ): cv.longitude,
-        vol.Optional(CONF_TIMEFRAME, default=60): vol.All(
+        vol.Optional(CONF_TIMEFRAME, default=DEFAULT_TIMEFRAME): vol.All(
             vol.Coerce(int), vol.Range(min=5, max=120)
         ),
         vol.Optional(CONF_NAME, default="br"): cv.string,
@@ -207,7 +207,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    timeframe = config.get(CONF_TIMEFRAME, DEFAULT_TIMEFRAME)
+    timeframe = config[CONF_TIMEFRAME]
 
     if None in (latitude, longitude):
         _LOGGER.error("Latitude or longitude not set in Home Assistant config")

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -102,7 +102,7 @@ class BrWeather(WeatherEntity):
     def __init__(self, data, config):
         """Initialise the platform with a data instance and station name."""
         self._stationname = config.get(CONF_NAME)
-        self._forecast = config.get(CONF_FORECAST)
+        self._forecast = config[CONF_FORECAST]
         self._data = data
 
     @property

--- a/homeassistant/components/canary/__init__.py
+++ b/homeassistant/components/canary/__init__.py
@@ -40,9 +40,9 @@ CANARY_COMPONENTS = ["alarm_control_panel", "camera", "sensor"]
 def setup(hass, config):
     """Set up the Canary component."""
     conf = config[DOMAIN]
-    username = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASSWORD)
-    timeout = conf.get(CONF_TIMEOUT)
+    username = conf[CONF_USERNAME]
+    password = conf[CONF_PASSWORD]
+    timeout = conf[CONF_TIMEOUT]
 
     try:
         hass.data[DATA_CANARY] = CanaryData(username, password, timeout)

--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                         location,
                         device,
                         DEFAULT_TIMEOUT,
-                        config.get(CONF_FFMPEG_ARGUMENTS),
+                        config[CONF_FFMPEG_ARGUMENTS],
                     )
                 )
 

--- a/homeassistant/components/channels/media_player.py
+++ b/homeassistant/components/channels/media_player.py
@@ -70,9 +70,7 @@ CHANNELS_SEEK_BY_SCHEMA = CHANNELS_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Channels platform."""
-    device = ChannelsPlayer(
-        config.get(CONF_NAME), config.get(CONF_HOST), config.get(CONF_PORT)
-    )
+    device = ChannelsPlayer(config[CONF_NAME], config[CONF_HOST], config[CONF_PORT])
 
     if DATA_CHANNELS not in hass.data:
         hass.data[DATA_CHANNELS] = []

--- a/homeassistant/components/cisco_ios/device_tracker.py
+++ b/homeassistant/components/cisco_ios/device_tracker.py
@@ -42,7 +42,7 @@ class CiscoDeviceScanner(DeviceScanner):
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.port = config.get(CONF_PORT)
-        self.password = config.get(CONF_PASSWORD)
+        self.password = config[CONF_PASSWORD]
 
         self.last_results = {}
 

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -44,7 +44,7 @@ def get_scanner(hass, config):
         config[CONF_USERNAME],
         config[CONF_PASSWORD],
         config[CONF_SSL],
-        config.get(CONF_VERIFY_SSL),
+        config[CONF_VERIFY_SSL],
     )
     if not controller.is_logged_in():
         return None

--- a/homeassistant/components/clementine/media_player.py
+++ b/homeassistant/components/clementine/media_player.py
@@ -58,9 +58,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Clementine platform."""
 
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    token = config.get(CONF_ACCESS_TOKEN)
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+    token = config[CONF_ACCESS_TOKEN]
 
     client = ClementineRemote(host, port, token, reconnect=True)
 

--- a/homeassistant/components/clementine/media_player.py
+++ b/homeassistant/components/clementine/media_player.py
@@ -60,7 +60,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     host = config[CONF_HOST]
     port = config[CONF_PORT]
-    token = config[CONF_ACCESS_TOKEN]
+    token = config.get(CONF_ACCESS_TOKEN)
 
     client = ClementineRemote(host, port, token, reconnect=True)
 

--- a/homeassistant/components/clickatell/notify.py
+++ b/homeassistant/components/clickatell/notify.py
@@ -29,8 +29,8 @@ class ClickatellNotificationService(BaseNotificationService):
 
     def __init__(self, config):
         """Initialize the service."""
-        self.api_key = config.get(CONF_API_KEY)
-        self.recipient = config.get(CONF_RECIPIENT)
+        self.api_key = config[CONF_API_KEY]
+        self.recipient = config[CONF_RECIPIENT]
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/clicksend_tts/notify.py
+++ b/homeassistant/components/clicksend_tts/notify.py
@@ -56,11 +56,11 @@ class ClicksendNotificationService(BaseNotificationService):
 
     def __init__(self, config):
         """Initialize the service."""
-        self.username = config.get(CONF_USERNAME)
-        self.api_key = config.get(CONF_API_KEY)
-        self.recipient = config.get(CONF_RECIPIENT)
-        self.language = config.get(CONF_LANGUAGE)
-        self.voice = config.get(CONF_VOICE)
+        self.username = config[CONF_USERNAME]
+        self.api_key = config[CONF_API_KEY]
+        self.recipient = config[CONF_RECIPIENT]
+        self.language = config[CONF_LANGUAGE]
+        self.voice = config[CONF_VOICE]
         self.caller = config.get(CONF_CALLER)
         if self.caller is None:
             self.caller = self.recipient

--- a/homeassistant/components/cmus/media_player.py
+++ b/homeassistant/components/cmus/media_player.py
@@ -61,8 +61,8 @@ def setup_platform(hass, config, add_entities, discover_info=None):
 
     host = config.get(CONF_HOST)
     password = config.get(CONF_PASSWORD)
-    port = config.get(CONF_PORT)
-    name = config.get(CONF_NAME)
+    port = config[CONF_PORT]
+    name = config[CONF_NAME]
 
     try:
         cmus_remote = CmusDevice(host, password, port, name)

--- a/homeassistant/components/coinbase/__init__.py
+++ b/homeassistant/components/coinbase/__init__.py
@@ -48,10 +48,10 @@ def setup(hass, config):
     Will automatically setup sensors to support
     wallets discovered on the network.
     """
-    api_key = config[DOMAIN].get(CONF_API_KEY)
-    api_secret = config[DOMAIN].get(CONF_API_SECRET)
+    api_key = config[DOMAIN][CONF_API_KEY]
+    api_secret = config[DOMAIN][CONF_API_SECRET]
     account_currencies = config[DOMAIN].get(CONF_ACCOUNT_CURRENCIES)
-    exchange_currencies = config[DOMAIN].get(CONF_EXCHANGE_CURRENCIES)
+    exchange_currencies = config[DOMAIN][CONF_EXCHANGE_CURRENCIES]
 
     hass.data[DATA_COINBASE] = coinbase_data = CoinbaseData(api_key, api_secret)
 

--- a/homeassistant/components/coinmarketcap/sensor.py
+++ b/homeassistant/components/coinmarketcap/sensor.py
@@ -42,9 +42,9 @@ SCAN_INTERVAL = timedelta(minutes=15)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_CURRENCY_ID, default=DEFAULT_CURRENCY_ID): cv.positive_int,
-        vol.Optional(
-            CONF_DISPLAY_CURRENCY, default=DEFAULT_DISPLAY_CURRENCY
-        ): cv.string,
+        vol.Optional(CONF_DISPLAY_CURRENCY, default=DEFAULT_DISPLAY_CURRENCY): vol.All(
+            cv.string, vol.Upper
+        ),
         vol.Optional(
             CONF_DISPLAY_CURRENCY_DECIMALS, default=DEFAULT_DISPLAY_CURRENCY_DECIMALS
         ): vol.All(vol.Coerce(int), vol.Range(min=1)),
@@ -55,7 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the CoinMarketCap sensor."""
     currency_id = config[CONF_CURRENCY_ID]
-    display_currency = config[CONF_DISPLAY_CURRENCY].upper()
+    display_currency = config[CONF_DISPLAY_CURRENCY]
     display_currency_decimals = config[CONF_DISPLAY_CURRENCY_DECIMALS]
 
     try:

--- a/homeassistant/components/coinmarketcap/sensor.py
+++ b/homeassistant/components/coinmarketcap/sensor.py
@@ -54,9 +54,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the CoinMarketCap sensor."""
-    currency_id = config.get(CONF_CURRENCY_ID)
-    display_currency = config.get(CONF_DISPLAY_CURRENCY).upper()
-    display_currency_decimals = config.get(CONF_DISPLAY_CURRENCY_DECIMALS)
+    currency_id = config[CONF_CURRENCY_ID]
+    display_currency = config[CONF_DISPLAY_CURRENCY].upper()
+    display_currency_decimals = config[CONF_DISPLAY_CURRENCY_DECIMALS]
 
     try:
         CoinMarketCapData(currency_id, display_currency).update()

--- a/homeassistant/components/comfoconnect/__init__.py
+++ b/homeassistant/components/comfoconnect/__init__.py
@@ -52,11 +52,11 @@ def setup(hass, config):
     """Set up the ComfoConnect bridge."""
 
     conf = config[DOMAIN]
-    host = conf.get(CONF_HOST)
-    name = conf.get(CONF_NAME)
-    token = conf.get(CONF_TOKEN)
-    user_agent = conf.get(CONF_USER_AGENT)
-    pin = conf.get(CONF_PIN)
+    host = conf[CONF_HOST]
+    name = conf[CONF_NAME]
+    token = conf[CONF_TOKEN]
+    user_agent = conf[CONF_USER_AGENT]
+    pin = conf[CONF_PIN]
 
     # Run discovery on the configured ip
     bridges = Bridge.discover(host)

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -46,11 +46,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Concord232 alarm control panel platform."""
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
     code = config.get(CONF_CODE)
-    mode = config.get(CONF_MODE)
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
+    mode = config[CONF_MODE]
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
 
     url = f"http://{host}:{port}"
 

--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -44,10 +44,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Concord232 binary sensor platform."""
 
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    exclude = config.get(CONF_EXCLUDE_ZONES)
-    zone_types = config.get(CONF_ZONE_TYPES)
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+    exclude = config[CONF_EXCLUDE_ZONES]
+    zone_types = config[CONF_ZONE_TYPES]
     sensors = []
 
     try:

--- a/homeassistant/components/cpuspeed/sensor.py
+++ b/homeassistant/components/cpuspeed/sensor.py
@@ -29,7 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the CPU speed sensor."""
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     add_entities([CpuSpeedSensor(name)], True)
 

--- a/homeassistant/components/crimereports/sensor.py
+++ b/homeassistant/components/crimereports/sensor.py
@@ -50,8 +50,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Crime Reports platform."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    name = config.get(CONF_NAME)
-    radius = config.get(CONF_RADIUS)
+    name = config[CONF_NAME]
+    radius = config[CONF_RADIUS]
     include = config.get(CONF_INCLUDE)
     exclude = config.get(CONF_EXCLUDE)
 

--- a/homeassistant/components/cups/sensor.py
+++ b/homeassistant/components/cups/sensor.py
@@ -53,10 +53,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the CUPS sensor."""
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    printers = config.get(CONF_PRINTERS)
-    is_cups = config.get(CONF_IS_CUPS_SERVER)
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+    printers = config[CONF_PRINTERS]
+    is_cups = config[CONF_IS_CUPS_SERVER]
 
     if is_cups:
         data = CupsData(host, port, None)

--- a/homeassistant/components/currencylayer/sensor.py
+++ b/homeassistant/components/currencylayer/sensor.py
@@ -40,15 +40,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Currencylayer sensor."""
-    base = config.get(CONF_BASE)
-    api_key = config.get(CONF_API_KEY)
+    base = config[CONF_BASE]
+    api_key = config[CONF_API_KEY]
     parameters = {"source": base, "access_key": api_key, "format": 1}
 
     rest = CurrencylayerData(_RESOURCE, parameters)
 
     response = requests.get(_RESOURCE, params=parameters, timeout=10)
     sensors = []
-    for variable in config["quote"]:
+    for variable in config[CONF_QUOTE]:
         sensors.append(CurrencylayerSensor(rest, base, variable))
     if "error" in response.json():
         return False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces incorrect use of `dict.get(key)` for required and optional config keys with a default value with `dict[key]` in various integrations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
