### PR TITLE
Add DEVICE_CLASS_BATTERY_CHARGING to binary_sensor

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -23,6 +23,9 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 # On means low, Off means normal
 DEVICE_CLASS_BATTERY = "battery"
 
+# On means charging, Off means not charging
+DEVICE_CLASS_BATTERY_CHARGING = "battery_charging"
+
 # On means cold, Off means normal
 DEVICE_CLASS_COLD = "cold"
 
@@ -91,6 +94,7 @@ DEVICE_CLASS_WINDOW = "window"
 
 DEVICE_CLASSES = [
     DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_BATTERY_CHARGING,
     DEVICE_CLASS_COLD,
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_DOOR,

--- a/homeassistant/components/binary_sensor/device_condition.py
+++ b/homeassistant/components/binary_sensor/device_condition.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import (
     DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_BATTERY_CHARGING,
     DEVICE_CLASS_COLD,
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_DOOR,
@@ -44,6 +45,8 @@ DEVICE_CLASS_NONE = "none"
 
 CONF_IS_BAT_LOW = "is_bat_low"
 CONF_IS_NOT_BAT_LOW = "is_not_bat_low"
+CONF_IS_CHARGING = "is_charging"
+CONF_IS_NOT_CHARGING = "is_not_charging"
 CONF_IS_COLD = "is_cold"
 CONF_IS_NOT_COLD = "is_not_cold"
 CONF_IS_CONNECTED = "is_connected"
@@ -85,6 +88,7 @@ CONF_IS_NOT_OPEN = "is_not_open"
 
 IS_ON = [
     CONF_IS_BAT_LOW,
+    CONF_IS_CHARGING,
     CONF_IS_COLD,
     CONF_IS_CONNECTED,
     CONF_IS_GAS,
@@ -109,6 +113,7 @@ IS_ON = [
 
 IS_OFF = [
     CONF_IS_NOT_BAT_LOW,
+    CONF_IS_NOT_CHARGING,
     CONF_IS_NOT_COLD,
     CONF_IS_NOT_CONNECTED,
     CONF_IS_NOT_HOT,
@@ -135,6 +140,10 @@ ENTITY_CONDITIONS = {
     DEVICE_CLASS_BATTERY: [
         {CONF_TYPE: CONF_IS_BAT_LOW},
         {CONF_TYPE: CONF_IS_NOT_BAT_LOW},
+    ],
+    DEVICE_CLASS_BATTERY_CHARGING: [
+        {CONF_TYPE: CONF_IS_CHARGING},
+        {CONF_TYPE: CONF_IS_NOT_CHARGING},
     ],
     DEVICE_CLASS_COLD: [{CONF_TYPE: CONF_IS_COLD}, {CONF_TYPE: CONF_IS_NOT_COLD}],
     DEVICE_CLASS_CONNECTIVITY: [

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity_registry import async_entries_for_device
 
 from . import (
     DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_BATTERY_CHARGING,
     DEVICE_CLASS_COLD,
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_DOOR,
@@ -44,6 +45,8 @@ DEVICE_CLASS_NONE = "none"
 
 CONF_BAT_LOW = "bat_low"
 CONF_NOT_BAT_LOW = "not_bat_low"
+CONF_CHARGING = "charging"
+CONF_NOT_CHARGING = "not_charging"
 CONF_COLD = "cold"
 CONF_NOT_COLD = "not_cold"
 CONF_CONNECTED = "connected"
@@ -135,6 +138,10 @@ TURNED_OFF = [
 
 ENTITY_TRIGGERS = {
     DEVICE_CLASS_BATTERY: [{CONF_TYPE: CONF_BAT_LOW}, {CONF_TYPE: CONF_NOT_BAT_LOW}],
+    DEVICE_CLASS_BATTERY_CHARGING: [
+        {CONF_TYPE: CONF_CHARGING},
+        {CONF_TYPE: CONF_NOT_CHARGING},
+    ],
     DEVICE_CLASS_COLD: [{CONF_TYPE: CONF_COLD}, {CONF_TYPE: CONF_NOT_COLD}],
     DEVICE_CLASS_CONNECTIVITY: [
         {CONF_TYPE: CONF_CONNECTED},


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In order to make this automatically discoverable via the registry
there needs to be a DEVICE_CLASS_BATTERY_CHARING in binary sensor
so we can tell what is a battery and what is a charge sensor.
https://github.com/home-assistant/architecture/issues/359

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12965 https://github.com/home-assistant/developers.home-assistant/pull/463

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
