### PR TITLE
UniFi - Logs spam with not adding disabled entity

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -120,6 +120,7 @@ def add_entities(controller, async_add_entities):
 class UniFiClientTracker(UniFiClient, ScannerEntity):
     """Representation of a network client."""
 
+    DOMAIN = DOMAIN
     TYPE = CLIENT_TRACKER
 
     def __init__(self, client, controller):
@@ -241,12 +242,13 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
 class UniFiDeviceTracker(UniFiBase, ScannerEntity):
     """Representation of a network infrastructure device."""
 
+    DOMAIN = DOMAIN
     TYPE = DEVICE_TRACKER
 
     def __init__(self, device, controller):
         """Set up tracked device."""
-        super().__init__(controller)
         self.device = device
+        super().__init__(controller)
 
     @property
     def mac(self):

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -53,6 +53,8 @@ def add_entities(controller, async_add_entities):
 class UniFiBandwidthSensor(UniFiClient):
     """UniFi bandwidth sensor base class."""
 
+    DOMAIN = DOMAIN
+
     @property
     def name(self) -> str:
         """Return the name of the client."""

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -138,6 +138,7 @@ def add_entities(controller, async_add_entities, switches_off):
 class UniFiPOEClientSwitch(UniFiClient, SwitchDevice, RestoreEntity):
     """Representation of a client that uses POE."""
 
+    DOMAIN = DOMAIN
     TYPE = POE_SWITCH
 
     def __init__(self, client, controller):
@@ -232,6 +233,7 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchDevice, RestoreEntity):
 class UniFiBlockClientSwitch(UniFiClient, SwitchDevice):
     """Representation of a blockable client."""
 
+    DOMAIN = DOMAIN
     TYPE = BLOCK_SWITCH
 
     @property

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -36,8 +36,8 @@ class UniFiClient(UniFiBase):
 
     def __init__(self, client, controller) -> None:
         """Set up client."""
-        super().__init__(controller)
         self.client = client
+        super().__init__(controller)
 
         self._is_wired = self.client.mac not in controller.wireless_clients
         self.is_blocked = self.client.blocked

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -13,7 +13,10 @@ class UniFiBase(Entity):
     TYPE = ""
 
     def __init__(self, controller) -> None:
-        """Set up UniFi entity base."""
+        """Set up UniFi entity base.
+
+        Register mac to controller entities to cover disabled entities.
+        """
         self.controller = controller
         self.controller.entities[self.DOMAIN][self.TYPE].add(self.mac)
 
@@ -33,7 +36,7 @@ class UniFiBase(Entity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect object when removed."""
-        self.controller.entities[self.platform.domain][self.TYPE].remove(self.mac)
+        self.controller.entities[self.DOMAIN][self.TYPE].remove(self.mac)
 
     async def async_remove(self):
         """Clean up when removing entity.

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -9,11 +9,13 @@ from homeassistant.helpers.entity_registry import async_entries_for_device
 class UniFiBase(Entity):
     """UniFi entity base class."""
 
+    DOMAIN = ""
     TYPE = ""
 
     def __init__(self, controller) -> None:
         """Set up UniFi entity base."""
         self.controller = controller
+        self.controller.entities[self.DOMAIN][self.TYPE].add(self.mac)
 
     @property
     def mac(self):
@@ -22,7 +24,6 @@ class UniFiBase(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""
-        self.controller.entities[self.platform.domain][self.TYPE].add(self.mac)
         for signal, method in (
             (self.controller.signal_reachable, self.async_update_callback),
             (self.controller.signal_options_update, self.options_updated),


### PR DESCRIPTION
…retty

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After the entity management refactor there was no control to catch added entities that are disabled, since registering added entities is done first in added_to_hass that would never happen on disabled entities, moving it to init solves this issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
