### PR TITLE
Split iRobot Braava "fan_speed" into seperate options

### DIFF
--- a/homeassistant/components/roomba/braava.py
+++ b/homeassistant/components/roomba/braava.py
@@ -13,9 +13,9 @@ ATTR_TANK_PRESENT = "tank_present"
 ATTR_TANK_LEVEL = "tank_level"
 ATTR_PAD_WETNESS = "spray_amount"
 
-OPTION_MOP_BEHAVIOR = "mop_behavior"
+OPTION_WET_MOP_BEHAVIOR = "wet_mop_behavior"
 OPTION_SPRAY_AMOUNT = "spray_amount"
-BRAAVA_OPTIONS = [OPTION_MOP_BEHAVIOR, OPTION_SPRAY_AMOUNT]
+BRAAVA_OPTIONS = [OPTION_WET_MOP_BEHAVIOR, OPTION_SPRAY_AMOUNT]
 
 OVERLAP_STANDARD = 67
 OVERLAP_DEEP = 85
@@ -50,7 +50,7 @@ class BraavaJet(IRobotVacuum):
         return SUPPORT_BRAAVA
 
     @property
-    def mop_behavior(self):
+    def wet_mop_behavior(self):
         """Return the mop behavior of the vacuum cleaner."""
         rank_overlap = self.vacuum_state.get("rankOverlap", {})
         behavior = None
@@ -63,7 +63,7 @@ class BraavaJet(IRobotVacuum):
         return behavior
 
     @property
-    def mop_behavior_list(self):
+    def wet_mop_behavior_list(self):
         """Return the available mop behaviors of the vacuum cleaner."""
         return BRAAVA_MOP_BEHAVIORS
 
@@ -106,7 +106,7 @@ class BraavaJet(IRobotVacuum):
 
     async def async_set_option(self, option, value):
         """Set option value."""
-        if option == OPTION_MOP_BEHAVIOR:
+        if option == OPTION_WET_MOP_BEHAVIOR:
             if value.capitalize() in BRAAVA_MOP_BEHAVIORS:
                 value = value.capitalize()
             if value not in BRAAVA_MOP_BEHAVIORS:
@@ -143,7 +143,7 @@ class BraavaJet(IRobotVacuum):
         else:
             _LOGGER.error(
                 "Option name error: expected %s or %s, got '%s'",
-                OPTION_MOP_BEHAVIOR,
+                OPTION_WET_MOP_BEHAVIOR,
                 OPTION_SPRAY_AMOUNT,
                 option,
             )

--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -85,3 +85,16 @@ set_fan_speed:
     fan_speed:
       description: Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium' or by percentage, between 0 and 100.
       example: "low"
+
+set_option:
+  description: Set an option of the vacuum cleaner.
+  fields:
+    entity_id:
+      description: Name of the vacuum_entity.
+      example: "vacuum.braava_jet"
+    option:
+      description: Platform dependent vacuum cleaner option name.
+      example: "mop_behavior"
+    value:
+      description: Value of the option to be set.
+      example: "deep"

--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -94,7 +94,7 @@ set_option:
       example: "vacuum.braava_jet"
     option:
       description: Platform dependent vacuum cleaner option name.
-      example: "mop_behavior"
+      example: "wet_mop_behavior"
     value:
       description: Value of the option to be set.
       example: "deep"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Braava support was added in #33616. Currently the mop behavior and spray amount are set together through `fan_speed`. This PR split them into individual options by add `SUPPORT_OPTION` feature and `set_option` service to the `vacuum` component.
![image](https://user-images.githubusercontent.com/7052824/80054269-9ae6bc00-84d3-11ea-8418-851707c48f3d.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Front end PR: [#5596](https://github.com/home-assistant/frontend/pull/5596)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
