### PR TITLE
UniFi - Support automatic removal of clients

### DIFF
--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -5,7 +5,14 @@ import ssl
 
 from aiohttp import CookieJar
 import aiounifi
-from aiounifi.controller import SIGNAL_CONNECTION_STATE
+from aiounifi.controller import (
+    DATA_CLIENT,
+    DATA_CLIENT_REMOVED,
+    DATA_DEVICE,
+    DATA_EVENT,
+    SIGNAL_CONNECTION_STATE,
+    SIGNAL_DATA,
+)
 from aiounifi.events import WIRELESS_CLIENT_CONNECTED, WIRELESS_GUEST_CONNECTED
 from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 import async_timeout
@@ -161,14 +168,19 @@ class UniFiController:
                 if not self.available:
                     self.hass.loop.call_later(RETRY_TIMER, self.reconnect)
 
-        elif signal == "new_data" and data:
-            if "event" in data:
-                if data["event"].event in (
+        elif signal == SIGNAL_DATA and data:
+
+            if DATA_EVENT in data:
+                if data[DATA_EVENT].event in (
                     WIRELESS_CLIENT_CONNECTED,
                     WIRELESS_GUEST_CONNECTED,
                 ):
                     self.update_wireless_clients()
-            elif "clients" in data or "devices" in data:
+
+            elif DATA_CLIENT in data or DATA_DEVICE in data:
+                async_dispatcher_send(self.hass, self.signal_update)
+
+            elif DATA_CLIENT_REMOVED in data:
                 async_dispatcher_send(self.hass, self.signal_update)
 
     @property
@@ -180,6 +192,11 @@ class UniFiController:
     def signal_update(self):
         """Event specific per UniFi entry to signal new data."""
         return f"unifi-update-{self.controller_id}"
+
+    @property
+    def signal_remove(self):
+        """Event specific per UniFi entry to signal removal of entities."""
+        return f"unifi-remove-{self.controller_id}"
 
     @property
     def signal_options_update(self):

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -181,7 +181,9 @@ class UniFiController:
                 async_dispatcher_send(self.hass, self.signal_update)
 
             elif DATA_CLIENT_REMOVED in data:
-                async_dispatcher_send(self.hass, self.signal_update)
+                async_dispatcher_send(
+                    self.hass, self.signal_remove, data[DATA_CLIENT_REMOVED]
+                )
 
     @property
     def signal_reachable(self) -> str:

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,11 +3,7 @@
   "name": "Ubiquiti UniFi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": [
-    "aiounifi==17"
-  ],
-  "codeowners": [
-    "@kane610"
-  ],
+  "requirements": ["aiounifi==18"],
+  "codeowners": ["@kane610"],
   "quality_scale": "platinum"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -211,7 +211,7 @@ aiopylgtv==0.3.3
 aioswitcher==1.1.0
 
 # homeassistant.components.unifi
-aiounifi==17
+aiounifi==18
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -94,7 +94,7 @@ aiopylgtv==0.3.3
 aioswitcher==1.1.0
 
 # homeassistant.components.unifi
-aiounifi==17
+aiounifi==18
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -177,6 +177,7 @@ async def test_controller_setup(hass):
     assert controller.mac is None
 
     assert controller.signal_update == "unifi-update-1.2.3.4-site_id"
+    assert controller.signal_remove == "unifi-remove-1.2.3.4-site_id"
     assert controller.signal_options_update == "unifi-options-1.2.3.4-site_id"
 
 

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -207,7 +207,7 @@ async def test_reset_after_successful_setup(hass):
     """Calling reset when the entry has been setup."""
     controller = await setup_unifi_integration(hass)
 
-    assert len(controller.listeners) == 6
+    assert len(controller.listeners) == 9
 
     result = await controller.async_reset()
     await hass.async_block_till_done()

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1,6 +1,9 @@
 """UniFi POE control platform tests."""
 from copy import deepcopy
 
+from aiounifi.controller import MESSAGE_CLIENT_REMOVED
+from aiounifi.websocket import SIGNAL_DATA
+
 from homeassistant import config_entries
 from homeassistant.components import unifi
 import homeassistant.components.switch as switch
@@ -173,6 +176,7 @@ BLOCKED = {
     "ip": "10.0.0.1",
     "is_guest": False,
     "is_wired": False,
+    "last_seen": 1562600145,
     "mac": "00:00:00:00:01:01",
     "name": "Block Client 1",
     "noted": True,
@@ -184,6 +188,7 @@ UNBLOCKED = {
     "ip": "10.0.0.2",
     "is_guest": False,
     "is_wired": True,
+    "last_seen": 1562600145,
     "mac": "00:00:00:00:01:02",
     "name": "Block Client 2",
     "noted": True,
@@ -298,6 +303,38 @@ async def test_switches(hass):
         "method": "post",
         "path": "/cmd/stamgr",
     }
+
+
+async def test_remove_switches(hass):
+    """Test the update_items function with some clients."""
+    controller = await setup_unifi_integration(
+        hass,
+        options={CONF_BLOCK_CLIENT: [UNBLOCKED["mac"]]},
+        clients_response=[CLIENT_1, UNBLOCKED],
+        devices_response=[DEVICE_1],
+    )
+    assert len(hass.states.async_entity_ids("switch")) == 2
+
+    poe_switch = hass.states.get("switch.poe_client_1")
+    assert poe_switch is not None
+
+    block_switch = hass.states.get("switch.block_client_2")
+    assert block_switch is not None
+
+    controller.api.websocket._data = {
+        "meta": {"message": MESSAGE_CLIENT_REMOVED},
+        "data": [CLIENT_1, UNBLOCKED],
+    }
+    controller.api.session_handler(SIGNAL_DATA)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids("switch")) == 0
+
+    poe_switch = hass.states.get("switch.poe_client_1")
+    assert poe_switch is None
+
+    block_switch = hass.states.get("switch.block_client_2")
+    assert block_switch is None
 
 
 async def test_new_client_discovered_on_block_control(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a user chooses to "forget" a client in UniFi controller a client_removed signal will be sent and UniFi integration will act accordingly and remove related entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32322
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
