### PR TITLE
Update bravia-tv backend

### DIFF
--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -3,10 +3,9 @@ import asyncio
 
 from bravia_tv import BraviaRC
 
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.const import CONF_HOST
 
-from .const import CLIENTID_PREFIX, DOMAIN, NICKNAME
+from .const import DOMAIN
 
 PLATFORMS = ["media_player"]
 
@@ -19,18 +18,9 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     """Set up a config entry."""
     host = config_entry.data[CONF_HOST]
-    mac = config_entry.data[CONF_MAC]
-    pin = config_entry.data[CONF_PIN]
-
-    braviarc = BraviaRC(host, mac)
-
-    await hass.async_add_executor_job(braviarc.connect, pin, CLIENTID_PREFIX, NICKNAME)
-
-    if not braviarc.is_connected():
-        raise ConfigEntryNotReady
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][config_entry.entry_id] = braviarc
+    hass.data[DOMAIN][config_entry.entry_id] = BraviaRC(host)
 
     for component in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 
 from bravia_tv import BraviaRC
 
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_MAC
 
 from .const import DOMAIN
 
@@ -18,9 +18,10 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     """Set up a config entry."""
     host = config_entry.data[CONF_HOST]
+    mac = config_entry.data[CONF_MAC]
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][config_entry.entry_id] = BraviaRC(host)
+    hass.data[DOMAIN][config_entry.entry_id] = BraviaRC(host, mac)
 
     for component in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -7,12 +7,13 @@ from bravia_tv import BraviaRC
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
-from homeassistant.const import CONF_HOST, CONF_PIN
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from .const import (  # pylint:disable=unused-import
     ATTR_CID,
+    ATTR_MAC,
     ATTR_MODEL,
     CLIENTID_PREFIX,
     CONF_IGNORED_SOURCES,
@@ -44,6 +45,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.braviarc = None
         self.host = None
         self.title = None
+        self.mac = None
 
     async def init_device(self, pin):
         """Initialize Bravia TV device."""
@@ -64,6 +66,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         self.title = system_info[ATTR_MODEL]
+        self.mac = system_info[ATTR_MAC]
 
     @staticmethod
     @callback
@@ -84,6 +87,8 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ModelNotSupported:
             _LOGGER.error("Import aborted, your TV is not supported")
             return self.async_abort(reason="unsupported_model")
+
+        user_input[CONF_MAC] = self.mac
 
         return self.async_create_entry(title=self.title, data=user_input)
 
@@ -119,6 +124,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unsupported_model"
             else:
                 user_input[CONF_HOST] = self.host
+                user_input[CONF_MAC] = self.mac
                 return self.async_create_entry(title=self.title, data=user_input)
 
         # Connecting with th PIN "0000" to start the pairing process on the TV.

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["bravia-tv==1.0.1"],
+  "requirements": ["bravia-tv==1.0.2"],
   "codeowners": ["@robbiet480", "@bieniu"],
   "config_flow": true
 }

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -214,9 +214,6 @@ class BraviaTVDevice(MediaPlayerDevice):
         playing_info = await self.hass.async_add_executor_job(
             self._braviarc.get_playing_info
         )
-        if not playing_info:
-            self._channel_name = "App"
-            playing_info = {}
         self._program_name = playing_info.get("programTitle")
         self._channel_name = playing_info.get("title")
         self._program_media_type = playing_info.get("programMediaType")
@@ -225,6 +222,8 @@ class BraviaTVDevice(MediaPlayerDevice):
         self._source = self._get_source()
         self._duration = playing_info.get("durationSec")
         self._start_date_time = playing_info.get("startDateTime")
+        if not playing_info:
+            self._channel_name = "App"
 
     @property
     def name(self):

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -144,44 +144,37 @@ class BraviaTVDevice(MediaPlayerDevice):
         self._unique_id = unique_id
         self._device_info = device_info
         self._ignored_sources = ignored_sources
+        self._state_change = False
+        self._need_refresh = True
 
-    def update(self):
+    async def async_update(self):
         """Update TV info."""
-        if not self._braviarc.is_connected():
-            if self._braviarc.get_power_status() != "off":
-                self._braviarc.connect(self._pin, CLIENTID_PREFIX, NICKNAME)
-            if not self._braviarc.is_connected():
+        if self._state_change:
+            return
+
+        if self._state == STATE_OFF:
+            self._need_refresh = True
+
+        power_status = await self.hass.async_add_executor_job(
+            self._braviarc.get_power_status
+        )
+        if power_status == "active":
+            if self._need_refresh:
+                connected = await self.hass.async_add_executor_job(
+                    self._braviarc.connect, self._pin, CLIENTID_PREFIX, NICKNAME
+                )
+                self._need_refresh = False
+            else:
+                connected = self._braviarc.is_connected()
+            if not connected:
                 return
 
-        # Retrieve the latest data.
-        try:
-            if self._state == STATE_ON:
-                # refresh volume info:
-                self._refresh_volume()
-                self._refresh_channels()
-
-            power_status = self._braviarc.get_power_status()
-            if power_status == "active":
-                self._state = STATE_ON
-                playing_info = self._braviarc.get_playing_info()
-                self._reset_playing_info()
-                if playing_info is None or not playing_info:
-                    self._channel_name = "App"
-                else:
-                    self._program_name = playing_info.get("programTitle")
-                    self._channel_name = playing_info.get("title")
-                    self._program_media_type = playing_info.get("programMediaType")
-                    self._channel_number = playing_info.get("dispNum")
-                    self._content_uri = playing_info.get("uri")
-                    self._source = self._get_source()
-                    self._duration = playing_info.get("durationSec")
-                    self._start_date_time = playing_info.get("startDateTime")
-            else:
-                self._state = STATE_OFF
-
-        except Exception as exception_instance:  # pylint: disable=broad-except
-            _LOGGER.error(exception_instance)
-            self._state = STATE_OFF
+            self._state = STATE_ON
+            if await self._async_refresh_volume():
+                if await self._async_refresh_channels():
+                    await self._async_refresh_playing_info()
+                    return
+        self._state = STATE_OFF
 
     def _get_source(self):
         """Return the name of the source."""
@@ -189,32 +182,49 @@ class BraviaTVDevice(MediaPlayerDevice):
             if value == self._content_uri:
                 return key
 
-    def _reset_playing_info(self):
-        self._program_name = None
-        self._channel_name = None
-        self._program_media_type = None
-        self._channel_number = None
-        self._source = None
-        self._content_uri = None
-        self._duration = None
-        self._start_date_time = None
-
-    def _refresh_volume(self):
+    async def _async_refresh_volume(self):
         """Refresh volume information."""
-        volume_info = self._braviarc.get_volume_info()
+        volume_info = await self.hass.async_add_executor_job(
+            self._braviarc.get_volume_info
+        )
         if volume_info is not None:
             self._volume = volume_info.get("volume")
             self._min_volume = volume_info.get("minVolume")
             self._max_volume = volume_info.get("maxVolume")
             self._muted = volume_info.get("mute")
+            return True
+        return False
 
-    def _refresh_channels(self):
+    async def _async_refresh_channels(self):
+        """Refresh source and channels list."""
         if not self._source_list:
-            self._content_mapping = self._braviarc.load_source_list()
+            self._content_mapping = await self.hass.async_add_executor_job(
+                self._braviarc.load_source_list
+            )
             self._source_list = []
+            if not self._content_mapping:
+                return False
             for key in self._content_mapping:
                 if key not in self._ignored_sources:
                     self._source_list.append(key)
+        return True
+
+    async def _async_refresh_playing_info(self):
+        """Refresh Playing information."""
+        playing_info = await self.hass.async_add_executor_job(
+            self._braviarc.get_playing_info
+        )
+        if not playing_info:
+            self._channel_name = "App"
+            playing_info = {}
+        self._program_name = playing_info.get("programTitle")
+        self._channel_name = playing_info.get("title")
+        self._program_media_type = playing_info.get("programMediaType")
+        self._channel_number = playing_info.get("dispNum")
+        self._content_uri = playing_info.get("uri")
+        self._source = self._get_source()
+        self._duration = playing_info.get("durationSec")
+        self._start_date_time = playing_info.get("startDateTime")
 
     @property
     def name(self):
@@ -294,11 +304,15 @@ class BraviaTVDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn the media player on."""
+        self._state_change = True
         self._braviarc.turn_on()
+        self._state_change = False
 
     def turn_off(self):
         """Turn off media player."""
+        self._state_change = True
         self._braviarc.turn_off()
+        self._state_change = False
 
     def volume_up(self):
         """Volume up the media player."""

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -170,10 +170,12 @@ class BraviaTVDevice(MediaPlayerDevice):
                 return
 
             self._state = STATE_ON
-            if await self._async_refresh_volume():
-                if await self._async_refresh_channels():
-                    await self._async_refresh_playing_info()
-                    return
+            if (
+                await self._async_refresh_volume()
+                and await self._async_refresh_channels()
+            ):
+                await self._async_refresh_playing_info()
+                return
         self._state = STATE_OFF
 
     def _get_source(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -355,7 +355,7 @@ bomradarloop==0.1.4
 boto3==1.9.252
 
 # homeassistant.components.braviatv
-bravia-tv==1.0.1
+bravia-tv==1.0.2
 
 # homeassistant.components.broadlink
 broadlink==0.13.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -137,7 +137,7 @@ bellows-homeassistant==0.15.2
 bomradarloop==0.1.4
 
 # homeassistant.components.braviatv
-bravia-tv==1.0.1
+bravia-tv==1.0.2
 
 # homeassistant.components.broadlink
 broadlink==0.13.1

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -68,7 +68,6 @@ async def test_import(hass):
         assert result["data"] == {
             CONF_HOST: "bravia-host",
             CONF_PIN: "1234",
-            CONF_MAC: "AA:BB:CC:DD:EE:FF",
         }
 
 
@@ -89,7 +88,7 @@ async def test_import_model_unsupported(hass):
     """Test that errors are shown when the TV is not supported during import."""
     with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
         "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch("bravia_tv.BraviaRC.get_system_info", side_effect=KeyError):
+    ), patch("bravia_tv.BraviaRC.get_system_info", return_value={}):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=IMPORT_CONFIG_IP,
         )
@@ -150,7 +149,7 @@ async def test_authorize_model_unsupported(hass):
     """Test that errors are shown when the TV is not supported at the authorize step."""
     with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
         "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch("bravia_tv.BraviaRC.get_system_info", side_effect=KeyError):
+    ), patch("bravia_tv.BraviaRC.get_system_info", return_value={}):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "10.10.10.12"},
         )
@@ -217,7 +216,6 @@ async def test_create_entry(hass):
         assert result["data"] == {
             CONF_HOST: "bravia-host",
             CONF_PIN: "1234",
-            CONF_MAC: "AA:BB:CC:DD:EE:FF",
         }
 
 

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -68,6 +68,7 @@ async def test_import(hass):
         assert result["data"] == {
             CONF_HOST: "bravia-host",
             CONF_PIN: "1234",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
         }
 
 
@@ -216,6 +217,7 @@ async def test_create_entry(hass):
         assert result["data"] == {
             CONF_HOST: "bravia-host",
             CONF_PIN: "1234",
+            CONF_MAC: "AA:BB:CC:DD:EE:FF",
         }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update bravia-tv to the latest release.
- Remove no longer required error handling.
- Removed mac address references -- bravia_tv dynamically handles this during connect() now.
- Fix and update the bravia entity update function. 
- Remove logic that requires TV to be on during HA reboot

The purpose of this PR is to address where home-assistant is rebooted and the BraviaTV is off, the BraviaTV instance will be a bad state where it is not controllable. This is a result of the BraviaTV instance held by home-assistant does not have the proper cookies and the RESTapi subtlety rejects all the commands. In addition to this, the logic that prevents home-assistant from loading a BraviaTV instance at boot needed to be removed. This PR also includes some code enhancements in the areas that were touched. False error logs should be greatly reduced. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

No change

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
