### PR TITLE
Add llamalab_automate optional message delivery priority

### DIFF
--- a/homeassistant/components/llamalab_automate/notify.py
+++ b/homeassistant/components/llamalab_automate/notify.py
@@ -6,8 +6,8 @@ import voluptuous as vol
 
 from homeassistant.components.notify import (
     ATTR_DATA,
-    BaseNotificationService,
     PLATFORM_SCHEMA,
+    BaseNotificationService,
 )
 from homeassistant.const import CONF_API_KEY, CONF_DEVICE, HTTP_OK
 from homeassistant.helpers import config_validation as cv

--- a/homeassistant/components/llamalab_automate/notify.py
+++ b/homeassistant/components/llamalab_automate/notify.py
@@ -4,12 +4,18 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+    ATTR_DATA,
+)
 from homeassistant.const import CONF_API_KEY, CONF_DEVICE, HTTP_OK
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = "https://llamalab.com/automate/cloud/message"
+
+ATTR_PRIORITY = "priority"
 
 CONF_TO = "to"
 
@@ -42,11 +48,20 @@ class AutomateNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        _LOGGER.debug("Sending to: %s, %s", self._recipient, str(self._device))
+
+        # Extract params from data dict
+        data = dict(kwargs.get(ATTR_DATA) or {})
+        priority = data.get(ATTR_PRIORITY, "Normal")
+
+        _LOGGER.debug(
+            "Sending to: %s, %s, prio: %s", self._recipient, str(self._device), priority
+        )
+
         data = {
             "secret": self._secret,
             "to": self._recipient,
             "device": self._device,
+            "priority": priority,
             "payload": message,
         }
 

--- a/homeassistant/components/llamalab_automate/notify.py
+++ b/homeassistant/components/llamalab_automate/notify.py
@@ -5,9 +5,9 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.notify import (
-    PLATFORM_SCHEMA,
-    BaseNotificationService,
     ATTR_DATA,
+    BaseNotificationService,
+    PLATFORM_SCHEMA,
 )
 from homeassistant.const import CONF_API_KEY, CONF_DEVICE, HTTP_OK
 from homeassistant.helpers import config_validation as cv


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change 
This PR adds the optional message delivery priority to the message as described in https://llamalab.com/automate/cloud/
Default value is "Normal", value "High" attempts to awaken the receiving device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
- service: notify.entity_id
      data:
        message: "This is the message"
        data:
          priority: High
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12978

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
