### PR TITLE
Ensure zone in update payload for konnected

### DIFF
--- a/homeassistant/components/konnected/__init__.py
+++ b/homeassistant/components/konnected/__init__.py
@@ -348,6 +348,7 @@ class KonnectedView(HomeAssistantView):
 
         try:
             zone_num = str(payload.get(CONF_ZONE) or PIN_TO_ZONE[payload[CONF_PIN]])
+            payload[CONF_ZONE] = zone_num
             zone_data = device[CONF_BINARY_SENSORS].get(zone_num) or next(
                 (s for s in device[CONF_SENSORS] if s[CONF_ZONE] == zone_num), None
             )

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -561,7 +561,7 @@ async def test_api(hass, aiohttp_client, mock_panel):
     assert result == {"message": "ok"}
 
 
-async def test_state_updates(hass, aiohttp_client, mock_panel):
+async def test_state_updates_zone(hass, aiohttp_client, mock_panel):
     """Test callback view."""
     await async_setup_component(hass, "http", {"http": {}})
 
@@ -701,6 +701,154 @@ async def test_state_updates(hass, aiohttp_client, mock_panel):
         "/api/konnected/device/112233445566",
         headers={"Authorization": "Bearer abcdefgh"},
         json={"zone": "5", "temp": 42, "addr": 1},
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {"message": "ok"}
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.temper_temperature").state == "42.0"
+
+
+async def test_state_updates_pin(hass, aiohttp_client, mock_panel):
+    """Test callback view."""
+    await async_setup_component(hass, "http", {"http": {}})
+
+    device_config = config_flow.CONFIG_ENTRY_SCHEMA(
+        {
+            "host": "1.2.3.4",
+            "port": 1234,
+            "id": "112233445566",
+            "model": "Konnected",
+            "access_token": "abcdefgh",
+            "default_options": config_flow.OPTIONS_SCHEMA({config_flow.CONF_IO: {}}),
+        }
+    )
+
+    device_options = config_flow.OPTIONS_SCHEMA(
+        {
+            "io": {
+                "1": "Binary Sensor",
+                "2": "Binary Sensor",
+                "3": "Binary Sensor",
+                "4": "Digital Sensor",
+                "5": "Digital Sensor",
+                "6": "Switchable Output",
+                "out": "Switchable Output",
+            },
+            "binary_sensors": [
+                {"zone": "1", "type": "door"},
+                {"zone": "2", "type": "window", "name": "winder", "inverse": True},
+                {"zone": "3", "type": "door"},
+            ],
+            "sensors": [
+                {"zone": "4", "type": "dht"},
+                {"zone": "5", "type": "ds18b20", "name": "temper"},
+            ],
+            "switches": [
+                {
+                    "zone": "out",
+                    "name": "switcher",
+                    "activation": "low",
+                    "momentary": 50,
+                    "pause": 100,
+                    "repeat": 4,
+                },
+                {"zone": "6"},
+            ],
+        }
+    )
+
+    entry = MockConfigEntry(
+        domain="konnected",
+        title="Konnected Alarm Panel",
+        data=device_config,
+        options=device_options,
+    )
+    entry.add_to_hass(hass)
+
+    # Add empty data field to ensure we process it correctly (possible if entry is ignored)
+    entry = MockConfigEntry(domain="konnected", title="Konnected Alarm Panel", data={},)
+    entry.add_to_hass(hass)
+
+    assert (
+        await async_setup_component(
+            hass,
+            konnected.DOMAIN,
+            {konnected.DOMAIN: {konnected.CONF_ACCESS_TOKEN: "1122334455"}},
+        )
+        is True
+    )
+
+    client = await aiohttp_client(hass.http.app)
+
+    # Test updating a binary sensor
+    resp = await client.post(
+        "/api/konnected/device/112233445566",
+        headers={"Authorization": "Bearer abcdefgh"},
+        json={"pin": "1", "state": 0},
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {"message": "ok"}
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.konnected_445566_zone_1").state == "off"
+
+    resp = await client.post(
+        "/api/konnected/device/112233445566",
+        headers={"Authorization": "Bearer abcdefgh"},
+        json={"pin": "1", "state": 1},
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {"message": "ok"}
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.konnected_445566_zone_1").state == "on"
+
+    # Test updating sht sensor
+    resp = await client.post(
+        "/api/konnected/device/112233445566",
+        headers={"Authorization": "Bearer abcdefgh"},
+        json={"pin": "6", "temp": 22, "humi": 20},
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {"message": "ok"}
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.konnected_445566_sensor_4_humidity").state == "20"
+    assert (
+        hass.states.get("sensor.konnected_445566_sensor_4_temperature").state == "22.0"
+    )
+
+    resp = await client.post(
+        "/api/konnected/device/112233445566",
+        headers={"Authorization": "Bearer abcdefgh"},
+        json={"pin": "6", "temp": 25, "humi": 23},
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {"message": "ok"}
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.konnected_445566_sensor_4_humidity").state == "23"
+    assert (
+        hass.states.get("sensor.konnected_445566_sensor_4_temperature").state == "25.0"
+    )
+
+    # Test updating ds sensor
+    resp = await client.post(
+        "/api/konnected/device/112233445566",
+        headers={"Authorization": "Bearer abcdefgh"},
+        json={"pin": "7", "temp": 32, "addr": 1},
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {"message": "ok"}
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.temper_temperature").state == "32.0"
+
+    resp = await client.post(
+        "/api/konnected/device/112233445566",
+        headers={"Authorization": "Bearer abcdefgh"},
+        json={"pin": "7", "temp": 42, "addr": 1},
     )
     assert resp.status == 200
     result = await resp.json()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Konnected integration processes updates based on Zone ID. Gen 1 Konnected Alarm Panels identify zones based on a pin #.  This pin # was not being converted to a zone in some code paths resulting in the updates not being processed correctly. In particular this impacted DS18b20 sensors.

The fix is to ensure we include `zone` in the processed update payload.  I also added a test to verify we handle all updates that can contain a pin ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32734 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
