### PR TITLE
Revert removal of JSON validator in hassfest

### DIFF
--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -9,6 +9,7 @@ from . import (
     config_flow,
     coverage,
     dependencies,
+    json,
     manifest,
     services,
     ssdp,
@@ -18,6 +19,7 @@ from . import (
 from .model import Config, Integration
 
 INTEGRATION_PLUGINS = [
+    json,
     codeowners,
     config_flow,
     dependencies,

--- a/script/hassfest/json.py
+++ b/script/hassfest/json.py
@@ -1,0 +1,29 @@
+"""Validate integration JSON files."""
+import json
+from typing import Dict
+
+from .model import Integration
+
+
+def validate_json_files(integration: Integration):
+    """Validate JSON files for integration."""
+    for json_file in integration.path.glob("**/*.json"):
+        if not json_file.is_file():
+            continue
+
+        try:
+            json.loads(json_file.read_text())
+        except json.JSONDecodeError:
+            relative_path = json_file.relative_to(integration.path)
+            integration.add_error("json", f"Invalid JSON file {relative_path}")
+
+    return
+
+
+def validate(integrations: Dict[str, Integration], config):
+    """Handle JSON files inside integrations."""
+    for integration in integrations.values():
+        if not integration.manifest:
+            continue
+
+        validate_json_files(integration)

--- a/script/hassfest/json.py
+++ b/script/hassfest/json.py
@@ -22,6 +22,9 @@ def validate_json_files(integration: Integration):
 
 def validate(integrations: Dict[str, Integration], config):
     """Handle JSON files inside integrations."""
+    if not config.specific_integrations:
+        return
+
     for integration in integrations.values():
         if not integration.manifest:
             continue


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With the ability of running Hassfest using a GitHub Action, it might be better to keep the basic JSON file validation. It was removed in #34272.

Reasoning: If a custom integration uses the Hassfest GitHub Action, it will get the JSON validation as well.

As a downside, it will add 0.3 seconds (my machine) to our Hassfest run, which IMHO is acceptable.

GitHub Action: <https://github.com/home-assistant/actions/tree/master/hassfest>

CC @balloob 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
