### PR TITLE
Fix for schluter unit system bug

### DIFF
--- a/homeassistant/components/schluter/climate.py
+++ b/homeassistant/components/schluter/climate.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from homeassistant.components.climate import (
     PLATFORM_SCHEMA,
     SCAN_INTERVAL,
+    TEMP_CELSIUS,
     ClimateDevice,
 )
 from homeassistant.components.climate.const import (
@@ -32,7 +33,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         return
     session_id = hass.data[DOMAIN][DATA_SCHLUTER_SESSION]
     api = hass.data[DOMAIN][DATA_SCHLUTER_API]
-    temp_unit = hass.config.units.temperature_unit
 
     async def async_update_data():
         try:
@@ -58,7 +58,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     await coordinator.async_refresh()
 
     async_add_entities(
-        SchluterThermostat(coordinator, serial_number, temp_unit, api, session_id)
+        SchluterThermostat(coordinator, serial_number, api, session_id)
         for serial_number, thermostat in coordinator.data.items()
     )
 
@@ -66,9 +66,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class SchluterThermostat(ClimateDevice):
     """Representation of a Schluter thermostat."""
 
-    def __init__(self, coordinator, serial_number, temp_unit, api, session_id):
+    def __init__(self, coordinator, serial_number, api, session_id):
         """Initialize the thermostat."""
-        self._unit = temp_unit
         self._coordinator = coordinator
         self._serial_number = serial_number
         self._api = api
@@ -102,8 +101,8 @@ class SchluterThermostat(ClimateDevice):
 
     @property
     def temperature_unit(self):
-        """Return the unit of measurement."""
-        return self._unit
+        """Schluter API always uses celsius."""
+        return TEMP_CELSIUS
 
     @property
     def current_temperature(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The temperature_unit field within the climate platform was misused. The Schluter API only uses celsius, so by using the temp_unit from the config as the climate platform temperature unit, it was causing conversion inaccuracies if unit system was set to imperial on HA boot.

The solution was to always return TEMP_CELSIUS for the platform temperature_unit, and let HA handle the conversions between unit systems.

Tested and works correctly whether imperial or metric is selected on HA boot.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/33934
- This PR is related to issue: https://github.com/home-assistant/core/issues/33934
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
