### PR TITLE
Fix relative_time datetime object without timezone

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -914,6 +914,27 @@ def random_every_time(context, values):
     return random.choice(values)
 
 
+def relative_time(value):
+    """
+    Take a datetime and return its "age" as a string.
+
+    The age can be in second, minute, hour, day, month or year. Only the
+    biggest unit is considered, e.g. if it's 2 days and 3 hours, "2 days" will
+    be returned.
+    Make sure date is not in the future, or else it will return None.
+
+    If the input are not a datetime object the input will be returned unmodified.
+    """
+
+    if not isinstance(value, datetime):
+        return value
+    if not value.tzinfo:
+        value = dt_util.as_local(value)
+    if dt_util.now() < value:
+        return value
+    return dt_util.get_age(value)
+
+
 class TemplateEnvironment(ImmutableSandboxedEnvironment):
     """The Home Assistant template environment."""
 
@@ -968,7 +989,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["now"] = dt_util.now
         self.globals["utcnow"] = dt_util.utcnow
         self.globals["as_timestamp"] = forgiving_as_timestamp
-        self.globals["relative_time"] = dt_util.get_age
+        self.globals["relative_time"] = relative_time
         self.globals["strptime"] = strptime
         if hass is None:
             return

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -197,9 +197,6 @@ def get_age(date: dt.datetime) -> str:
         """Return quotient and remaining."""
         return first // second, first % second
 
-    if type(date) is dt.datetime and not date.tzinfo:
-        date = as_local(date)
-
     delta = now() - date
     day = delta.days
     second = delta.seconds

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -197,6 +197,9 @@ def get_age(date: dt.datetime) -> str:
         """Return quotient and remaining."""
         return first // second, first % second
 
+    if type(date) is dt.datetime and not date.tzinfo:
+        date = as_local(date)
+
     delta = now() - date
     day = delta.days
     second = delta.seconds

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -865,6 +865,10 @@ def test_relative_time(mock_is_safe, hass):
                 hass,
             ).async_render()
         )
+        assert (
+            "string"
+            == template.Template('{{relative_time("string")}}', hass,).async_render()
+        )
 
 
 @patch(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -833,6 +833,37 @@ def test_now(mock_is_safe, hass):
     "homeassistant.helpers.template.TemplateEnvironment.is_safe_callable",
     return_value=True,
 )
+def test_relative_time(mock_is_safe, hass):
+    """Test relative_time method."""
+    now = datetime.strptime("2000-01-01 10:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z")
+    with patch("homeassistant.util.dt.now", return_value=now):
+        assert (
+            "1 hour"
+            == template.Template(
+                '{{relative_time(strptime("2000-01-01 09:00:00","%Y-%m-%d %H:%M:%S"))}}',
+                hass,
+            ).async_render()
+        )
+        assert (
+            "2 hours"
+            == template.Template(
+                '{{relative_time(strptime("2000-01-01 09:00:00 +01:00","%Y-%m-%d %H:%M:%S %z"))}}',
+                hass,
+            ).async_render()
+        )
+        assert (
+            "1 hour"
+            == template.Template(
+                '{{relative_time(strptime("2000-01-01 03:00:00 -06:00","%Y-%m-%d %H:%M:%S %z"))}}',
+                hass,
+            ).async_render()
+        )
+
+
+@patch(
+    "homeassistant.helpers.template.TemplateEnvironment.is_safe_callable",
+    return_value=True,
+)
 def test_utcnow(mock_is_safe, hass):
     """Test utcnow method."""
     now = dt_util.utcnow()

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -840,21 +840,28 @@ def test_relative_time(mock_is_safe, hass):
         assert (
             "1 hour"
             == template.Template(
-                '{{relative_time(strptime("2000-01-01 09:00:00","%Y-%m-%d %H:%M:%S"))}}',
+                '{{relative_time(strptime("2000-01-01 09:00:00", "%Y-%m-%d %H:%M:%S"))}}',
                 hass,
             ).async_render()
         )
         assert (
             "2 hours"
             == template.Template(
-                '{{relative_time(strptime("2000-01-01 09:00:00 +01:00","%Y-%m-%d %H:%M:%S %z"))}}',
+                '{{relative_time(strptime("2000-01-01 09:00:00 +01:00", "%Y-%m-%d %H:%M:%S %z"))}}',
                 hass,
             ).async_render()
         )
         assert (
             "1 hour"
             == template.Template(
-                '{{relative_time(strptime("2000-01-01 03:00:00 -06:00","%Y-%m-%d %H:%M:%S %z"))}}',
+                '{{relative_time(strptime("2000-01-01 03:00:00 -06:00", "%Y-%m-%d %H:%M:%S %z"))}}',
+                hass,
+            ).async_render()
+        )
+        assert (
+            str(template.strptime("2000-01-01 11:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z"))
+            == template.Template(
+                '{{relative_time(strptime("2000-01-01 11:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z"))}}',
                 hass,
             ).async_render()
         )


### PR DESCRIPTION
#34250: Fixes bug when relative_time gets a datetime object without timezone set. Now it will set local time.

Added tests

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`relative_time` template function can receive datetime objects that are offset-native. relative_time will convert all offset-native datetime object as local timezone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34250
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
