### PR TITLE
Clean up access to config in various integrations v5

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -42,7 +42,7 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    hosts = config[DOMAIN].get(CONF_HOSTS)
+    hosts = config[DOMAIN][CONF_HOSTS]
     if not hosts:
         hass.async_create_task(
             hass.config_entries.flow.async_init(

--- a/homeassistant/components/datadog/__init__.py
+++ b/homeassistant/components/datadog/__init__.py
@@ -45,10 +45,10 @@ def setup(hass, config):
     """Set up the Datadog component."""
 
     conf = config[DOMAIN]
-    host = conf.get(CONF_HOST)
-    port = conf.get(CONF_PORT)
-    sample_rate = conf.get(CONF_RATE)
-    prefix = conf.get(CONF_PREFIX)
+    host = conf[CONF_HOST]
+    port = conf[CONF_PORT]
+    sample_rate = conf[CONF_RATE]
+    prefix = conf[CONF_PREFIX]
 
     initialize(statsd_host=host, statsd_port=port)
 

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -34,8 +34,8 @@ NOTIFICATION_TITLE = "myLeviton Decora Setup"
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Decora WiFi platform."""
 
-    email = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
+    email = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
     session = DecoraWiFiSession()
 
     try:

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -49,11 +49,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Deluge sensors."""
 
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
-    port = config.get(CONF_PORT)
+    name = config[CONF_NAME]
+    host = config[CONF_HOST]
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    port = config[CONF_PORT]
 
     deluge_api = DelugeRPCClient(host, port, username, password)
     try:

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -37,11 +37,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Deluge switch."""
 
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
-    port = config.get(CONF_PORT)
+    name = config[CONF_NAME]
+    host = config[CONF_HOST]
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    port = config[CONF_PORT]
 
     deluge_api = DelugeRPCClient(host, port, username, password)
     try:

--- a/homeassistant/components/denon/media_player.py
+++ b/homeassistant/components/denon/media_player.py
@@ -80,7 +80,7 @@ MEDIA_MODES = {
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Denon platform."""
-    denon = DenonDevice(config.get(CONF_NAME), config.get(CONF_HOST))
+    denon = DenonDevice(config[CONF_NAME], config[CONF_HOST])
 
     if denon.update():
         add_entities([denon])

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -103,8 +103,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         cache = hass.data[KEY_DENON_CACHE] = set()
 
     # Get config option for show_all_sources and timeout
-    show_all_sources = config.get(CONF_SHOW_ALL_SOURCES)
-    timeout = config.get(CONF_TIMEOUT)
+    show_all_sources = config[CONF_SHOW_ALL_SOURCES]
+    timeout = config[CONF_TIMEOUT]
 
     # Get config option for additional zones
     zones = config.get(CONF_ZONES)

--- a/homeassistant/components/deutsche_bahn/sensor.py
+++ b/homeassistant/components/deutsche_bahn/sensor.py
@@ -36,9 +36,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Deutsche Bahn Sensor."""
     start = config.get(CONF_START)
-    destination = config.get(CONF_DESTINATION)
-    offset = config.get(CONF_OFFSET)
-    only_direct = config.get(CONF_ONLY_DIRECT)
+    destination = config[CONF_DESTINATION]
+    offset = config[CONF_OFFSET]
+    only_direct = config[CONF_ONLY_DIRECT]
 
     add_entities([DeutscheBahnSensor(start, destination, offset, only_direct)], True)
 

--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -65,9 +65,9 @@ async def async_setup(hass, config):
     light = hass.components.light
     person = hass.components.person
     conf = config[DOMAIN]
-    disable_turn_off = conf.get(CONF_DISABLE_TURN_OFF)
+    disable_turn_off = conf[CONF_DISABLE_TURN_OFF]
     light_group = conf.get(CONF_LIGHT_GROUP)
-    light_profile = conf.get(CONF_LIGHT_PROFILE)
+    light_profile = conf[CONF_LIGHT_PROFILE]
 
     device_group = conf.get(CONF_DEVICE_GROUP)
 

--- a/homeassistant/components/dht/sensor.py
+++ b/homeassistant/components/dht/sensor.py
@@ -63,10 +63,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         "DHT11": Adafruit_DHT.DHT11,
         "DHT22": Adafruit_DHT.DHT22,
     }
-    sensor = available_sensors.get(config.get(CONF_SENSOR))
-    pin = config.get(CONF_PIN)
-    temperature_offset = config.get(CONF_TEMPERATURE_OFFSET)
-    humidity_offset = config.get(CONF_HUMIDITY_OFFSET)
+    sensor = available_sensors.get(config[CONF_SENSOR])
+    pin = config[CONF_PIN]
+    temperature_offset = config[CONF_TEMPERATURE_OFFSET]
+    humidity_offset = config[CONF_HUMIDITY_OFFSET]
 
     if not sensor:
         _LOGGER.error("DHT sensor type is not supported")
@@ -74,7 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     data = DHTClient(Adafruit_DHT, sensor, pin)
     dev = []
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     try:
         for variable in config[CONF_MONITORED_CONDITIONS]:

--- a/homeassistant/components/digital_ocean/__init__.py
+++ b/homeassistant/components/digital_ocean/__init__.py
@@ -41,7 +41,7 @@ def setup(hass, config):
     """Set up the Digital Ocean component."""
 
     conf = config[DOMAIN]
-    access_token = conf.get(CONF_ACCESS_TOKEN)
+    access_token = conf[CONF_ACCESS_TOKEN]
 
     digital = DigitalOcean(access_token)
 

--- a/homeassistant/components/digital_ocean/binary_sensor.py
+++ b/homeassistant/components/digital_ocean/binary_sensor.py
@@ -37,7 +37,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if not digital:
         return False
 
-    droplets = config.get(CONF_DROPLETS)
+    droplets = config[CONF_DROPLETS]
 
     dev = []
     for droplet in droplets:

--- a/homeassistant/components/digital_ocean/switch.py
+++ b/homeassistant/components/digital_ocean/switch.py
@@ -37,7 +37,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if not digital:
         return False
 
-    droplets = config.get(CONF_DROPLETS)
+    droplets = config[CONF_DROPLETS]
 
     dev = []
     for droplet in droplets:

--- a/homeassistant/components/digitalloggers/switch.py
+++ b/homeassistant/components/digitalloggers/switch.py
@@ -47,12 +47,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Find and return DIN III Relay switch."""
 
-    host = config.get(CONF_HOST)
-    controller_name = config.get(CONF_NAME)
-    user = config.get(CONF_USERNAME)
-    pswd = config.get(CONF_PASSWORD)
-    tout = config.get(CONF_TIMEOUT)
-    cycl = config.get(CONF_CYCLETIME)
+    host = config[CONF_HOST]
+    controller_name = config[CONF_NAME]
+    user = config[CONF_USERNAME]
+    pswd = config[CONF_PASSWORD]
+    tout = config[CONF_TIMEOUT]
+    cycl = config[CONF_CYCLETIME]
 
     power_switch = dlipower.PowerSwitch(
         hostname=host, userid=user, password=pswd, timeout=tout, cycletime=cycl

--- a/homeassistant/components/discogs/sensor.py
+++ b/homeassistant/components/discogs/sensor.py
@@ -83,7 +83,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
 
     sensors = []
-    for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
+    for sensor_type in config[CONF_MONITORED_CONDITIONS]:
         sensors.append(DiscogsSensor(discogs_data, name, sensor_type))
 
     add_entities(sensors, True)

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -23,7 +23,7 @@ ATTR_IMAGES = "images"
 
 def get_service(hass, config, discovery_info=None):
     """Get the Discord notification service."""
-    token = config.get(CONF_TOKEN)
+    token = config[CONF_TOKEN]
     return DiscordNotificationService(hass, token)
 
 

--- a/homeassistant/components/dlink/switch.py
+++ b/homeassistant/components/dlink/switch.py
@@ -44,11 +44,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up a D-Link Smart Plug."""
 
-    host = config.get(CONF_HOST)
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
-    use_legacy_protocol = config.get(CONF_USE_LEGACY_PROTOCOL)
-    name = config.get(CONF_NAME)
+    host = config[CONF_HOST]
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    use_legacy_protocol = config[CONF_USE_LEGACY_PROTOCOL]
+    name = config[CONF_NAME]
 
     smartplug = SmartPlug(host, password, username, use_legacy_protocol)
     data = SmartPlugData(smartplug)

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -39,18 +39,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the DNS IP sensor."""
-    hostname = config.get(CONF_HOSTNAME)
+    hostname = config[CONF_HOSTNAME]
     name = config.get(CONF_NAME)
     if not name:
         if hostname == DEFAULT_HOSTNAME:
             name = DEFAULT_NAME
         else:
             name = hostname
-    ipv6 = config.get(CONF_IPV6)
+    ipv6 = config[CONF_IPV6]
     if ipv6:
-        resolver = config.get(CONF_RESOLVER_IPV6)
+        resolver = config[CONF_RESOLVER_IPV6]
     else:
-        resolver = config.get(CONF_RESOLVER)
+        resolver = config[CONF_RESOLVER]
 
     async_add_devices([WanIpSensor(hass, name, hostname, resolver, ipv6)], True)
 

--- a/homeassistant/components/dovado/__init__.py
+++ b/homeassistant/components/dovado/__init__.py
@@ -41,8 +41,8 @@ def setup(hass, config):
 
     hass.data[DOMAIN] = DovadoData(
         dovado.Dovado(
-            config[DOMAIN].get(CONF_USERNAME),
-            config[DOMAIN].get(CONF_PASSWORD),
+            config[DOMAIN][CONF_USERNAME],
+            config[DOMAIN][CONF_PASSWORD],
             config[DOMAIN].get(CONF_HOST),
             config[DOMAIN].get(CONF_PORT),
         )

--- a/homeassistant/components/dte_energy_bridge/sensor.py
+++ b/homeassistant/components/dte_energy_bridge/sensor.py
@@ -32,9 +32,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the DTE energy bridge sensor."""
-    name = config.get(CONF_NAME)
-    ip_address = config.get(CONF_IP_ADDRESS)
-    version = config.get(CONF_VERSION, 1)
+    name = config[CONF_NAME]
+    ip_address = config[CONF_IP_ADDRESS]
+    version = config[CONF_VERSION]
 
     add_entities([DteEnergyBridgeSensor(ip_address, name, version)], True)
 

--- a/homeassistant/components/dublin_bus_transport/sensor.py
+++ b/homeassistant/components/dublin_bus_transport/sensor.py
@@ -59,9 +59,9 @@ def due_in_minutes(timestamp):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Dublin public transport sensor."""
-    name = config.get(CONF_NAME)
-    stop = config.get(CONF_STOP_ID)
-    route = config.get(CONF_ROUTE)
+    name = config[CONF_NAME]
+    stop = config[CONF_STOP_ID]
+    route = config[CONF_ROUTE]
 
     data = PublicTransportData(stop, route)
     add_entities([DublinPublicTransportSensor(data, stop, route, name)], True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces incorrect use of `dict.get(key)` for required and optional config keys with a default value with `dict[key]` in various integrations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
