### PR TITLE
Ensure existing SimpliSafe notifications trigger event on HASS startup

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -490,7 +490,7 @@ class SimpliSafe:
                         system
                     )
 
-                return self._hass.loop.create_task(process_when_running())
+                return asyncio.create_task(process_when_running())
 
             self._hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_START, process_notifications_listener

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -482,7 +482,7 @@ class SimpliSafe:
             async def process_notifications(_):
                 while self._hass.state != CoreState.running:
                     await asyncio.sleep(1)
-                self._async_process_new_notifications(system)
+                self._async_process_new_notifications(system)  # pylint: disable: W0640
 
             self._hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_START, process_notifications

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -482,7 +482,7 @@ class SimpliSafe:
             async def process_notifications(_):
                 while self._hass.state != CoreState.running:
                     await asyncio.sleep(1)
-                self._async_process_new_notifications(system)  # pylint: disable: W0640
+                self._async_process_new_notifications(system)  # pylint: disable=W0640
 
             self._hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_START, process_notifications

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -478,11 +478,9 @@ class SimpliSafe:
             # they will trigger SIMPLISAFE_NOTIFICATION events before other critical
             # components – such as automation – are ready. Therefore, we schedule an
             # update of notifications as soon as HASS is fully started:
-            def process_notifications(_):
-                self._async_process_new_notifications(system)
-
             self._hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_START, process_notifications
+                EVENT_HOMEASSISTANT_START,
+                lambda event: self._async_process_new_notifications(system),
             )
 
         async def refresh(event_time):

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -496,9 +496,7 @@ class SimpliSafe:
         async def update_system(system):
             """Update a system."""
             await system.update()
-
             self._async_process_new_notifications(system)
-
             _LOGGER.debug('Updated REST API data for "%s"', system.address)
             async_dispatcher_send(
                 self._hass, TOPIC_UPDATE_REST_API.format(system.system_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If SimpliSafe notifications existed when HASS started, there was a high chance that `SIMPLISAFE_NOTIFICATION` events would fire before anything downstream (e.g., `automation`) was set up to receive them. This PR updates the notification processing mechanism to only run when HASS is fully running.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_email
      password: !secret simplisafe_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/34231
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
