### PR TITLE
Add lg_netcast option to configure a custom "turn_off_action"

### DIFF
--- a/homeassistant/components/lg_netcast/media_player.py
+++ b/homeassistant/components/lg_netcast/media_player.py
@@ -197,15 +197,8 @@ class LgTVDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        if self._on_action_script and self._off_action_script:
-            return SUPPORT_LGTV | SUPPORT_TURN_ON | SUPPORT_TURN_OFF
-
         if self._on_action_script:
             return SUPPORT_LGTV | SUPPORT_TURN_ON
-
-        if self._off_action_script:
-            return SUPPORT_LGTV | SUPPORT_TURN_OFF
-
         return SUPPORT_LGTV
 
     @property

--- a/homeassistant/components/lg_netcast/media_player.py
+++ b/homeassistant/components/lg_netcast/media_player.py
@@ -36,6 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = "LG TV Remote"
 
 CONF_ON_ACTION = "turn_on_action"
+CONF_OFF_ACTION = "turn_off_action"
 
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
@@ -54,6 +55,7 @@ SUPPORT_LGTV = (
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_OFF_ACTION): cv.SCRIPT_SCHEMA,
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_ACCESS_TOKEN): vol.All(cv.string, vol.Length(max=6)),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -68,22 +70,25 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     access_token = config.get(CONF_ACCESS_TOKEN)
     name = config.get(CONF_NAME)
     on_action = config.get(CONF_ON_ACTION)
+    off_action = config.get(CONF_OFF_ACTION)
 
     client = LgNetCastClient(host, access_token)
     on_action_script = Script(hass, on_action) if on_action else None
+    off_action_script = Script(hass, off_action) if off_action else None
 
-    add_entities([LgTVDevice(client, name, on_action_script)], True)
+    add_entities([LgTVDevice(client, name, on_action_script, off_action_script)], True)
 
 
 class LgTVDevice(MediaPlayerDevice):
     """Representation of a LG TV."""
 
-    def __init__(self, client, name, on_action_script):
+    def __init__(self, client, name, on_action_script, off_action_script):
         """Initialize the LG TV device."""
         self._client = client
         self._name = name
         self._muted = False
         self._on_action_script = on_action_script
+        self._off_action_script = off_action_script
         # Assume that the TV is in Play mode
         self._playing = True
         self._volume = 0
@@ -192,8 +197,15 @@ class LgTVDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
+        if self._on_action_script and self._off_action_script:
+            return SUPPORT_LGTV | SUPPORT_TURN_ON | SUPPORT_TURN_OFF
+
         if self._on_action_script:
             return SUPPORT_LGTV | SUPPORT_TURN_ON
+
+        if self._off_action_script:
+            return SUPPORT_LGTV | SUPPORT_TURN_OFF
+
         return SUPPORT_LGTV
 
     @property
@@ -205,7 +217,10 @@ class LgTVDevice(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn off media player."""
-        self.send_command(1)
+        if self._off_action_script:
+            self._off_action_script.run()
+        else:
+            self.send_command(1)
 
     def turn_on(self):
         """Turn on the media player."""


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This update for the lg_netcast integration adds the possiblity to override the default "tv off" option with a custom service call (exactly like the already implemented "tv on" action service call). 
This is useful, if you want to handle the power on and off calls with a smart power plug and not with the native "tv off" functionality which turns the tv in standby.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
  - platform: lg_netcast
    access_token: <token>
    host: 192.168.1.23
    turn_on_action:
      service: switch.turn_on
      data:
        entity_id: switch.my_tv
    turn_off_action:
      service: switch.turn_off
      data:
        entity_id: switch.my_tv
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13018

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io