### PR TITLE
Add Daikin total/cool/heat power sensors

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -119,7 +119,7 @@ async def daikin_api_setup(hass, host, key, uuid, password):
 class DaikinApi:
     """Keep the Daikin instance in one place and centralize the update."""
 
-    def __init__(self, device):
+    def __init__(self, device: Appliance):
         """Initialize the Daikin Handle."""
         self.device = device
         self.name = device.values.get("name", "Daikin AC")

--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -4,11 +4,16 @@ from homeassistant.const import CONF_ICON, CONF_NAME, CONF_TYPE
 ATTR_TARGET_TEMPERATURE = "target_temperature"
 ATTR_INSIDE_TEMPERATURE = "inside_temperature"
 ATTR_OUTSIDE_TEMPERATURE = "outside_temperature"
+ATTR_TOTAL_POWER = "total_power"
+ATTR_COOL_ENERGY = "cool_energy"
+ATTR_HEAT_ENERGY = "heat_energy"
 
 ATTR_STATE_ON = "on"
 ATTR_STATE_OFF = "off"
 
 SENSOR_TYPE_TEMPERATURE = "temperature"
+SENSOR_TYPE_POWER = "power"
+SENSOR_TYPE_ENERGY = "energy"
 
 SENSOR_TYPES = {
     ATTR_INSIDE_TEMPERATURE: {
@@ -20,6 +25,21 @@ SENSOR_TYPES = {
         CONF_NAME: "Outside Temperature",
         CONF_ICON: "mdi:thermometer",
         CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
+    },
+    ATTR_TOTAL_POWER: {
+        CONF_NAME: "Total Power Consumption",
+        CONF_ICON: "mdi:flash",
+        CONF_TYPE: SENSOR_TYPE_POWER,
+    },
+    ATTR_COOL_ENERGY: {
+        CONF_NAME: "Cool Energy Consumption",
+        CONF_ICON: "mdi:snowflake",
+        CONF_TYPE: SENSOR_TYPE_ENERGY,
+    },
+    ATTR_HEAT_ENERGY: {
+        CONF_NAME: "Heat Power Consumption",
+        CONF_ICON: "mdi:fire",
+        CONF_TYPE: SENSOR_TYPE_ENERGY,
     },
 }
 

--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -1,5 +1,16 @@
 """Constants for Daikin."""
-from homeassistant.const import CONF_ICON, CONF_NAME, CONF_TYPE
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_ICON,
+    CONF_NAME,
+    CONF_TYPE,
+    CONF_UNIT_OF_MEASUREMENT,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+    ENERGY_KILO_WATT_HOUR,
+    POWER_KILO_WATT,
+    TEMP_CELSIUS,
+)
 
 ATTR_TARGET_TEMPERATURE = "target_temperature"
 ATTR_INSIDE_TEMPERATURE = "inside_temperature"
@@ -18,28 +29,33 @@ SENSOR_TYPE_ENERGY = "energy"
 SENSOR_TYPES = {
     ATTR_INSIDE_TEMPERATURE: {
         CONF_NAME: "Inside Temperature",
-        CONF_ICON: "mdi:thermometer",
         CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        CONF_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
     },
     ATTR_OUTSIDE_TEMPERATURE: {
         CONF_NAME: "Outside Temperature",
-        CONF_ICON: "mdi:thermometer",
         CONF_TYPE: SENSOR_TYPE_TEMPERATURE,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        CONF_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
     },
     ATTR_TOTAL_POWER: {
         CONF_NAME: "Total Power Consumption",
-        CONF_ICON: "mdi:flash",
         CONF_TYPE: SENSOR_TYPE_POWER,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
+        CONF_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
     },
     ATTR_COOL_ENERGY: {
         CONF_NAME: "Cool Energy Consumption",
-        CONF_ICON: "mdi:snowflake",
         CONF_TYPE: SENSOR_TYPE_ENERGY,
+        CONF_ICON: "mdi:snowflake",
+        CONF_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     ATTR_HEAT_ENERGY: {
-        CONF_NAME: "Heat Power Consumption",
-        CONF_ICON: "mdi:fire",
+        CONF_NAME: "Heat Energy Consumption",
         CONF_TYPE: SENSOR_TYPE_ENERGY,
+        CONF_ICON: "mdi:fire",
+        CONF_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
 }
 

--- a/homeassistant/components/daikin/sensor.py
+++ b/homeassistant/components/daikin/sensor.py
@@ -2,14 +2,11 @@
 import logging
 
 from homeassistant.const import (
+    CONF_DEVICE_CLASS,
     CONF_ICON,
     CONF_NAME,
     CONF_TYPE,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_TEMPERATURE,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_KILO_WATT,
-    TEMP_CELSIUS,
+    CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.helpers.entity import Entity
 
@@ -74,11 +71,6 @@ class DaikinSensor(Entity):
         return f"{self._api.device.mac}-{self._device_attribute}"
 
     @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return self._sensor[CONF_ICON]
-
-    @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
@@ -91,12 +83,17 @@ class DaikinSensor(Entity):
     @property
     def device_class(self):
         """Return the class of this device."""
-        raise NotImplementedError
+        return self._sensor.get(CONF_DEVICE_CLASS)
+
+    @property
+    def icon(self):
+        """Return the icon of this device."""
+        return self._sensor.get(CONF_ICON)
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        raise NotImplementedError
+        return self._sensor[CONF_UNIT_OF_MEASUREMENT]
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -112,16 +109,6 @@ class DaikinClimateSensor(DaikinSensor):
     """Representation of a Climate Sensor."""
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return TEMP_CELSIUS
-
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return DEVICE_CLASS_TEMPERATURE
-
-    @property
     def state(self):
         """Return the internal state of the sensor."""
         if self._device_attribute == ATTR_INSIDE_TEMPERATURE:
@@ -133,20 +120,6 @@ class DaikinClimateSensor(DaikinSensor):
 
 class DaikinPowerSensor(DaikinSensor):
     """Representation of a power/energy consumption sensor."""
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        if self._device_attribute == ATTR_TOTAL_POWER:
-            return POWER_KILO_WATT
-        if self._device_attribute in (ATTR_COOL_ENERGY, ATTR_HEAT_ENERGY):
-            return ENERGY_KILO_WATT_HOUR
-        return None
-
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return DEVICE_CLASS_POWER
 
     @property
     def state(self):

--- a/homeassistant/components/daikin/sensor.py
+++ b/homeassistant/components/daikin/sensor.py
@@ -5,6 +5,8 @@ from homeassistant.const import (
     CONF_ICON,
     CONF_NAME,
     CONF_TYPE,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
     ENERGY_KILO_WATT_HOUR,
     POWER_KILO_WATT,
     TEMP_CELSIUS,
@@ -87,6 +89,11 @@ class DaikinSensor(Entity):
         raise NotImplementedError
 
     @property
+    def device_class(self):
+        """Return the class of this device."""
+        raise NotImplementedError
+
+    @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         raise NotImplementedError
@@ -99,6 +106,29 @@ class DaikinSensor(Entity):
     def device_info(self):
         """Return a device description for device registry."""
         return self._api.device_info
+
+
+class DaikinClimateSensor(DaikinSensor):
+    """Representation of a Climate Sensor."""
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def device_class(self):
+        """Return the class of this device."""
+        return DEVICE_CLASS_TEMPERATURE
+
+    @property
+    def state(self):
+        """Return the internal state of the sensor."""
+        if self._device_attribute == ATTR_INSIDE_TEMPERATURE:
+            return self._api.device.inside_temperature
+        if self._device_attribute == ATTR_OUTSIDE_TEMPERATURE:
+            return self._api.device.outside_temperature
+        return None
 
 
 class DaikinPowerSensor(DaikinSensor):
@@ -114,6 +144,11 @@ class DaikinPowerSensor(DaikinSensor):
         return None
 
     @property
+    def device_class(self):
+        """Return the class of this device."""
+        return DEVICE_CLASS_POWER
+
+    @property
     def state(self):
         """Return the state of the sensor."""
         if self._device_attribute == ATTR_TOTAL_POWER:
@@ -122,22 +157,4 @@ class DaikinPowerSensor(DaikinSensor):
             return self._api.device.last_hour_cool_power_consumption
         if self._device_attribute == ATTR_HEAT_ENERGY:
             return self._api.device.last_hour_heat_power_consumption
-        return None
-
-
-class DaikinClimateSensor(DaikinSensor):
-    """Representation of a Climate Sensor."""
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return TEMP_CELSIUS
-
-    @property
-    def state(self):
-        """Return the internal state of the sensor."""
-        if self._device_attribute == ATTR_INSIDE_TEMPERATURE:
-            return self._api.device.inside_temperature
-        if self._device_attribute == ATTR_OUTSIDE_TEMPERATURE:
-            return self._api.device.outside_temperature
         return None

--- a/homeassistant/components/daikin/sensor.py
+++ b/homeassistant/components/daikin/sensor.py
@@ -1,11 +1,27 @@
 """Support for Daikin AC sensors."""
 import logging
 
-from homeassistant.const import CONF_ICON, CONF_NAME, TEMP_CELSIUS
+from homeassistant.const import (
+    CONF_ICON,
+    CONF_NAME,
+    CONF_TYPE,
+    ENERGY_KILO_WATT_HOUR,
+    POWER_KILO_WATT,
+    TEMP_CELSIUS,
+)
 from homeassistant.helpers.entity import Entity
 
-from . import DOMAIN as DAIKIN_DOMAIN
-from .const import ATTR_INSIDE_TEMPERATURE, ATTR_OUTSIDE_TEMPERATURE, SENSOR_TYPES
+from . import DOMAIN as DAIKIN_DOMAIN, DaikinApi
+from .const import (
+    ATTR_COOL_ENERGY,
+    ATTR_HEAT_ENERGY,
+    ATTR_INSIDE_TEMPERATURE,
+    ATTR_OUTSIDE_TEMPERATURE,
+    ATTR_TOTAL_POWER,
+    SENSOR_TYPE_POWER,
+    SENSOR_TYPE_TEMPERATURE,
+    SENSOR_TYPES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,13 +40,26 @@ async def async_setup_entry(hass, entry, async_add_entities):
     sensors = [ATTR_INSIDE_TEMPERATURE]
     if daikin_api.device.support_outside_temperature:
         sensors.append(ATTR_OUTSIDE_TEMPERATURE)
-    async_add_entities([DaikinClimateSensor(daikin_api, sensor) for sensor in sensors])
+    if daikin_api.device.support_energy_consumption:
+        sensors.append(ATTR_TOTAL_POWER)
+        sensors.append(ATTR_COOL_ENERGY)
+        sensors.append(ATTR_HEAT_ENERGY)
+    async_add_entities([DaikinSensor.factory(daikin_api, sensor) for sensor in sensors])
 
 
-class DaikinClimateSensor(Entity):
+class DaikinSensor(Entity):
     """Representation of a Sensor."""
 
-    def __init__(self, api, monitored_state) -> None:
+    @staticmethod
+    def factory(api: DaikinApi, monitored_state: str):
+        """Initialize any DaikinSensor."""
+        cls = {
+            SENSOR_TYPE_TEMPERATURE: DaikinClimateSensor,
+            SENSOR_TYPE_POWER: DaikinPowerSensor,
+        }[SENSOR_TYPES[monitored_state][CONF_TYPE]]
+        return cls(api, monitored_state)
+
+    def __init__(self, api: DaikinApi, monitored_state: str) -> None:
         """Initialize the sensor."""
         self._api = api
         self._sensor = SENSOR_TYPES[monitored_state]
@@ -55,16 +84,12 @@ class DaikinClimateSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if self._device_attribute == ATTR_INSIDE_TEMPERATURE:
-            return self._api.device.inside_temperature
-        if self._device_attribute == ATTR_OUTSIDE_TEMPERATURE:
-            return self._api.device.outside_temperature
-        return None
+        raise NotImplementedError
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        raise NotImplementedError
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -74,3 +99,45 @@ class DaikinClimateSensor(Entity):
     def device_info(self):
         """Return a device description for device registry."""
         return self._api.device_info
+
+
+class DaikinPowerSensor(DaikinSensor):
+    """Representation of a power/energy consumption sensor."""
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        if self._device_attribute == ATTR_TOTAL_POWER:
+            return POWER_KILO_WATT
+        if self._device_attribute in (ATTR_COOL_ENERGY, ATTR_HEAT_ENERGY):
+            return ENERGY_KILO_WATT_HOUR
+        return None
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        if self._device_attribute == ATTR_TOTAL_POWER:
+            return self._api.device.current_total_power_consumption
+        if self._device_attribute == ATTR_COOL_ENERGY:
+            return self._api.device.last_hour_cool_power_consumption
+        if self._device_attribute == ATTR_HEAT_ENERGY:
+            return self._api.device.last_hour_heat_power_consumption
+        return None
+
+
+class DaikinClimateSensor(DaikinSensor):
+    """Representation of a Climate Sensor."""
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def state(self):
+        """Return the internal state of the sensor."""
+        if self._device_attribute == ATTR_INSIDE_TEMPERATURE:
+            return self._api.device.inside_temperature
+        if self._device_attribute == ATTR_OUTSIDE_TEMPERATURE:
+            return self._api.device.outside_temperature
+        return None

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -346,6 +346,7 @@ ATTR_TEMPERATURE = "temperature"
 # #### UNITS OF MEASUREMENT ####
 # Power units
 POWER_WATT = "W"
+POWER_KILO_WATT = f"k{POWER_WATT}"
 
 # Voltage units
 VOLT = "V"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The current Daikin integration does not monitor the power consumption whereas it is published by the AC API. This PR adds sensors for that on top of the existing integration.

This PR focuses on those two AC endpoints:
* the hourly consumption by AC and by mode (updated hourly) watched by the Cool & Heat Energy sensors (kWh).
* the total daily consumption (updated in live) watched by the Total Power sensor (kW) .

To test this feature I had to simulate a real AC power consumption with the `freezegun` package. I would have prefer not to add it in the MANIFEST but I don't any other way to specify test requirements yet (is there one)?

The `pydaikin` package does not publish the power consumption endpoint directly. I had to dynamically add one URL to the watched endpoints.


## Type of change

- [X] Dependency upgrade (testing dependency only)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

Pull request locally tested with 3 Daikin PERFERA Air Conditioners.


## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for www.home-assistant.io (PR: https://github.com/home-assistant/home-assistant.io/pull/13352)

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
