### PR TITLE
Add unique_id for Xiaomi Vacuums

### DIFF
--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -189,21 +189,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     # Create handler
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
-
-    unique_id = None
+    vacuum = Vacuum(host, token)
 
     try:
-        vacuum = Vacuum(host, token)
         device_info = await hass.async_add_executor_job(vacuum.info)
-        unique_id = device_info.mac_address
-        _LOGGER.info(
-            "%s %s %s detected",
-            device_info.model,
-            device_info.firmware_version,
-            device_info.hardware_version,
-        )
     except DeviceException:
         raise PlatformNotReady
+
+    unique_id = device_info.mac_address
+    _LOGGER.debug(
+        "%s %s %s detected",
+        device_info.model,
+        device_info.firmware_version,
+        device_info.hardware_version,
+    )
 
     mirobo = MiroboVacuum(name, vacuum, unique_id)
     hass.data[DATA_KEY][host] = mirobo

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -195,7 +195,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     try:
         vacuum = Vacuum(host, token)
         device_info = await hass.async_add_executor_job(vacuum.info)
-        unique_id = f"{device_info.model}-{device_info.mac_address}"
+        unique_id = device_info.mac_address
         _LOGGER.info(
             "%s %s %s detected",
             device_info.model,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a unique_id property for Xiaomi Vacuums.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Implement the unique_id property for Xiaomi Miio Vacuum devices so they can be renamed and manipulated in the UI better. Unique ID used is the same format as the other Miio device domains (Model-MAC Address).

- This PR fixes or closes issue: (no issue created) Xiaomi/Miio Vacuums do not implement a unique_id and cannot have the entity_id or friendly_name customized via the UI.
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] - N/A

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  N/A
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.   N/A
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`. N/A

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
