### PR TITLE
UniFi - Simplify config option of block clients to just a multi select drop down

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -34,7 +34,6 @@ from .const import (
 from .controller import get_controller
 from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
 
-CONF_NEW_CLIENT = "new_client"
 DEFAULT_PORT = 8443
 DEFAULT_SITE_ID = "default"
 DEFAULT_VERIFY_SSL = False
@@ -230,53 +229,27 @@ class UnifiOptionsFlowHandler(config_entries.OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            new_client = user_input.pop(CONF_NEW_CLIENT, None)
             self.options.update(user_input)
-
-            if new_client:
-                if (
-                    new_client in self.controller.api.clients
-                    or new_client in self.controller.api.clients_all
-                ):
-                    self.options[CONF_BLOCK_CLIENT].append(new_client)
-
-                else:
-                    errors["base"] = "unknown_client_mac"
-
-            else:
-                return await self.async_step_statistics_sensors()
+            return await self.async_step_statistics_sensors()
 
         clients_to_block = {}
 
-        for mac in self.options[CONF_BLOCK_CLIENT]:
-
-            name = None
-
-            for clients in [
-                self.controller.api.clients,
-                self.controller.api.clients_all,
-            ]:
-                if mac in clients:
-                    name = f"{clients[mac].name or clients[mac].hostname} ({mac})"
-                    break
-
-            if not name:
-                name = mac
-
-            clients_to_block[mac] = name
+        for client in self.controller.api.clients.values():
+            clients_to_block[
+                client.mac
+            ] = f"{client.name or client.hostname} ({client.mac})"
 
         return self.async_show_form(
             step_id="client_control",
             data_schema=vol.Schema(
                 {
                     vol.Optional(
+                        CONF_BLOCK_CLIENT, default=self.options[CONF_BLOCK_CLIENT]
+                    ): cv.multi_select(clients_to_block),
+                    vol.Optional(
                         CONF_POE_CLIENTS,
                         default=self.options.get(CONF_POE_CLIENTS, DEFAULT_POE_CLIENTS),
                     ): bool,
-                    vol.Optional(
-                        CONF_BLOCK_CLIENT, default=self.options[CONF_BLOCK_CLIENT]
-                    ): cv.multi_select(clients_to_block),
-                    vol.Optional(CONF_NEW_CLIENT): str,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -41,7 +41,6 @@
       "client_control": {
         "data": {
           "block_client": "Network access controlled clients",
-          "new_client": "Add new client for network access control",
           "poe_clients": "Allow POE control of clients"
         },
         "description": "Configure client controls\n\nCreate switches for serial numbers you want to control network access for.",

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -5,7 +5,6 @@ from asynctest import patch
 from homeassistant import data_entry_flow
 from homeassistant.components import unifi
 from homeassistant.components.unifi import config_flow
-from homeassistant.components.unifi.config_flow import CONF_NEW_CLIENT
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
     CONF_BLOCK_CLIENT,
@@ -293,38 +292,9 @@ async def test_option_flow(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "client_control"
 
-    clients_to_block = hass.config_entries.options._progress[result["flow_id"]].options[
-        CONF_BLOCK_CLIENT
-    ]
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_BLOCK_CLIENT: clients_to_block,
-            CONF_NEW_CLIENT: "00:00:00:00:00:01",
-            CONF_POE_CLIENTS: False,
-        },
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "client_control"
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_BLOCK_CLIENT: clients_to_block,
-            CONF_NEW_CLIENT: "00:00:00:00:00:02",
-        },
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "client_control"
-    assert result["errors"] == {"base": "unknown_client_mac"}
-
-    clients_to_block = hass.config_entries.options._progress[result["flow_id"]].options[
-        CONF_BLOCK_CLIENT
-    ]
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={CONF_BLOCK_CLIENT: clients_to_block},
+        user_input={CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]], CONF_POE_CLIENTS: False},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -343,6 +313,6 @@ async def test_option_flow(hass):
         CONF_DETECTION_TIME: 100,
         CONF_IGNORE_WIRED_BUG: False,
         CONF_POE_CLIENTS: False,
-        CONF_BLOCK_CLIENT: ["00:00:00:00:00:01"],
+        CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
         CONF_ALLOW_BANDWIDTH_SENSORS: True,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify selection of block clients to just a multi select drop down. No manual input of MAC is allowed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
