### PR TITLE
Fix default elkm1 temp units

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -15,6 +15,8 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_TEMPERATURE_UNIT,
     CONF_USERNAME,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -119,7 +121,9 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Optional(CONF_USERNAME, default=""): cv.string,
         vol.Optional(CONF_PASSWORD, default=""): cv.string,
         vol.Optional(CONF_AUTO_CONFIGURE, default=False): cv.boolean,
-        vol.Optional(CONF_TEMPERATURE_UNIT, default="F"): cv.temperature_unit,
+        vol.Optional(
+            CONF_TEMPERATURE_UNIT, default=TEMP_FAHRENHEIT
+        ): cv.temperature_unit,
         vol.Optional(CONF_AREA, default={}): DEVICE_SCHEMA_SUBDOMAIN,
         vol.Optional(CONF_COUNTER, default={}): DEVICE_SCHEMA_SUBDOMAIN,
         vol.Optional(CONF_KEYPAD, default={}): DEVICE_SCHEMA_SUBDOMAIN,
@@ -187,7 +191,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     _LOGGER.debug("Setting up elkm1 %s", conf["host"])
 
-    config = {"temperature_unit": conf[CONF_TEMPERATURE_UNIT]}
+    temperature_unit = TEMP_FAHRENHEIT
+    if conf[CONF_TEMPERATURE_UNIT] in ("C", TEMP_CELSIUS):
+        temperature_unit = TEMP_CELSIUS
+
+    config = {"temperature_unit": temperature_unit}
 
     if not conf[CONF_AUTO_CONFIGURE]:
         # With elkm1-lib==0.7.16 and later auto configure is available

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -25,6 +25,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    BARE_TEMP_CELSIUS,
+    BARE_TEMP_FAHRENHEIT,
     CONF_AREA,
     CONF_AUTO_CONFIGURE,
     CONF_COUNTER,
@@ -121,8 +123,9 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Optional(CONF_USERNAME, default=""): cv.string,
         vol.Optional(CONF_PASSWORD, default=""): cv.string,
         vol.Optional(CONF_AUTO_CONFIGURE, default=False): cv.boolean,
+        # cv.temperature_unit will mutate 'C' -> '°C' and 'F' -> '°F'
         vol.Optional(
-            CONF_TEMPERATURE_UNIT, default=TEMP_FAHRENHEIT
+            CONF_TEMPERATURE_UNIT, default=BARE_TEMP_FAHRENHEIT
         ): cv.temperature_unit,
         vol.Optional(CONF_AREA, default={}): DEVICE_SCHEMA_SUBDOMAIN,
         vol.Optional(CONF_COUNTER, default={}): DEVICE_SCHEMA_SUBDOMAIN,
@@ -192,7 +195,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.debug("Setting up elkm1 %s", conf["host"])
 
     temperature_unit = TEMP_FAHRENHEIT
-    if conf[CONF_TEMPERATURE_UNIT] in ("C", TEMP_CELSIUS):
+    if conf[CONF_TEMPERATURE_UNIT] in (BARE_TEMP_CELSIUS, TEMP_CELSIUS):
         temperature_unit = TEMP_CELSIUS
 
     config = {"temperature_unit": temperature_unit}

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -14,7 +14,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
-from homeassistant.const import PRECISION_WHOLE, STATE_ON, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import PRECISION_WHOLE, STATE_ON
 
 from . import ElkEntity, create_elk_entities
 from .const import DOMAIN
@@ -55,7 +55,7 @@ class ElkThermostat(ElkEntity, ClimateDevice):
     @property
     def temperature_unit(self):
         """Return the temperature unit."""
-        return TEMP_FAHRENHEIT if self._temperature_unit == "F" else TEMP_CELSIUS
+        return self._temperature_unit
 
     @property
     def current_temperature(self):

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -13,6 +13,8 @@ from homeassistant.const import (
     CONF_PROTOCOL,
     CONF_TEMPERATURE_UNIT,
     CONF_USERNAME,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
 )
 from homeassistant.util import slugify
 
@@ -33,7 +35,9 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_USERNAME, default=""): str,
         vol.Optional(CONF_PASSWORD, default=""): str,
         vol.Optional(CONF_PREFIX, default=""): str,
-        vol.Optional(CONF_TEMPERATURE_UNIT, default="F"): vol.In(["F", "C"]),
+        vol.Optional(CONF_TEMPERATURE_UNIT, default=TEMP_FAHRENHEIT): vol.In(
+            [TEMP_FAHRENHEIT, TEMP_CELSIUS]
+        ),
     }
 )
 

--- a/homeassistant/components/elkm1/const.py
+++ b/homeassistant/components/elkm1/const.py
@@ -18,6 +18,9 @@ CONF_ZONE = "zone"
 CONF_PREFIX = "prefix"
 
 
+BARE_TEMP_FAHRENHEIT = "F"
+BARE_TEMP_CELSIUS = "C"
+
 ELK_ELEMENTS = {
     CONF_AREA: Max.AREAS.value,
     CONF_COUNTER: Max.COUNTERS.value,

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_form_user_with_secure_elk(hass):
                 "address": "1.2.3.4",
                 "username": "test-username",
                 "password": "test-password",
-                "temperature_unit": "F",
+                "temperature_unit": "°F",
                 "prefix": "",
             },
         )
@@ -51,7 +51,7 @@ async def test_form_user_with_secure_elk(hass):
         "host": "elks://1.2.3.4",
         "password": "test-password",
         "prefix": "",
-        "temperature_unit": "F",
+        "temperature_unit": "°F",
         "username": "test-username",
     }
     await hass.async_block_till_done()
@@ -82,7 +82,7 @@ async def test_form_user_with_non_secure_elk(hass):
             {
                 "protocol": "non-secure",
                 "address": "1.2.3.4",
-                "temperature_unit": "F",
+                "temperature_unit": "°F",
                 "prefix": "guest_house",
             },
         )
@@ -95,7 +95,7 @@ async def test_form_user_with_non_secure_elk(hass):
         "prefix": "guest_house",
         "username": "",
         "password": "",
-        "temperature_unit": "F",
+        "temperature_unit": "°F",
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -125,7 +125,7 @@ async def test_form_user_with_serial_elk(hass):
             {
                 "protocol": "serial",
                 "address": "/dev/ttyS0:115200",
-                "temperature_unit": "F",
+                "temperature_unit": "°C",
                 "prefix": "",
             },
         )
@@ -138,7 +138,7 @@ async def test_form_user_with_serial_elk(hass):
         "prefix": "",
         "username": "",
         "password": "",
-        "temperature_unit": "F",
+        "temperature_unit": "°C",
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -166,7 +166,7 @@ async def test_form_cannot_connect(hass):
                 "address": "1.2.3.4",
                 "username": "test-username",
                 "password": "test-password",
-                "temperature_unit": "F",
+                "temperature_unit": "°F",
                 "prefix": "",
             },
         )
@@ -193,7 +193,7 @@ async def test_form_invalid_auth(hass):
                 "address": "1.2.3.4",
                 "username": "test-username",
                 "password": "test-password",
-                "temperature_unit": "F",
+                "temperature_unit": "°F",
                 "prefix": "",
             },
         )


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The yaml config uses `cv.temperature_unit` which mutates "F" -> "°F".   The config flow conversion didn't contemplate that. We need the units in  "°F" format for the config flow.

The default unit was "F" but the value needed to be "°F"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34278
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
