### PR TITLE
Fix translations merging

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -110,9 +110,7 @@ def build_resources(
             continue
 
         if isinstance(new_value, dict):
-            domain_resources.setdefault(category, {}).update(
-                new_value
-            )
+            domain_resources.setdefault(category, {}).update(new_value)
         else:
             domain_resources[category] = new_value
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -111,10 +111,10 @@ def build_resources(
 
         if isinstance(new_value, dict):
             domain_resources.setdefault(category, {}).update(
-                translation_cache[component][category]
+                new_value
             )
         else:
-            domain_resources[category] = translation_cache[component][category]
+            domain_resources[category] = new_value
 
     return {"component": resources}
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -104,12 +104,17 @@ def build_resources(
             domain_resources.update(translation_cache[component])
             continue
 
-        if category not in translation_cache[component]:
+        new_value = translation_cache[component].get(category)
+
+        if new_value is None:
             continue
 
-        domain_resources.setdefault(category, {}).update(
-            translation_cache[component][category]
-        )
+        if isinstance(new_value, dict):
+            domain_resources.setdefault(category, {}).update(
+                translation_cache[component][category]
+            )
+        else:
+            domain_resources[category] = translation_cache[component][category]
 
     return {"component": resources}
 

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -192,3 +192,17 @@ async def test_get_translations_while_loading_components(hass):
         "component.component1.title": "Component 1",
         "component.component1.hello": "world",
     }
+
+
+async def test_get_translation_titles_for_config_flow(hass):
+    """Test the get translations helper loads config flow translations."""
+    with patch.object(translation, "async_get_config_flows", return_value={"light"}):
+        translations = await translation.async_get_translations(
+            hass, "en", "title", None, True
+        )
+        assert "component.light.title" in translations
+
+        translations = await translation.async_get_translations(
+            hass, "en", "device_automation", None, True
+        )
+        assert "component.light.device_automation.action_type.turn_on" in translations

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -194,7 +194,7 @@ async def test_get_translations_while_loading_components(hass):
     }
 
 
-async def test_get_translation_titles_for_config_flow(hass):
+async def test_get_translation_categories(hass):
     """Test the get translations helper loads config flow translations."""
     with patch.object(translation, "async_get_config_flows", return_value={"light"}):
         translations = await translation.async_get_translations(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix translation merging if category contains just a string, not a dict.

There is still the issue that merging translations from ie `sensor/strings.json` and `moon/strings.sensor.json` will be permanently written to the `sensor/strings.json` cache. That is for another PR as that is an existing bug.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
