### PR TITLE
Enable tracing support for Sentry

### DIFF
--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -1,5 +1,6 @@
 """The sentry integration."""
 import logging
+from typing import Any, Optional
 
 import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -11,12 +12,68 @@ from homeassistant.const import __version__
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN
+from .const import (
+    CONF_DSN,
+    CONF_ENVIRONMENT,
+    CONF_TRACING,
+    CONF_TRACING_SAMPLE_RATE,
+    DOMAIN,
+)
+
+
+def _get_integrations() -> list:
+    """Detect available Sentry integrations.
+
+    Return a list of enabled integrations based on modules available.
+    """
+    integrations = []
+
+    try:
+        import sqlalchemy  # NOQA
+        from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+    except ImportError:
+        pass
+    else:
+        integrations.append(SqlalchemyIntegration())
+
+    try:
+        import aiohttp  # NOQA
+        from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+    except ImportError:
+        pass
+    else:
+        integrations.append(AioHttpIntegration())
+
+    return integrations
+
+
+def sample_rate(value: Optional[Any]) -> float:
+    """Validate sample_rate float between 0.0 and 1.0.
+
+    None coerced to 1.0
+    """
+    if value is None:
+        return 1.0
+    try:
+        float_value = float(value)
+        if float_value < 0.0 or float_value > 1.0:
+            raise vol.Invalid(
+                "Invalid sample_rate value. float >= 0.0 and <= 1.0 required."
+            )
+        return float_value
+    except Exception as err:
+        raise vol.Invalid(f"Invalid sample_rate value: {err}")
+
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {vol.Required(CONF_DSN): cv.string, CONF_ENVIRONMENT: cv.string}
+            {
+                vol.Required(CONF_DSN): cv.string,
+                CONF_ENVIRONMENT: cv.string,
+                CONF_TRACING: cv.boolean,
+                CONF_TRACING_SAMPLE_RATE: sample_rate,
+            }
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -42,16 +99,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN] = conf
 
-    # https://docs.sentry.io/platforms/python/logging/
-    sentry_logging = LoggingIntegration(
-        level=logging.INFO,  # Capture info and above as breadcrumbs
-        event_level=logging.ERROR,  # Send errors as events
-    )
+    with_tracing = conf.get(CONF_TRACING)
 
     sentry_sdk.init(
         dsn=conf.get(CONF_DSN),
         environment=conf.get(CONF_ENVIRONMENT),
-        integrations=[sentry_logging],
+        integrations=[
+            # https://docs.sentry.io/platforms/python/logging/
+            LoggingIntegration(
+                level=logging.INFO,  # Capture info and above as breadcrumbs
+                event_level=logging.ERROR,  # Send errors as events
+            ),
+            *_get_integrations(),
+        ],
+        traces_sample_rate=(
+            conf.get(CONF_TRACING_SAMPLE_RATE, 1.0) or 0.0 if with_tracing else 0.0
+        ),
+        traceparent_v2=with_tracing,
         release=f"homeassistant-{__version__}",
     )
 

--- a/homeassistant/components/sentry/const.py
+++ b/homeassistant/components/sentry/const.py
@@ -4,3 +4,5 @@ DOMAIN = "sentry"
 
 CONF_DSN = "dsn"
 CONF_ENVIRONMENT = "environment"
+CONF_TRACING = "tracing"
+CONF_TRACING_SAMPLE_RATE = "tracing_sample_rate"

--- a/homeassistant/components/sentry/manifest.json
+++ b/homeassistant/components/sentry/manifest.json
@@ -3,6 +3,6 @@
   "name": "Sentry",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sentry",
-  "requirements": ["sentry-sdk==0.13.5"],
+  "requirements": ["sentry-sdk==0.14.3"],
   "codeowners": ["@dcramer"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1866,7 +1866,7 @@ sense-hat==2.2.0
 sense_energy==0.7.1
 
 # homeassistant.components.sentry
-sentry-sdk==0.13.5
+sentry-sdk==0.14.3
 
 # homeassistant.components.aquostv
 sharp_aquos_rc==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -709,7 +709,7 @@ samsungtvws[websocket]==1.4.0
 sense_energy==0.7.1
 
 # homeassistant.components.sentry
-sentry-sdk==0.13.5
+sentry-sdk==0.14.3
 
 # homeassistant.components.sighthound
 simplehound==0.3


### PR DESCRIPTION
## Proposed change

This enables some early tracing support for the Sentry SDK, as well as the aiohttp and sqlalchemy integrations.

There may be other relevant integrations, but our goal is to have the SDK eventually safely auto detect and instrument as needed, and these seem like they'd be the most functional.

When tracing is not enabled, the aiohttp and sqlalchemy support will still enable better information capture within those relevant modules.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml to enable tracing
sentry:
  tracing: true
  tracing_sample_rate: 0.25
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Leaving this undocumented as this feature is currently not available to all users in Sentry.