### PR TITLE
Support DirecTV music channels with extended meta

### DIFF
--- a/homeassistant/components/directv/media_player.py
+++ b/homeassistant/components/directv/media_player.py
@@ -8,6 +8,7 @@ from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     MEDIA_TYPE_MOVIE,
+    MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_TVSHOW,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
@@ -177,7 +178,7 @@ class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerDevice):
         if self._is_standby or self._program is None:
             return None
 
-        known_types = [MEDIA_TYPE_MOVIE, MEDIA_TYPE_TVSHOW]
+        known_types = [MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW]
         if self._program.program_type in known_types:
             return self._program.program_type
 
@@ -213,7 +214,26 @@ class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerDevice):
         if self._is_standby or self._program is None:
             return None
 
+        if self.media_content_type == MEDIA_TYPE_MUSIC:
+            return self._program.music_title
+
         return self._program.title
+
+    @property
+    def media_artist(self):
+        """Artist of current playing media, music track only."""
+        if self._is_standby or self._program is None:
+            return None
+
+        return self._program.music_artist
+
+    @property
+    def media_album_name(self):
+        """Album name of current playing media, music track only."""
+        if self._is_standby or self._program is None:
+            return None
+
+        return self._program.music_album
 
     @property
     def media_series_title(self):

--- a/homeassistant/components/directv/media_player.py
+++ b/homeassistant/components/directv/media_player.py
@@ -35,6 +35,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+KNOWN_MEDIA_TYPES = [MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW]
+
 SUPPORT_DTV = (
     SUPPORT_PAUSE
     | SUPPORT_TURN_ON
@@ -178,8 +180,7 @@ class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerDevice):
         if self._is_standby or self._program is None:
             return None
 
-        known_types = [MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW]
-        if self._program.program_type in known_types:
+        if self._program.program_type in KNOWN_MEDIA_TYPES:
             return self._program.program_type
 
         return MEDIA_TYPE_MOVIE

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -63,7 +63,7 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
         text=load_fixture("directv/tv-get-tuned.json"),
         headers={"Content-Type": "application/json"},
     )
-    
+
     aioclient_mock.get(
         f"http://{HOST}:8080/tv/getTuned",
         params={"clientAddr": "A01234567890"},

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -1,7 +1,7 @@
 """Tests for the DirecTV component."""
 from homeassistant.components.directv.const import CONF_RECEIVER_ID, DOMAIN
 from homeassistant.components.ssdp import ATTR_SSDP_LOCATION
-from homeassistant.const import CONF_HOST, HTTP_INTERNAL_SERVER_ERROR
+from homeassistant.const import CONF_HOST, HTTP_FORBIDDEN, HTTP_INTERNAL_SERVER_ERROR
 from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.common import MockConfigEntry, load_fixture
@@ -75,6 +75,14 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
         f"http://{HOST}:8080/tv/getTuned",
         params={"clientAddr": "A01234567890"},
         text=load_fixture("directv/tv-get-tuned-music.json"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    aioclient_mock.get(
+        f"http://{HOST}:8080/tv/getTuned",
+        params={"clientAddr": "C01234567890"},
+        status=HTTP_FORBIDDEN,
+        text=load_fixture("directv/tv-get-tuned-restricted.json"),
         headers={"Content-Type": "application/json"},
     )
 

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -63,6 +63,13 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
         text=load_fixture("directv/tv-get-tuned.json"),
         headers={"Content-Type": "application/json"},
     )
+    
+    aioclient_mock.get(
+        f"http://{HOST}:8080/tv/getTuned",
+        params={"clientAddr": "A01234567890"},
+        text=load_fixture("directv/tv-get-tuned-music.json"),
+        headers={"Content-Type": "application/json"},
+    )
 
     aioclient_mock.get(
         f"http://{HOST}:8080/tv/getTuned",

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -33,6 +33,13 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
 
     aioclient_mock.get(
         f"http://{HOST}:8080/info/mode",
+        params={"clientAddr": "B01234567890"},
+        text=load_fixture("directv/info-mode-standby.json"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    aioclient_mock.get(
+        f"http://{HOST}:8080/info/mode",
         params={"clientAddr": "9XXXXXXXXXX9"},
         status=HTTP_INTERNAL_SERVER_ERROR,
         text=load_fixture("directv/info-mode-error.json"),

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -62,6 +62,7 @@ ATTR_UNIQUE_ID = "unique_id"
 CLIENT_ENTITY_ID = f"{MP_DOMAIN}.client"
 MAIN_ENTITY_ID = f"{MP_DOMAIN}.host"
 MUSIC_ENTITY_ID = f"{MP_DOMAIN}.music_client"
+RESTRICTED_ENTITY_ID = f"{MP_DOMAIN}.restricted_client"
 STANDBY_ENTITY_ID = f"{MP_DOMAIN}.standby_client"
 UNAVAILABLE_ENTITY_ID = f"{MP_DOMAIN}.unavailable_client"
 
@@ -279,6 +280,24 @@ async def test_check_attributes(
 
     state = hass.states.get(STANDBY_ENTITY_ID)
     assert state.state == STATE_OFF
+
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) is None
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) is None
+    assert state.attributes.get(ATTR_MEDIA_DURATION) is None
+    assert state.attributes.get(ATTR_MEDIA_POSITION) is None
+    assert state.attributes.get(ATTR_MEDIA_POSITION_UPDATED_AT) is None
+    assert state.attributes.get(ATTR_MEDIA_TITLE) is None
+    assert state.attributes.get(ATTR_MEDIA_ARTIST) is None
+    assert state.attributes.get(ATTR_MEDIA_ALBUM_NAME) is None
+    assert state.attributes.get(ATTR_MEDIA_SERIES_TITLE) is None
+    assert state.attributes.get(ATTR_MEDIA_CHANNEL) is None
+    assert state.attributes.get(ATTR_INPUT_SOURCE) is None
+    assert not state.attributes.get(ATTR_MEDIA_CURRENTLY_RECORDING)
+    assert state.attributes.get(ATTR_MEDIA_RATING) is None
+    assert not state.attributes.get(ATTR_MEDIA_RECORDED)
+
+    state = hass.states.get(RESTRICTED_ENTITY_ID)
+    assert state.state == STATE_ON
 
     assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) is None
     assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) is None

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -13,6 +13,7 @@ from homeassistant.components.directv.media_player import (
 )
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_ARTIST,
     ATTR_MEDIA_CHANNEL,
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
@@ -24,6 +25,7 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_TITLE,
     DOMAIN as MP_DOMAIN,
     MEDIA_TYPE_MOVIE,
+    MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_TVSHOW,
     SERVICE_PLAY_MEDIA,
     SUPPORT_NEXT_TRACK,
@@ -57,6 +59,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 ATTR_UNIQUE_ID = "unique_id"
 CLIENT_ENTITY_ID = f"{MP_DOMAIN}.client"
 MAIN_ENTITY_ID = f"{MP_DOMAIN}.host"
+MUSIC_ENTITY_ID = f"{MP_DOMAIN}.fireplace"
 UNAVAILABLE_ENTITY_ID = f"{MP_DOMAIN}.unavailable_client"
 
 # pylint: disable=redefined-outer-name
@@ -248,6 +251,27 @@ async def test_check_attributes(
     assert state.attributes.get(ATTR_MEDIA_RECORDED)
     assert state.attributes.get(ATTR_MEDIA_START_TIME) == datetime(
         2010, 7, 5, 15, 0, 8, tzinfo=dt_util.UTC
+    )
+    
+    state = hass.states.get(MUSIC_ENTITY_ID)
+    assert state.state == STATE_PLAYING
+
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) == "76917562"
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_MUSIC
+    assert state.attributes.get(ATTR_MEDIA_DURATION) == 86400
+    assert state.attributes.get(ATTR_MEDIA_POSITION) == 15050
+    assert state.attributes.get(ATTR_MEDIA_POSITION_UPDATED_AT)
+    assert state.attributes.get(ATTR_MEDIA_TITLE) == "Sparkle In Your Eyes"
+    assert state.attributes.get(ATTR_MEDIA_ARTIST) == "Gerald Albright"
+    assert state.attributes.get(ATTR_MEDIA_ALBUM) == "Slam Dunk (2014)"
+    assert state.attributes.get(ATTR_MEDIA_SERIES_TITLE) is None
+    assert state.attributes.get(ATTR_MEDIA_CHANNEL) == "{} ({})".format("MCSJ", "851")
+    assert state.attributes.get(ATTR_INPUT_SOURCE) == "851"
+    assert not state.attributes.get(ATTR_MEDIA_CURRENTLY_RECORDING)
+    assert state.attributes.get(ATTR_MEDIA_RATING) == "TV-PG"
+    assert not state.attributes.get(ATTR_MEDIA_RECORDED)
+    assert state.attributes.get(ATTR_MEDIA_START_TIME) == datetime(
+        2020, 3, 21, 10, 0, 0, tzinfo=dt_util.UTC
     )
 
     state = hass.states.get(UNAVAILABLE_ENTITY_ID)

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -297,7 +297,7 @@ async def test_check_attributes(
     assert not state.attributes.get(ATTR_MEDIA_RECORDED)
 
     state = hass.states.get(RESTRICTED_ENTITY_ID)
-    assert state.state == STATE_ON
+    assert state.state == STATE_PLAYING
 
     assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) is None
     assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) is None

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -47,6 +47,7 @@ from homeassistant.const import (
     SERVICE_MEDIA_STOP,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
     STATE_PAUSED,
     STATE_PLAYING,
     STATE_UNAVAILABLE,
@@ -61,6 +62,7 @@ ATTR_UNIQUE_ID = "unique_id"
 CLIENT_ENTITY_ID = f"{MP_DOMAIN}.client"
 MAIN_ENTITY_ID = f"{MP_DOMAIN}.host"
 MUSIC_ENTITY_ID = f"{MP_DOMAIN}.music_client"
+STANDBY_ENTITY_ID = f"{MP_DOMAIN}.standby_client"
 UNAVAILABLE_ENTITY_ID = f"{MP_DOMAIN}.unavailable_client"
 
 # pylint: disable=redefined-outer-name
@@ -274,6 +276,24 @@ async def test_check_attributes(
     assert state.attributes.get(ATTR_MEDIA_START_TIME) == datetime(
         2020, 3, 21, 10, 0, 0, tzinfo=dt_util.UTC
     )
+
+    state = hass.states.get(STANDBY_ENTITY_ID)
+    assert state.state == STATE_OFF
+
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) is None
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) is None
+    assert state.attributes.get(ATTR_MEDIA_DURATION) is None
+    assert state.attributes.get(ATTR_MEDIA_POSITION) is None
+    assert state.attributes.get(ATTR_MEDIA_POSITION_UPDATED_AT) is None
+    assert state.attributes.get(ATTR_MEDIA_TITLE) is None
+    assert state.attributes.get(ATTR_MEDIA_ARTIST) is None
+    assert state.attributes.get(ATTR_MEDIA_ALBUM_NAME) is None
+    assert state.attributes.get(ATTR_MEDIA_SERIES_TITLE) is None
+    assert state.attributes.get(ATTR_MEDIA_CHANNEL) is None
+    assert state.attributes.get(ATTR_INPUT_SOURCE) is None
+    assert not state.attributes.get(ATTR_MEDIA_CURRENTLY_RECORDING)
+    assert state.attributes.get(ATTR_MEDIA_RATING) is None
+    assert not state.attributes.get(ATTR_MEDIA_RECORDED)
 
     state = hass.states.get(UNAVAILABLE_ENTITY_ID)
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -59,7 +59,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 ATTR_UNIQUE_ID = "unique_id"
 CLIENT_ENTITY_ID = f"{MP_DOMAIN}.client"
 MAIN_ENTITY_ID = f"{MP_DOMAIN}.host"
-MUSIC_ENTITY_ID = f"{MP_DOMAIN}.fireplace"
+MUSIC_ENTITY_ID = f"{MP_DOMAIN}.music_client"
 UNAVAILABLE_ENTITY_ID = f"{MP_DOMAIN}.unavailable_client"
 
 # pylint: disable=redefined-outer-name

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -13,6 +13,7 @@ from homeassistant.components.directv.media_player import (
 )
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_ALBUM_NAME,
     ATTR_MEDIA_ARTIST,
     ATTR_MEDIA_CHANNEL,
     ATTR_MEDIA_CONTENT_ID,
@@ -233,7 +234,7 @@ async def test_check_attributes(
     assert state.attributes.get(ATTR_MEDIA_START_TIME) == datetime(
         2020, 3, 21, 13, 0, tzinfo=dt_util.UTC
     )
-
+    
     state = hass.states.get(CLIENT_ENTITY_ID)
     assert state.state == STATE_PLAYING
 
@@ -252,7 +253,7 @@ async def test_check_attributes(
     assert state.attributes.get(ATTR_MEDIA_START_TIME) == datetime(
         2010, 7, 5, 15, 0, 8, tzinfo=dt_util.UTC
     )
-    
+
     state = hass.states.get(MUSIC_ENTITY_ID)
     assert state.state == STATE_PLAYING
 
@@ -263,7 +264,7 @@ async def test_check_attributes(
     assert state.attributes.get(ATTR_MEDIA_POSITION_UPDATED_AT)
     assert state.attributes.get(ATTR_MEDIA_TITLE) == "Sparkle In Your Eyes"
     assert state.attributes.get(ATTR_MEDIA_ARTIST) == "Gerald Albright"
-    assert state.attributes.get(ATTR_MEDIA_ALBUM) == "Slam Dunk (2014)"
+    assert state.attributes.get(ATTR_MEDIA_ALBUM_NAME) == "Slam Dunk (2014)"
     assert state.attributes.get(ATTR_MEDIA_SERIES_TITLE) is None
     assert state.attributes.get(ATTR_MEDIA_CHANNEL) == "{} ({})".format("MCSJ", "851")
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "851"

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -234,7 +234,7 @@ async def test_check_attributes(
     assert state.attributes.get(ATTR_MEDIA_START_TIME) == datetime(
         2020, 3, 21, 13, 0, tzinfo=dt_util.UTC
     )
-    
+
     state = hass.states.get(CLIENT_ENTITY_ID)
     assert state.state == STATE_PLAYING
 

--- a/tests/fixtures/directv/info-get-locations.json
+++ b/tests/fixtures/directv/info-get-locations.json
@@ -9,6 +9,10 @@
       "locationName": "Client"
     },
     {
+      "clientAddr": "A01234567890",
+      "locationName": "Music Client"
+    },
+    {
       "clientAddr": "9XXXXXXXXXX9",
       "locationName": "Unavailable Client"
     }

--- a/tests/fixtures/directv/info-get-locations.json
+++ b/tests/fixtures/directv/info-get-locations.json
@@ -17,6 +17,10 @@
       "locationName": "Standby Client"
     },
     {
+      "clientAddr": "C01234567890",
+      "locationName": "Restricted Client"
+    },
+    {
       "clientAddr": "9XXXXXXXXXX9",
       "locationName": "Unavailable Client"
     }

--- a/tests/fixtures/directv/info-get-locations.json
+++ b/tests/fixtures/directv/info-get-locations.json
@@ -13,6 +13,10 @@
       "locationName": "Music Client"
     },
     {
+      "clientAddr": "B01234567890",
+      "locationName": "Standby Client"
+    },
+    {
       "clientAddr": "9XXXXXXXXXX9",
       "locationName": "Unavailable Client"
     }

--- a/tests/fixtures/directv/info-mode-standby.json
+++ b/tests/fixtures/directv/info-mode-standby.json
@@ -1,0 +1,9 @@
+{
+  "mode": 1,
+  "status": {
+    "code": 200,
+    "commandResult": 0,
+    "msg": "OK",
+    "query": "/info/mode"
+  }
+}

--- a/tests/fixtures/directv/tv-get-tuned-music.json
+++ b/tests/fixtures/directv/tv-get-tuned-music.json
@@ -1,7 +1,7 @@
 {
   "callsign": "MCSJ",
   "duration": 86400,
-  "isOffAir": False,
+  "isOffAir": false,
   "isPclocked": 3,
   "isPpv": false,
   "isRecording": false,

--- a/tests/fixtures/directv/tv-get-tuned-music.json
+++ b/tests/fixtures/directv/tv-get-tuned-music.json
@@ -1,0 +1,28 @@
+{
+  "callsign": "MCSJ",
+  "duration": 86400,
+  "isOffAir": False,
+  "isPclocked": 3,
+  "isPpv": false,
+  "isRecording": false,
+  "isVod": false,
+  "major": 851,
+  "minor": 65535,
+  "music": {
+      "by": "Gerald Albright",
+      "cd": "Slam Dunk (2014)",
+      "title": "Sparkle In Your Eyes",
+  },
+  "offset": 15050,
+  "programId": "76917562",
+  "rating": "TV-PG",
+  "startTime": 1584784800,
+  "stationId": 2872196,
+  "status": {
+    "code": 200,
+    "commandResult": 0,
+    "msg": "OK.",
+    "query": "/tv/getTuned"
+  },
+  "title": "Smooth Jazz"
+}

--- a/tests/fixtures/directv/tv-get-tuned-music.json
+++ b/tests/fixtures/directv/tv-get-tuned-music.json
@@ -9,9 +9,9 @@
   "major": 851,
   "minor": 65535,
   "music": {
-      "by": "Gerald Albright",
-      "cd": "Slam Dunk (2014)",
-      "title": "Sparkle In Your Eyes",
+    "by": "Gerald Albright",
+    "cd": "Slam Dunk (2014)",
+    "title": "Sparkle In Your Eyes"
   },
   "offset": 15050,
   "programId": "76917562",

--- a/tests/fixtures/directv/tv-get-tuned-restricted.json
+++ b/tests/fixtures/directv/tv-get-tuned-restricted.json
@@ -1,0 +1,8 @@
+{
+  "status": {
+    "code": 403,
+    "commandResult": 1,
+    "msg": "Forbidden.",
+    "query": "/tv/getTuned"
+  }
+}


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

DirecTV music channels aka Music Choice offer a bit of song metadata when playing. We can expose this as media type of music.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
