### PR TITLE
Powerwall sensor add is_active, round state attributes and change thresholding for charging status sensor

### DIFF
--- a/homeassistant/components/powerwall/binary_sensor.py
+++ b/homeassistant/components/powerwall/binary_sensor.py
@@ -14,7 +14,6 @@ from .const import (
     ATTR_GRID_CODE,
     ATTR_NOMINAL_SYSTEM_POWER,
     ATTR_REGION,
-    CHARGING_MARGIN_OF_ERROR,
     DOMAIN,
     POWERWALL_API_DEVICE_TYPE,
     POWERWALL_API_GRID_STATUS,
@@ -139,7 +138,7 @@ class PowerWallGridStatusSensor(PowerWallEntity, BinarySensorDevice):
 
 
 class PowerWallChargingStatusSensor(PowerWallEntity, BinarySensorDevice):
-    """Representation of an Powerwall grid status sensor."""
+    """Representation of an Powerwall charging status sensor."""
 
     @property
     def name(self):
@@ -158,10 +157,8 @@ class PowerWallChargingStatusSensor(PowerWallEntity, BinarySensorDevice):
 
     @property
     def is_on(self):
-        """Grid is online."""
-        return (
-            self._coordinator.data[POWERWALL_API_METERS][
-                POWERWALL_BATTERY_METER
-            ].instant_power
-            < CHARGING_MARGIN_OF_ERROR
-        )
+        """Powerwall is charging."""
+        # is_sending_to returns true for values greater than 100 watts
+        return self._coordinator.data[POWERWALL_API_METERS][
+            POWERWALL_BATTERY_METER
+        ].is_sending_to()

--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -10,10 +10,11 @@ UPDATE_INTERVAL = 30
 ATTR_REGION = "region"
 ATTR_GRID_CODE = "grid_code"
 ATTR_FREQUENCY = "frequency"
-ATTR_ENERGY_EXPORTED = "energy_exported"
-ATTR_ENERGY_IMPORTED = "energy_imported"
+ATTR_ENERGY_EXPORTED = "energy_exported_(in_kW)"
+ATTR_ENERGY_IMPORTED = "energy_imported_(in_kW)"
 ATTR_INSTANT_AVERAGE_VOLTAGE = "instant_average_voltage"
 ATTR_NOMINAL_SYSTEM_POWER = "nominal_system_power_kW"
+ATTR_IS_ACTIVE = "is_active"
 
 SITE_INFO_UTILITY = "utility"
 SITE_INFO_GRID_CODE = "grid_code"
@@ -43,11 +44,6 @@ POWERWALL_CONNECTED_KEY = "connected_to_tesla"
 POWERWALL_RUNNING_KEY = "running"
 
 POWERWALL_BATTERY_METER = "battery"
-
-# We only declare charging if they are getting
-# at least 40W incoming as measuring the fields
-# is not an exact science because of interference
-CHARGING_MARGIN_OF_ERROR = -40
 
 MODEL = "PowerWall 2"
 MANUFACTURER = "Tesla"

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -1,7 +1,7 @@
 """Support for August sensors."""
 import logging
 
-from tesla_powerwall import MeterType
+from tesla_powerwall import MeterType, convert_to_kw
 
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
@@ -14,6 +14,7 @@ from .const import (
     ATTR_ENERGY_IMPORTED,
     ATTR_FREQUENCY,
     ATTR_INSTANT_AVERAGE_VOLTAGE,
+    ATTR_IS_ACTIVE,
     DOMAIN,
     ENERGY_KILO_WATT,
     POWERWALL_API_CHARGE,
@@ -143,8 +144,9 @@ class PowerWallEnergySensor(PowerWallEntity):
         """Return the device specific state attributes."""
         meter = self._coordinator.data[POWERWALL_API_METERS].get(self._meter)
         return {
-            ATTR_FREQUENCY: meter.frequency,
-            ATTR_ENERGY_EXPORTED: meter.energy_exported,
-            ATTR_ENERGY_IMPORTED: meter.energy_imported,
-            ATTR_INSTANT_AVERAGE_VOLTAGE: meter.instant_average_voltage,
+            ATTR_FREQUENCY: round(meter.frequency, 1),
+            ATTR_ENERGY_EXPORTED: convert_to_kw(meter.energy_exported),
+            ATTR_ENERGY_IMPORTED: convert_to_kw(meter.energy_imported),
+            ATTR_INSTANT_AVERAGE_VOLTAGE: round(meter.instant_average_voltage, 1),
+            ATTR_IS_ACTIVE: meter.is_active(),
         }

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -36,12 +36,13 @@ async def test_sensors(hass):
     assert state.state == "0.032"
     expected_attributes = {
         "frequency": 60,
-        "energy_exported": 10429451.9916853,
-        "energy_imported": 4824191.60668611,
-        "instant_average_voltage": 120.650001525879,
+        "energy_exported_(in_kW)": 10429.5,
+        "energy_imported_(in_kW)": 4824.2,
+        "instant_average_voltage": 120.7,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Site Now",
         "device_class": "power",
+        "is_active": False,
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
@@ -52,12 +53,13 @@ async def test_sensors(hass):
     assert state.state == "1.971"
     expected_attributes = {
         "frequency": 60,
-        "energy_exported": 1056797.48917483,
-        "energy_imported": 4692987.91889705,
-        "instant_average_voltage": 120.650001525879,
+        "energy_exported_(in_kW)": 1056.8,
+        "energy_imported_(in_kW)": 4693.0,
+        "instant_average_voltage": 120.7,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Load Now",
         "device_class": "power",
+        "is_active": True,
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
@@ -67,13 +69,14 @@ async def test_sensors(hass):
     state = hass.states.get("sensor.powerwall_battery_now")
     assert state.state == "-8.55"
     expected_attributes = {
-        "frequency": 60.014,
-        "energy_exported": 3620010,
-        "energy_imported": 4216170,
-        "instant_average_voltage": 240.56,
+        "frequency": 60.0,
+        "energy_exported_(in_kW)": 3620.0,
+        "energy_imported_(in_kW)": 4216.2,
+        "instant_average_voltage": 240.6,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Battery Now",
         "device_class": "power",
+        "is_active": True,
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
@@ -84,12 +87,13 @@ async def test_sensors(hass):
     assert state.state == "10.49"
     expected_attributes = {
         "frequency": 60,
-        "energy_exported": 9864205.82222448,
-        "energy_imported": 28177.5358355867,
-        "instant_average_voltage": 120.685001373291,
+        "energy_exported_(in_kW)": 9864.2,
+        "energy_imported_(in_kW)": 28.2,
+        "instant_average_voltage": 120.7,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Solar Now",
         "device_class": "power",
+        "is_active": True,
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

* Add `is_active` to Meter sensor
* Round `device_state_attributes` of Meter sensor
* Use `is_sending_to` for `PowerWallChargingStatusSensor` so it behaves the same way as in the web UI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
