### PR TITLE
Add set_central_heating_ovrd service to opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -133,9 +133,7 @@ def register_services(hass):
             vol.Required(ATTR_GW_ID): vol.All(
                 cv.string, vol.In(hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS])
             ),
-            vol.Required(ATTR_CH_OVRD): vol.All(
-                vol.Coerce(int), vol.Range(min=0, max=1)
-            ),
+            vol.Required(ATTR_CH_OVRD): cv.boolean,
         }
     )
     service_set_clock_schema = vol.Schema(
@@ -248,7 +246,7 @@ def register_services(hass):
     async def set_ch_ovrd(call):
         """Set the central heating override on the OpenTherm Gateway."""
         gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        await gw_dev.gateway.set_ch_enable_bit(call.data[ATTR_CH_OVRD])
+        await gw_dev.gateway.set_ch_enable_bit(1 if call.data[ATTR_CH_OVRD] else 0)
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -248,9 +248,7 @@ def register_services(hass):
     async def set_ch_ovrd(call):
         """Set the central heating override on the OpenTherm Gateway."""
         gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        hass.async_create_task(
-            gw_dev.gateway.set_ch_enable_bit(call.data[ATTR_CH_OVRD])
-        )
+        await gw_dev.gateway.set_ch_enable_bit(call.data[ATTR_CH_OVRD])
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/opentherm_gw/const.py
+++ b/homeassistant/components/opentherm_gw/const.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
 ATTR_GW_ID = "gateway_id"
 ATTR_LEVEL = "level"
 ATTR_DHW_OVRD = "dhw_override"
+ATTR_CH_OVRD = "ch_override"
 
 CONF_CLIMATE = "climate"
 CONF_FLOOR_TEMP = "floor_temperature"
@@ -27,6 +28,7 @@ DEVICE_CLASS_PROBLEM = "problem"
 DOMAIN = "opentherm_gw"
 
 SERVICE_RESET_GATEWAY = "reset_gateway"
+SERVICE_SET_CH_OVRD = "set_central_heating_ovrd"
 SERVICE_SET_CLOCK = "set_clock"
 SERVICE_SET_CONTROL_SETPOINT = "set_control_setpoint"
 SERVICE_SET_HOT_WATER_OVRD = "set_hot_water_ovrd"

--- a/homeassistant/components/opentherm_gw/services.yaml
+++ b/homeassistant/components/opentherm_gw/services.yaml
@@ -20,8 +20,8 @@ set_central_heating_ovrd:
       example: "opentherm_gateway"
     ch_override:
       description: >
-        The desired value for the central heating override. Use 0 to disable or 1 to enable.
-      example: "1"
+        The desired boolean value for the central heating override.
+      example: "on"
 
 set_clock:
   description: Set the clock and day of the week on the connected thermostat.

--- a/homeassistant/components/opentherm_gw/services.yaml
+++ b/homeassistant/components/opentherm_gw/services.yaml
@@ -7,6 +7,22 @@ reset_gateway:
       description: The gateway_id of the OpenTherm Gateway.
       example: "opentherm_gateway"
 
+set_central_heating_ovrd:
+  description: >
+    Set the central heating override option on the gateway.
+    When overriding the control setpoint (via a set_control_setpoint service call with a value other than 0), the gateway automatically enables the central heating override to start heating.
+    This service can then be used to control the central heating override status.
+    To return control of the central heating to the thermostat, call the set_control_setpoint service with temperature value 0.
+    You will only need this if you are writing your own software thermostat.
+  fields:
+    gateway_id:
+      description: The gateway_id of the OpenTherm Gateway.
+      example: "opentherm_gateway"
+    ch_override:
+      description: >
+        The desired value for the central heating override. Use 0 to disable or 1 to enable.
+      example: "1"
+
 set_clock:
   description: Set the clock and day of the week on the connected thermostat.
   fields:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `opentherm_gw.set_central_heating_ovrd` service to allow for more fine-grained control of the heating system. This feature has been requested a few times in the past, but never got implemented until now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24632
- This PR is related to issue: #24632
- Link to documentation pull request: home-assistant/home-assistant.io#13082 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
