### PR TITLE
Fix synology_dsm i/o in event loop

### DIFF
--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -139,15 +139,19 @@ class SynoApi:
             self._use_ssl,
             dsm_version=self._api_version,
         )
-        self.information = self._dsm.information
-        self.utilisation = self._dsm.utilisation
-        self.storage = self._dsm.storage
 
+        await self._hass.async_add_executor_job(self._fetch_device_configuration)
         await self.update()
 
         self._unsub_dispatcher = async_track_time_interval(
             self._hass, self.update, SCAN_INTERVAL
         )
+
+    def _fetch_device_configuration(self):
+        """Fetch initial device config."""
+        self.information = self._dsm.information
+        self.utilisation = self._dsm.utilisation
+        self.storage = self._dsm.storage
 
     async def async_unload(self):
         """Stop interacting with the NAS and prepare for removal from hass."""


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix synology_dsm i/o in event loop
```
2020-04-16 02:59:42 WARNING (MainThread) [homeassistant.util.async_] Detected I/O inside the event loop. This is causing stability issues. Please report issue to the custom component author for synology_dsm doing I/O at custom_components/synology_dsm/init.py, line 147: self.information = self.dsm.information
2020-04-16 02:59:42 WARNING (MainThread) [homeassistant.util.async] Detected I/O inside the event loop. This is causing stability issues. Please report issue to the custom component author for synology_dsm doing I/O at custom_components/synology_dsm/init.py, line 147: self.information = self.dsm.information
2020-04-16 02:59:42 WARNING (MainThread) [homeassistant.util.async] Detected I/O inside the event loop. This is causing stability issues. Please report issue to the custom component author for synology_dsm doing I/O at custom_components/synology_dsm/init.py, line 148: self.utilisation = self.dsm.utilisation
2020-04-16 02:59:43 WARNING (MainThread) [homeassistant.util.async] Detected I/O inside the event loop. This is causing stability issues. Please report issue to the custom component author for synology_dsm doing I/O at custom_components/synology_dsm/init.py, line 149: self.storage = self._dsm.storage
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
