### PR TITLE
Clean up access to config in various integrations v6

### DIFF
--- a/homeassistant/components/dunehd/media_player.py
+++ b/homeassistant/components/dunehd/media_player.py
@@ -49,8 +49,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the DuneHD media player platform."""
 
     sources = config.get(CONF_SOURCES, {})
-    host = config.get(CONF_HOST)
-    name = config.get(CONF_NAME)
+    host = config[CONF_HOST]
+    name = config[CONF_NAME]
 
     add_entities([DuneHDPlayerEntity(DuneHDPlayer(host), name, sources)], True)
 

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the DWD-Weather-Warnings sensor."""
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
     region_name = config.get(CONF_REGION_NAME)
 
     api = DwdWeatherWarningsAPI(region_name)

--- a/homeassistant/components/dweet/__init__.py
+++ b/homeassistant/components/dweet/__init__.py
@@ -39,8 +39,8 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the Dweet.io component."""
     conf = config[DOMAIN]
-    name = conf.get(CONF_NAME)
-    whitelist = conf.get(CONF_WHITELIST)
+    name = conf[CONF_NAME]
+    whitelist = conf[CONF_WHITELIST]
     json_body = {}
 
     def dweet_event_listener(event):

--- a/homeassistant/components/dyson/__init__.py
+++ b/homeassistant/components/dyson/__init__.py
@@ -45,15 +45,15 @@ def setup(hass, config):
         hass.data[DYSON_DEVICES] = []
 
     dyson_account = DysonAccount(
-        config[DOMAIN].get(CONF_USERNAME),
-        config[DOMAIN].get(CONF_PASSWORD),
-        config[DOMAIN].get(CONF_LANGUAGE),
+        config[DOMAIN][CONF_USERNAME],
+        config[DOMAIN][CONF_PASSWORD],
+        config[DOMAIN][CONF_LANGUAGE],
     )
 
     logged = dyson_account.login()
 
-    timeout = config[DOMAIN].get(CONF_TIMEOUT)
-    retry = config[DOMAIN].get(CONF_RETRY)
+    timeout = config[DOMAIN][CONF_TIMEOUT]
+    retry = config[DOMAIN][CONF_RETRY]
 
     if not logged:
         _LOGGER.error("Not connected to Dyson account. Unable to add devices")
@@ -61,7 +61,7 @@ def setup(hass, config):
 
     _LOGGER.info("Connected to Dyson account")
     dyson_devices = dyson_account.devices()
-    if CONF_DEVICES in config[DOMAIN] and config[DOMAIN].get(CONF_DEVICES):
+    if CONF_DEVICES in config[DOMAIN] and config[DOMAIN][CONF_DEVICES]:
         configured_devices = config[DOMAIN].get(CONF_DEVICES)
         for device in configured_devices:
             dyson_device = next(

--- a/homeassistant/components/ebox/sensor.py
+++ b/homeassistant/components/ebox/sensor.py
@@ -69,13 +69,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the EBox sensor."""
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
 
     httpsession = hass.helpers.aiohttp_client.async_get_clientsession()
     ebox_data = EBoxData(username, password, httpsession)
 
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     try:
         await ebox_data.async_update()

--- a/homeassistant/components/ebusd/__init__.py
+++ b/homeassistant/components/ebusd/__init__.py
@@ -62,8 +62,8 @@ def setup(hass, config):
     conf = config[DOMAIN]
     name = conf[CONF_NAME]
     circuit = conf[CONF_CIRCUIT]
-    monitored_conditions = conf.get(CONF_MONITORED_CONDITIONS)
-    server_address = (conf.get(CONF_HOST), conf.get(CONF_PORT))
+    monitored_conditions = conf[CONF_MONITORED_CONDITIONS]
+    server_address = (conf[CONF_HOST], conf[CONF_PORT])
 
     try:
         _LOGGER.debug("Ebusd integration setup started")

--- a/homeassistant/components/econet/water_heater.py
+++ b/homeassistant/components/econet/water_heater.py
@@ -81,8 +81,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     hass.data[ECONET_DATA] = {}
     hass.data[ECONET_DATA]["water_heaters"] = []
 
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
 
     econet = PyEcoNet(username, password)
     water_heaters = econet.get_water_heaters()

--- a/homeassistant/components/ecovacs/__init__.py
+++ b/homeassistant/components/ecovacs/__init__.py
@@ -47,10 +47,10 @@ def setup(hass, config):
 
     ecovacs_api = EcoVacsAPI(
         ECOVACS_API_DEVICEID,
-        config[DOMAIN].get(CONF_USERNAME),
-        EcoVacsAPI.md5(config[DOMAIN].get(CONF_PASSWORD)),
-        config[DOMAIN].get(CONF_COUNTRY),
-        config[DOMAIN].get(CONF_CONTINENT),
+        config[DOMAIN][CONF_USERNAME],
+        EcoVacsAPI.md5(config[DOMAIN][CONF_PASSWORD]),
+        config[DOMAIN][CONF_COUNTRY],
+        config[DOMAIN][CONF_CONTINENT],
     )
 
     devices = ecovacs_api.devices()

--- a/homeassistant/components/eddystone_temperature/sensor.py
+++ b/homeassistant/components/eddystone_temperature/sensor.py
@@ -46,9 +46,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Validate configuration, create devices and start monitoring thread."""
-    bt_device_id = config.get("bt_device_id")
+    bt_device_id = config[CONF_BT_DEVICE_ID]
 
-    beacons = config.get(CONF_BEACONS)
+    beacons = config[CONF_BEACONS]
     devices = []
 
     for dev_name, properties in beacons.items():

--- a/homeassistant/components/edimax/switch.py
+++ b/homeassistant/components/edimax/switch.py
@@ -28,9 +28,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Find and return Edimax Smart Plugs."""
-    host = config.get(CONF_HOST)
-    auth = (config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
-    name = config.get(CONF_NAME)
+    host = config[CONF_HOST]
+    auth = (config[CONF_USERNAME], config[CONF_PASSWORD])
+    name = config[CONF_NAME]
 
     add_entities([SmartPlugSwitch(SmartPlug(host, auth), name)], True)
 

--- a/homeassistant/components/efergy/sensor.py
+++ b/homeassistant/components/efergy/sensor.py
@@ -57,8 +57,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Efergy sensor."""
-    app_token = config.get(CONF_APPTOKEN)
-    utc_offset = str(config.get(CONF_UTC_OFFSET))
+    app_token = config[CONF_APPTOKEN]
+    utc_offset = str(config[CONF_UTC_OFFSET])
 
     dev = []
     for variable in config[CONF_MONITORED_VARIABLES]:

--- a/homeassistant/components/egardia/__init__.py
+++ b/homeassistant/components/egardia/__init__.py
@@ -81,13 +81,13 @@ def setup(hass, config):
     """Set up the Egardia platform."""
 
     conf = config[DOMAIN]
-    username = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASSWORD)
+    username = conf[CONF_USERNAME]
+    password = conf[CONF_PASSWORD]
     host = conf.get(CONF_HOST)
-    port = conf.get(CONF_PORT)
-    version = conf.get(CONF_VERSION)
-    rs_enabled = conf.get(CONF_REPORT_SERVER_ENABLED)
-    rs_port = conf.get(CONF_REPORT_SERVER_PORT)
+    port = conf[CONF_PORT]
+    version = conf[CONF_VERSION]
+    rs_enabled = conf[CONF_REPORT_SERVER_ENABLED]
+    rs_port = conf[CONF_REPORT_SERVER_PORT]
     try:
         device = hass.data[EGARDIA_DEVICE] = egardiadevice.EgardiaDevice(
             host, port, username, password, "", version

--- a/homeassistant/components/eight_sleep/__init__.py
+++ b/homeassistant/components/eight_sleep/__init__.py
@@ -102,9 +102,9 @@ async def async_setup(hass, config):
     """Set up the Eight Sleep component."""
 
     conf = config.get(DOMAIN)
-    user = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASSWORD)
-    partner = conf.get(CONF_PARTNER)
+    user = conf[CONF_USERNAME]
+    password = conf[CONF_PASSWORD]
+    partner = conf[CONF_PARTNER]
 
     if hass.config.time_zone is None:
         _LOGGER.error("Timezone is not set in Home Assistant.")

--- a/homeassistant/components/eliqonline/sensor.py
+++ b/homeassistant/components/eliqonline/sensor.py
@@ -35,9 +35,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the ELIQ Online sensor."""
-    access_token = config.get(CONF_ACCESS_TOKEN)
-    name = config.get(CONF_NAME, DEFAULT_NAME)
-    channel_id = config.get(CONF_CHANNEL_ID)
+    access_token = config[CONF_ACCESS_TOKEN]
+    name = config[CONF_NAME]
+    channel_id = config[CONF_CHANNEL_ID]
     session = async_get_clientsession(hass)
 
     api = eliqonline.API(session=session, access_token=access_token)

--- a/homeassistant/components/emby/media_player.py
+++ b/homeassistant/components/emby/media_player.py
@@ -68,8 +68,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Emby platform."""
 
-    host = config.get(CONF_HOST)
-    key = config.get(CONF_API_KEY)
+    host = config[CONF_HOST]
+    key = config[CONF_API_KEY]
     port = config.get(CONF_PORT)
     ssl = config[CONF_SSL]
 

--- a/homeassistant/components/emoncms/sensor.py
+++ b/homeassistant/components/emoncms/sensor.py
@@ -69,11 +69,11 @@ def get_id(sensorid, feedtag, feedname, feedid, feeduserid):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Emoncms sensor."""
-    apikey = config.get(CONF_API_KEY)
-    url = config.get(CONF_URL)
-    sensorid = config.get(CONF_ID)
+    apikey = config[CONF_API_KEY]
+    url = config[CONF_URL]
+    sensorid = config[CONF_ID]
     value_template = config.get(CONF_VALUE_TEMPLATE)
-    config_unit = config.get(CONF_UNIT_OF_MEASUREMENT)
+    config_unit = config[CONF_UNIT_OF_MEASUREMENT]
     exclude_feeds = config.get(CONF_EXCLUDE_FEEDID)
     include_only_feeds = config.get(CONF_ONLY_INCLUDE_FEEDID)
     sensor_names = config.get(CONF_SENSOR_NAMES)

--- a/homeassistant/components/emoncms_history/__init__.py
+++ b/homeassistant/components/emoncms_history/__init__.py
@@ -43,7 +43,7 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the Emoncms history component."""
     conf = config[DOMAIN]
-    whitelist = conf.get(CONF_WHITELIST)
+    whitelist = conf[CONF_WHITELIST]
 
     def send_data(url, apikey, node, payload):
         """Send payload data to Emoncms."""
@@ -88,14 +88,11 @@ def setup(hass, config):
             )
 
             send_data(
-                conf.get(CONF_URL),
-                conf.get(CONF_API_KEY),
-                str(conf.get(CONF_INPUTNODE)),
-                payload,
+                conf[CONF_URL], conf[CONF_API_KEY], str(conf[CONF_INPUTNODE]), payload
             )
 
         track_point_in_time(
-            hass, update_emoncms, time + timedelta(seconds=conf.get(CONF_SCAN_INTERVAL))
+            hass, update_emoncms, time + timedelta(seconds=conf[CONF_SCAN_INTERVAL])
         )
 
     update_emoncms(dt_util.utcnow())

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -169,7 +169,7 @@ class Config:
     def __init__(self, hass, conf):
         """Initialize the instance."""
         self.hass = hass
-        self.type = conf.get(CONF_TYPE)
+        self.type = conf[CONF_TYPE]
         self.numbers = None
         self.cached_states = {}
 
@@ -189,7 +189,7 @@ class Config:
             )
 
         # Get the port that the Hue bridge will listen on
-        self.listen_port = conf.get(CONF_LISTEN_PORT)
+        self.listen_port = conf[CONF_LISTEN_PORT]
         if not isinstance(self.listen_port, int):
             self.listen_port = DEFAULT_LISTEN_PORT
             _LOGGER.info(

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -104,14 +104,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     device = CreateDevice(
         host=config[CONF_HOST],
-        port=config.get(CONF_PORT),
-        username=config.get(CONF_USERNAME),
-        password=config.get(CONF_PASSWORD),
+        port=config[CONF_PORT],
+        username=config[CONF_USERNAME],
+        password=config[CONF_PASSWORD],
         is_https=config[CONF_SSL],
-        prefer_picon=config.get(CONF_USE_CHANNEL_ICON),
-        mac_address=config.get(CONF_MAC_ADDRESS),
-        turn_off_to_deep=config.get(CONF_DEEP_STANDBY),
-        source_bouquet=config.get(CONF_SOURCE_BOUQUET),
+        prefer_picon=config[CONF_USE_CHANNEL_ICON],
+        mac_address=config[CONF_MAC_ADDRESS],
+        turn_off_to_deep=config[CONF_DEEP_STANDBY],
+        source_bouquet=config[CONF_SOURCE_BOUQUET],
     )
 
     add_devices([Enigma2Device(config[CONF_NAME], device)], True)

--- a/homeassistant/components/enocean/__init__.py
+++ b/homeassistant/components/enocean/__init__.py
@@ -25,7 +25,7 @@ SIGNAL_SEND_MESSAGE = "enocean.send_message"
 
 def setup(hass, config):
     """Set up the EnOcean component."""
-    serial_dev = config[DOMAIN].get(CONF_DEVICE)
+    serial_dev = config[DOMAIN][CONF_DEVICE]
     dongle = EnOceanDongle(hass, serial_dev)
     hass.data[DATA_ENOCEAN] = dongle
 

--- a/homeassistant/components/enocean/binary_sensor.py
+++ b/homeassistant/components/enocean/binary_sensor.py
@@ -29,8 +29,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Binary Sensor platform for EnOcean."""
-    dev_id = config.get(CONF_ID)
-    dev_name = config.get(CONF_NAME)
+    dev_id = config[CONF_ID]
+    dev_name = config[CONF_NAME]
     device_class = config.get(CONF_DEVICE_CLASS)
 
     add_entities([EnOceanBinarySensor(dev_id, dev_name, device_class)])

--- a/homeassistant/components/enocean/light.py
+++ b/homeassistant/components/enocean/light.py
@@ -32,9 +32,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the EnOcean light platform."""
-    sender_id = config.get(CONF_SENDER_ID)
-    dev_name = config.get(CONF_NAME)
-    dev_id = config.get(CONF_ID)
+    sender_id = config[CONF_SENDER_ID]
+    dev_name = config[CONF_NAME]
+    dev_id = config[CONF_ID]
 
     add_entities([EnOceanLight(sender_id, dev_id, dev_name)])
 

--- a/homeassistant/components/enocean/sensor.py
+++ b/homeassistant/components/enocean/sensor.py
@@ -77,15 +77,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up an EnOcean sensor device."""
-    dev_id = config.get(CONF_ID)
-    dev_name = config.get(CONF_NAME)
-    sensor_type = config.get(CONF_DEVICE_CLASS)
+    dev_id = config[CONF_ID]
+    dev_name = config[CONF_NAME]
+    sensor_type = config[CONF_DEVICE_CLASS]
 
     if sensor_type == SENSOR_TYPE_TEMPERATURE:
-        temp_min = config.get(CONF_MIN_TEMP)
-        temp_max = config.get(CONF_MAX_TEMP)
-        range_from = config.get(CONF_RANGE_FROM)
-        range_to = config.get(CONF_RANGE_TO)
+        temp_min = config[CONF_MIN_TEMP]
+        temp_max = config[CONF_MAX_TEMP]
+        range_from = config[CONF_RANGE_FROM]
+        range_to = config[CONF_RANGE_TO]
         add_entities(
             [
                 EnOceanTemperatureSensor(

--- a/homeassistant/components/enocean/switch.py
+++ b/homeassistant/components/enocean/switch.py
@@ -25,9 +25,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the EnOcean switch platform."""
-    channel = config.get(CONF_CHANNEL)
-    dev_id = config.get(CONF_ID)
-    dev_name = config.get(CONF_NAME)
+    channel = config[CONF_CHANNEL]
+    dev_id = config[CONF_ID]
+    dev_name = config[CONF_NAME]
 
     add_entities([EnOceanSwitch(dev_id, dev_name, channel)])
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces incorrect use of `dict.get(key)` for required and optional config keys with a default value with `dict[key]` in various integrations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
