### PR TITLE
Add foundation for state translations

### DIFF
--- a/homeassistant/components/ebusd/strings.json
+++ b/homeassistant/components/ebusd/strings.json
@@ -1,6 +1,0 @@
-{
-  "state": {
-    "day": "Day",
-    "night": "Night"
-  }
-}

--- a/homeassistant/components/moon/.translations/sensor.en.json
+++ b/homeassistant/components/moon/.translations/sensor.en.json
@@ -1,12 +1,14 @@
 {
     "state": {
-        "first_quarter": "First quarter",
-        "full_moon": "Full moon",
-        "last_quarter": "Last quarter",
-        "new_moon": "New moon",
-        "waning_crescent": "Waning crescent",
-        "waning_gibbous": "Waning gibbous",
-        "waxing_crescent": "Waxing crescent",
-        "waxing_gibbous": "Waxing gibbous"
+        "moon__phase": {
+            "first_quarter": "First quarter",
+            "full_moon": "Full moon",
+            "last_quarter": "Last quarter",
+            "new_moon": "New moon",
+            "waning_crescent": "Waning crescent",
+            "waning_gibbous": "Waning gibbous",
+            "waxing_crescent": "Waxing crescent",
+            "waxing_gibbous": "Waxing gibbous"
+        }
     }
 }

--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -56,8 +56,13 @@ class MoonSensor(Entity):
 
     @property
     def name(self):
-        """Return the name of the device."""
+        """Return the name of the entity."""
         return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class of the entity."""
+        return "moon__phase"
 
     @property
     def state(self):

--- a/homeassistant/components/moon/strings.sensor.json
+++ b/homeassistant/components/moon/strings.sensor.json
@@ -1,12 +1,14 @@
 {
   "state": {
-    "new_moon": "New moon",
-    "waxing_crescent": "Waxing crescent",
-    "first_quarter": "First quarter",
-    "waxing_gibbous": "Waxing gibbous",
-    "full_moon": "Full moon",
-    "waning_gibbous": "Waning gibbous",
-    "last_quarter": "Last quarter",
-    "waning_crescent": "Waning crescent"
+    "moon__phase": {
+      "new_moon": "New moon",
+      "waxing_crescent": "Waxing crescent",
+      "first_quarter": "First quarter",
+      "waxing_gibbous": "Waxing gibbous",
+      "full_moon": "Full moon",
+      "waning_gibbous": "Waning gibbous",
+      "last_quarter": "Last quarter",
+      "waning_crescent": "Waning crescent"
+    }
   }
 }

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -117,7 +117,7 @@ class UserOnboardingView(_BaseOnboardingView):
 
             # Create default areas using the users supplied language.
             translations = await hass.helpers.translation.async_get_translations(
-                data["language"], integration=DOMAIN
+                data["language"], "area", DOMAIN
             )
 
             area_registry = await hass.helpers.area_registry.async_get_registry()

--- a/homeassistant/components/season/.translations/sensor.en.json
+++ b/homeassistant/components/season/.translations/sensor.en.json
@@ -1,8 +1,10 @@
 {
     "state": {
-        "autumn": "Autumn",
-        "spring": "Spring",
-        "summer": "Summer",
-        "winter": "Winter"
+        "season__season": {
+            "autumn": "Autumn",
+            "spring": "Spring",
+            "summer": "Summer",
+            "winter": "Winter"
+        }
     }
 }

--- a/homeassistant/components/season/sensor.py
+++ b/homeassistant/components/season/sensor.py
@@ -132,6 +132,11 @@ class Season(Entity):
         return self.season
 
     @property
+    def device_class(self):
+        """Return the device class."""
+        return "season__season"
+
+    @property
     def icon(self):
         """Icon to use in the frontend, if any."""
         return SEASON_ICONS.get(self.season, "mdi:cloud")

--- a/homeassistant/components/season/strings.sensor.json
+++ b/homeassistant/components/season/strings.sensor.json
@@ -1,8 +1,10 @@
 {
   "state": {
-    "spring": "Spring",
-    "summer": "Summer",
-    "autumn": "Autumn",
-    "winter": "Winter"
+    "season__season": {
+      "spring": "Spring",
+      "summer": "Summer",
+      "autumn": "Autumn",
+      "winter": "Winter"
+    }
   }
 }

--- a/script/translations/lokalise.py
+++ b/script/translations/lokalise.py
@@ -3,11 +3,10 @@ from pprint import pprint
 
 import requests
 
-from .const import CORE_PROJECT_ID
 from .util import get_lokalise_token
 
 
-def get_api(project_id=CORE_PROJECT_ID, debug=False) -> "Lokalise":
+def get_api(project_id, debug=False) -> "Lokalise":
     """Get Lokalise API."""
     return Lokalise(project_id, get_lokalise_token(), debug)
 

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -11,8 +11,6 @@ import homeassistant.helpers.translation as translation
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro
-
 
 @pytest.fixture
 def mock_config_flows():
@@ -146,7 +144,7 @@ async def test_get_translations_loads_config_flows(hass, mock_config_flows):
     integration.name = "Component 1"
 
     with patch.object(
-        translation, "component_translation_path", return_value=mock_coro("bla.json")
+        translation, "component_translation_path", return_value="bla.json"
     ), patch.object(
         translation,
         "load_translations_files",
@@ -179,7 +177,7 @@ async def test_get_translations_while_loading_components(hass):
         return {"component1": {"hello": "world"}}
 
     with patch.object(
-        translation, "component_translation_path", return_value=mock_coro("bla.json")
+        translation, "component_translation_path", return_value="bla.json"
     ), patch.object(
         translation, "load_translations_files", side_effect=mock_load_translation_files,
     ), patch(
@@ -223,7 +221,7 @@ async def test_translation_merging(hass, caplog):
     hass.config.components.add("sensor.bad_translations")
 
     with patch.object(
-        translation, "component_translation_path", return_value=mock_coro("bla.json")
+        translation, "component_translation_path", return_value="bla.json"
     ), patch.object(
         translation,
         "load_translations_files",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the foundation for managing state translations in the backend as per [Translations 2.0](https://github.com/home-assistant/core/issues/34264).

Recap of the problem: there are integrations like moon, and season that want to translate their states in the UI. They are defined in the backend and so this is where the translations need to live. 

Original plan was to force such integrations to live under their own domain. So `moon.phase` and `season.season`. These sensors won't have a device class, so with the new state format this would end up as:

```json5
// moon/strings.json
{
  "state": {
    "default": {
      "first_quarter": "First Quarter",
      // ...
    }
  }
}
```

However, this makes it a lot more difficult for people to contribute these sensors, as they need to create entity component, entity platform. It also means that it's still unclear what these entities do for external systems.

So instead, we're going to allow these entities to stay the same, but we're going to add special device classes. These are unofficial, and so only are used to provide translations. You cannot override official translations because those are standardized.

Custom device classes will need to be prefixed with the `<domain>__`. Hassfest is updated to check for this. For custom components it's currently a warning but will become an error in a release or two.

This also updates the merging code in translations helper to be slightly faster and no longer change the original value.

Note, these new states for moon/season are not used yet. They will be used once I migrate the frontend too. Which is going to be the next step together with migrating the existing state translations from backend to frontend.

When merged, we should also rename the keys for moon and sensor to new name.

Dev docs update will come once all translation tasks are done.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
