### PR TITLE
Fix emulated_hue brightness off by one

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -367,7 +367,7 @@ class HueOneLightChangeView(HomeAssistantView):
                 cover.DOMAIN,
                 climate.DOMAIN,
             ]:
-                # Convert 0-255 to 0-100
+                # Convert 0-254 to 0-100
                 level = (parsed[STATE_BRIGHTNESS] / HUE_API_STATE_BRI_MAX) * 100
                 parsed[STATE_BRIGHTNESS] = round(level)
                 parsed[STATE_ON] = True
@@ -390,7 +390,9 @@ class HueOneLightChangeView(HomeAssistantView):
             if parsed[STATE_ON]:
                 if entity_features & SUPPORT_BRIGHTNESS:
                     if parsed[STATE_BRIGHTNESS] is not None:
-                        data[ATTR_BRIGHTNESS] = parsed[STATE_BRIGHTNESS]
+                        data[ATTR_BRIGHTNESS] = hue_brightness_to_hass(
+                            parsed[STATE_BRIGHTNESS]
+                        )
 
                 if entity_features & SUPPORT_COLOR:
                     if any((parsed[STATE_HUE], parsed[STATE_SATURATION])):
@@ -536,7 +538,9 @@ def get_entity_state(config, entity):
         data[STATE_ON] = entity.state != STATE_OFF
 
         if data[STATE_ON]:
-            data[STATE_BRIGHTNESS] = entity.attributes.get(ATTR_BRIGHTNESS, 0)
+            data[STATE_BRIGHTNESS] = hass_to_hue_brightness(
+                entity.attributes.get(ATTR_BRIGHTNESS, 0)
+            )
             hue_sat = entity.attributes.get(ATTR_HS_COLOR)
             if hue_sat is not None:
                 hue = hue_sat[0]
@@ -563,32 +567,32 @@ def get_entity_state(config, entity):
                 pass
         elif entity.domain == climate.DOMAIN:
             temperature = entity.attributes.get(ATTR_TEMPERATURE, 0)
-            # Convert 0-100 to 0-255
-            data[STATE_BRIGHTNESS] = round(temperature * 255 / 100)
+            # Convert 0-100 to 0-254
+            data[STATE_BRIGHTNESS] = round(temperature * HUE_API_STATE_BRI_MAX / 100)
         elif entity.domain == media_player.DOMAIN:
             level = entity.attributes.get(
                 ATTR_MEDIA_VOLUME_LEVEL, 1.0 if data[STATE_ON] else 0.0
             )
-            # Convert 0.0-1.0 to 0-255
-            data[STATE_BRIGHTNESS] = round(min(1.0, level) * 255)
+            # Convert 0.0-1.0 to 0-254
+            data[STATE_BRIGHTNESS] = round(min(1.0, level) * HUE_API_STATE_BRI_MAX)
         elif entity.domain == fan.DOMAIN:
             speed = entity.attributes.get(ATTR_SPEED, 0)
-            # Convert 0.0-1.0 to 0-255
+            # Convert 0.0-1.0 to 0-254
             data[STATE_BRIGHTNESS] = 0
             if speed == SPEED_LOW:
                 data[STATE_BRIGHTNESS] = 85
             elif speed == SPEED_MEDIUM:
                 data[STATE_BRIGHTNESS] = 170
             elif speed == SPEED_HIGH:
-                data[STATE_BRIGHTNESS] = 255
+                data[STATE_BRIGHTNESS] = HUE_API_STATE_BRI_MAX
         elif entity.domain == cover.DOMAIN:
             level = entity.attributes.get(ATTR_CURRENT_POSITION, 0)
-            data[STATE_BRIGHTNESS] = round(level / 100 * 255)
+            data[STATE_BRIGHTNESS] = round(level / 100 * HUE_API_STATE_BRI_MAX)
     else:
         data = cached_state
         # Make sure brightness is valid
         if data[STATE_BRIGHTNESS] is None:
-            data[STATE_BRIGHTNESS] = 255 if data[STATE_ON] else 0
+            data[STATE_BRIGHTNESS] = HUE_API_STATE_BRI_MAX if data[STATE_ON] else 0
 
         # Make sure hue/saturation are valid
         if (data[STATE_HUE] is None) or (data[STATE_SATURATION] is None):
@@ -723,3 +727,13 @@ def create_list_of_entities(config, request):
             json_response[number] = entity_to_json(config, entity)
 
     return json_response
+
+
+def hue_brightness_to_hass(value):
+    """Convert hue brightness 1..254 to hass format 0..255."""
+    return min(255, round((value / 254) * 255))
+
+
+def hass_to_hue_brightness(value):
+    """Convert hass brightness 0..255 to hue 1..254 scale."""
+    return max(1, round((value / 255) * 254))

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -393,11 +393,6 @@ class HueOneLightChangeView(HomeAssistantView):
                         data[ATTR_BRIGHTNESS] = hue_brightness_to_hass(
                             parsed[STATE_BRIGHTNESS]
                         )
-                        _LOGGER.debug(
-                            "Set brightness incoming from hueapi: %s outgoing to hass: %s",
-                            parsed[STATE_BRIGHTNESS],
-                            data[ATTR_BRIGHTNESS],
-                        )
 
                 if entity_features & SUPPORT_COLOR:
                     if any((parsed[STATE_HUE], parsed[STATE_SATURATION])):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -731,9 +731,9 @@ def create_list_of_entities(config, request):
 
 def hue_brightness_to_hass(value):
     """Convert hue brightness 1..254 to hass format 0..255."""
-    return min(255, round((value / HUE_API_STATE_HUE_MAX) * 255))
+    return min(255, round((value / HUE_API_STATE_BRI_MAX) * 255))
 
 
 def hass_to_hue_brightness(value):
     """Convert hass brightness 0..255 to hue 1..254 scale."""
-    return max(1, round((value / 255) * HUE_API_STATE_HUE_MAX))
+    return max(1, round((value / 255) * HUE_API_STATE_BRI_MAX))

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -393,6 +393,11 @@ class HueOneLightChangeView(HomeAssistantView):
                         data[ATTR_BRIGHTNESS] = hue_brightness_to_hass(
                             parsed[STATE_BRIGHTNESS]
                         )
+                        _LOGGER.debug(
+                            "Set brightness incoming from hueapi: %s outgoing to hass: %s",
+                            parsed[STATE_BRIGHTNESS],
+                            data[ATTR_BRIGHTNESS],
+                        )
 
                 if entity_features & SUPPORT_COLOR:
                     if any((parsed[STATE_HUE], parsed[STATE_SATURATION])):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -731,9 +731,9 @@ def create_list_of_entities(config, request):
 
 def hue_brightness_to_hass(value):
     """Convert hue brightness 1..254 to hass format 0..255."""
-    return min(255, round((value / 254) * 255))
+    return min(255, round((value / HUE_API_STATE_HUE_MAX) * 255))
 
 
 def hass_to_hue_brightness(value):
     """Convert hass brightness 0..255 to hue 1..254 scale."""
-    return max(1, round((value / 255) * 254))
+    return max(1, round((value / 255) * HUE_API_STATE_HUE_MAX))


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hue uses a max brightness of 254, Home Assistant
uses a max brightness of 255. Values > 127 were
off by one.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34173
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
