### PR TITLE
Improve error handling for Powerwall

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -128,9 +128,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         await hass.async_add_executor_job(power_wall.detect_and_pin_version)
         powerwall_data = await hass.async_add_executor_job(call_base_info, power_wall)
-    except PowerwallError as e:
+    except PowerwallError as err:
         http_session.close()
-        await handle_setup_error(hass, entry, e)
+        await handle_setup_error(hass, entry, err)
         raise ConfigEntryNotReady
 
     await _migrate_old_unique_ids(hass, entry_id, powerwall_data)

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -156,7 +156,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             POWERWALL_OBJECT: power_wall,
             POWERWALL_COORDINATOR: coordinator,
             POWERWALL_HTTP_SESSION: http_session,
-            PowerwallError: None,
+            POWERWALL_ERROR: None,
         }
     )
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -27,9 +27,9 @@ async def validate_input(hass: core.HomeAssistant, data):
         site_info = await hass.async_add_executor_job(power_wall.get_site_info)
     except PowerwallUnreachableError:
         raise CannotConnect
-    except APIChangedError as e:
+    except APIChangedError as err:
         # Only log the exception without the traceback
-        _LOGGER.error(str(e))
+        _LOGGER.error(str(err))
         raise WrongVersion
 
     # Return info that you want to store in the config entry.

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Tesla Powerwall integration."""
 import logging
 
-from tesla_powerwall import APIError, Powerwall, PowerwallUnreachableError
+from tesla_powerwall import APIChangedError, Powerwall, PowerwallUnreachableError
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
@@ -25,8 +25,12 @@ async def validate_input(hass: core.HomeAssistant, data):
     try:
         await hass.async_add_executor_job(power_wall.detect_and_pin_version)
         site_info = await hass.async_add_executor_job(power_wall.get_site_info)
-    except (PowerwallUnreachableError, APIError, ConnectionError):
+    except PowerwallUnreachableError:
         raise CannotConnect
+    except APIChangedError as e:
+        # Only log the exception without the traceback
+        _LOGGER.error(str(e))
+        raise WrongVersion
 
     # Return info that you want to store in the config entry.
     return {"title": site_info.site_name}
@@ -46,6 +50,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
+            except WrongVersion:
+                errors["base"] = "wrong_version"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -69,3 +75,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""
+
+
+class WrongVersion(exceptions.HomeAssistantError):
+    """Error to indicate the powerwall uses a software version we cannot interact with."""

--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -4,7 +4,7 @@ DOMAIN = "powerwall"
 
 POWERWALL_OBJECT = "powerwall"
 POWERWALL_COORDINATOR = "coordinator"
-POWERWALL_ERROR = "error"
+POWERWALL_API_CHANGED = "api_changed"
 
 UPDATE_INTERVAL = 30
 

--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -4,6 +4,7 @@ DOMAIN = "powerwall"
 
 POWERWALL_OBJECT = "powerwall"
 POWERWALL_COORDINATOR = "coordinator"
+POWERWALL_ERROR = "error"
 
 UPDATE_INTERVAL = 30
 
@@ -14,14 +15,6 @@ ATTR_ENERGY_EXPORTED = "energy_exported"
 ATTR_ENERGY_IMPORTED = "energy_imported"
 ATTR_INSTANT_AVERAGE_VOLTAGE = "instant_average_voltage"
 ATTR_NOMINAL_SYSTEM_POWER = "nominal_system_power_kW"
-
-SITE_INFO_UTILITY = "utility"
-SITE_INFO_GRID_CODE = "grid_code"
-SITE_INFO_NOMINAL_SYSTEM_POWER_KW = "nominal_system_power_kW"
-SITE_INFO_NOMINAL_SYSTEM_ENERGY_KWH = "nominal_system_energy_kWh"
-SITE_INFO_REGION = "region"
-
-DEVICE_TYPE_DEVICE_TYPE = "device_type"
 
 STATUS_VERSION = "version"
 
@@ -37,10 +30,6 @@ POWERWALL_API_SITE_INFO = "site_info"
 POWERWALL_API_SERIAL_NUMBERS = "serial_numbers"
 
 POWERWALL_HTTP_SESSION = "http_session"
-
-POWERWALL_GRID_ONLINE = "SystemGridConnected"
-POWERWALL_CONNECTED_KEY = "connected_to_tesla"
-POWERWALL_RUNNING_KEY = "running"
 
 POWERWALL_BATTERY_METER = "battery"
 

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -8,6 +8,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect, please try again",
+      "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved.",
       "unknown": "Unexpected error"
     },
     "abort": { "already_configured": "The powerwall is already configured" }

--- a/homeassistant/components/powerwall/translations/en.json
+++ b/homeassistant/components/powerwall/translations/en.json
@@ -5,7 +5,8 @@
         },
         "error": {
             "cannot_connect": "Failed to connect, please try again",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved."
         },
         "step": {
             "user": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This improves error handling and reporting for when the Powerwall is not available or uses an unknown software version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
