### PR TITLE
Add new optional parameter for ConfigEntries.async_entries to specify whether or not ignored entries should be included

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -584,7 +584,10 @@ class ConfigEntries:
     ) -> List[ConfigEntry]:
         """Return all entries or entries for a specific domain."""
         if domain is None:
-            return list(self._entries)
+            if include_ignored:
+                return list(self._entries)
+
+            return [entry for entry in self._entries if entry.source != SOURCE_IGNORE]
 
         if include_ignored:
             return [entry for entry in self._entries if entry.domain == domain]

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -579,11 +579,21 @@ class ConfigEntries:
         return None
 
     @callback
-    def async_entries(self, domain: Optional[str] = None) -> List[ConfigEntry]:
+    def async_entries(
+        self, domain: Optional[str] = None, include_ignored: bool = True
+    ) -> List[ConfigEntry]:
         """Return all entries or entries for a specific domain."""
         if domain is None:
             return list(self._entries)
-        return [entry for entry in self._entries if entry.domain == domain]
+
+        if include_ignored:
+            return [entry for entry in self._entries if entry.domain == domain]
+
+        return [
+            entry
+            for entry in self._entries
+            if entry.domain == domain and entry.source != SOURCE_IGNORE
+        ]
 
     async def async_add(self, entry: ConfigEntry) -> None:
         """Add and setup an entry."""

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7,6 +7,7 @@ from asynctest import CoroutineMock
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, loader
+from homeassistant.config_entries import SOURCE_IGNORE
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
@@ -1558,3 +1559,13 @@ async def test_async_setup_update_entry(hass):
         assert len(entries) == 1
         assert entries[0].state == config_entries.ENTRY_STATE_LOADED
         assert entries[0].data == {"value": "updated"}
+
+    async def test_async_entries_ignore_parameter(hass):
+        """Test `include_ignored` parameter in ConfigEntries.async_entries."""
+        MockConfigEntry(domain="test", entry_id="test1").add_to_hass(hass)
+        MockConfigEntry(
+            domain="test", entry_id="test2", source=SOURCE_IGNORE
+        ).add_to_hass(hass)
+
+        assert len(hass.config_entries.async_entries("test")) == 2
+        assert len(hass.config_entries.async_entries("test", False)) == 1

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1569,3 +1569,5 @@ async def test_async_setup_update_entry(hass):
 
         assert len(hass.config_entries.async_entries("test")) == 2
         assert len(hass.config_entries.async_entries("test", False)) == 1
+        assert len(hass.config_entries.async_entries()) == 2
+        assert len(hass.config_entries.async_entries(include_ignored=False)) == 1


### PR DESCRIPTION
## Proposed change
In fixing an issue with the `vizio` integration I thought it would be nice if the `async_entries` function could return only non-ignored config entries so that other integrations do not have to build custom logic like `vizio` has. This change adds an optional additional parameter to the function that will optionally filter ignored config entries out. The default is set to make this change backwards compatible.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #33458 and #34280

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
