### PR TITLE
Ecobee to use HVAC mode heat-cool instead of auto

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -15,9 +15,9 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_IDLE,
     FAN_AUTO,
     FAN_ON,
-    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
     PRESET_AWAY,
     PRESET_NONE,
@@ -64,7 +64,7 @@ ECOBEE_HVAC_TO_HASS = collections.OrderedDict(
     [
         ("heat", HVAC_MODE_HEAT),
         ("cool", HVAC_MODE_COOL),
-        ("auto", HVAC_MODE_AUTO),
+        ("auto", HVAC_MODE_HEAT_COOL),
         ("off", HVAC_MODE_OFF),
         ("auxHeatOnly", HVAC_MODE_HEAT),
     ]
@@ -259,7 +259,7 @@ class Thermostat(ClimateDevice):
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
         self._name = self.thermostat["name"]
         self.vacation = None
-        self._last_active_hvac_mode = HVAC_MODE_AUTO
+        self._last_active_hvac_mode = HVAC_MODE_HEAT_COOL
 
         self._operation_list = []
         if (
@@ -270,7 +270,7 @@ class Thermostat(ClimateDevice):
         if self.thermostat["settings"]["coolStages"]:
             self._operation_list.append(HVAC_MODE_COOL)
         if len(self._operation_list) == 2:
-            self._operation_list.insert(0, HVAC_MODE_AUTO)
+            self._operation_list.insert(0, HVAC_MODE_HEAT_COOL)
         self._operation_list.append(HVAC_MODE_OFF)
 
         self._preset_modes = {
@@ -347,21 +347,21 @@ class Thermostat(ClimateDevice):
     @property
     def target_temperature_low(self):
         """Return the lower bound temperature we try to reach."""
-        if self.hvac_mode == HVAC_MODE_AUTO:
+        if self.hvac_mode == HVAC_MODE_HEAT_COOL:
             return self.thermostat["runtime"]["desiredHeat"] / 10.0
         return None
 
     @property
     def target_temperature_high(self):
         """Return the upper bound temperature we try to reach."""
-        if self.hvac_mode == HVAC_MODE_AUTO:
+        if self.hvac_mode == HVAC_MODE_HEAT_COOL:
             return self.thermostat["runtime"]["desiredCool"] / 10.0
         return None
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self.hvac_mode == HVAC_MODE_AUTO:
+        if self.hvac_mode == HVAC_MODE_HEAT_COOL:
             return None
         if self.hvac_mode == HVAC_MODE_HEAT:
             return self.thermostat["runtime"]["desiredHeat"] / 10.0
@@ -599,7 +599,7 @@ class Thermostat(ClimateDevice):
         high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temp = kwargs.get(ATTR_TEMPERATURE)
 
-        if self.hvac_mode == HVAC_MODE_AUTO and (
+        if self.hvac_mode == HVAC_MODE_HEAT_COOL and (
             low_temp is not None or high_temp is not None
         ):
             self.set_auto_temp_hold(low_temp, high_temp)

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -107,25 +107,25 @@ class TestEcobee(unittest.TestCase):
 
     def test_hvac_mode(self):
         """Test current operation property."""
-        assert "auto" == self.thermostat.hvac_mode
+        assert self.thermostat.hvac_mode == "heat_cool"
         self.ecobee["settings"]["hvacMode"] = "heat"
-        assert "heat" == self.thermostat.hvac_mode
+        assert self.thermostat.hvac_mode == "heat"
         self.ecobee["settings"]["hvacMode"] = "cool"
-        assert "cool" == self.thermostat.hvac_mode
+        assert self.thermostat.hvac_mode == "cool"
         self.ecobee["settings"]["hvacMode"] = "auxHeatOnly"
-        assert "heat" == self.thermostat.hvac_mode
+        assert self.thermostat.hvac_mode == "heat"
         self.ecobee["settings"]["hvacMode"] = "off"
-        assert "off" == self.thermostat.hvac_mode
+        assert self.thermostat.hvac_mode == "off"
 
     def test_hvac_modes(self):
         """Test operation list property."""
-        assert ["auto", "heat", "cool", "off"] == self.thermostat.hvac_modes
+        assert ["heat_cool", "heat", "cool", "off"] == self.thermostat.hvac_modes
 
     def test_hvac_mode2(self):
         """Test operation mode property."""
-        assert "auto" == self.thermostat.hvac_mode
+        assert self.thermostat.hvac_mode == "heat_cool"
         self.ecobee["settings"]["hvacMode"] = "heat"
-        assert "heat" == self.thermostat.hvac_mode
+        assert self.thermostat.hvac_mode == "heat"
 
     def test_device_state_attributes(self):
         """Test device state attributes property."""
@@ -222,7 +222,7 @@ class TestEcobee(unittest.TestCase):
     def test_set_hvac_mode(self):
         """Test operation mode setter."""
         self.data.reset_mock()
-        self.thermostat.set_hvac_mode("auto")
+        self.thermostat.set_hvac_mode("heat_cool")
         self.data.ecobee.set_hvac_mode.assert_has_calls([mock.call(1, "auto")])
         self.data.reset_mock()
         self.thermostat.set_hvac_mode("heat")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Ecobee now uses HVAC mode `heat_cool` instead of `auto`. Ecobee accidentally used HVAC mode "auto", which is reserved for when the user has no control over the temperature. In Ecobee this was not the case and the user has control over the temperature.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ecobee accidentally used HVAC mode "auto", which is reserved for when the user has no control over the temperature. In Ecobee this was not the case and the user has control over the temperature.

Fixes #30009

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
