### PR TITLE
Set mqtt binary_sensor unavailable if expire_after specified

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -119,7 +119,11 @@ class MqttBinarySensor(
         self._sub_state = None
         self._expiration_trigger = None
         self._delay_listener = None
-        self._expired = None
+        expire_after = config.get(CONF_EXPIRE_AFTER)
+        if expire_after is not None and expire_after > 0:
+            self._expired = True
+        else:
+            self._expired = None
         device_config = config.get(CONF_DEVICE)
 
         MqttAttributes.__init__(self, config)

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -109,7 +109,6 @@ async def test_setting_sensor_value_expires(hass, mqtt_mock, caplog):
 
 async def expires_helper(hass, mqtt_mock, caplog):
     """Run the basic expiry code."""
-
     now = datetime(2017, 1, 1, 1, tzinfo=dt_util.UTC)
     with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
         async_fire_time_changed(hass, now)
@@ -472,8 +471,7 @@ async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
 async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
     hass, mqtt_mock, caplog
 ):
-    """Test that binary_sensor with expire_after set behaves correctly on discovery and discovery update"""
-
+    """Test that binary_sensor with expire_after set behaves correctly on discovery and discovery update."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN)
     await async_start(hass, "homeassistant", {}, entry)
 

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -4,7 +4,8 @@ from datetime import datetime, timedelta
 import json
 from unittest.mock import patch
 
-from homeassistant.components import binary_sensor
+from homeassistant.components import binary_sensor, mqtt
+from homeassistant.components.mqtt.discovery import async_start
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_OFF,
@@ -42,9 +43,6 @@ from tests.common import (
     async_fire_mqtt_message,
     async_fire_time_changed,
 )
-
-from homeassistant.components import mqtt
-from homeassistant.components.mqtt.discovery import async_start
 
 DEFAULT_CONFIG = {
     binary_sensor.DOMAIN: {

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -37,7 +37,14 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-from tests.common import async_fire_mqtt_message, async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    async_fire_mqtt_message,
+    async_fire_time_changed,
+)
+
+from homeassistant.components import mqtt
+from homeassistant.components.mqtt.discovery import async_start
 
 DEFAULT_CONFIG = {
     binary_sensor.DOMAIN: {
@@ -70,8 +77,9 @@ async def test_setting_sensor_value_expires_availability_topic(hass, mqtt_mock, 
 
     async_fire_mqtt_message(hass, "availability-topic", "online")
 
+    # State should be unavailable since expire_after is defined and > 0
     state = hass.states.get("binary_sensor.test")
-    assert state.state != STATE_UNAVAILABLE
+    assert state.state == STATE_UNAVAILABLE
 
     await expires_helper(hass, mqtt_mock, caplog)
 
@@ -92,8 +100,9 @@ async def test_setting_sensor_value_expires(hass, mqtt_mock, caplog):
         },
     )
 
+    # State should be unavailable since expire_after is defined and > 0
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNAVAILABLE
 
     await expires_helper(hass, mqtt_mock, caplog)
 
@@ -458,6 +467,89 @@ async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, binary_sensor.DOMAIN, data1, data2
     )
+
+
+async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
+    hass, mqtt_mock, caplog
+):
+    """Test that binary_sensor with expire_after set behaves correctly on discovery and discovery update"""
+
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, "homeassistant", {}, entry)
+
+    config = {
+        "name": "Test",
+        "state_topic": "test-topic",
+        "expire_after": 4,
+        "force_update": True,
+    }
+
+    config_msg = json.dumps(config)
+
+    # Set time and publish config message to create binary_sensor via discovery with 4 s expiry
+    now = datetime(2017, 1, 1, 1, tzinfo=dt_util.UTC)
+    with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(
+            hass, "homeassistant/binary_sensor/bla/config", config_msg
+        )
+        await hass.async_block_till_done()
+
+    # Test that binary_sensor is not available
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    # Publish state message
+    with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
+        async_fire_mqtt_message(hass, "test-topic", "ON")
+        await hass.async_block_till_done()
+
+    # Test that binary_sensor has correct state
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    # Advance +3 seconds
+    now = now + timedelta(seconds=3)
+    with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+    # binary_sensor is not yet expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    # Resend config message to update discovery
+    with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(
+            hass, "homeassistant/binary_sensor/bla/config", config_msg
+        )
+        await hass.async_block_till_done()
+
+    # Test that binary_sensor has not expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    # Add +2 seconds
+    now = now + timedelta(seconds=2)
+    with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+    # Test that binary_sensor has expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    # Resend config message to update discovery
+    with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
+        async_fire_mqtt_message(
+            hass, "homeassistant/binary_sensor/bla/config", config_msg
+        )
+        await hass.async_block_till_done()
+
+    # Test that binary_sensor is still expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_discovery_broken(hass, mqtt_mock, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make `binary_sensor`'s with `expire_after `set be unavailable after restart of HA or (re-)publishing of `config `messages, so that the binary_sensor is only available (briefly) after a `state `message

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32975 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
