### PR TITLE
Allow fetching translations by categories

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -536,7 +536,13 @@ def websocket_get_themes(hass, connection, msg):
 
 
 @websocket_api.websocket_command(
-    {"type": "frontend/get_translations", vol.Required("language"): str}
+    {
+        "type": "frontend/get_translations",
+        vol.Required("language"): str,
+        vol.Required("category"): str,
+        vol.Optional("integration"): str,
+        vol.Optional("config_flow"): bool,
+    }
 )
 @websocket_api.async_response
 async def websocket_get_translations(hass, connection, msg):
@@ -544,7 +550,13 @@ async def websocket_get_translations(hass, connection, msg):
 
     Async friendly.
     """
-    resources = await async_get_translations(hass, msg["language"])
+    resources = await async_get_translations(
+        hass,
+        msg["language"],
+        msg["category"],
+        msg.get("integration"),
+        msg.get("config_flow"),
+    )
     connection.send_message(
         websocket_api.result_message(msg["id"], {"resources": resources})
     )

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -117,7 +117,7 @@ class UserOnboardingView(_BaseOnboardingView):
 
             # Create default areas using the users supplied language.
             translations = await hass.helpers.translation.async_get_translations(
-                data["language"]
+                data["language"], integration=DOMAIN
             )
 
             area_registry = await hass.helpers.area_registry.async_get_registry()

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -111,7 +111,7 @@ def build_resources(
             translation_cache[component][category]
         )
 
-    return resources
+    return {"component": resources}
 
 
 async def async_get_component_cache(
@@ -210,14 +210,10 @@ async def async_get_translations(
     async with lock:
         results = await asyncio.gather(*tasks)
 
-    resources = flatten(
-        {"component": build_resources(results[0], components, category)}
-    )
+    resources = flatten(build_resources(results[0], components, category))
 
     if language != "en":
-        base_resources = flatten(
-            {"component": build_resources(results[1], components, category)}
-        )
+        base_resources = flatten(build_resources(results[1], components, category))
         resources = {**base_resources, **resources}
 
     return resources

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -204,10 +204,11 @@ async def async_get_translations(
     resources: Dict[str, Any] = results[0]
 
     if category is not None:
-        resources = {
-            domain: {category: resources[domain].get(category) or {}}
-            for domain in resources
-        }
+        new_resources = {}
+        for domain, data in resources.items():
+            if category in data:
+                new_resources[domain] = {category: data[category]}
+        resources = new_resources
 
     resources = flatten({"component": resources})
 
@@ -215,10 +216,11 @@ async def async_get_translations(
         base_resources = results[1]
 
         if category is not None:
-            base_resources = {
-                domain: {category: base_resources[domain].get(category) or {}}
-                for domain in base_resources
-            }
+            new_base_resources = {}
+            for domain, data in base_resources.items():
+                if category in data:
+                    new_base_resources[domain] = {category: data[category]}
+            base_resources = new_base_resources
 
         base_resources = flatten({"component": base_resources})
 

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import HTTP_NOT_FOUND
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_capture_events, mock_coro
+from tests.common import async_capture_events
 
 CONFIG_THEMES = {DOMAIN: {CONF_THEMES: {"happy": {"primary-color": "red"}}}}
 
@@ -283,10 +283,17 @@ async def test_get_translations(hass, hass_ws_client):
 
     with patch(
         "homeassistant.components.frontend.async_get_translations",
-        side_effect=lambda hass, lang: mock_coro({"lang": lang}),
+        side_effect=lambda hass, lang, category, integration, config_flow: {
+            "lang": lang
+        },
     ):
         await client.send_json(
-            {"id": 5, "type": "frontend/get_translations", "language": "nl"}
+            {
+                "id": 5,
+                "type": "frontend/get_translations",
+                "language": "nl",
+                "category": "lang",
+            }
         )
         msg = await client.receive_json()
 

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -35,7 +35,7 @@ def test_flatten():
     }
 
 
-async def test_component_translation_file(hass):
+async def test_component_translation_path(hass):
     """Test the component translation file function."""
     assert await async_setup_component(
         hass,
@@ -58,13 +58,13 @@ async def test_component_translation_file(hass):
     )
 
     assert path.normpath(
-        translation.component_translation_file("switch.test", "en", int_test)
+        translation.component_translation_path("switch.test", "en", int_test)
     ) == path.normpath(
         hass.config.path("custom_components", "test", ".translations", "switch.en.json")
     )
 
     assert path.normpath(
-        translation.component_translation_file(
+        translation.component_translation_path(
             "switch.test_embedded", "en", int_test_embedded
         )
     ) == path.normpath(
@@ -74,14 +74,14 @@ async def test_component_translation_file(hass):
     )
 
     assert (
-        translation.component_translation_file(
+        translation.component_translation_path(
             "test_standalone", "en", int_test_standalone
         )
         is None
     )
 
     assert path.normpath(
-        translation.component_translation_file("test_package", "en", int_test_package)
+        translation.component_translation_path("test_package", "en", int_test_package)
     ) == path.normpath(
         hass.config.path(
             "custom_components", "test_package", ".translations", "en.json"
@@ -145,7 +145,7 @@ async def test_get_translations_loads_config_flows(hass, mock_config_flows):
     integration.name = "Component 1"
 
     with patch.object(
-        translation, "component_translation_file", return_value=mock_coro("bla.json")
+        translation, "component_translation_path", return_value=mock_coro("bla.json")
     ), patch.object(
         translation,
         "load_translations_files",
@@ -179,7 +179,7 @@ async def test_get_translations_while_loading_components(hass):
         return {"component1": {"hello": "world"}}
 
     with patch.object(
-        translation, "component_translation_file", return_value=mock_coro("bla.json")
+        translation, "component_translation_path", return_value=mock_coro("bla.json")
     ), patch.object(
         translation, "load_translations_files", side_effect=mock_load_translation_files,
     ), patch(

--- a/tests/testing_config/custom_components/test/.translations/switch.en.json
+++ b/tests/testing_config/custom_components/test/.translations/switch.en.json
@@ -2,5 +2,6 @@
   "state": {
     "string1": "Value 1",
     "string2": "Value 2"
-  }
+  },
+  "something": "else"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows fetching translations by categories instead of fetching everything at once. This also allows specifying if you want to load a single integration, all set up integrations or all set up integrations + all integrations that have config flows.

~~Marked WIP until I finish frontend PR.~~

Frontend PR https://github.com/home-assistant/frontend/pull/5560

Part of #34264

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
