### PR TITLE
Reduce tplink loss of precision during brightness conversion

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -75,12 +75,12 @@ def add_entity(device: SmartBulb, async_add_entities):
 
 def brightness_to_percentage(byt):
     """Convert brightness from absolute 0..255 to percentage."""
-    return int((byt * 100.0) / 255.0)
+    return round((byt * 100.0) / 255.0)
 
 
 def brightness_from_percentage(percent):
     """Convert percentage to absolute value 0..255."""
-    return (percent * 255.0) / 100.0
+    return round((percent * 255.0) / 100.0)
 
 
 class LightState(NamedTuple):

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -287,7 +287,6 @@ async def test_smartswitch(
 
     state = hass.states.get("light.dimmer1")
     assert state.state == "on"
-    # We are still going to loose some precision here (less though)
     assert state.attributes["brightness"] == 51
     assert sys_info["relay_state"] == 1
 

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -390,7 +390,6 @@ async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> Non
 
     state = hass.states.get("light.light1")
     assert state.state == "on"
-    # We are still going to loose some precision here (less though)
     assert state.attributes["brightness"] == 56
     assert state.attributes["hs_color"] == (23, 27)
     assert light_state["brightness"] == 22

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -301,7 +301,6 @@ async def test_smartswitch(
 
     state = hass.states.get("light.dimmer1")
     assert state.state == "on"
-    # We are still going to loose some precision here (less though)
     assert state.attributes["brightness"] == 56
     assert sys_info["brightness"] == 22
 

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -374,7 +374,6 @@ async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> Non
 
     state = hass.states.get("light.light1")
     assert state.state == "on"
-    # We are still going to loose some precision here (less though)
     assert state.attributes["brightness"] == 51
     assert state.attributes["hs_color"] == (110, 90)
     assert state.attributes["color_temp"] == 222

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -287,7 +287,8 @@ async def test_smartswitch(
 
     state = hass.states.get("light.dimmer1")
     assert state.state == "on"
-    assert state.attributes["brightness"] == 48.45
+    # We are still going to loose some precision here (less though)
+    assert state.attributes["brightness"] == 51
     assert sys_info["relay_state"] == 1
 
     await hass.services.async_call(
@@ -301,8 +302,9 @@ async def test_smartswitch(
 
     state = hass.states.get("light.dimmer1")
     assert state.state == "on"
-    assert state.attributes["brightness"] == 53.55
-    assert sys_info["brightness"] == 21
+    # We are still going to loose some precision here (less though)
+    assert state.attributes["brightness"] == 56
+    assert sys_info["brightness"] == 22
 
     sys_info["relay_state"] = 0
     sys_info["brightness"] = 66
@@ -327,7 +329,7 @@ async def test_smartswitch(
 
     state = hass.states.get("light.dimmer1")
     assert state.state == "on"
-    assert state.attributes["brightness"] == 168.3
+    assert state.attributes["brightness"] == 168
     assert sys_info["brightness"] == 66
 
 
@@ -373,7 +375,8 @@ async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> Non
 
     state = hass.states.get("light.light1")
     assert state.state == "on"
-    assert state.attributes["brightness"] == 48.45
+    # We are still going to loose some precision here (less though)
+    assert state.attributes["brightness"] == 51
     assert state.attributes["hs_color"] == (110, 90)
     assert state.attributes["color_temp"] == 222
     assert light_state["on_off"] == 1
@@ -389,9 +392,10 @@ async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> Non
 
     state = hass.states.get("light.light1")
     assert state.state == "on"
-    assert state.attributes["brightness"] == 53.55
+    # We are still going to loose some precision here (less though)
+    assert state.attributes["brightness"] == 56
     assert state.attributes["hs_color"] == (23, 27)
-    assert light_state["brightness"] == 21
+    assert light_state["brightness"] == 22
     assert light_state["hue"] == 23
     assert light_state["saturation"] == 27
 
@@ -423,7 +427,7 @@ async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> Non
 
     state = hass.states.get("light.light1")
     assert state.state == "on"
-    assert state.attributes["brightness"] == 168.3
+    assert state.attributes["brightness"] == 168
     assert state.attributes["hs_color"] == (77, 78)
     assert state.attributes["color_temp"] == 156
     assert light_state["brightness"] == 66
@@ -434,7 +438,7 @@ async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> Non
     await update_entity(hass, "light.light1")
 
     state = hass.states.get("light.light1")
-    assert state.attributes["brightness"] == 232.05
+    assert state.attributes["brightness"] == 232
 
 
 async def test_get_light_state_retry(


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is another case where homekit, alexa, and other integrations
will see the percentage off by one on round trip.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
