### PR TITLE
Skip ignored hosts when checking existing config entries in config flow

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PIN,
     CONF_PORT,
-    CONF_SOURCE,
     CONF_TYPE,
 )
 from homeassistant.core import callback
@@ -205,7 +204,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Check if new config entry matches any existing config entries
             for entry in self.hass.config_entries.async_entries(DOMAIN):
                 # If source is ignore bypass host and name check and continue through loop
-                if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
+                if entry.source == SOURCE_IGNORE:
                     continue
 
                 if _host_is_same(entry.data[CONF_HOST], user_input[CONF_HOST]):
@@ -282,7 +281,8 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Check if new config entry matches any existing config entries
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             # If source is ignore bypass host check and continue through loop
-            if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
+            if entry.source == SOURCE_IGNORE:
+                _LOGGER.error("done")
                 continue
 
             if _host_is_same(entry.data[CONF_HOST], import_config[CONF_HOST]):
@@ -350,7 +350,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Check if new config entry matches any existing config entries and abort if so
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             # If source is ignore bypass host check and continue through loop
-            if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
+            if entry.source == SOURCE_IGNORE:
                 continue
 
             if _host_is_same(entry.data[CONF_HOST], discovery_info[CONF_HOST]):

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -279,9 +279,10 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a config entry from configuration.yaml."""
         # Check if new config entry matches any existing config entries
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data.get(CONF_SOURCE) != SOURCE_IGNORE and _host_is_same(
-                entry.data[CONF_HOST], import_config[CONF_HOST]
-            ):
+            # If source is ignore bypass host and name check and continue through loop
+            if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
+                continue
+            if _host_is_same(entry.data[CONF_HOST], import_config[CONF_HOST]):
                 updated_options = {}
                 updated_data = {}
                 remove_apps = False
@@ -345,9 +346,10 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Check if new config entry matches any existing config entries and abort if so
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data.get(CONF_SOURCE) != SOURCE_IGNORE and _host_is_same(
-                entry.data[CONF_HOST], discovery_info[CONF_HOST]
-            ):
+            # If source is ignore bypass host and name check and continue through loop
+            if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
+                continue
+            if _host_is_same(entry.data[CONF_HOST], discovery_info[CONF_HOST]):
                 return self.async_abort(reason="already_setup")
 
         # Set default name to discovered device name by stripping zeroconf service

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -204,11 +204,13 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Check if new config entry matches any existing config entries
             for entry in self.hass.config_entries.async_entries(DOMAIN):
-                if entry.data.get(CONF_SOURCE) != SOURCE_IGNORE:
-                    if _host_is_same(entry.data[CONF_HOST], user_input[CONF_HOST]):
-                        errors[CONF_HOST] = "host_exists"
-                    if entry.data[CONF_NAME] == user_input[CONF_NAME]:
-                        errors[CONF_NAME] = "name_exists"
+                # If source is ignore bypass host and name check and continue through loop
+                if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
+                    continue
+                if _host_is_same(entry.data[CONF_HOST], user_input[CONF_HOST]):
+                    errors[CONF_HOST] = "host_exists"
+                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                    errors[CONF_NAME] = "name_exists"
 
             if not errors:
                 # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -279,7 +279,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a config entry from configuration.yaml."""
         # Check if new config entry matches any existing config entries
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            # If source is ignore bypass host and name check and continue through loop
+            # If source is ignore bypass host check and continue through loop
             if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
                 continue
             if _host_is_same(entry.data[CONF_HOST], import_config[CONF_HOST]):
@@ -346,7 +346,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Check if new config entry matches any existing config entries and abort if so
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            # If source is ignore bypass host and name check and continue through loop
+            # If source is ignore bypass host check and continue through loop
             if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
                 continue
             if _host_is_same(entry.data[CONF_HOST], discovery_info[CONF_HOST]):

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -282,7 +282,6 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             # If source is ignore bypass host check and continue through loop
             if entry.source == SOURCE_IGNORE:
-                _LOGGER.error("done")
                 continue
 
             if _host_is_same(entry.data[CONF_HOST], import_config[CONF_HOST]):

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -207,8 +207,10 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # If source is ignore bypass host and name check and continue through loop
                 if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
                     continue
+
                 if _host_is_same(entry.data[CONF_HOST], user_input[CONF_HOST]):
                     errors[CONF_HOST] = "host_exists"
+
                 if entry.data[CONF_NAME] == user_input[CONF_NAME]:
                     errors[CONF_NAME] = "name_exists"
 
@@ -282,6 +284,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # If source is ignore bypass host check and continue through loop
             if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
                 continue
+
             if _host_is_same(entry.data[CONF_HOST], import_config[CONF_HOST]):
                 updated_options = {}
                 updated_data = {}
@@ -349,6 +352,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # If source is ignore bypass host check and continue through loop
             if entry.data.get(CONF_SOURCE) == SOURCE_IGNORE:
                 continue
+
             if _host_is_same(entry.data[CONF_HOST], discovery_info[CONF_HOST]):
                 return self.async_abort(reason="already_setup")
 


### PR DESCRIPTION
## Proposed change
There was a bug report that pointed out that when a `vizio` device has been ignored, config flow will fail because it expected the `host` key but the ignored config entry doesn't have it. This change only checks for expected keys when the config entry is not an ignored one. I wasn't sure how to test this, I found that the `config` component does a test like this by calling the WebSocket client to ignore an entry but that seemed messy. Happy to add tests if needed. If there's another hotfix version released for 0.108, it would be great to include this in that, otherwise it should go out with 0.109


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33458

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
