### PR TITLE
Allow hassfest to validate specific integrations

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -96,7 +96,7 @@ stages:
           pip install -e .
     - script: |
         . venv/bin/activate
-        python -m script.hassfest validate
+        python -m script.hassfest --action validate
       displayName: 'Validate manifests'
     - script: |
         . venv/bin/activate

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -18,6 +18,7 @@ from . import (
 from .model import Config, Integration
 
 INTEGRATION_PLUGINS = [
+    codeowners,
     config_flow,
     dependencies,
     manifest,
@@ -27,7 +28,6 @@ INTEGRATION_PLUGINS = [
     zeroconf,
 ]
 HASS_PLUGINS = [
-    codeowners,
     coverage,
 ]
 

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -1,4 +1,5 @@
 """Validate manifests."""
+import argparse
 import pathlib
 import sys
 from time import monotonic
@@ -16,10 +17,8 @@ from . import (
 )
 from .model import Config, Integration
 
-PLUGINS = [
-    codeowners,
+INTEGRATION_PLUGINS = [
     config_flow,
-    coverage,
     dependencies,
     manifest,
     services,
@@ -27,16 +26,53 @@ PLUGINS = [
     translations,
     zeroconf,
 ]
+HASS_PLUGINS = [
+    codeowners,
+    coverage,
+]
+
+
+def valid_integration_path(integration_path):
+    """Test if it's a valid integration."""
+    path = pathlib.Path(integration_path)
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError(f"{integration_path} is not a directory.")
+
+    return path
 
 
 def get_config() -> Config:
     """Return config."""
-    if not pathlib.Path("requirements_all.txt").is_file():
-        raise RuntimeError("Run from project root")
+    parser = argparse.ArgumentParser(description="Hassfest")
+    parser.add_argument(
+        "--action", type=str, choices=["validate", "generate"], default=None
+    )
+    parser.add_argument(
+        "--integration-path",
+        action="append",
+        type=valid_integration_path,
+        help="Validate a single integration",
+    )
+    parsed = parser.parse_args()
+
+    if parsed.action is None:
+        parsed.action = "validate" if parsed.integration_path else "generate"
+
+    if parsed.action == "generate" and parsed.integration_path:
+        raise RuntimeError(
+            "Generate is not allowed when limiting to specific integrations"
+        )
+
+    if (
+        not parsed.integration_path
+        and not pathlib.Path("requirements_all.txt").is_file()
+    ):
+        raise RuntimeError("Run from Home Assistant root")
 
     return Config(
         root=pathlib.Path(".").absolute(),
-        action="validate" if sys.argv[-1] == "validate" else "generate",
+        specific_integrations=parsed.integration_path,
+        action=parsed.action,
     )
 
 
@@ -48,9 +84,21 @@ def main():
         print(err)
         return 1
 
-    integrations = Integration.load_dir(pathlib.Path("homeassistant/components"))
+    plugins = INTEGRATION_PLUGINS
 
-    for plugin in PLUGINS:
+    if config.specific_integrations:
+        integrations = {}
+
+        for int_path in config.specific_integrations:
+            integration = Integration(int_path)
+            integration.load_manifest()
+            integrations[integration.domain] = integration
+
+    else:
+        integrations = Integration.load_dir(pathlib.Path("homeassistant/components"))
+        plugins += HASS_PLUGINS
+
+    for plugin in plugins:
         try:
             start = monotonic()
             print(f"Validating {plugin.__name__.split('.')[-1]}...", end="", flush=True)
@@ -77,14 +125,15 @@ def main():
         general_errors = config.errors
         invalid_itg = [itg for itg in integrations.values() if itg.errors]
 
+    print()
     print("Integrations:", len(integrations))
     print("Invalid integrations:", len(invalid_itg))
 
     if not invalid_itg and not general_errors:
-        for plugin in PLUGINS:
-            if hasattr(plugin, "generate"):
-                plugin.generate(integrations, config)
-
+        if config.action == "generate":
+            for plugin in plugins:
+                if hasattr(plugin, "generate"):
+                    plugin.generate(integrations, config)
         return 0
 
     print()
@@ -99,7 +148,8 @@ def main():
         print()
 
     for integration in sorted(invalid_itg, key=lambda itg: itg.domain):
-        print(f"Integration {integration.domain}:")
+        extra = f" - {integration.path}" if config.specific_integrations else ""
+        print(f"Integration {integration.domain}{extra}:")
         for error in integration.errors:
             print("*", error)
         print()

--- a/script/hassfest/codeowners.py
+++ b/script/hassfest/codeowners.py
@@ -60,6 +60,9 @@ def validate(integrations: Dict[str, Integration], config: Config):
     codeowners_path = config.root / "CODEOWNERS"
     config.cache["codeowners"] = content = generate_and_validate(integrations)
 
+    if config.specific_integrations:
+        return
+
     with open(str(codeowners_path)) as fp:
         if fp.read().strip() != content:
             config.add_error(

--- a/script/hassfest/config_flow.py
+++ b/script/hassfest/config_flow.py
@@ -68,6 +68,9 @@ def validate(integrations: Dict[str, Integration], config: Config):
     config_flow_path = config.root / "homeassistant/generated/config_flows.py"
     config.cache["config_flow"] = content = generate_and_validate(integrations)
 
+    if config.specific_integrations:
+        return
+
     with open(str(config_flow_path)) as fp:
         if fp.read().strip() != content:
             config.add_error(

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -249,6 +249,9 @@ def validate(integrations: Dict[str, Integration], config):
 
         validate_dependencies(integrations, integration)
 
+        if config.specific_integrations:
+            continue
+
         # check that all referenced dependencies exist
         for dep in integration.manifest.get("dependencies", []):
             if dep not in integrations:

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -10,7 +10,7 @@ from .model import Integration
 DOCUMENTATION_URL_SCHEMA = "https"
 DOCUMENTATION_URL_HOST = "www.home-assistant.io"
 DOCUMENTATION_URL_PATH_PREFIX = "/integrations/"
-DOCUMENTATION_URL_EXCEPTIONS = ["https://www.home-assistant.io/hassio"]
+DOCUMENTATION_URL_EXCEPTIONS = {"https://www.home-assistant.io/hassio"}
 
 SUPPORTED_QUALITY_SCALES = ["gold", "internal", "platinum", "silver"]
 
@@ -23,9 +23,9 @@ def documentation_url(value: str) -> str:
     parsed_url = urlparse(value)
     if not parsed_url.scheme == DOCUMENTATION_URL_SCHEMA:
         raise vol.Invalid("Documentation url is not prefixed with https")
-    if not parsed_url.netloc == DOCUMENTATION_URL_HOST:
-        raise vol.Invalid("Documentation url not hosted at www.home-assistant.io")
-    if not parsed_url.path.startswith(DOCUMENTATION_URL_PATH_PREFIX):
+    if parsed_url.netloc == DOCUMENTATION_URL_HOST and not parsed_url.path.startswith(
+        DOCUMENTATION_URL_PATH_PREFIX
+    ):
         raise vol.Invalid(
             "Documentation url does not begin with www.home-assistant.io/integrations"
         )

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -2,7 +2,7 @@
 import importlib
 import json
 import pathlib
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import attr
 
@@ -24,10 +24,11 @@ class Error:
 class Config:
     """Config for the run."""
 
-    root = attr.ib(type=pathlib.Path)
-    action = attr.ib(type=str)
-    errors = attr.ib(type=List[Error], factory=list)
-    cache = attr.ib(type=Dict[str, Any], factory=dict)
+    specific_integrations: Optional[pathlib.Path] = attr.ib()
+    root: pathlib.Path = attr.ib()
+    action: str = attr.ib()
+    errors: List[Error] = attr.ib(factory=list)
+    cache: Dict[str, Any] = attr.ib(factory=dict)
 
     def add_error(self, *args, **kwargs):
         """Add an error."""

--- a/script/hassfest/ssdp.py
+++ b/script/hassfest/ssdp.py
@@ -65,6 +65,9 @@ def validate(integrations: Dict[str, Integration], config: Config):
     ssdp_path = config.root / "homeassistant/generated/ssdp.py"
     config.cache["ssdp"] = content = generate_and_validate(integrations)
 
+    if config.specific_integrations:
+        return
+
     with open(str(ssdp_path)) as fp:
         if fp.read().strip() != content:
             config.add_error(

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -120,6 +120,9 @@ def validate(integrations: Dict[str, Integration], config: Config):
     zeroconf_path = config.root / "homeassistant/generated/zeroconf.py"
     config.cache["zeroconf"] = content = generate_and_validate(integrations)
 
+    if config.specific_integrations:
+        return
+
     with open(str(zeroconf_path)) as fp:
         current = fp.read().strip()
         if current != content:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update Hassfest to accept `--integration-path path/to/integration` one or many times to validate those integrations instead of the default of validating all Home Assistant integrations.

```
› python3 -m script.hassfest --integration-path homeassistant/components/hue --integration-path tests/testing_config/custom_components/test
Validating codeowners... done in 0.00s
Validating config_flow... done in 0.00s
Validating dependencies... done in 0.04s
Validating manifest... done in 0.00s
Validating services... done in 0.00s
Validating ssdp... done in 0.00s
Validating translations... done in 0.00s
Validating zeroconf... done in 0.00s

Integrations: 2
Invalid integrations: 1

Integration test - tests/testing_config/custom_components/test:
* [MANIFEST] Invalid manifest: Documentation url is not prefixed with https for dictionary value @ data['documentation']. Got 'http://example.com'
```

This allows hassfest to be used in a GitHub Action, which we should promote for custom integration developers. If the GitHub Action checks out the latest Home Assistant dev and runs it on every PR + at midnight, custom integrations can make sure they follow the latest and greatest rules.

@ludeeus, you want to give a stab at creating a reusable GitHub Action for this?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
