### PR TITLE
Improve the transmission integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -398,7 +398,7 @@ homeassistant/components/tplink/* @rytilahti
 homeassistant/components/traccar/* @ludeeus
 homeassistant/components/tradfri/* @ggravlingen
 homeassistant/components/trafikverket_train/* @endor-force
-homeassistant/components/transmission/* @engrbm87 @JPHutchins @zhulik
+homeassistant/components/transmission/* @engrbm87 @JPHutchins
 homeassistant/components/tts/* @pvizeli
 homeassistant/components/twentemilieu/* @frenck
 homeassistant/components/twilio_call/* @robbiet480

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -398,7 +398,7 @@ homeassistant/components/tplink/* @rytilahti
 homeassistant/components/traccar/* @ludeeus
 homeassistant/components/tradfri/* @ggravlingen
 homeassistant/components/trafikverket_train/* @endor-force
-homeassistant/components/transmission/* @engrbm87 @JPHutchins
+homeassistant/components/transmission/* @engrbm87 @JPHutchins @zhulik
 homeassistant/components/tts/* @pvizeli
 homeassistant/components/twentemilieu/* @frenck
 homeassistant/components/twilio_call/* @robbiet480

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -355,8 +355,8 @@ class TransmissionData:
         actual_torrents = self.torrents
         actual_all_torrents = [var.name for var in actual_torrents]
 
-        tmp_all_torrents = list(set(self.all_torrents).difference(actual_all_torrents))
-        for var in tmp_all_torrents:
+        removed_torrents = list(set(self.all_torrents).difference(actual_all_torrents))
+        for var in removed_torrents:
             self.hass.bus.fire(EVENT_REMOVED_TORRENT, {"name": var})
         self.all_torrents = actual_all_torrents
 

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -314,10 +314,13 @@ class TransmissionData:
 
     def check_started_torrent_info(self):
         """Get started torrent info functionality."""
-        all_torrents = self._api.get_torrents()
+        actual_torrents = self.torrents
+        if not actual_torrents:
+            return
+
         current_down = {}
 
-        for torrent in all_torrents:
+        for torrent in actual_torrents:
             if torrent.status == "downloading":
                 info = self.started_torrent_dict[torrent.name] = {
                     "added_date": torrent.addedDate,

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -180,6 +180,7 @@ class TransmissionClient:
                 ("http", "ftp:", "magnet:")
             ) or self.hass.config.is_allowed_path(torrent):
                 tm_client.tm_api.add_torrent(torrent)
+                tm_client.api.update()
             else:
                 _LOGGER.warning(
                     "Could not add torrent: unsupported type or no permission"

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -310,14 +310,6 @@ class TransmissionData:
             self.hass.bus.fire("transmission_started_torrent", {"name": var})
         self.started_torrents = actual_started_torrents
 
-    def get_started_torrent_count(self):
-        """Get the number of started torrents."""
-        return len(self.started_torrents)
-
-    def get_completed_torrent_count(self):
-        """Get the number of completed torrents."""
-        return len(self.completed_torrents)
-
     def start_torrents(self):
         """Start all torrents."""
         self._api.start_all()

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -20,7 +20,7 @@ DEFAULT_NAME = "Transmission"
 DEFAULT_PORT = 9091
 DEFAULT_SCAN_INTERVAL = 120
 
-STATE_ATTR_TORRENT_INFO = "`torrent_info`"
+STATE_ATTR_TORRENT_INFO = "torrent_info"
 ATTR_TORRENT = "torrent"
 SERVICE_ADD_TORRENT = "add_torrent"
 

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -1,16 +1,12 @@
 """Constants for the Transmission Bittorent Client component."""
 
-from homeassistant.const import DATA_RATE_MEGABYTES_PER_SECOND
-
 DOMAIN = "transmission"
 
 SENSOR_TYPES = {
     "active_torrents": ["Active Torrents", "Torrents"],
     "current_status": ["Status", None],
-    "download_speed": ["Down Speed", DATA_RATE_MEGABYTES_PER_SECOND],
     "paused_torrents": ["Paused Torrents", "Torrents"],
     "total_torrents": ["Total Torrents", "Torrents"],
-    "upload_speed": ["Up Speed", DATA_RATE_MEGABYTES_PER_SECOND],
     "completed_torrents": ["Completed Torrents", "Torrents"],
     "started_torrents": ["Started Torrents", "Torrents"],
 }

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -18,3 +18,7 @@ SERVICE_ADD_TORRENT = "add_torrent"
 SERVICE_REMOVE_TORRENT = "remove_torrent"
 
 DATA_UPDATED = "transmission_data_updated"
+
+EVENT_STARTED_TORRENT = "transmission_started_torrent"
+EVENT_REMOVED_TORRENT = "transmission_removed_torrent"
+EVENT_DOWNLOADED_TORRENT = "transmission_downloaded_torrent"

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -2,13 +2,6 @@
 
 DOMAIN = "transmission"
 
-SENSOR_TYPES = {
-    "active_torrents": ["Active Torrents", "Torrents"],
-    "paused_torrents": ["Paused Torrents", "Torrents"],
-    "total_torrents": ["Total Torrents", "Torrents"],
-    "completed_torrents": ["Completed Torrents", "Torrents"],
-    "started_torrents": ["Started Torrents", "Torrents"],
-}
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 
 DEFAULT_NAME = "Transmission"

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -20,7 +20,7 @@ DEFAULT_NAME = "Transmission"
 DEFAULT_PORT = 9091
 DEFAULT_SCAN_INTERVAL = 120
 
-STATE_ATTR_TORRENT_INFO = "torrent_info"
+STATE_ATTR_TORRENT_INFO = "`torrent_info`"
 ATTR_TORRENT = "torrent"
 SERVICE_ADD_TORRENT = "add_torrent"
 

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -4,12 +4,17 @@ DOMAIN = "transmission"
 
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 
+DEFAULT_DELETE_DATA = False
 DEFAULT_NAME = "Transmission"
 DEFAULT_PORT = 9091
 DEFAULT_SCAN_INTERVAL = 120
 
 STATE_ATTR_TORRENT_INFO = "torrent_info"
+
+ATTR_DELETE_DATA = "delete_data"
 ATTR_TORRENT = "torrent"
+
 SERVICE_ADD_TORRENT = "add_torrent"
+SERVICE_REMOVE_TORRENT = "remove_torrent"
 
 DATA_UPDATED = "transmission_data_updated"

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -4,7 +4,6 @@ DOMAIN = "transmission"
 
 SENSOR_TYPES = {
     "active_torrents": ["Active Torrents", "Torrents"],
-    "current_status": ["Status", None],
     "paused_torrents": ["Paused Torrents", "Torrents"],
     "total_torrents": ["Total Torrents", "Torrents"],
     "completed_torrents": ["Completed Torrents", "Torrents"],

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -75,7 +75,11 @@ class TransmissionSensor(Entity):
             """Update the state."""
             self.async_schedule_update_ha_state(True)
 
-        self.async_on_remove(async_dispatcher_connect(self.hass, DOMAIN, update))
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self._tm_client.api.signal_update, update
+            )
+        )
 
 
 class TransmissionSpeedSensor(TransmissionSensor):

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -84,19 +84,19 @@ class TransmissionSensor(Entity):
         if self.type == "started_torrents":
             return {
                 STATE_ATTR_TORRENT_INFO: _torrents_info(
-                    self._tm_client.api.torrents, "downloading"
+                    self._tm_client.api.torrents, ("downloading")
                 )
             }
         if self.type == "completed_torrents":
             return {
                 STATE_ATTR_TORRENT_INFO: _torrents_info(
-                    self._tm_client.api.torrents, "seeding"
+                    self._tm_client.api.torrents, ("seeding")
                 )
             }
         if self.type == "paused_torrents":
             return {
                 STATE_ATTR_TORRENT_INFO: _torrents_info(
-                    self._tm_client.api.torrents, "stopped"
+                    self._tm_client.api.torrents, ("stopped")
                 )
             }
         if self.type == "total_torrents":
@@ -104,7 +104,11 @@ class TransmissionSensor(Entity):
                 STATE_ATTR_TORRENT_INFO: _torrents_info(self._tm_client.api.torrents)
             }
         if self.type == "active_torrents":
-            return {STATE_ATTR_TORRENT_INFO: {}}
+            return {
+                STATE_ATTR_TORRENT_INFO: _torrents_info(
+                    self._tm_client.api.torrents, ("seeding", "downloading")
+                )
+            }
         return None
 
     async def async_added_to_hass(self):
@@ -166,10 +170,10 @@ class TransmissionSensor(Entity):
                 self._state = self._data.torrentCount
 
 
-def _torrents_info(torrents, status=None):
+def _torrents_info(torrents, statuses=None):
     infos = {}
     for torrent in torrents:
-        if torrent.status == status or status is None:
+        if statuses is None or torrent.status in statuses:
             info = infos[torrent.name] = {
                 "added_date": torrent.addedDate,
                 "percent_done": f"{torrent.percentDone * 100:.2f}",

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -41,7 +41,6 @@ class TransmissionSensor(Entity):
         self._name = sensor_name
         self._sub_type = sub_type
         self._state = None
-        self._unsub_update = None
 
     @property
     def name(self):
@@ -70,21 +69,13 @@ class TransmissionSensor(Entity):
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
-        self._unsub_update = async_dispatcher_connect(
-            self.hass,
-            self._tm_client.api.signal_update,
-            self._schedule_immediate_update,
-        )
 
-    @callback
-    def _schedule_immediate_update(self):
-        self.async_schedule_update_ha_state(True)
+        @callback
+        def update():
+            """Update the state."""
+            self.async_schedule_update_ha_state(True)
 
-    async def will_remove_from_hass(self):
-        """Unsubscribe from update dispatcher."""
-        if self._unsub_update:
-            self._unsub_update()
-            self._unsub_update = None
+        self.async_on_remove(async_dispatcher_connect(self.hass, DOMAIN, update))
 
 
 class TransmissionSpeedSensor(TransmissionSensor):

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -183,5 +183,5 @@ def _torrents_info(torrents, statuses=None):
             try:
                 info["eta"] = str(torrent.eta)
             except ValueError:
-                info["eta"] = "unknown"
+                pass
     return infos

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -7,3 +7,16 @@ add_torrent:
     torrent:
       description: URL, magnet link or Base64 encoded file.
       example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent
+
+remove_torrent:
+  description: Demove a torrent
+  fields:
+    name:
+      description: Instance name as entered during entry config
+      example: Transmission
+    id:
+      description: ID of a torrent
+      example: 123
+    delete_data:
+      description: Delete torrent data
+      example: false

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -9,7 +9,7 @@ add_torrent:
       example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent
 
 remove_torrent:
-  description: Demove a torrent
+  description: Remove a torrent
   fields:
     name:
       description: Instance name as entered during entry config


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The PR contains 4 changes: 
* Force update sensors in the `transmission.add_torrent` service to make them reflect the updated state of the server quicker, without waiting for the next scheduled scan.
* Add introduced in #27111 torrent_info attribute to all sensors, so the `total_torrents` sensor has a full list of torrents, and the `stopped_torrents` - a list of stopped torrents and so on.
* Add `transmission.remove_torrent` service
* Add `transmission_removed_torrent` event

The second change does not change the format of the attribute, but only extends it, so it's fully backward compatible.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/13053

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
