### PR TITLE
Fixes for Sonos media titles

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -419,7 +419,7 @@ class SonosEntity(MediaPlayerDevice):
         if self._status in ("PAUSED_PLAYBACK", "STOPPED",):
             # Sonos can consider itself "paused" but without having media loaded
             # (happens if playing Spotify and via Spotify app you pick another device to play on)
-            if self._media_title is None:
+            if self.media_title is None:
                 return STATE_IDLE
             return STATE_PAUSED
         if self._status in ("PLAYING", "TRANSITIONING"):
@@ -614,12 +614,19 @@ class SonosEntity(MediaPlayerDevice):
         except (TypeError, KeyError, AttributeError):
             pass
 
-        # Radios without tagging can have part of the radio URI as title.
-        # Non-playing radios will not have a current title. In these cases we
-        # try to use the radio name instead.
+        # Non-playing radios will not have a current title. Radios without tagging
+        # can have part of the radio URI as title. In these cases we try to use the
+        # radio name instead.
         try:
-            if self._media_title in self._uri or self.state != STATE_PLAYING:
-                self._media_title = variables["enqueued_transport_uri_meta_data"].title
+            uri_meta_data = variables["enqueued_transport_uri_meta_data"]
+            if isinstance(
+                uri_meta_data, pysonos.data_structures.DidlAudioBroadcast
+            ) and (
+                self.state != STATE_PLAYING
+                or self.soco.is_radio_uri(self._media_title)
+                or self._media_title in self._uri
+            ):
+                self._media_title = uri_meta_data.title
         except (TypeError, KeyError, AttributeError):
             pass
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This fixes a few issues regarding Sonos media titles since the rework in #33063:
* Use property rather than attribute (unreported issue with #32712)
* Use `soco.is_radio_uri` to identify more radio stations (fixes #34128, reverts part of #33609)
* Only access `variables["enqueued_transport_uri_meta_data"]` if it is of the expected type (fixes #33952, fixes #34134, fixes #34226)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34128, fixes #33952, fixes #34134, fixes #34226
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
