### PR TITLE
Add NetdataAlarms sensor to additionally collect alarm information

### DIFF
--- a/homeassistant/components/netdata/manifest.json
+++ b/homeassistant/components/netdata/manifest.json
@@ -2,6 +2,6 @@
   "domain": "netdata",
   "name": "Netdata",
   "documentation": "https://www.home-assistant.io/integrations/netdata",
-  "requirements": ["netdata==0.1.2"],
+  "requirements": ["netdata==0.2.0"],
   "codeowners": ["@fabaff"]
 }

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -172,9 +172,9 @@ class NetdataAlarms(Entity):
         """Status symbol if type is symbol."""
         if self._state == "ok":
             return "mdi:check"
-        elif self._state == "warning":
+        if self._state == "warning":
             return "mdi:alert-outline"
-        elif self._state == "critical":
+        if self._state == "critical":
             return "mdi:alert"
         return "mdi:crosshairs-question"
 

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -54,7 +54,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Netdata sensor."""
 
@@ -169,16 +168,16 @@ class NetdataAlarms(Entity):
         return self._state
 
     @property
-    def entity_picture(self):
+    def icon(self):
         """Status symbol if type is symbol."""
         if self._state == "ok":
-            return "https://cdn2.iconfinder.com/data/icons/function_icon_set/circle_green.png"
+            return "mdi:check"
         elif self._state == "warning":
-            return "https://cdn2.iconfinder.com/data/icons/function_icon_set/warning_48.png"
+            return "mdi:alert-outline"
         elif self._state == "critical":
-            return "https://cdn2.iconfinder.com/data/icons/function_icon_set/circle_red.png"
+            return "mdi:alert"
         else:
-            return "https://cdn2.iconfinder.com/data/icons/function_icon_set/refresh_48.png"
+            return "mdi:crosshairs-question"
 
     @property
     def available(self):

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -1,7 +1,7 @@
 """Support gathering system information of hosts which are running netdata."""
 from datetime import timedelta
+import json
 import logging
-from typing import Any, Dict, Optional
 
 from netdata import Netdata
 from netdata.exceptions import NetdataError
@@ -169,11 +169,6 @@ class NetdataAlarms(Entity):
         return self._state
 
     @property
-    def device_info(self) -> Optional[Dict[str, Any]]:
-        """Return host information, e.g. the url to netdata dashboard."""
-        return {"url": f"http://{self._host}:{self._port}"}
-
-    @property
     def entity_picture(self):
         """Status symbol if type is symbol."""
         if self._state == "ok":
@@ -192,14 +187,12 @@ class NetdataAlarms(Entity):
 
     async def async_update(self):
         """Get the latest alarms from Netdata REST API."""
-        import json
-
         await self.netdata.async_update()
         info = json.loads(self.netdata.api.alarms)
-        self._state = "unknown"
+        self._state = None
         number_of_alarms = len(info["alarms"])
 
-        _LOGGER.debug(f"Host {self.name} has {number_of_alarms} alarms")
+        _LOGGER.debug("Host %s has %s alarms", self.name, number_of_alarms)
 
         alarms = info["alarms"]
         n = number_of_alarms

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -53,6 +53,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Netdata sensor."""
 

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -176,8 +176,7 @@ class NetdataAlarms(Entity):
             return "mdi:alert-outline"
         elif self._state == "critical":
             return "mdi:alert"
-        else:
-            return "mdi:crosshairs-question"
+        return "mdi:crosshairs-question"
 
     @property
     def available(self):
@@ -190,17 +189,17 @@ class NetdataAlarms(Entity):
         alarms = self.netdata.api.alarms["alarms"]
         self._state = None
         number_of_alarms = len(alarms)
-        n = number_of_alarms
+        number_of_relevant_alamrs = number_of_alarms
 
         _LOGGER.debug("Host %s has %s alarms", self.name, number_of_alarms)
 
         for alarm in alarms:
             if alarms[alarm]["recipient"] == "silent":
-                n = n - 1
+                number_of_relevant_alamrs = number_of_relevant_alamrs - 1
             elif alarms[alarm]["status"] == "CRITICAL":
                 self._state = "critical"
                 return
-        self._state = "ok" if n == 0 else "warning"
+        self._state = "ok" if number_of_relevant_alamrs == 0 else "warning"
 
 
 class NetdataData:

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -189,17 +189,17 @@ class NetdataAlarms(Entity):
         alarms = self.netdata.api.alarms["alarms"]
         self._state = None
         number_of_alarms = len(alarms)
-        number_of_relevant_alamrs = number_of_alarms
+        number_of_relevant_alarms = number_of_alarms
 
         _LOGGER.debug("Host %s has %s alarms", self.name, number_of_alarms)
 
         for alarm in alarms:
             if alarms[alarm]["recipient"] == "silent":
-                number_of_relevant_alamrs = number_of_relevant_alamrs - 1
+                number_of_relevant_alarms = number_of_relevant_alarms - 1
             elif alarms[alarm]["status"] == "CRITICAL":
                 self._state = "critical"
                 return
-        self._state = "ok" if number_of_relevant_alamrs == 0 else "warning"
+        self._state = "ok" if number_of_relevant_alarms == 0 else "warning"
 
 
 class NetdataData:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -914,7 +914,7 @@ ndms2_client==0.0.11
 nessclient==0.9.15
 
 # homeassistant.components.netdata
-netdata==0.1.2
+netdata==0.2.0
 
 # homeassistant.components.discovery
 # homeassistant.components.ssdp


### PR DESCRIPTION
… from the netdata host

## Proposed change

The existing NetData component collects data from configured hosts that run NetData and provide the NetData API endpoint. This host data is already useful, but this PR adds the new feature to also collect information about alarms on the given host. To start with, thir PR collects all open alarms and determines if at least one is either CRITICAL or WARNING and sets the entity state accordingly. Otherwise the state is set to OK.

This does not require any configuration changes, that just uses the already existing configuration of the existing NetData integration.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This allows to display at a glance the status in a traffic light like overview with green, yellow or red status symbols for each host. Here is an example:

![Screenshot from 2020-04-17 12-59-23](https://user-images.githubusercontent.com/1475675/79563218-a2a9f900-80ac-11ea-86c3-9ec82db34d61.png)

Of course, the state change can then also be used for automation.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
