### PR TITLE
Fix Cloud UI bug preventing managing Google 2FA

### DIFF
--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -492,7 +492,7 @@ async def google_assistant_list(hass, connection, msg):
             {
                 "entity_id": entity.entity_id,
                 "traits": [trait.name for trait in entity.traits()],
-                "might_2fa": entity.might_2fa(),
+                "might_2fa": entity.might_2fa_traits(),
             }
         )
 

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -379,7 +379,7 @@ class GoogleEntity:
 
     @callback
     def might_2fa_traits(self) -> bool:
-        """Return if the entity might encounter 2FA."""
+        """Return if the entity might encounter 2FA based on just traits."""
         state = self.state
         domain = state.domain
         features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -372,13 +372,18 @@ class GoogleEntity:
     @callback
     def might_2fa(self) -> bool:
         """Return if the entity might encounter 2FA."""
+        if not self.config.should_2fa(self.state):
+            return False
+
+        return self.might_2fa_traits()
+
+    @callback
+    def might_2fa_traits(self) -> bool:
+        """Return if the entity might encounter 2FA."""
         state = self.state
         domain = state.domain
         features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         device_class = state.attributes.get(ATTR_DEVICE_CLASS)
-
-        if not self.config.should_2fa(state):
-            return False
 
         return any(
             trait.might_2fa(domain, features, device_class) for trait in self.traits()

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -688,19 +688,29 @@ async def test_list_google_entities(hass, hass_ws_client, setup_api, mock_cloud_
     entity = GoogleEntity(
         hass, MockConfig(should_expose=lambda *_: False), State("light.kitchen", "on")
     )
+    entity2 = GoogleEntity(
+        hass,
+        MockConfig(should_expose=lambda *_: True, should_2fa=lambda *_: False),
+        State("cover.garage", "open", {"device_class": "garage"}),
+    )
     with patch(
         "homeassistant.components.google_assistant.helpers.async_get_entities",
-        return_value=[entity],
+        return_value=[entity, entity2],
     ):
         await client.send_json({"id": 5, "type": "cloud/google_assistant/entities"})
         response = await client.receive_json()
 
     assert response["success"]
-    assert len(response["result"]) == 1
+    assert len(response["result"]) == 2
     assert response["result"][0] == {
         "entity_id": "light.kitchen",
         "might_2fa": False,
         "traits": ["action.devices.traits.OnOff"],
+    }
+    assert response["result"][1] == {
+        "entity_id": "cover.garage",
+        "might_2fa": True,
+        "traits": ["action.devices.traits.OpenClose"],
     }
 
 

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -33,6 +33,7 @@ class MockConfig(helpers.AbstractConfig):
         """Initialize config."""
         super().__init__(hass)
         self._should_expose = should_expose
+        self._should_2fa = should_2fa
         self._secure_devices_pin = secure_devices_pin
         self._entity_config = entity_config or {}
         self._local_sdk_webhook_id = local_sdk_webhook_id
@@ -72,6 +73,10 @@ class MockConfig(helpers.AbstractConfig):
     def should_expose(self, state):
         """Expose it all."""
         return self._should_expose is None or self._should_expose(state)
+
+    def should_2fa(self, state):
+        """Expose it all."""
+        return self._should_2fa is None or self._should_2fa(state)
 
 
 BASIC_CONFIG = MockConfig()

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -845,10 +845,8 @@ async def test_lock_unlock_unlock(hass):
     assert err.value.code == const.ERR_CHALLENGE_NOT_SETUP
 
     # Test with 2FA override
-    with patch(
-        "homeassistant.components.google_assistant.helpers"
-        ".AbstractConfig.should_2fa",
-        return_value=False,
+    with patch.object(
+        BASIC_CONFIG, "should_2fa", return_value=False,
     ):
         await trt.execute(trait.COMMAND_LOCKUNLOCK, BASIC_DATA, {"lock": False}, {})
     assert len(calls) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The cloud UI would not allow people to re-enable 2FA if they had once disabled 2FA for an entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
