### PR TITLE
Migrate HomeKit to use describe_event for logbook support

### DIFF
--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -2,6 +2,7 @@
   "domain": "homekit",
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
-  "requirements": ["HAP-python==2.8.2","fnvhash==0.1.0"],
-  "codeowners": ["@bdraco"]
+  "requirements": ["HAP-python==2.8.2", "fnvhash==0.1.0"],
+  "codeowners": ["@bdraco"],
+  "after_dependencies": ["logbook"]
 }

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -8,12 +8,6 @@ from sqlalchemy.exc import SQLAlchemyError
 import voluptuous as vol
 
 from homeassistant.components import sun
-from homeassistant.components.homekit.const import (
-    ATTR_DISPLAY_NAME,
-    ATTR_VALUE,
-    DOMAIN as DOMAIN_HOMEKIT,
-    EVENT_HOMEKIT_CHANGED,
-)
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.recorder.models import Events, States
 from homeassistant.components.recorder.util import (
@@ -26,7 +20,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_HIDDEN,
     ATTR_NAME,
-    ATTR_SERVICE,
     CONF_EXCLUDE,
     CONF_INCLUDE,
     EVENT_AUTOMATION_TRIGGERED,
@@ -89,7 +82,6 @@ ALL_EVENT_TYPES = [
     EVENT_LOGBOOK_ENTRY,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
-    EVENT_HOMEKIT_CHANGED,
     EVENT_AUTOMATION_TRIGGERED,
     EVENT_SCRIPT_STARTED,
 ]
@@ -324,24 +316,6 @@ def humanify(hass, events):
                     "context_user_id": event.context.user_id,
                 }
 
-            elif event.event_type == EVENT_HOMEKIT_CHANGED:
-                data = event.data
-                entity_id = data.get(ATTR_ENTITY_ID)
-                value = data.get(ATTR_VALUE)
-
-                value_msg = f" to {value}" if value else ""
-                message = f"send command {data[ATTR_SERVICE]}{value_msg} for {data[ATTR_DISPLAY_NAME]}"
-
-                yield {
-                    "when": event.time_fired,
-                    "name": "HomeKit",
-                    "message": message,
-                    "domain": DOMAIN_HOMEKIT,
-                    "entity_id": entity_id,
-                    "context_id": event.context.id,
-                    "context_user_id": event.context.user_id,
-                }
-
             elif event.event_type == EVENT_AUTOMATION_TRIGGERED:
                 yield {
                     "when": event.time_fired,
@@ -497,9 +471,6 @@ def _keep_event(hass, event, entities_filter):
 
     elif event.event_type in hass.data.get(DOMAIN, {}):
         domain = hass.data[DOMAIN][event.event_type][0]
-
-    elif event.event_type == EVENT_HOMEKIT_CHANGED:
-        domain = DOMAIN_HOMEKIT
 
     if not entity_id and domain:
         entity_id = f"{domain}."

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -1,0 +1,54 @@
+"""Test HomeKit initialization."""
+from asynctest import patch
+
+from homeassistant import core as ha
+from homeassistant.components import logbook
+from homeassistant.components.homekit.const import (
+    ATTR_DISPLAY_NAME,
+    ATTR_VALUE,
+    DOMAIN as DOMAIN_HOMEKIT,
+    EVENT_HOMEKIT_CHANGED,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_SERVICE
+from homeassistant.setup import async_setup_component
+
+
+async def test_humanify_homekit_changed_event(hass, hk_driver):
+    """Test humanifying HomeKit changed event."""
+    with patch("homeassistant.components.homekit.HomeKit"):
+        assert await async_setup_component(hass, "homekit", {"homekit": {}})
+
+    event1, event2 = list(
+        logbook.humanify(
+            hass,
+            [
+                ha.Event(
+                    EVENT_HOMEKIT_CHANGED,
+                    {
+                        ATTR_ENTITY_ID: "lock.front_door",
+                        ATTR_DISPLAY_NAME: "Front Door",
+                        ATTR_SERVICE: "lock",
+                    },
+                ),
+                ha.Event(
+                    EVENT_HOMEKIT_CHANGED,
+                    {
+                        ATTR_ENTITY_ID: "cover.window",
+                        ATTR_DISPLAY_NAME: "Window",
+                        ATTR_SERVICE: "set_cover_position",
+                        ATTR_VALUE: 75,
+                    },
+                ),
+            ],
+        )
+    )
+
+    assert event1["name"] == "HomeKit"
+    assert event1["domain"] == DOMAIN_HOMEKIT
+    assert event1["message"] == "send command lock for Front Door"
+    assert event1["entity_id"] == "lock.front_door"
+
+    assert event2["name"] == "HomeKit"
+    assert event2["domain"] == DOMAIN_HOMEKIT
+    assert event2["message"] == "send command set_cover_position to 75 for Window"
+    assert event2["entity_id"] == "cover.window"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR switches HomeKit to use `logbook.async_describe_event` instead of Logbook having hardcoded support for it.

This was causing an issue when setting up Alexa, which would import logbook to describe its event, but then would crash on HomeKits dependency not being installed. I noticed this because HomeKit got a new dependency which my dev env didn't have.

```
2020-04-20 16:34:09 ERROR (MainThread) [homeassistant.setup] Error during setup of component alexa
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/setup.py", line 171, in _async_setup_component
    hass, processed_config
  File "/Users/paulus/dev/hass/core/homeassistant/components/alexa/__init__.py", line 103, in async_setup
    hass.components.logbook.async_describe_event(
  File "/Users/paulus/dev/hass/core/homeassistant/loader.py", line 465, in __getattr__
    component: Optional[ModuleType] = integration.get_component()
  File "/Users/paulus/dev/hass/core/homeassistant/loader.py", line 270, in get_component
    cache[self.domain] = importlib.import_module(self.pkg_path)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/paulus/dev/hass/core/homeassistant/components/logbook/__init__.py", line 11, in <module>
    from homeassistant.components.homekit.const import (
  File "/Users/paulus/dev/hass/core/homeassistant/components/homekit/__init__.py", line 34, in <module>
    from .aidmanager import AccessoryAidStorage
  File "/Users/paulus/dev/hass/core/homeassistant/components/homekit/aidmanager.py", line 16, in <module>
    from fnvhash import fnv1a_32
ModuleNotFoundError: No module named 'fnvhash'
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
