### PR TITLE
Remove deprecated homekit_controller credential storage locations

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -1,6 +1,5 @@
 """Support for Homekit device discovery."""
 import logging
-import os
 from typing import Any, Dict
 
 import aiohomekit
@@ -215,16 +214,6 @@ async def async_setup(hass, config):
 
     hass.data[CONTROLLER] = aiohomekit.Controller()
     hass.data[KNOWN_DEVICES] = {}
-
-    dothomekit_dir = hass.config.path(".homekit")
-    if os.path.exists(dothomekit_dir):
-        _LOGGER.warning(
-            (
-                "Legacy homekit_controller state found in %s. Support for reading "
-                "the folder is deprecated and will be removed in 0.109.0."
-            ),
-            dothomekit_dir,
-        )
 
     return True
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow to configure homekit_controller."""
-import json
 import logging
-import os
 import re
 
 import aiohomekit
@@ -21,32 +19,6 @@ PAIRING_FILE = "pairing.json"
 PIN_FORMAT = re.compile(r"^(\d{3})-{0,1}(\d{2})-{0,1}(\d{3})$")
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def load_old_pairings(hass):
-    """Load any old pairings from on-disk json fragments."""
-    old_pairings = {}
-
-    data_dir = os.path.join(hass.config.path(), HOMEKIT_DIR)
-    pairing_file = os.path.join(data_dir, PAIRING_FILE)
-
-    # Find any pairings created with in HA 0.85 / 0.86
-    if os.path.exists(pairing_file):
-        with open(pairing_file) as pairing_file:
-            old_pairings.update(json.load(pairing_file))
-
-    # Find any pairings created in HA <= 0.84
-    if os.path.exists(data_dir):
-        for device in os.listdir(data_dir):
-            if not device.startswith("hk-"):
-                continue
-            alias = device[3:]
-            if alias in old_pairings:
-                continue
-            with open(os.path.join(data_dir, device)) as pairing_data_fp:
-                old_pairings[alias] = json.load(pairing_data_fp)
-
-    return old_pairings
 
 
 def normalize_hkid(hkid):
@@ -218,15 +190,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         self.context["title_placeholders"] = {"name": name}
 
         if paired:
-            old_pairings = await self.hass.async_add_executor_job(
-                load_old_pairings, self.hass
-            )
-
-            if hkid in old_pairings:
-                return await self.async_import_legacy_pairing(
-                    properties, old_pairings[hkid]
-                )
-
             # Device is paired but not to us - ignore it
             _LOGGER.debug("HomeKit device %s ignored as already paired", hkid)
             return self.async_abort(reason="already_paired")

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -3,7 +3,6 @@ import logging
 import re
 
 import aiohomekit
-from aiohomekit.controller.ip import IpPairing
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -207,23 +206,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         # directly as it has side effects (will ask the device to show a
         # pairing code)
         return self._async_step_pair_show_form()
-
-    async def async_import_legacy_pairing(self, discovery_props, pairing_data):
-        """Migrate a legacy pairing to config entries."""
-
-        hkid = discovery_props["id"]
-
-        _LOGGER.info(
-            (
-                "Legacy configuration %s for homekit"
-                "accessory migrated to configuration entries"
-            ),
-            hkid,
-        )
-
-        pairing = IpPairing(pairing_data)
-
-        return await self._entry_from_accessory(pairing)
 
     async def async_step_pair(self, pair_info=None):
         """Pair with a new HomeKit accessory."""

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for homekit_controller config flow."""
-import json
 from unittest import mock
 
 import aiohomekit
@@ -13,7 +12,6 @@ import pytest
 from homeassistant.components.homekit_controller import config_flow
 
 from tests.common import MockConfigEntry
-from tests.components.homekit_controller.common import setup_platform
 
 PAIRING_START_FORM_ERRORS = [
     (aiohomekit.BusyError, "busy_error"),
@@ -494,175 +492,6 @@ async def test_user_no_unpaired_devices(hass, controller):
 
     assert result["type"] == "abort"
     assert result["reason"] == "no_devices"
-
-
-async def test_parse_new_homekit_json(hass):
-    """Test migrating recent .homekit/pairings.json files."""
-    accessory = Accessory.create_with_info(
-        "TestDevice", "example.com", "Test", "0001", "0.1"
-    )
-    service = accessory.add_service(ServicesTypes.LIGHTBULB)
-    on_char = service.add_char(CharacteristicsTypes.ON)
-    on_char.value = 0
-
-    accessories = Accessories()
-    accessories.add_accessory(accessory)
-
-    fake_controller = await setup_platform(hass)
-    pairing = await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
-    pairing.pairing_data = {"AccessoryPairingID": "00:00:00:00:00:00"}
-
-    mock_path = mock.Mock()
-    mock_path.exists.side_effect = [True, False]
-
-    read_data = {"00:00:00:00:00:00": pairing.pairing_data}
-    mock_open = mock.mock_open(read_data=json.dumps(read_data))
-
-    discovery_info = {
-        "name": "TestDevice",
-        "host": "127.0.0.1",
-        "port": 8080,
-        "properties": {"md": "TestDevice", "id": "00:00:00:00:00:00", "c#": 1, "sf": 0},
-    }
-
-    flow = _setup_flow_handler(hass)
-
-    pairing_cls_imp = (
-        "homeassistant.components.homekit_controller.config_flow.IpPairing"
-    )
-
-    with mock.patch(pairing_cls_imp) as pairing_cls:
-        pairing_cls.return_value = pairing
-        with mock.patch("builtins.open", mock_open):
-            with mock.patch("os.path", mock_path):
-                result = await flow.async_step_zeroconf(discovery_info)
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "TestDevice"
-    assert result["data"]["AccessoryPairingID"] == "00:00:00:00:00:00"
-    assert flow.context == {
-        "hkid": "00:00:00:00:00:00",
-        "title_placeholders": {"name": "TestDevice"},
-        "unique_id": "00:00:00:00:00:00",
-    }
-
-
-async def test_parse_old_homekit_json(hass):
-    """Test migrating original .homekit/hk-00:00:00:00:00:00 files."""
-    accessory = Accessory.create_with_info(
-        "TestDevice", "example.com", "Test", "0001", "0.1"
-    )
-    service = accessory.add_service(ServicesTypes.LIGHTBULB)
-    on_char = service.add_char(CharacteristicsTypes.ON)
-    on_char.value = 0
-
-    accessories = Accessories()
-    accessories.add_accessory(accessory)
-
-    fake_controller = await setup_platform(hass)
-    pairing = await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
-    pairing.pairing_data = {"AccessoryPairingID": "00:00:00:00:00:00"}
-
-    mock_path = mock.Mock()
-    mock_path.exists.side_effect = [False, True]
-
-    mock_listdir = mock.Mock()
-    mock_listdir.return_value = ["hk-00:00:00:00:00:00", "pairings.json"]
-
-    read_data = {"AccessoryPairingID": "00:00:00:00:00:00"}
-    mock_open = mock.mock_open(read_data=json.dumps(read_data))
-
-    discovery_info = {
-        "name": "TestDevice",
-        "host": "127.0.0.1",
-        "port": 8080,
-        "properties": {"md": "TestDevice", "id": "00:00:00:00:00:00", "c#": 1, "sf": 0},
-    }
-
-    flow = _setup_flow_handler(hass)
-
-    pairing_cls_imp = (
-        "homeassistant.components.homekit_controller.config_flow.IpPairing"
-    )
-
-    with mock.patch(pairing_cls_imp) as pairing_cls:
-        pairing_cls.return_value = pairing
-        with mock.patch("builtins.open", mock_open):
-            with mock.patch("os.path", mock_path):
-                with mock.patch("os.listdir", mock_listdir):
-                    result = await flow.async_step_zeroconf(discovery_info)
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "TestDevice"
-    assert result["data"]["AccessoryPairingID"] == "00:00:00:00:00:00"
-    assert flow.context == {
-        "hkid": "00:00:00:00:00:00",
-        "title_placeholders": {"name": "TestDevice"},
-        "unique_id": "00:00:00:00:00:00",
-    }
-
-
-async def test_parse_overlapping_homekit_json(hass):
-    """Test migrating .homekit/pairings.json files when hk- exists too."""
-    accessory = Accessory.create_with_info(
-        "TestDevice", "example.com", "Test", "0001", "0.1"
-    )
-    service = accessory.add_service(ServicesTypes.LIGHTBULB)
-    on_char = service.add_char(CharacteristicsTypes.ON)
-    on_char.value = 0
-
-    accessories = Accessories()
-    accessories.add_accessory(accessory)
-
-    fake_controller = await setup_platform(hass)
-    pairing = await fake_controller.add_paired_device(accessories)
-    pairing.pairing_data = {"AccessoryPairingID": "00:00:00:00:00:00"}
-
-    mock_listdir = mock.Mock()
-    mock_listdir.return_value = ["hk-00:00:00:00:00:00", "pairings.json"]
-
-    mock_path = mock.Mock()
-    mock_path.exists.side_effect = [True, True]
-
-    # First file to get loaded is .homekit/pairing.json
-    read_data_1 = {"00:00:00:00:00:00": {"AccessoryPairingID": "00:00:00:00:00:00"}}
-    mock_open_1 = mock.mock_open(read_data=json.dumps(read_data_1))
-
-    # Second file to get loaded is .homekit/hk-00:00:00:00:00:00
-    read_data_2 = {"AccessoryPairingID": "00:00:00:00:00:00"}
-    mock_open_2 = mock.mock_open(read_data=json.dumps(read_data_2))
-
-    side_effects = [mock_open_1.return_value, mock_open_2.return_value]
-
-    discovery_info = {
-        "name": "TestDevice",
-        "host": "127.0.0.1",
-        "port": 8080,
-        "properties": {"md": "TestDevice", "id": "00:00:00:00:00:00", "c#": 1, "sf": 0},
-    }
-
-    flow = _setup_flow_handler(hass)
-
-    pairing_cls_imp = (
-        "homeassistant.components.homekit_controller.config_flow.IpPairing"
-    )
-    with mock.patch(pairing_cls_imp) as pairing_cls:
-        pairing_cls.return_value = pairing
-        with mock.patch("builtins.open", side_effect=side_effects):
-            with mock.patch("os.path", mock_path):
-                with mock.patch("os.listdir", mock_listdir):
-                    result = await flow.async_step_zeroconf(discovery_info)
-
-        await hass.async_block_till_done()
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "TestDevice"
-    assert result["data"]["AccessoryPairingID"] == "00:00:00:00:00:00"
-    assert flow.context == {
-        "hkid": "00:00:00:00:00:00",
-        "title_placeholders": {"name": "TestDevice"},
-        "unique_id": "00:00:00:00:00:00",
-    }
 
 
 async def test_unignore_works(hass, controller):


### PR DESCRIPTION
## Breaking change

Support for homekit_controller's legacy pairing data folder `.homekit` has now been removed. This has not been how pairings are saved since Home Assistant 0.94. If you are running Home Assistant 0.94 or later this does not affect you as your pairings were automatically migrated to the new scheme already. If you are running an older release then you will need to re-pair after upgrading.

## Proposed change

As per #32158, this removes some legacy code that was used when homekit_controller was migrated to config entries. This removes over 200 lines of code that have had plenty of time to run everywhere now and gets rid of some older config flow tests that were a bit brittle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #32158
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
