### PR TITLE
Use entry ID when IPP printer offers no identifier

### DIFF
--- a/homeassistant/components/ipp/__init__.py
+++ b/homeassistant/components/ipp/__init__.py
@@ -135,6 +135,7 @@ class IPPEntity(Entity):
         enabled_default: bool = True,
     ) -> None:
         """Initialize the IPP entity."""
+        self._device_id = device_id
         self._enabled_default = enabled_default
         self._entry_id = entry_id
         self._icon = icon

--- a/homeassistant/components/ipp/__init__.py
+++ b/homeassistant/components/ipp/__init__.py
@@ -128,23 +128,18 @@ class IPPEntity(Entity):
         self,
         *,
         entry_id: str,
+        device_id: str,
         coordinator: IPPDataUpdateCoordinator,
         name: str,
         icon: str,
         enabled_default: bool = True,
     ) -> None:
         """Initialize the IPP entity."""
-        self._device_id = None
         self._enabled_default = enabled_default
         self._entry_id = entry_id
         self._icon = icon
         self._name = name
         self.coordinator = coordinator
-
-        if coordinator.data.info.uuid is not None:
-            self._device_id = coordinator.data.info.uuid
-        elif coordinator.data.info.serial is not None:
-            self._device_id = coordinator.data.info.serial
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/ipp/sensor.py
+++ b/homeassistant/components/ipp/sensor.py
@@ -66,6 +66,8 @@ class IPPSensor(IPPEntity):
             self._unique_id = f"{coordinator.data.info.uuid}_{key}"
         elif coordinator.data.info.serial is not None:
             self._unique_id = f"{coordinator.data.info.serial}_{key}"
+        elif entry_id is not None:
+            self._unique_id = f"{entry_id}_{key}"
 
         super().__init__(
             entry_id=entry_id,

--- a/homeassistant/components/ipp/sensor.py
+++ b/homeassistant/components/ipp/sensor.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
     unique_id = entry.unique_id
 
     if unique_id is None:
-       unique_id = entry.entry_id
+        unique_id = entry.entry_id
 
     sensors = []
 
@@ -70,7 +70,7 @@ class IPPSensor(IPPEntity):
         self._unique_id = None
 
         if unique_id is not None:
-           self._unique_id = f"{unique_id}_{key}"
+            self._unique_id = f"{unique_id}_{key}"
 
         super().__init__(
             entry_id=entry_id,

--- a/homeassistant/components/ipp/sensor.py
+++ b/homeassistant/components/ipp/sensor.py
@@ -44,7 +44,9 @@ async def async_setup_entry(
     sensors.append(IPPUptimeSensor(entry.entry_id, unique_id, coordinator))
 
     for marker_index in range(len(coordinator.data.markers)):
-        sensors.append(IPPMarkerSensor(entry.entry_id, unique_id, coordinator, marker_index))
+        sensors.append(
+            IPPMarkerSensor(entry.entry_id, unique_id, coordinator, marker_index)
+        )
 
     async_add_entities(sensors, True)
 
@@ -95,7 +97,11 @@ class IPPMarkerSensor(IPPSensor):
     """Defines an IPP marker sensor."""
 
     def __init__(
-        self, entry_id: str, unique_id: str, coordinator: IPPDataUpdateCoordinator, marker_index: int
+        self,
+        entry_id: str,
+        unique_id: str,
+        coordinator: IPPDataUpdateCoordinator,
+        marker_index: int,
     ) -> None:
         """Initialize IPP marker sensor."""
         self.marker_index = marker_index
@@ -139,7 +145,9 @@ class IPPMarkerSensor(IPPSensor):
 class IPPPrinterSensor(IPPSensor):
     """Defines an IPP printer sensor."""
 
-    def __init__(self, entry_id: str, unique_id: str, coordinator: IPPDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, unique_id: str, coordinator: IPPDataUpdateCoordinator
+    ) -> None:
         """Initialize IPP printer sensor."""
         super().__init__(
             coordinator=coordinator,
@@ -173,7 +181,9 @@ class IPPPrinterSensor(IPPSensor):
 class IPPUptimeSensor(IPPSensor):
     """Defines a IPP uptime sensor."""
 
-    def __init__(self, entry_id: str, unique_id: str, coordinator: IPPDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, unique_id: str, coordinator: IPPDataUpdateCoordinator
+    ) -> None:
         """Initialize IPP uptime sensor."""
         super().__init__(
             coordinator=coordinator,

--- a/homeassistant/components/ipp/sensor.py
+++ b/homeassistant/components/ipp/sensor.py
@@ -76,7 +76,7 @@ class IPPSensor(IPPEntity):
 
         super().__init__(
             entry_id=entry_id,
-            unique_id=unique_id,
+            device_id=unique_id,
             coordinator=coordinator,
             name=name,
             icon=icon,

--- a/homeassistant/components/ipp/sensor.py
+++ b/homeassistant/components/ipp/sensor.py
@@ -76,6 +76,7 @@ class IPPSensor(IPPEntity):
 
         super().__init__(
             entry_id=entry_id,
+            unique_id=unique_id,
             coordinator=coordinator,
             name=name,
             icon=icon,

--- a/tests/components/ipp/__init__.py
+++ b/tests/components/ipp/__init__.py
@@ -62,7 +62,11 @@ def load_fixture_binary(filename):
 
 
 async def init_integration(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, skip_setup: bool = False,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    skip_setup: bool = False,
+    uuid: str = "cfe92100-67c4-11d4-a45f-f8d027761251",
+    unique_id: str = "cfe92100-67c4-11d4-a45f-f8d027761251",
 ) -> MockConfigEntry:
     """Set up the IPP integration in Home Assistant."""
     fixture = "ipp/get-printer-attributes.bin"
@@ -74,14 +78,14 @@ async def init_integration(
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="cfe92100-67c4-11d4-a45f-f8d027761251",
+        unique_id=unique_id,
         data={
             CONF_HOST: "192.168.1.31",
             CONF_PORT: 631,
             CONF_SSL: False,
             CONF_VERIFY_SSL: True,
             CONF_BASE_PATH: "/ipp/print",
-            CONF_UUID: "cfe92100-67c4-11d4-a45f-f8d027761251",
+            CONF_UUID: uuid,
         },
     )
 

--- a/tests/components/ipp/test_sensor.py
+++ b/tests/components/ipp/test_sensor.py
@@ -94,3 +94,15 @@ async def test_disabled_by_default_sensors(
     assert entry
     assert entry.disabled
     assert entry.disabled_by == "integration"
+
+
+async def test_missing_entry_unique_id(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the unique_id of IPP sensor when printer is missing identifiers."""
+    entry = await init_integration(hass, aioclient_mock, uuid=None, unique_id=None)
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entity = registry.async_get("sensor.epson_xp_6000_series_printer")
+    assert entity
+    assert entity.unique_id == f"{entry.entry_id}_printer"

--- a/tests/components/ipp/test_sensor.py
+++ b/tests/components/ipp/test_sensor.py
@@ -103,6 +103,6 @@ async def test_missing_entry_unique_id(
     entry = await init_integration(hass, aioclient_mock, uuid=None, unique_id=None)
     registry = await hass.helpers.entity_registry.async_get_registry()
 
-    entity = registry.async_get("sensor.epson_xp_6000_series_printer")
+    entity = registry.async_get("sensor.epson_xp_6000_series")
     assert entity
     assert entity.unique_id == f"{entry.entry_id}_printer"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change reduces the many locations that unique id was being determined. If config flow provides no unique id we fallback to the config entry id so that everything is properly connected and editable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x]  There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
