### PR TITLE
Bump plexapi to 3.4.0, remove workarounds

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -39,6 +39,3 @@ X_PLEX_DEVICE_NAME = "Home Assistant"
 X_PLEX_PLATFORM = "Home Assistant"
 X_PLEX_PRODUCT = "Home Assistant"
 X_PLEX_VERSION = __version__
-
-COMMAND_MEDIA_TYPE_MUSIC = "music"
-COMMAND_MEDIA_TYPE_VIDEO = "video"

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -3,7 +3,7 @@
   "name": "Plex Media Server",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/plex",
-  "requirements": ["plexapi==3.3.0", "plexauth==0.0.5", "plexwebsocket==0.0.7"],
+  "requirements": ["plexapi==3.4.0", "plexauth==0.0.5", "plexwebsocket==0.0.7"],
   "dependencies": ["http"],
   "codeowners": ["@jjlawren"]
 }

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -1,7 +1,6 @@
 """Support to interface with the Plex API."""
 import json
 import logging
-from xml.etree.ElementTree import ParseError
 
 import plexapi.exceptions
 import requests.exceptions
@@ -27,8 +26,6 @@ from homeassistant.helpers.entity_registry import async_get_registry
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    COMMAND_MEDIA_TYPE_MUSIC,
-    COMMAND_MEDIA_TYPE_VIDEO,
     COMMON_PLAYERS,
     CONF_SERVER_IDENTIFIER,
     DISPATCHERS,
@@ -563,11 +560,9 @@ class PlexMediaPlayer(MediaPlayerDevice):
         shuffle = src.get("shuffle", 0)
 
         media = None
-        command_media_type = COMMAND_MEDIA_TYPE_VIDEO
 
         if media_type == "MUSIC":
             media = self._get_music_media(library, src)
-            command_media_type = COMMAND_MEDIA_TYPE_MUSIC
         elif media_type == "EPISODE":
             media = self._get_tv_media(library, src)
         elif media_type == "PLAYLIST":
@@ -581,10 +576,7 @@ class PlexMediaPlayer(MediaPlayerDevice):
 
         playqueue = self.plex_server.create_playqueue(media, shuffle=shuffle)
         try:
-            self.device.playMedia(playqueue, type=command_media_type)
-        except ParseError:
-            # Temporary workaround for Plexamp / plexapi issue
-            pass
+            self.device.playMedia(playqueue)
         except requests.exceptions.ConnectTimeout:
             _LOGGER.error("Timed out playing on %s", self.name)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1041,7 +1041,7 @@ pillow==7.1.1
 pizzapi==0.0.3
 
 # homeassistant.components.plex
-plexapi==3.3.0
+plexapi==3.4.0
 
 # homeassistant.components.plex
 plexauth==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -401,7 +401,7 @@ pilight==0.1.1
 pillow==7.1.1
 
 # homeassistant.components.plex
-plexapi==3.3.0
+plexapi==3.4.0
 
 # homeassistant.components.plex
 plexauth==0.0.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `plexapi` library to 3.4.0 and remove previous workarounds for older versions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32686
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
