### PR TITLE
Add Plex play_media logging and troubleshooting tools

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -563,7 +563,7 @@ class PlexMediaPlayer(MediaPlayerDevice):
 
         media_type = media_type.lower()
         src = json.loads(media_id)
-        if media_type == "plex" and isinstance(src, int):
+        if media_type == PLEX_DOMAIN and isinstance(src, int):
             try:
                 media = self.plex_server.fetch_item(src)
             except plexapi.exceptions.NotFound:

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -553,26 +553,42 @@ class PlexMediaPlayer(MediaPlayerDevice):
     def play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
         if not (self.device and "playback" in self._device_protocol_capabilities):
+            _LOGGER.debug(
+                "Client is not currently accepting playback controls: %s", self.name
+            )
             return
 
         src = json.loads(media_id)
-        library = src.get("library_name")
-        shuffle = src.get("shuffle", 0)
+        if media_type == "KEY" and isinstance(src, int):
+            try:
+                media = self.plex_server.fetch_item(src)
+            except plexapi.exceptions.NotFound:
+                _LOGGER.error("Media for key %s not found", src)
+                return
+            shuffle = 0
+        else:
+            library = src.get("library_name")
+            shuffle = src.get("shuffle", 0)
+            media = None
 
-        media = None
-
-        if media_type == "MUSIC":
-            media = self._get_music_media(library, src)
-        elif media_type == "EPISODE":
-            media = self._get_tv_media(library, src)
-        elif media_type == "PLAYLIST":
-            media = self.plex_server.playlist(src["playlist_name"])
-        elif media_type == "VIDEO":
-            media = self.plex_server.library.section(library).get(src["video_name"])
+        try:
+            if media_type == "MUSIC":
+                media = self._get_music_media(library, src)
+            elif media_type == "EPISODE":
+                media = self._get_tv_media(library, src)
+            elif media_type == "PLAYLIST":
+                media = self.plex_server.playlist(src["playlist_name"])
+            elif media_type == "VIDEO":
+                media = self.plex_server.library.section(library).get(src["video_name"])
+        except plexapi.exceptions.NotFound:
+            _LOGGER.error("Media could not be found: %s", media_id)
+            return
 
         if media is None:
             _LOGGER.error("Media could not be found: %s", media_id)
             return
+
+        _LOGGER.debug("Attempting to play %s on %s", media, self.name)
 
         playqueue = self.plex_server.create_playqueue(media, shuffle=shuffle)
         try:

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -7,9 +7,12 @@ import requests.exceptions
 
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_EPISODE,
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
+    MEDIA_TYPE_PLAYLIST,
     MEDIA_TYPE_TVSHOW,
+    MEDIA_TYPE_VIDEO,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
@@ -558,8 +561,9 @@ class PlexMediaPlayer(MediaPlayerDevice):
             )
             return
 
+        media_type = media_type.lower()
         src = json.loads(media_id)
-        if media_type == "KEY" and isinstance(src, int):
+        if media_type == "plex" and isinstance(src, int):
             try:
                 media = self.plex_server.fetch_item(src)
             except plexapi.exceptions.NotFound:
@@ -572,13 +576,13 @@ class PlexMediaPlayer(MediaPlayerDevice):
             media = None
 
         try:
-            if media_type == "MUSIC":
+            if media_type == MEDIA_TYPE_MUSIC:
                 media = self._get_music_media(library, src)
-            elif media_type == "EPISODE":
+            elif media_type == MEDIA_TYPE_EPISODE:
                 media = self._get_tv_media(library, src)
-            elif media_type == "PLAYLIST":
+            elif media_type == MEDIA_TYPE_PLAYLIST:
                 media = self.plex_server.playlist(src["playlist_name"])
-            elif media_type == "VIDEO":
+            elif media_type == MEDIA_TYPE_VIDEO:
                 media = self.plex_server.library.section(library).get(src["video_name"])
         except plexapi.exceptions.NotFound:
             _LOGGER.error("Media could not be found: %s", media_id)

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -332,3 +332,7 @@ class PlexServer:
     def create_playqueue(self, media, **kwargs):
         """Create playqueue on Plex server."""
         return plexapi.playqueue.PlayQueue.create(self._plex_server, media, **kwargs)
+
+    def fetch_item(self, item):
+        """Fetch item from Plex server."""
+        return self._plex_server.fetchItem(item)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many of the issues raised for the Plex component relate to the `media_player.play_media` service and (usually silent) failures. Many of these failures are networking setups or lack of client support, but it's always difficult to be certain. This PR adds a few things to improve troubleshooting abilities:

1. Explicit logging when the client does not support playback controls.
2. Logging of the specific media found immediately before playback is requested (in case nothing happens).
3. Use of an improved exception in the `plexapi` library when media lookup fails.
4. Accept a new `media_content_type` named "KEY". Instead of the existing escaped JSON required for `media_content_id`, this allows a user to specify a plain integer associated with the media by the Plex server. This can be found via Plex Web by going to Get Info -> View XML on the media and looking for `ratingKey`.

Existing style:
```
entity_id: media_player.plex_player
media_content_type: MUSIC
media_content_id: '{"library_name": "Music", "artist_name": "Stevie Wonder", "album_name": "Innervisions"}'
```
"Key" style:
```
entity_id: media_player.plex_player
media_content_type: KEY
media_content_id: 54
```
I do _not_ intend to document the "key" style at the moment as its use is currently intended for troubleshooting purposes. However, this could become useful in the future if https://github.com/home-assistant/architecture/issues/331 is implemented.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
