### PR TITLE
Limit clone/view stats to repos with push access

### DIFF
--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -133,13 +133,17 @@ class GitHubSensor(Entity):
             ATTR_OPEN_PULL_REQUESTS: self._pull_request_count,
             ATTR_STARGAZERS: self._stargazers,
             ATTR_FORKS: self._forks,
-            ATTR_CLONES: self._clones,
-            ATTR_CLONES_UNIQUE: self._clones_unique,
-            ATTR_VIEWS: self._views,
-            ATTR_VIEWS_UNIQUE: self._views_unique,
         }
         if self._latest_release_tag is not None:
             attrs[ATTR_LATEST_RELEASE_TAG] = self._latest_release_tag
+        if self._clones is not None:
+            attrs[ATTR_CLONES] = self._clones
+        if self._clones_unique is not None:
+            attrs[ATTR_CLONES_UNIQUE] = self._clones_unique
+        if self._views is not None:
+            attrs[ATTR_VIEWS] = self._views
+        if self._views_unique is not None:
+            attrs[ATTR_VIEWS_UNIQUE] = self._views_unique
         return attrs
 
     @property
@@ -244,15 +248,16 @@ class GitHubData:
             if releases and releases.totalCount > 0:
                 self.latest_release_url = releases[0].html_url
 
-            clones = repo.get_clones_traffic()
-            if clones is not None:
-                self.clones = clones.get("count")
-                self.clones_unique = clones.get("uniques")
+            if repo.permissions.push:
+                clones = repo.get_clones_traffic()
+                if clones is not None:
+                    self.clones = clones.get("count")
+                    self.clones_unique = clones.get("uniques")
 
-            views = repo.get_views_traffic()
-            if views is not None:
-                self.views = views.get("count")
-                self.views_unique = views.get("uniques")
+                views = repo.get_views_traffic()
+                if views is not None:
+                    self.views = views.get("count")
+                    self.views_unique = views.get("uniques")
 
             self.available = True
         except self._github.GithubException as err:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The views/clones stats that was added in #33300 require push access to the repo.
This PR, limits the fetching of those stats to only be gathered if the user has push access to the repo.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: github
    access_token: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
    repositories:
      - path: "home-assistant/actions"
      - path: "hacs/bot"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34564
- This PR is related to issue: 
- Link to documentation pull request: 

![image](https://user-images.githubusercontent.com/15093472/80071264-9a3a3e00-8544-11ea-8055-cfbf0ce98ac5.png)
I do not have push access to "home-assistant/core", but have it to "hacs/bot".

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
