### PR TITLE
Update Honeywell climate to support temporary and permanent holds

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -18,6 +18,7 @@ from homeassistant.components.climate.const import (
     FAN_AUTO,
     FAN_DIFFUSE,
     FAN_ON,
+    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
@@ -47,11 +48,21 @@ ATTR_FAN_ACTION = "fan_action"
 
 CONF_COOL_AWAY_TEMPERATURE = "away_cool_temperature"
 CONF_HEAT_AWAY_TEMPERATURE = "away_heat_temperature"
+CONF_USE_SCHEDULES = "use_schedules"
+CONF_SCHEDULE_HVAC_MODE = "schedule_hvac_moe"
 
 DEFAULT_COOL_AWAY_TEMPERATURE = 88
 DEFAULT_HEAT_AWAY_TEMPERATURE = 61
 DEFAULT_REGION = "eu"
+DEFAULT_SCHEDULE_HVAC_MODE = None
+SCHEDULE_HVAC_MODES = [None, HVAC_MODE_HEAT_COOL, HVAC_MODE_HEAT, HVAC_MODE_COOL]
 REGIONS = ["eu", "us"]
+
+HOLD_MODE_TEMPORARY = "temporary"
+HOLD_MODE_PERMANENT = "permanent"
+HOLD_MODE_SCHEDULE = "schedule"
+
+PRESET_TEMP_OVERRIDE = "Temp Override"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -63,6 +74,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(
             CONF_HEAT_AWAY_TEMPERATURE, default=DEFAULT_HEAT_AWAY_TEMPERATURE
         ): vol.Coerce(int),
+        vol.Optional(CONF_USE_SCHEDULES, default=False): cv.boolean,
+        vol.Optional(
+            CONF_SCHEDULE_HVAC_MODE, default=DEFAULT_SCHEDULE_HVAC_MODE
+        ): vol.In(SCHEDULE_HVAC_MODES),
         vol.Optional(CONF_REGION, default=DEFAULT_REGION): vol.In(REGIONS),
     }
 )
@@ -122,11 +137,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         loc_id = config.get("location")
         cool_away_temp = config.get(CONF_COOL_AWAY_TEMPERATURE)
         heat_away_temp = config.get(CONF_HEAT_AWAY_TEMPERATURE)
+        use_schedules = config.get(CONF_USE_SCHEDULES)
+        schedule_hvac_mode = config.get(CONF_SCHEDULE_HVAC_MODE)
 
         add_entities(
             [
                 HoneywellUSThermostat(
-                    client, device, cool_away_temp, heat_away_temp, username, password
+                    client,
+                    device,
+                    cool_away_temp,
+                    heat_away_temp,
+                    use_schedules,
+                    schedule_hvac_mode,
+                    username,
+                    password,
                 )
                 for location in client.locations_by_id.values()
                 for device in location.devices_by_id.values()
@@ -149,14 +173,24 @@ class HoneywellUSThermostat(ClimateEntity):
     """Representation of a Honeywell US Thermostat."""
 
     def __init__(
-        self, client, device, cool_away_temp, heat_away_temp, username, password
+        self,
+        client,
+        device,
+        cool_away_temp,
+        heat_away_temp,
+        use_schedules,
+        schedule_hvac_mode,
+        username,
+        password,
     ):
         """Initialize the thermostat."""
         self._client = client
         self._device = device
         self._cool_away_temp = cool_away_temp
         self._heat_away_temp = heat_away_temp
+        self._schedule_hvac_mode = schedule_hvac_mode
         self._away = False
+        self._away_timestamp = datetime.datetime.now()
         self._username = username
         self._password = password
 
@@ -166,11 +200,24 @@ class HoneywellUSThermostat(ClimateEntity):
         mappings = [v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]]
         self._hvac_mode_map = {k: v for d in mappings for k, v in d.items()}
 
-        self._supported_features = (
-            SUPPORT_PRESET_MODE
-            | SUPPORT_TARGET_TEMPERATURE
-            | SUPPORT_TARGET_TEMPERATURE_RANGE
-        )
+        self._supported_features = SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE
+
+        if HVAC_MODE_HEAT_COOL in mappings:
+            self.supported_features |= SUPPORT_TARGET_TEMPERATURE_RANGE
+        if use_schedules:
+            if not self._schedule_hvac_mode:
+                schedule_hvac_modes = list(
+                    set(self._hvac_mode_map.keys()).intersection(
+                        set(SCHEDULE_HVAC_MODES)
+                    )
+                )
+                if len(schedule_hvac_modes) != 1:
+                    _LOGGER.error("Scheduled HVAC mode misconfigured!")
+                    self._schedule_hvac_mode = None
+                else:
+                    self._schedule_hvac_mode = schedule_hvac_modes[0]
+            if self._schedule_hvac_mode is not None:
+                self._schedule_hvac_mode = self._hvac_mode_map[self._schedule_hvac_mode]
 
         if device._data["canControlHumidification"]:
             self._supported_features |= SUPPORT_TARGET_HUMIDITY
@@ -178,14 +225,15 @@ class HoneywellUSThermostat(ClimateEntity):
         if device.raw_ui_data["SwitchEmergencyHeatAllowed"]:
             self._supported_features |= SUPPORT_AUX_HEAT
 
-        if not device._data["hasFan"]:
-            return
+        if device._data["hasFan"]:
+            # not all honeywell fans support all modes
+            mappings = [v for k, v in FAN_MODE_TO_HW.items() if device.raw_fan_data[k]]
+            self._fan_mode_map = {k: v for d in mappings for k, v in d.items()}
 
-        # not all honeywell fans support all modes
-        mappings = [v for k, v in FAN_MODE_TO_HW.items() if device.raw_fan_data[k]]
-        self._fan_mode_map = {k: v for d in mappings for k, v in d.items()}
+            self._supported_features |= SUPPORT_FAN_MODE
 
-        self._supported_features |= SUPPORT_FAN_MODE
+        if self._is_away_temp_set_for_mode():
+            self._away = True
 
     @property
     def name(self) -> Optional[str]:
@@ -195,10 +243,25 @@ class HoneywellUSThermostat(ClimateEntity):
     @property
     def device_state_attributes(self) -> Dict[str, Any]:
         """Return the device specific state attributes."""
-        data = {}
-        data[ATTR_FAN_ACTION] = "running" if self._device.fan_running else "idle"
+        honeywell = {}
+        data = {
+            "honeywell": honeywell,
+            ATTR_FAN_ACTION: "running" if self._device.fan_running else "idle",
+        }
         if self._device.raw_dr_data:
-            data["dr_phase"] = self._device.raw_dr_data.get("Phase")
+            honeywell["dr_phase"] = self._device.raw_dr_data.get("Phase")
+        if HVAC_MODE_HEAT in self._hvac_mode_map:
+            honeywell["hold_heat"] = self._hold_for_mode("heat")
+        if HVAC_MODE_COOL in self._hvac_mode_map:
+            honeywell["hold_cool"] = self._hold_for_mode("cool")
+        if self._use_schedules:
+            data["schedule_hvac_mode"] = self._schedule_hvac_mode
+        data["hvac_mode"] = self._hvac_mode
+        honeywell["system_mode"] = self._device.system_mode
+        honeywell["equipment_output_status"] = self._device.equipment_output_status
+        honeywell["device_id"] = self._device.deviceid
+        honeywell["name"] = self._device.name
+        honeywell["macid"] = self._device.mac_address
         return data
 
     @property
@@ -209,18 +272,18 @@ class HoneywellUSThermostat(ClimateEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        if self.hvac_mode in [HVAC_MODE_COOL, HVAC_MODE_HEAT_COOL]:
+        if self._hvac_mode in [HVAC_MODE_COOL, HVAC_MODE_HEAT_COOL]:
             return self._device.raw_ui_data["CoolLowerSetptLimit"]
-        if self.hvac_mode == HVAC_MODE_HEAT:
+        if self._hvac_mode == HVAC_MODE_HEAT:
             return self._device.raw_ui_data["HeatLowerSetptLimit"]
         return None
 
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        if self.hvac_mode == HVAC_MODE_COOL:
+        if self._hvac_mode == HVAC_MODE_COOL:
             return self._device.raw_ui_data["CoolUpperSetptLimit"]
-        if self.hvac_mode in [HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL]:
+        if self._hvac_mode in [HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL]:
             return self._device.raw_ui_data["HeatUpperSetptLimit"]
         return None
 
@@ -237,17 +300,39 @@ class HoneywellUSThermostat(ClimateEntity):
     @property
     def hvac_mode(self) -> str:
         """Return hvac operation ie. heat, cool mode."""
+        if self._use_schedules:
+            hm = self.hold_mode
+            if hm in [HOLD_MODE_SCHEDULE, HOLD_MODE_TEMPORARY]:
+                return HVAC_MODE_AUTO
+        return self._hvac_mode
+
+    def __repr__(self):
+        """Print just its name."""
+        return f"<Honeywell {self.name}: >"
+
+    @property
+    def _hvac_mode(self) -> str:
         return HW_MODE_TO_HVAC_MODE[self._device.system_mode]
+
+    @property
+    def _use_schedules(self) -> bool:
+        return self._schedule_hvac_mode is not None
 
     @property
     def hvac_modes(self) -> List[str]:
         """Return the list of available hvac operation modes."""
+        if self._use_schedules:
+            return self._hvac_modes + [HVAC_MODE_AUTO]
+        return self._hvac_modes
+
+    @property
+    def _hvac_modes(self) -> List[str]:
         return list(self._hvac_mode_map)
 
     @property
     def hvac_action(self) -> Optional[str]:
         """Return the current running hvac operation if supported."""
-        if self.hvac_mode == HVAC_MODE_OFF:
+        if self._hvac_mode == HVAC_MODE_OFF:
             return None
         return HW_MODE_TO_HA_HVAC_ACTION[self._device.equipment_output_status]
 
@@ -259,34 +344,73 @@ class HoneywellUSThermostat(ClimateEntity):
     @property
     def target_temperature(self) -> Optional[float]:
         """Return the temperature we try to reach."""
-        if self.hvac_mode == HVAC_MODE_COOL:
+        if self._hvac_mode == HVAC_MODE_COOL:
             return self._device.setpoint_cool
-        if self.hvac_mode == HVAC_MODE_HEAT:
+        if self._hvac_mode == HVAC_MODE_HEAT:
             return self._device.setpoint_heat
         return None
 
     @property
     def target_temperature_high(self) -> Optional[float]:
         """Return the highbound target temperature we try to reach."""
-        if self.hvac_mode == HVAC_MODE_HEAT_COOL:
+        if self._hvac_mode == HVAC_MODE_HEAT_COOL:
             return self._device.setpoint_cool
         return None
 
     @property
+    def hold_mode(self) -> Optional[bool]:
+        """Return if the thermostat is in permanent hold."""
+        return self._hold
+
+    @property
+    def _hold(self) -> Optional[bool]:
+        mode = self._current_system_mode()
+        if mode not in ["heat", "cool"]:
+            return None
+        return self._hold_for_mode(mode)
+
+    def _hold_for_mode(self, mode: str) -> Optional[bool]:
+        hold_mode = getattr(self._device, f"hold_{mode}")
+        if hold_mode is True:
+            return HOLD_MODE_PERMANENT
+        if hold_mode is False:
+            return HOLD_MODE_SCHEDULE
+        return HOLD_MODE_TEMPORARY
+
+    @property
     def target_temperature_low(self) -> Optional[float]:
         """Return the lowbound target temperature we try to reach."""
-        if self.hvac_mode == HVAC_MODE_HEAT_COOL:
+        if self._hvac_mode == HVAC_MODE_HEAT_COOL:
             return self._device.setpoint_heat
         return None
 
     @property
+    def away(self) -> bool:
+        """Return whether or not the thermostat is away. Requires away boolean and validation of settings."""
+        if self._away:
+            if self._is_away_temp_set_for_mode():
+                return True
+            else:
+                if (datetime.datetime.now() - self._away_timestamp).seconds > 60:
+                    self._away = False
+        return False
+
+    @property
     def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
-        return PRESET_AWAY if self._away else None
+        if (
+            self._use_schedules
+            and self.hvac_mode == HVAC_MODE_AUTO
+            and self.hold_mode == HOLD_MODE_TEMPORARY
+        ):
+            return PRESET_TEMP_OVERRIDE
+        return PRESET_AWAY if self.away else PRESET_NONE
 
     @property
     def preset_modes(self) -> Optional[List[str]]:
         """Return a list of available preset modes."""
+        if self._use_schedules and self.hvac_mode == HVAC_MODE_AUTO:
+            return [PRESET_NONE, PRESET_AWAY, PRESET_TEMP_OVERRIDE]
         return [PRESET_NONE, PRESET_AWAY]
 
     @property
@@ -304,33 +428,35 @@ class HoneywellUSThermostat(ClimateEntity):
         """Return the list of available fan modes."""
         return list(self._fan_mode_map)
 
-    def _set_temperature(self, **kwargs) -> None:
+    def _set_temperature(self, temperature: int, mode: str) -> None:
         """Set new target temperature."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
-        if temperature is None:
-            return
         try:
             # Get current mode
-            mode = self._device.system_mode
-            # Set hold if this is not the case
-            if getattr(self._device, f"hold_{mode}") is False:
-                # Get next period key
-                next_period_key = f"{mode.capitalize()}NextPeriod"
-                # Get next period raw value
-                next_period = self._device.raw_ui_data.get(next_period_key)
-                # Get next period time
-                hour, minute = divmod(next_period * 15, 60)
-                # Set hold time
-                setattr(self._device, f"hold_{mode}", datetime.time(hour, minute))
             # Set temperature
             setattr(self._device, f"setpoint_{mode}", temperature)
         except somecomfort.SomeComfortError:
             _LOGGER.error("Temperature %.1f out of range", temperature)
 
+    def _set_temporary_hold(self, mode: str) -> None:
+        # Set temporary hold if we aren't in permanent hold
+        if getattr(self._device, f"hold_{mode}") is False:
+            # Get next period key
+            next_period_key = f"{mode.capitalize()}NextPeriod"
+            # Get next period raw value
+            next_period = self._device.raw_ui_data.get(next_period_key)
+            # Get next period time
+            hour, minute = divmod(next_period * 15, 60)
+            # Set hold time
+            setattr(self._device, f"hold_{mode}", datetime.time(hour, minute))
+
     def set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         if {HVAC_MODE_COOL, HVAC_MODE_HEAT} & set(self._hvac_mode_map):
-            self._set_temperature(**kwargs)
+            temperature = kwargs.get(ATTR_TEMPERATURE)
+            if temperature is not None:
+                mode = self._current_system_mode()
+                self._set_temporary_hold(mode)
+                self._set_temperature(temperature, mode)
 
         try:
             if HVAC_MODE_HEAT_COOL in self._hvac_mode_map:
@@ -349,7 +475,39 @@ class HoneywellUSThermostat(ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
-        self._device.system_mode = self._hvac_mode_map[hvac_mode]
+        if self._use_schedules and hvac_mode == HVAC_MODE_AUTO:
+            # disable hold if we aren't already in AUTO.
+            if self.hvac_mode != HVAC_MODE_AUTO:
+                self._disable_holds()
+            if self._device.system_mode != self._schedule_hvac_mode:
+                self._device.system_mode = self._schedule_hvac_mode
+        else:
+            new_mode = self._hvac_mode_map[hvac_mode]
+            self._device.system_mode = new_mode
+            if self._use_schedules and hvac_mode != HVAC_MODE_OFF:
+                self._set_permanent_hold(new_mode)
+                self._set_temperature(
+                    getattr(self._device, f"setpoint_{new_mode}"), new_mode
+                )
+
+    def _away_target_for_mode(self, mode: str) -> int:
+        """Check for away mode settings."""
+        return int(getattr(self, f"_{mode}_away_temp"))
+
+    def _is_away_temp_set_for_mode(self) -> bool:
+        """Check if away mode is properly set."""
+        if self.hold_mode != HOLD_MODE_PERMANENT:
+            return False
+        try:
+            # Get current mode
+            mode = self._device.system_mode
+        except somecomfort.SomeComfortError:
+            _LOGGER.error("Can not get system mode")
+            return False
+        # Get temperature
+        hw_target = getattr(self._device, f"setpoint_{mode}")
+        away_target = self._away_target_for_mode(mode)
+        return hw_target == away_target
 
     def _turn_away_mode_on(self) -> None:
         """Turn away on.
@@ -359,28 +517,23 @@ class HoneywellUSThermostat(ClimateEntity):
         it doesn't get overwritten when away mode is switched on.
         """
         self._away = True
-        try:
-            # Get current mode
-            mode = self._device.system_mode
-        except somecomfort.SomeComfortError:
-            _LOGGER.error("Can not get system mode")
-            return
-        try:
+        self._away_timestamp = datetime.datetime.now()
+        mode = self._current_system_mode()
+        self._set_permanent_hold(mode)
+        target_temp = self._away_target_for_mode(mode)
+        self._set_temperature(target_temp, mode)
 
-            # Set permanent hold
-            setattr(self._device, f"hold_{mode}", True)
-            # Set temperature
-            setattr(
-                self._device, f"setpoint_{mode}", getattr(self, f"_{mode}_away_temp")
-            )
-        except somecomfort.SomeComfortError:
-            _LOGGER.error(
-                "Temperature %.1f out of range", getattr(self, f"_{mode}_away_temp")
-            )
+    def _set_permanent_hold(self, mode) -> None:
+        # Set permanent hold
+        setattr(self._device, f"hold_{mode}", True)
 
-    def _turn_away_mode_off(self) -> None:
-        """Turn away off."""
-        self._away = False
+    def _current_system_mode(self) -> str:
+        return self._device.system_mode
+
+    def _away_mode_temp(self, current_mode: str) -> int:
+        return int(getattr(self, f"_{current_mode}_away_temp"))
+
+    def _disable_holds(self) -> None:
         try:
             # Disabling all hold modes
             self._device.hold_cool = False
@@ -388,11 +541,21 @@ class HoneywellUSThermostat(ClimateEntity):
         except somecomfort.SomeComfortError:
             _LOGGER.error("Can not stop hold mode")
 
+    def _turn_away_mode_off(self) -> None:
+        """Turn away off."""
+        self._away = False
+        if not self._use_schedules:
+            self._disable_holds()
+
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode == PRESET_AWAY:
+            if self._use_schedules:
+                self._device.system_mode = self._schedule_hvac_mode
             self._turn_away_mode_on()
         else:
+            # Can't manually set TEMP_OVERRIDE. Change temperature instead. If set to None or TempOverride, just
+            # make sure away mode is off
             self._turn_away_mode_off()
 
     def turn_aux_heat_on(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
AFAIK, none. Opt in changes.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Update Honeywell integration to:
  * better support temporary and permanent holds
  * better map to HomeKit when using

This was motivated due to my usage of our Honeywell thermostats. They primary live in the "Schedule" mode, with only heating capabilities. As needed, we adjust the thermostats to create "temporary holds" (Honeywell's phraseology), which adjust the temperature until the next schedule time slot. Occasionally, when the weather is more agreeable, we use "Permanent Holds" to ensure a minimum temperature, without following the schedule.

With the `use_schedules` option, one now gets the ability of temporary and permanent holds through the "Heat" and "Auto" options. I'm not sure if this is abusing these settings, but it works very well for my usage. The "Heat" option corresponds to permanent hold, and the Auto option corresponds to schedule mode. When the target temp is adjusted in auto, it perform a temporary hold.

Another purpose for the above change was to map natively into the HomeKit thermostat interface. We now get the same behavior in HomeKit as listed above, with the one exception of not knowing whether the current "Auto" temperature is via temporary hold or not, like we get via the HASS presets dropdown.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example climate.yaml
- platform: honeywell_jbh
  username: jhenkens@github.com
  password: !secret honeywell
  region: us
  away_heat_temperature: 50
  scan_interval: 360
  use_schedules: true


```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

_I'd like some general feedback before I proceed further with the below checklist items, if possible_.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
 *don't know how to do this one *
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
