### PR TITLE
Clean up access to config in various integrations v7

### DIFF
--- a/homeassistant/components/entur_public_transport/sensor.py
+++ b/homeassistant/components/entur_public_transport/sensor.py
@@ -90,13 +90,13 @@ def due_in_minutes(timestamp: datetime) -> int:
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Entur public transport sensor."""
 
-    expand = config.get(CONF_EXPAND_PLATFORMS)
-    line_whitelist = config.get(CONF_WHITELIST_LINES)
-    name = config.get(CONF_NAME)
-    show_on_map = config.get(CONF_SHOW_ON_MAP)
-    stop_ids = config.get(CONF_STOP_IDS)
-    omit_non_boarding = config.get(CONF_OMIT_NON_BOARDING)
-    number_of_departures = config.get(CONF_NUMBER_OF_DEPARTURES)
+    expand = config[CONF_EXPAND_PLATFORMS]
+    line_whitelist = config[CONF_WHITELIST_LINES]
+    name = config[CONF_NAME]
+    show_on_map = config[CONF_SHOW_ON_MAP]
+    stop_ids = config[CONF_STOP_IDS]
+    omit_non_boarding = config[CONF_OMIT_NON_BOARDING]
+    number_of_departures = config[CONF_NUMBER_OF_DEPARTURES]
 
     stops = [s for s in stop_ids if "StopPlace" in s]
     quays = [s for s in stop_ids if "Quay" in s]

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -54,12 +54,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if config.get(CONF_STATION):
         ec_data = ECData(
-            station_id=config[CONF_STATION], language=config.get(CONF_LANGUAGE)
+            station_id=config[CONF_STATION], language=config[CONF_LANGUAGE]
         )
     else:
         lat = config.get(CONF_LATITUDE, hass.config.latitude)
         lon = config.get(CONF_LONGITUDE, hass.config.longitude)
-        ec_data = ECData(coordinates=(lat, lon), language=config.get(CONF_LANGUAGE))
+        ec_data = ECData(coordinates=(lat, lon), language=config[CONF_LANGUAGE])
 
     sensor_list = list(ec_data.conditions.keys()) + list(ec_data.alerts.keys())
     add_entities([ECSensor(sensor_type, ec_data) for sensor_type in sensor_list], True)

--- a/homeassistant/components/envirophat/sensor.py
+++ b/homeassistant/components/envirophat/sensor.py
@@ -56,7 +56,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.error("No Enviro pHAT was found.")
         return False
 
-    data = EnvirophatData(envirophat, config.get(CONF_USE_LEDS))
+    data = EnvirophatData(envirophat, config[CONF_USE_LEDS])
 
     dev = []
     for variable in config[CONF_DISPLAY_OPTIONS]:

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -102,19 +102,19 @@ async def async_setup(hass, config):
 
     conf = config.get(DOMAIN)
 
-    host = conf.get(CONF_HOST)
-    port = conf.get(CONF_EVL_PORT)
+    host = conf[CONF_HOST]
+    port = conf[CONF_EVL_PORT]
     code = conf.get(CONF_CODE)
-    panel_type = conf.get(CONF_PANEL_TYPE)
-    panic_type = conf.get(CONF_PANIC)
-    version = conf.get(CONF_EVL_VERSION)
-    user = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASS)
-    keep_alive = conf.get(CONF_EVL_KEEPALIVE)
-    zone_dump = conf.get(CONF_ZONEDUMP_INTERVAL)
+    panel_type = conf[CONF_PANEL_TYPE]
+    panic_type = conf[CONF_PANIC]
+    version = conf[CONF_EVL_VERSION]
+    user = conf[CONF_USERNAME]
+    password = conf[CONF_PASS]
+    keep_alive = conf[CONF_EVL_KEEPALIVE]
+    zone_dump = conf[CONF_ZONEDUMP_INTERVAL]
     zones = conf.get(CONF_ZONES)
     partitions = conf.get(CONF_PARTITIONS)
-    connection_timeout = conf.get(CONF_TIMEOUT)
+    connection_timeout = conf[CONF_TIMEOUT]
     sync_connect = asyncio.Future()
 
     controller = EnvisalinkAlarmPanel(

--- a/homeassistant/components/ephember/climate.py
+++ b/homeassistant/components/ephember/climate.py
@@ -55,8 +55,8 @@ HA_STATE_TO_EPH = {value: key for key, value in EPH_TO_HA_STATE.items()}
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ephember thermostat."""
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
 
     try:
         ember = EphEmber(username, password)

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -87,9 +87,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_EPSON not in hass.data:
         hass.data[DATA_EPSON] = []
 
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
+    name = config[CONF_NAME]
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
     ssl = config[CONF_SSL]
 
     epson_proj = EpsonProjector(

--- a/homeassistant/components/epsonworkforce/sensor.py
+++ b/homeassistant/components/epsonworkforce/sensor.py
@@ -33,7 +33,7 @@ SCAN_INTERVAL = timedelta(minutes=60)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the cartridge sensor."""
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
 
     api = EpsonPrinterAPI(host)
     if not api.available:

--- a/homeassistant/components/etherscan/sensor.py
+++ b/homeassistant/components/etherscan/sensor.py
@@ -27,7 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Etherscan.io sensors."""
-    address = config.get(CONF_ADDRESS)
+    address = config[CONF_ADDRESS]
     name = config.get(CONF_NAME)
     token = config.get(CONF_TOKEN)
     token_address = config.get(CONF_TOKEN_ADDRESS)

--- a/homeassistant/components/fail2ban/sensor.py
+++ b/homeassistant/components/fail2ban/sensor.py
@@ -25,7 +25,7 @@ SCAN_INTERVAL = timedelta(seconds=120)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_JAILS): vol.All(cv.ensure_list, vol.Length(min=1)),
-        vol.Optional(CONF_FILE_PATH): cv.isfile,
+        vol.Optional(CONF_FILE_PATH, default=DEFAULT_LOG): cv.isfile,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
@@ -33,9 +33,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the fail2ban sensor."""
-    name = config.get(CONF_NAME)
-    jails = config.get(CONF_JAILS)
-    log_file = config.get(CONF_FILE_PATH, DEFAULT_LOG)
+    name = config[CONF_NAME]
+    jails = config[CONF_JAILS]
+    log_file = config[CONF_FILE_PATH]
 
     device_list = []
     log_parser = BanLogParser(log_file)

--- a/homeassistant/components/familyhub/camera.py
+++ b/homeassistant/components/familyhub/camera.py
@@ -24,8 +24,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Family Hub Camera."""
 
-    address = config.get(CONF_IP_ADDRESS)
-    name = config.get(CONF_NAME)
+    address = config[CONF_IP_ADDRESS]
+    name = config[CONF_NAME]
 
     session = async_get_clientsession(hass)
     family_hub_cam = FamilyHubCam(address, hass.loop, session)

--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -43,8 +43,8 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the Feedreader component."""
     urls = config.get(DOMAIN)[CONF_URLS]
-    scan_interval = config.get(DOMAIN).get(CONF_SCAN_INTERVAL)
-    max_entries = config.get(DOMAIN).get(CONF_MAX_ENTRIES)
+    scan_interval = config.get(DOMAIN)[CONF_SCAN_INTERVAL]
+    max_entries = config.get(DOMAIN)[CONF_MAX_ENTRIES]
     data_file = hass.config.path(f"{DOMAIN}.pickle")
     storage = StoredData(data_file)
     feeds = [

--- a/homeassistant/components/ffmpeg/__init__.py
+++ b/homeassistant/components/ffmpeg/__init__.py
@@ -56,7 +56,7 @@ async def async_setup(hass, config):
     """Set up the FFmpeg component."""
     conf = config.get(DOMAIN, {})
 
-    manager = FFmpegManager(hass, conf.get(CONF_FFMPEG_BIN, DEFAULT_BINARY))
+    manager = FFmpegManager(hass, conf[CONF_FFMPEG_BIN])
 
     await manager.async_get_version()
 

--- a/homeassistant/components/ffmpeg/camera.py
+++ b/homeassistant/components/ffmpeg/camera.py
@@ -40,9 +40,9 @@ class FFmpegCamera(Camera):
         super().__init__()
 
         self._manager = hass.data[DATA_FFMPEG]
-        self._name = config.get(CONF_NAME)
-        self._input = config.get(CONF_INPUT)
-        self._extra_arguments = config.get(CONF_EXTRA_ARGUMENTS)
+        self._name = config[CONF_NAME]
+        self._input = config[CONF_INPUT]
+        self._extra_arguments = config[CONF_EXTRA_ARGUMENTS]
 
     @property
     def supported_features(self):

--- a/homeassistant/components/ffmpeg_motion/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_motion/binary_sensor.py
@@ -60,11 +60,11 @@ class FFmpegBinarySensor(FFmpegBase, BinarySensorDevice):
 
     def __init__(self, config):
         """Init for the binary sensor noise detection."""
-        super().__init__(config.get(CONF_INITIAL_STATE))
+        super().__init__(config[CONF_INITIAL_STATE])
 
         self._state = False
         self._config = config
-        self._name = config.get(CONF_NAME)
+        self._name = config[CONF_NAME]
 
     @callback
     def _async_callback(self, state):
@@ -104,15 +104,15 @@ class FFmpegMotion(FFmpegBinarySensor):
 
         # init config
         self.ffmpeg.set_options(
-            time_reset=self._config.get(CONF_RESET),
+            time_reset=self._config[CONF_RESET],
             time_repeat=self._config.get(CONF_REPEAT_TIME, 0),
             repeat=self._config.get(CONF_REPEAT, 0),
-            changes=self._config.get(CONF_CHANGES),
+            changes=self._config[CONF_CHANGES],
         )
 
         # run
         await self.ffmpeg.open_sensor(
-            input_source=self._config.get(CONF_INPUT),
+            input_source=self._config[CONF_INPUT],
             extra_cmd=self._config.get(CONF_EXTRA_ARGUMENTS),
         )
 

--- a/homeassistant/components/ffmpeg_noise/binary_sensor.py
+++ b/homeassistant/components/ffmpeg_noise/binary_sensor.py
@@ -70,13 +70,13 @@ class FFmpegNoise(FFmpegBinarySensor):
             return
 
         self.ffmpeg.set_options(
-            time_duration=self._config.get(CONF_DURATION),
-            time_reset=self._config.get(CONF_RESET),
-            peak=self._config.get(CONF_PEAK),
+            time_duration=self._config[CONF_DURATION],
+            time_reset=self._config[CONF_RESET],
+            peak=self._config[CONF_PEAK],
         )
 
         await self.ffmpeg.open_sensor(
-            input_source=self._config.get(CONF_INPUT),
+            input_source=self._config[CONF_INPUT],
             output_dest=self._config.get(CONF_OUTPUT),
             extra_cmd=self._config.get(CONF_EXTRA_ARGUMENTS),
         )

--- a/homeassistant/components/fido/sensor.py
+++ b/homeassistant/components/fido/sensor.py
@@ -71,8 +71,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Fido sensor."""
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
 
     httpsession = hass.helpers.aiohttp_client.async_get_clientsession()
     fido_data = FidoData(username, password, httpsession)
@@ -80,7 +80,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if ret is False:
         return
 
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
 
     sensors = []
     for number in fido_data.client.get_phone_numbers():

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -29,8 +29,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the file sensor."""
-    file_path = config.get(CONF_FILE_PATH)
-    name = config.get(CONF_NAME)
+    file_path = config[CONF_FILE_PATH]
+    name = config[CONF_NAME]
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
 

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -24,7 +24,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the file size sensor."""
     sensors = []
-    for path in config.get(CONF_FILE_PATHS):
+    for path in config[CONF_FILE_PATHS]:
         if not hass.config.is_allowed_path(path):
             _LOGGER.error("Filepath %s is not valid or allowed", path)
             continue

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -151,7 +151,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template sensors."""
     name = config.get(CONF_NAME)
-    entity_id = config.get(CONF_ENTITY_ID)
+    entity_id = config[CONF_ENTITY_ID]
 
     filters = [
         FILTERS[_filter.pop(CONF_FILTER_NAME)](entity=entity_id, **_filter)

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -261,7 +261,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if int(time.time()) - expires_at > 3600:
             authd_client.client.refresh_token()
 
-        unit_system = config.get(CONF_UNIT_SYSTEM)
+        unit_system = config[CONF_UNIT_SYSTEM]
         if unit_system == "default":
             authd_client.system = authd_client.user_profile_get()["user"]["locale"]
             if authd_client.system != "en_GB":
@@ -274,8 +274,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         dev = []
         registered_devs = authd_client.get_devices()
-        clock_format = config.get(CONF_CLOCK_FORMAT)
-        for resource in config.get(CONF_MONITORED_RESOURCES):
+        clock_format = config[CONF_CLOCK_FORMAT]
+        for resource in config[CONF_MONITORED_RESOURCES]:
 
             # monitor battery for all linked FitBit devices
             if resource == "devices/battery":

--- a/homeassistant/components/fixer/sensor.py
+++ b/homeassistant/components/fixer/sensor.py
@@ -38,9 +38,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Fixer.io sensor."""
 
-    api_key = config.get(CONF_API_KEY)
-    name = config.get(CONF_NAME)
-    target = config.get(CONF_TARGET)
+    api_key = config[CONF_API_KEY]
+    name = config[CONF_NAME]
+    target = config[CONF_TARGET]
 
     try:
         Fixerio(symbols=[target], access_key=api_key).latest()

--- a/homeassistant/components/fleetgo/device_tracker.py
+++ b/homeassistant/components/fleetgo/device_tracker.py
@@ -42,14 +42,14 @@ class FleetGoDeviceScanner:
     def __init__(self, config, see):
         """Initialize FleetGoDeviceScanner."""
 
-        self._include = config.get(CONF_INCLUDE)
+        self._include = config[CONF_INCLUDE]
         self._see = see
 
         self._api = API(
-            config.get(CONF_CLIENT_ID),
-            config.get(CONF_CLIENT_SECRET),
-            config.get(CONF_USERNAME),
-            config.get(CONF_PASSWORD),
+            config[CONF_CLIENT_ID],
+            config[CONF_CLIENT_SECRET],
+            config[CONF_USERNAME],
+            config[CONF_PASSWORD],
         )
 
     def setup(self, hass):

--- a/homeassistant/components/flexit/climate.py
+++ b/homeassistant/components/flexit/climate.py
@@ -36,9 +36,9 @@ SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Flexit Platform."""
-    modbus_slave = config.get(CONF_SLAVE)
-    name = config.get(CONF_NAME)
-    hub = hass.data[MODBUS_DOMAIN][config.get(CONF_HUB)]
+    modbus_slave = config[CONF_SLAVE]
+    name = config[CONF_NAME]
+    hub = hass.data[MODBUS_DOMAIN][config[CONF_HUB]]
     add_entities([Flexit(hub, modbus_slave, name)], True)
 
 

--- a/homeassistant/components/flic/binary_sensor.py
+++ b/homeassistant/components/flic/binary_sensor.py
@@ -60,9 +60,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Initialize flic client responsible for
     # connecting to buttons and retrieving events
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    discovery = config.get(CONF_DISCOVERY)
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+    discovery = config[CONF_DISCOVERY]
 
     try:
         client = FlicClient(host, port)
@@ -115,7 +115,7 @@ def start_scanning(config, add_entities, client):
 
 def setup_button(hass, config, add_entities, client, address):
     """Set up a single button device."""
-    timeout = config.get(CONF_TIMEOUT)
+    timeout = config[CONF_TIMEOUT]
     ignored_click_types = config.get(CONF_IGNORED_CLICK_TYPES)
     button = FlicButton(hass, client, address, timeout, ignored_click_types)
     _LOGGER.info("Connected to button %s", address)

--- a/homeassistant/components/flock/notify.py
+++ b/homeassistant/components/flock/notify.py
@@ -18,7 +18,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_ACCESS_TOKEN): cv.st
 
 async def async_get_service(hass, config, discovery_info=None):
     """Get the Flock notification service."""
-    access_token = config.get(CONF_ACCESS_TOKEN)
+    access_token = config[CONF_ACCESS_TOKEN]
     url = f"{_RESOURCE}{access_token}"
     session = async_get_clientsession(hass)
 

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -131,18 +131,18 @@ async def async_set_lights_rgb(hass, lights, rgb, transition):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Flux switches."""
-    name = config.get(CONF_NAME)
-    lights = config.get(CONF_LIGHTS)
+    name = config[CONF_NAME]
+    lights = config[CONF_LIGHTS]
     start_time = config.get(CONF_START_TIME)
     stop_time = config.get(CONF_STOP_TIME)
-    start_colortemp = config.get(CONF_START_CT)
-    sunset_colortemp = config.get(CONF_SUNSET_CT)
-    stop_colortemp = config.get(CONF_STOP_CT)
+    start_colortemp = config[CONF_START_CT]
+    sunset_colortemp = config[CONF_SUNSET_CT]
+    stop_colortemp = config[CONF_STOP_CT]
     brightness = config.get(CONF_BRIGHTNESS)
     disable_brightness_adjust = config.get(CONF_DISABLE_BRIGHTNESS_ADJUST)
-    mode = config.get(CONF_MODE)
-    interval = config.get(CONF_INTERVAL)
-    transition = config.get(ATTR_TRANSITION)
+    mode = config[CONF_MODE]
+    interval = config[CONF_INTERVAL]
+    transition = config[ATTR_TRANSITION]
     flux = FluxSwitch(
         name,
         hass,

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -144,7 +144,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     lights = []
     light_ips = []
 
-    for ipaddr, device_config in config.get(CONF_DEVICES, {}).items():
+    for ipaddr, device_config in config[CONF_DEVICES].items():
         device = {}
         device["name"] = device_config[CONF_NAME]
         device["ipaddr"] = ipaddr
@@ -155,7 +155,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         lights.append(light)
         light_ips.append(ipaddr)
 
-    if not config.get(CONF_AUTOMATIC_ADD, False):
+    if not config[CONF_AUTOMATIC_ADD]:
         add_entities(lights, True)
         return
 

--- a/homeassistant/components/folder/sensor.py
+++ b/homeassistant/components/folder/sensor.py
@@ -42,12 +42,12 @@ def get_size(files_list):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the folder sensor."""
-    path = config.get(CONF_FOLDER_PATHS)
+    path = config[CONF_FOLDER_PATHS]
 
     if not hass.config.is_allowed_path(path):
         _LOGGER.error("folder %s is not valid or allowed", path)
     else:
-        folder = Folder(path, config.get(CONF_FILTER))
+        folder = Folder(path, config[CONF_FILTER])
         add_entities([folder], True)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces incorrect use of `dict.get(key)` for required and optional config keys with a default value with `dict[key]` in various integrations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
