### PR TITLE
Improve error message when people have not moved config flow title yet

### DIFF
--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -66,6 +66,7 @@ class Integration:
     path = attr.ib(type=pathlib.Path)
     manifest = attr.ib(type=dict, default=None)
     errors = attr.ib(type=List[Error], factory=list)
+    warnings = attr.ib(type=List[Error], factory=list)
 
     @property
     def domain(self) -> str:
@@ -85,6 +86,10 @@ class Integration:
     def add_error(self, *args, **kwargs):
         """Add an error."""
         self.errors.append(Error(*args, **kwargs))
+
+    def add_warning(self, *args, **kwargs):
+        """Add an warning."""
+        self.warnings.append(Error(*args, **kwargs))
 
     def load_manifest(self) -> None:
         """Load manifest."""

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -1,11 +1,15 @@
 """Validate integration translation files."""
+from functools import partial
 import json
+import logging
 from typing import Dict
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
-from .model import Integration
+from .model import Config, Integration
+
+_LOGGER = logging.getLogger(__name__)
 
 UNDEFINED = 0
 REQUIRED = 1
@@ -19,15 +23,26 @@ REMOVED_TITLE_MSG = (
 )
 
 
-def removed_title_validator(value):
+def removed_title_validator(config, integration, value):
     """Mark removed title."""
-    raise vol.Invalid(REMOVED_TITLE_MSG)
+    if not config.specific_integrations:
+        raise vol.Invalid(REMOVED_TITLE_MSG)
+
+    # Don't mark it as an error yet for custom components to allow backwards compat.
+    integration.add_warning("translations", REMOVED_TITLE_MSG)
+    return value
 
 
-def data_entry_schema(*, flow_title: int, require_step_title: bool):
+def gen_data_entry_schema(
+    *,
+    config: Config,
+    integration: Integration,
+    flow_title: int,
+    require_step_title: bool,
+):
     """Generate a data entry schema."""
     step_title_class = vol.Required if require_step_title else vol.Optional
-    data_entry_schema = {
+    schema = {
         vol.Optional("flow_title"): str,
         vol.Required("step"): {
             str: {
@@ -41,46 +56,63 @@ def data_entry_schema(*, flow_title: int, require_step_title: bool):
         vol.Optional("create_entry"): {str: str},
     }
     if flow_title == REQUIRED:
-        data_entry_schema[vol.Required("title")] = str
+        schema[vol.Required("title")] = str
     elif flow_title == REMOVED:
-        data_entry_schema[
-            vol.Optional("title", msg=REMOVED_TITLE_MSG)
-        ] = removed_title_validator
+        schema[vol.Optional("title", msg=REMOVED_TITLE_MSG)] = partial(
+            removed_title_validator, config, integration
+        )
 
-    return data_entry_schema
+    return schema
 
 
-STRINGS_SCHEMA = vol.Schema(
-    {
-        vol.Optional("title"): str,
-        vol.Optional("config"): data_entry_schema(
-            flow_title=REMOVED, require_step_title=True
-        ),
-        vol.Optional("options"): data_entry_schema(
-            flow_title=UNDEFINED, require_step_title=False
-        ),
-        vol.Optional("device_automation"): {
-            vol.Optional("action_type"): {str: str},
-            vol.Optional("condition_type"): {str: str},
-            vol.Optional("trigger_type"): {str: str},
-            vol.Optional("trigger_subtype"): {str: str},
-        },
-        vol.Optional("state"): {str: str},
-    }
-)
-
-AUTH_SCHEMA = vol.Schema(
-    {
-        vol.Optional("mfa_setup"): {
-            str: data_entry_schema(flow_title=REQUIRED, require_step_title=True)
+def gen_strings_schema(config: Config, integration: Integration):
+    """Generate a strings schema."""
+    return vol.Schema(
+        {
+            vol.Optional("title"): str,
+            vol.Optional("config"): gen_data_entry_schema(
+                config=config,
+                integration=integration,
+                flow_title=REMOVED,
+                require_step_title=True,
+            ),
+            vol.Optional("options"): gen_data_entry_schema(
+                config=config,
+                integration=integration,
+                flow_title=UNDEFINED,
+                require_step_title=False,
+            ),
+            vol.Optional("device_automation"): {
+                vol.Optional("action_type"): {str: str},
+                vol.Optional("condition_type"): {str: str},
+                vol.Optional("trigger_type"): {str: str},
+                vol.Optional("trigger_subtype"): {str: str},
+            },
+            vol.Optional("state"): {str: str},
         }
-    }
-)
+    )
+
+
+def gen_auth_schema(config: Config, integration: Integration):
+    """Generate auth schema."""
+    return vol.Schema(
+        {
+            vol.Optional("mfa_setup"): {
+                str: gen_data_entry_schema(
+                    config=config,
+                    integration=integration,
+                    flow_title=REQUIRED,
+                    require_step_title=True,
+                )
+            }
+        }
+    )
+
 
 ONBOARDING_SCHEMA = vol.Schema({vol.Required("area"): {str: str}})
 
 
-def validate_translation_file(integration: Integration):
+def validate_translation_file(config: Config, integration: Integration):
     """Validate translation files for integration."""
     strings_file = integration.path / "strings.json"
 
@@ -90,11 +122,11 @@ def validate_translation_file(integration: Integration):
     strings = json.loads(strings_file.read_text())
 
     if integration.domain == "auth":
-        schema = AUTH_SCHEMA
+        schema = gen_auth_schema(config, integration)
     elif integration.domain == "onboarding":
         schema = ONBOARDING_SCHEMA
     else:
-        schema = STRINGS_SCHEMA
+        schema = gen_strings_schema(config, integration)
 
     try:
         schema(strings)
@@ -104,7 +136,7 @@ def validate_translation_file(integration: Integration):
         )
 
 
-def validate(integrations: Dict[str, Integration], config):
+def validate(integrations: Dict[str, Integration], config: Config):
     """Handle JSON files inside integrations."""
     for integration in integrations.values():
-        validate_translation_file(integration)
+        validate_translation_file(config, integration)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We want hassfest to be used by custom components. To do that, we need to make sure that we show helpful error messages when the integration format changes. 

This captures a change we made to translations that custom components need to change: move `title` from config to root or delete it.

Example error message if found inside config:

```
Integration deconz:
* [TRANSLATIONS] Invalid strings.json: config.title key has been moved out of config and into the root of strings.json. Starting Home Assistant 0.109 you only need to define this key in the root if the title needs to be different than the name of your integration in the manifest. for dictionary value @ data['config']['title']. Got 'bla'
``` 

For custom integrations it's marked as a warning for now:

```
Integration deconz - homeassistant/components/deconz:
* [WARNING] [TRANSLATIONS] config.title key has been moved out of config and into the root of strings.json. Starting Home Assistant 0.109 you only need to define this key in the root if the title needs to be different than the name of your integration in the manifest.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
