### PR TITLE
Ignore non-ASCII keys in zeroconf payloads

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -157,7 +157,14 @@ def info_from_service(service):
         # See https://ietf.org/rfc/rfc6763.html#section-6.4 and
         # https://ietf.org/rfc/rfc6763.html#section-6.5 for expected encodings
         # for property keys and values
-        key = key.decode("ascii")
+        try:
+            key = key.decode("ascii")
+        except UnicodeDecodeError:
+            _LOGGER.debug(
+                "Ignoring invalid key provided by [%s]: %s", service.name, key
+            )
+            continue
+
         properties["_raw"][key] = value
 
         try:

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -131,17 +131,14 @@ async def test_homekit_match_full(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
 
 
-async def test_info_from_service_non_utf8(hass, caplog):
+async def test_info_from_service_non_utf8(hass):
     """Test info_from_service handles non UTF-8 property keys and values correctly."""
     service_type = "_test._tcp.local."
-    service_info_mock = get_service_info_mock(service_type, f"test.{service_type}")
-    info = zeroconf.info_from_service(service_info_mock)
+    info = zeroconf.info_from_service(
+        get_service_info_mock(service_type, f"test.{service_type}")
+    )
     raw_info = info["properties"].pop("_raw", False)
     assert raw_info
-    assert (
-        f"Ignoring invalid key provided by [{service_info_mock.name}]: {NON_ASCII_KEY}"
-        in caplog.text
-    )
     assert len(raw_info) == len(PROPERTIES) - 1
     assert NON_ASCII_KEY not in raw_info
     assert len(info["properties"]) <= len(raw_info)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Key names must be ASCII-encoded according to https://ietf.org/rfc/rfc6763.html#section-6.4.

I've encountered a Samsung printer that returns an invalid key name in its IPP response:
```
Exception in thread zeroconf-ServiceBrowser__ipp._tcp.local.:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/home/homeassistant/src/home-assistant/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 1496, in run
    handler(self.zc)
  File "/home/homeassistant/src/home-assistant/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 1436, in <lambda>
    zeroconf=zeroconf, service_type=self.type, name=name, state_change=state_change
  File "/home/homeassistant/src/home-assistant/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 1314, in fire
    h(**kwargs)
  File "/home/homeassistant/src/home-assistant/homeassistant/components/zeroconf/__init__.py", line 89, in service_update
    info = info_from_service(service_info)
  File "/home/homeassistant/src/home-assistant/homeassistant/components/zeroconf/__init__.py", line 160, in info_from_service
    key = key.decode("ascii")
UnicodeDecodeError: 'ascii' codec can't decode byte 0xb0 in position 6: ordinal not in range(128)
```

Raw info:
```
ServiceInfo(type='_ipp._tcp.local.', name='Samsung M2835._ipp._tcp.local.', addresses=[b'\n\x00\xc8j'], port=631, weight=0, priority=0, server='printer.local.', properties={b'txtvers': b'1', b'note': b'', b'ty': b'Samsung M283x Series', b'rp': b'ipp/print', b'qtotal': b'1', b'priority': b'51', b'product': b'(Samsung M283x Series)', b'pdl': b'application/octet-stream,application/PCL,application/vnd.hp-PCL,application/vnd.hp-PCLXL,application/x-QPDL,text/plain,image/urf,application/PCLm', b'adminurl': b'http://printer.local./sws/index.html?link=/sws/app/settings/network/AirPrint/AirPrint.html', b'usb_MFG': b'Samsung', b'usb_MDL': b'M283x Series', b'usb_CMD': b'MFG:Samsung;CMD:SPL,PCL6,URF,PIC,SPDS,FWV,EXT;MDL:M283x Series;CID:SA_PCL6_BW;CLS:PRINTER;MODE:SPL3,R000105,SCP;', b'MFG': b'Samsung', b'MDL': b'M283x Series', b'UUID': b'16a35700-008c-1000-bb49-30cea7c63a65', b'print_wfds': b'T', b'URF': b'W8,RS600,IS1,CP1,IFU0,PQ4,OB10,DM1,V1.2', b'Bind': b'F', b'Collate': b'F', b'Color': b'F', b'Copies': b'T', b'Duplex': b'T', b'PaperCustom': b'T', b'Punch': b'0', b'Scan': b'F', b'Fax': b'F', b'Sort': b'F', b'Staple': b'F', b'SC\x01\x00\x00\x00\xb0\xf5\x1e\x00da\xbb\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00': None})
```

This PR drops these invalid keys.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
