### PR TITLE
Don't log same MQTT message multiple times

### DIFF
--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -24,7 +24,8 @@ def log_messages(hass: HomeAssistantType, entity_id: str) -> MessageCallbackType
         messages = debug_info["entities"][entity_id]["subscriptions"][
             msg.subscribed_topic
         ]
-        messages.append((msg.payload, msg.topic))
+        if msg not in messages:
+            messages.append(msg)
 
     def _decorator(msg_callback: MessageCallbackType):
         @wraps(msg_callback)
@@ -125,7 +126,8 @@ async def info_for_device(hass, device_id):
             {
                 "topic": topic,
                 "messages": [
-                    {"payload": msg[0], "topic": msg[1]} for msg in list(messages)
+                    {"payload": msg.payload, "time": msg.timestamp, "topic": msg.topic}
+                    for msg in list(messages)
                 ],
             }
             for topic, messages in entity_info["subscriptions"].items()

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -1,4 +1,5 @@
 """Modesl used by multiple MQTT modules."""
+import datetime as dt
 from typing import Callable, Union
 
 import attr
@@ -15,6 +16,7 @@ class Message:
     qos = attr.ib(type=int)
     retain = attr.ib(type=bool)
     subscribed_topic = attr.ib(type=str, default=None)
+    timestamp = attr.ib(type=dt.datetime, default=None)
 
 
 MessageCallbackType = Callable[[Message], None]

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the MQTT component."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
 import ssl
 import unittest
@@ -1266,11 +1266,63 @@ async def test_debug_info_wildcard(hass, mqtt_mock):
         "subscriptions"
     ]
 
-    async_fire_mqtt_message(hass, "sensor/abc", "123")
+    start_dt = datetime(2019, 1, 1, 0, 0, 0)
+    with mock.patch("homeassistant.util.dt.utcnow") as dt_utcnow:
+        dt_utcnow.return_value = start_dt
+        async_fire_mqtt_message(hass, "sensor/abc", "123")
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
     assert len(debug_info_data["entities"][0]["subscriptions"]) >= 1
     assert {
         "topic": "sensor/#",
-        "messages": [{"topic": "sensor/abc", "payload": "123"}],
+        "messages": [{"topic": "sensor/abc", "payload": "123", "time": start_dt}],
     } in debug_info_data["entities"][0]["subscriptions"]
+
+
+async def test_debug_info_filter_same(hass, mqtt_mock):
+    """Test debug info removes messages with same timestamp."""
+    config = {
+        "device": {"identifiers": ["helloworld"]},
+        "platform": "mqtt",
+        "name": "test",
+        "state_topic": "sensor/#",
+        "unique_id": "veryunique",
+    }
+
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry.add_to_hass(hass)
+    await async_start(hass, "homeassistant", {}, entry)
+    registry = await hass.helpers.device_registry.async_get_registry()
+
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    assert device is not None
+
+    debug_info_data = await debug_info.info_for_device(hass, device.id)
+    assert len(debug_info_data["entities"][0]["subscriptions"]) >= 1
+    assert {"topic": "sensor/#", "messages": []} in debug_info_data["entities"][0][
+        "subscriptions"
+    ]
+
+    dt1 = datetime(2019, 1, 1, 0, 0, 0)
+    dt2 = datetime(2019, 1, 1, 0, 0, 1)
+    with mock.patch("homeassistant.util.dt.utcnow") as dt_utcnow:
+        dt_utcnow.return_value = dt1
+        async_fire_mqtt_message(hass, "sensor/abc", "123")
+        async_fire_mqtt_message(hass, "sensor/abc", "123")
+        dt_utcnow.return_value = dt2
+        async_fire_mqtt_message(hass, "sensor/abc", "123")
+
+    debug_info_data = await debug_info.info_for_device(hass, device.id)
+    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
+    assert len(debug_info_data["entities"][0]["subscriptions"][0]["messages"]) == 2
+    assert {
+        "topic": "sensor/#",
+        "messages": [
+            {"topic": "sensor/abc", "payload": "123", "time": dt1},
+            {"topic": "sensor/abc", "payload": "123", "time": dt2},
+        ],
+    } == debug_info_data["entities"][0]["subscriptions"][0]


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
An entity may subscribe to the same MQTT topic several times.
For example, an MQTT light may get updates on brightness and color on the same topic.

When this is the case, only log once.

Implemented by adding a timestamp to received MQTT messages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
