### PR TITLE
Fix setting up multiple UPSes with NUT in 0.108.x

### DIFF
--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -99,7 +99,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _host_port_alias_already_configured(self, host, port, alias):
         """See if we already have a nut entry matching user input configured."""
         existing_host_port_aliases = {
-            _format_host_port_alias(host, port, alias)
+            _format_host_port_alias(
+                entry.data[CONF_HOST], entry.data[CONF_PORT], entry.data.get(CONF_ALIAS)
+            )
             for entry in self._async_current_entries()
         }
         return _format_host_port_alias(host, port, alias) in existing_host_port_aliases

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -4,6 +4,8 @@ from asynctest import MagicMock, patch
 from homeassistant import config_entries, setup
 from homeassistant.components.nut.const import DOMAIN
 
+from tests.common import MockConfigEntry
+
 
 def _get_mock_pynutclient(list_vars=None):
     pynutclient = MagicMock()
@@ -62,6 +64,12 @@ async def test_form_import(hass):
     """Test we get the form with import source."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "2.2.2.2", "port": 123, "resources": ["battery.charge"]},
+    )
+    config_entry.add_to_hass(hass)
+
     mock_pynut = _get_mock_pynutclient(list_vars={"battery.voltage": "serial"})
 
     with patch(
@@ -92,7 +100,7 @@ async def test_form_import(hass):
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 2
 
 
 async def test_form_cannot_connect(hass):


### PR DESCRIPTION
**This code is no longer present in dev 0.109.x so this PR was sent to master so there isn't a conflict during cherry-pick**. If there is a better way to do this I'll adjust.

This is already fixed in 0.109, however the original fix
never made it back to 0.108 as it wasn't back-portable because the code had changed.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix setting up multiple UPSes in 0.108.x. (0.109 dev does not have this issue)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34411
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
