### PR TITLE
Improve SmartThings stale refresh token handling

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -37,6 +37,7 @@ from .const import (
     TOKEN_REFRESH_INTERVAL,
 )
 from .smartapp import (
+    create_reauthorize_notification,
     setup_smartapp,
     setup_smartapp_endpoint,
     smartapp_sync_subscriptions,
@@ -145,18 +146,20 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     except APIInvalidGrant as ex:
         _LOGGER.error(
-            "Unable to obtain a new refresh token for '%s': %s - Reauthorize the SmartApp inside the SmartThings mobile app",
+            "Unable to obtain a new refresh token for '%s': %s - Reauthorize the SmartApp",
             entry.title,
             ex,
         )
+        create_reauthorize_notification(hass, entry)
         return False
 
     except ClientResponseError as ex:
         if ex.status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN):
             _LOGGER.exception(
-                "Unable to setup '%s' due to a security issue - Reauthorize the SmartApp inside the SmartThings mobile app",
+                "Unable to setup '%s' due to a security issue - Reauthorize the SmartApp",
                 entry.title,
             )
+            create_reauthorize_notification(hass, entry)
             return False
         # Retry for other types of errors
         _LOGGER.debug(ex, exc_info=True)

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -24,6 +24,7 @@ from pysmartthings import (
 )
 
 from homeassistant.components import webhook
+from homeassistant.config_entries import ENTRY_STATE_SETUP_ERROR
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
@@ -419,6 +420,9 @@ async def smartapp_update(hass: HomeAssistantType, req, resp, app):
             req.installed_app_id,
             app.app_id,
         )
+        # Try reloading the entry if the token was updated and it failed to setup
+        if entry.state == ENTRY_STATE_SETUP_ERROR:
+            await hass.config_entries.async_reload(entry.entry_id)
 
     flow = next(
         (

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -61,7 +61,7 @@ async def test_api_security_errors_returns_false(
     )
 
     # Assert setup returns false
-    assert not await smartthings.async_setup_entry(hass, config_entry)
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
     assert "due to a security issue" in caplog.text
 
 
@@ -76,7 +76,7 @@ async def test_api_refresh_token_errors_returns_false(
         "Invalid refresh token"
     )
 
-    assert not await smartthings.async_setup_entry(hass, config_entry)
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
     assert "Unable to obtain a new refresh token" in caplog.text
 
 


### PR DESCRIPTION
## Breaking change

## Proposed change
Improves handling of when the SmartThings refresh token is stale/invalid:
- No longer removes the config entry and instead fails entry setup
- Creates a notification with a link and instructions to reauthorize the SmartApp
- Recovers (reloads the config entry) when the user reauthorizes, which sends a new refresh token to HA


## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to an existing integration)

## Additional information
- This PR fixes or closes issue: fixes #34102

There are two ways to reauthorize the SmartApp and recover the integration: Follow the link in the notification displayed in the frontend or through the SmartThings mobile application:
1. While HA is running, open the SmartThings mobile application and go into the SmartApps panel.
1. Click the Home Assistant (or whatever you named it) SmartApp
1. Click 'Done' then 'Allow'.  HA will update automatically.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [X] No score or internal