### PR TITLE
Add utility functions for mapping/processing objects with retries

### DIFF
--- a/homeassistant/util/processor.py
+++ b/homeassistant/util/processor.py
@@ -80,7 +80,7 @@ async def async_map_retry(
     :param hass: The current home assistant instance.
     :param objects: The objects to map.
     :param map_function: Maps the original object to a new object. Note: Throwing an exception or returning None from this function results in the original object being retried later.
-    :param process_function: Processes the new object once it was successfull mapped.
+    :param process_function: Processes the new object once it was successful mapped.
     :param retry_interval: Time between attempts to map and process objects.
     :param timeout_attempts: Number of attempts before giving up. A value of 0 means it runs forever.
     :param run_in_parallel: When True, objects will be handled in parallel. (Default: True)

--- a/homeassistant/util/processor.py
+++ b/homeassistant/util/processor.py
@@ -1,0 +1,150 @@
+"""Processor util methods."""
+import asyncio
+from datetime import timedelta
+from typing import Awaitable, Callable, Iterable, List, NamedTuple, TypeVar
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_time_interval
+
+OriginalObjectType = TypeVar("OriginalObjectType")
+NewObjectType = TypeVar("NewObjectType")
+ObjectsType = Iterable[OriginalObjectType]
+MapFunctionType = Callable[
+    [HomeAssistant, OriginalObjectType], Awaitable[NewObjectType]
+]
+ProcessFunctionType = Callable[[HomeAssistant, NewObjectType], Awaitable]
+CancelFunctionType = Callable[[], None]
+
+
+class MapObjectResult(NamedTuple):
+    """The result of processing an object in async_add_entities_retry."""
+
+    original_object: OriginalObjectType
+    new_object: NewObjectType
+    success: bool
+
+
+DEFAULT_RETRY_INTERVAL = timedelta(minutes=5)
+DEFAULT_TIMEOUT_ATTEMPTS = 0
+DEFAULT_RUN_IN_PARALLEL = True
+
+
+async def async_add_entities_retry(
+    hass: HomeAssistant,
+    objects: ObjectsType,
+    map_function: MapFunctionType,
+    async_add_entities: Callable[[Iterable[Entity]], Awaitable[None]],
+    retry_interval: timedelta = DEFAULT_RETRY_INTERVAL,
+    timeout_attempts: int = DEFAULT_TIMEOUT_ATTEMPTS,
+    run_in_parallel: bool = DEFAULT_RUN_IN_PARALLEL,
+    update_before_add: bool = None,
+) -> CancelFunctionType:
+    """Asynchronously create and add entities with retries.
+
+    :param hass: The current home assistant instance.
+    :param objects: The objects to map.
+    :param map_function: Maps the original object to a new object. Note: Throwing an exception or returning None from this function results in the original object being retried later.
+    :param async_add_entities: The same function provided to a platform's async_setup_entry function.
+    :param retry_interval: Time between attempts to map and process objects.
+    :param timeout_attempts: Number of attempts before giving up. A value of 0 means it runs forever.
+    :param run_in_parallel: When True, objects will be handled in parallel. (Default: True)
+    :return: A function that can be used to cancel future object processing.
+    """
+
+    async def async_process_entity(hass: HomeAssistant, entity: Entity) -> None:
+        await async_add_entities([entity], update_before_add=update_before_add)
+
+    return await async_map_retry(
+        hass,
+        objects,
+        map_function,
+        async_process_entity,
+        retry_interval,
+        timeout_attempts,
+        run_in_parallel,
+    )
+
+
+async def async_map_retry(
+    hass: HomeAssistant,
+    objects: ObjectsType,
+    map_function: MapFunctionType,
+    process_function: ProcessFunctionType,
+    retry_interval: timedelta = DEFAULT_RETRY_INTERVAL,
+    timeout_attempts: int = DEFAULT_TIMEOUT_ATTEMPTS,
+    run_in_parallel: bool = DEFAULT_RUN_IN_PARALLEL,
+) -> CancelFunctionType:
+    """Asynchronously map and process objects with retries.
+
+    :param hass: The current home assistant instance.
+    :param objects: The objects to map.
+    :param map_function: Maps the original object to a new object. Note: Throwing an exception or returning None from this function results in the original object being retried later.
+    :param process_function: Processes the new object once it was successfull mapped.
+    :param retry_interval: Time between attempts to map and process objects.
+    :param timeout_attempts: Number of attempts before giving up. A value of 0 means it runs forever.
+    :param run_in_parallel: When True, objects will be handled in parallel. (Default: True)
+    :return: A function that can be used to cancel future object processing.
+    """
+    original_objects = list(objects)
+    attempt_count = 0
+    cancel_func1 = None
+
+    @callback
+    def cancel() -> None:
+        nonlocal cancel_func1
+        cancel_func1()
+
+    async def map_object(original_object: OriginalObjectType) -> MapObjectResult:
+        try:
+            new_object = await map_function(hass, original_object)
+            if new_object is None:
+                raise Exception("Failed to map object.")
+
+            await process_function(hass, new_object)
+            return MapObjectResult(
+                original_object=original_object, new_object=new_object, success=True
+            )
+
+        except Exception:  # pylint: disable=broad-except
+            return MapObjectResult(
+                original_object=original_object, new_object=None, success=False
+            )
+
+    @callback
+    async def map_objects(*args) -> None:
+        nonlocal original_objects, attempt_count, run_in_parallel
+        attempt_count += 1
+
+        # Process objects in parallel.
+        if run_in_parallel:
+            results: List[MapObjectResult] = await asyncio.gather(
+                *[
+                    map_object(original_object)
+                    for original_object in tuple(original_objects)
+                ],
+                loop=hass.loop,
+            )
+        # Process object serially.
+        else:
+            results = [
+                await map_object(original_object)
+                for original_object in tuple(original_objects)
+            ]
+
+        # Remove processed objects.
+        for result in results:
+            if result.success:
+                original_objects.remove(result.original_object)
+
+        # Determine if we've finished processing objects.
+        if not original_objects or attempt_count >= timeout_attempts > 0:
+            cancel()
+
+    # Schedule the retry interval.
+    cancel_func1 = async_track_time_interval(hass, map_objects, retry_interval)
+
+    # Attempt to add the objects.
+    await map_objects()
+
+    return cancel

--- a/homeassistant/util/processor.py
+++ b/homeassistant/util/processor.py
@@ -149,7 +149,7 @@ async def async_map_retry(
                 ],
                 loop=hass.loop,
             )
-        # Process object serially.
+        # Process objects serially.
         else:
             results = [
                 await map_object(original_object)

--- a/tests/util/test_processor.py
+++ b/tests/util/test_processor.py
@@ -1,0 +1,222 @@
+"""Test Home Assistant processor util methods."""
+from datetime import timedelta
+
+from asynctest import CoroutineMock
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
+from homeassistant.util.processor import async_add_entities_retry, async_map_retry
+
+from tests.common import async_fire_time_changed
+
+
+class SimpleEntity(Entity):
+    """Simple entity for testing."""
+
+    def __init__(self, name: str):
+        """Initialize the object."""
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        """Get the name of the entity."""
+        return self._name
+
+
+ORIGINAL_OBJECTS = (
+    "object0",
+    "object1",
+    "object2",
+    "object3",
+)
+
+NEW_OBJECTS = (
+    SimpleEntity(ORIGINAL_OBJECTS[0]),
+    SimpleEntity(ORIGINAL_OBJECTS[1]),
+    SimpleEntity(ORIGINAL_OBJECTS[2]),
+    SimpleEntity(ORIGINAL_OBJECTS[3]),
+)
+
+MAP_FUNCTION_SIDE_EFFECTS = (
+    # Attempt 1
+    Exception(""),  # object0
+    None,  # object1
+    None,  # object2
+    Exception(""),  # object3
+    # Attempt 2
+    Exception(""),  # object0
+    NEW_OBJECTS[1],  # object1
+    Exception(""),  # object2
+    NEW_OBJECTS[3],  # object3
+    # Attempt 3
+    NEW_OBJECTS[0],  # object0
+    Exception(""),  # object2
+    # Attempt 4
+    Exception(""),  # object2
+    # Attempt 5
+    NEW_OBJECTS[2],  # object2
+)
+
+
+async def test_async_add_entities_retry(hass: HomeAssistant) -> None:
+    """Test adding entities with retry map."""
+
+    async def map_function(hass: HomeAssistant, original_object: str) -> Entity:
+        return SimpleEntity(original_object)
+
+    async_add_entities = CoroutineMock()
+
+    cancel_function = await async_add_entities_retry(
+        hass, ORIGINAL_OBJECTS, map_function, async_add_entities
+    )
+    assert hasattr(cancel_function, "__call__")
+    await hass.async_block_till_done()
+
+    assert len(async_add_entities.await_args_list) == len(ORIGINAL_OBJECTS)
+    for index, args in enumerate(async_add_entities.await_args_list):
+        assert args
+        assert args[0][0]
+        assert isinstance(args[0][0], list)
+        assert args[0][0][0].name == ORIGINAL_OBJECTS[index]
+
+
+@pytest.mark.parametrize(["run_in_parallel"], [[True], [False]])
+async def test_async_map_retry_map_with_errors(
+    hass: HomeAssistant, run_in_parallel: bool
+) -> None:
+    """Test mapping objects encountering errors in parallel or serial."""
+    map_function = CoroutineMock(side_effect=MAP_FUNCTION_SIDE_EFFECTS)
+
+    process_function = CoroutineMock()
+    now = dt_util.utcnow()
+
+    # Attempt 1
+    await async_map_retry(
+        hass,
+        ORIGINAL_OBJECTS,
+        map_function,
+        process_function,
+        run_in_parallel=run_in_parallel,
+    )
+    await hass.async_block_till_done()
+    assert map_function.await_count == 4
+    for original_object in ORIGINAL_OBJECTS:
+        map_function.assert_any_await(hass, original_object)
+
+    # Attempt 2
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 4
+    assert process_function.await_count == 2
+    process_function.assert_any_await(hass, NEW_OBJECTS[1])
+    process_function.assert_any_await(hass, NEW_OBJECTS[3])
+
+    # Attempt 3
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 2
+    assert process_function.await_count == 1
+    process_function.assert_any_await(hass, NEW_OBJECTS[0])
+
+    # Attempt 4
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 1
+    assert process_function.await_count == 0
+
+    # Attempt 5
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 1
+    assert process_function.await_count == 1
+    process_function.assert_any_await(hass, NEW_OBJECTS[2])
+
+
+async def test_async_map_retry_map_with_cancel(hass: HomeAssistant) -> None:
+    """Test mapping and cancel it mid way through."""
+    map_function = CoroutineMock(side_effect=MAP_FUNCTION_SIDE_EFFECTS)
+
+    process_function = CoroutineMock()
+    now = dt_util.utcnow()
+
+    # Attempt 1
+    cancel_function = await async_map_retry(
+        hass, ORIGINAL_OBJECTS, map_function, process_function
+    )
+    assert hasattr(cancel_function, "__call__")
+    await hass.async_block_till_done()
+    assert map_function.await_count == 4
+    for original_object in ORIGINAL_OBJECTS:
+        map_function.assert_any_await(hass, original_object)
+
+    cancel_function()
+
+    # Attempt 2
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 0
+    assert process_function.await_count == 0
+
+    # Attempt 2
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 0
+    assert process_function.await_count == 0
+
+
+async def test_async_map_retry_map_with_timeout(hass: HomeAssistant) -> None:
+    """Test mapping with a timeout."""
+    map_function = CoroutineMock(side_effect=MAP_FUNCTION_SIDE_EFFECTS)
+
+    process_function = CoroutineMock()
+    now = dt_util.utcnow()
+
+    # Attempt 1
+    cancel_function = await async_map_retry(
+        hass, ORIGINAL_OBJECTS, map_function, process_function, timeout_attempts=2
+    )
+    assert hasattr(cancel_function, "__call__")
+    await hass.async_block_till_done()
+    assert map_function.await_count == 4
+    for original_object in ORIGINAL_OBJECTS:
+        map_function.assert_any_await(hass, original_object)
+
+    # Attempt 2
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 4
+    assert process_function.await_count == 2
+    process_function.assert_any_await(hass, NEW_OBJECTS[1])
+    process_function.assert_any_await(hass, NEW_OBJECTS[3])
+
+    # Attempt 3
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 0
+    assert process_function.await_count == 0
+
+    # Attempt 4
+    map_function.reset_mock()
+    process_function.reset_mock()
+    async_fire_time_changed(hass, now + timedelta(minutes=6))
+    await hass.async_block_till_done()
+    assert map_function.await_count == 0
+    assert process_function.await_count == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Home Assistant (HA) expects all devices and services to be available upon boot. If HA encounters a device that has no power (at the moment), the device erroneously sends a bad response or the request initially times out, then HA starts up with those devices missing. Rebooting HA is the only way to get those devices to show. However, the act of rebooting could result in a different device being unresponsive.

This Pull Request (PR) attempts to start a dialog to address this use-case by providing generic utility methods for mapping and processing objects in the background with delays and retries.

The example below demonstrates a platform that needs to add multiple devices network attached devices. The device can be online during initial boot or not at all. If the device cannot be accessed, HA will try to add it again later.
```python
from typing import Optional

from homeassistant.config_entries import ConfigEntry
from homeassistant.core import HomeAssistant
from homeassistant.exceptions import PlatformNotReady
from homeassistant.helpers.entity import Entity
from homeassistant.util.processor import async_background_add_entities_retry, async_foreground_retry


class DeviceApi:
    def __init__(self, host):
        self.host = host

    async def check_is_available(self) -> bool:
        # Perform action that could throw exception.
        return True


class DeviceEntity(Entity):
    def __init__(self, hass: HomeAssistant, device_api: DeviceApi):
        self._hass = hass
        self._api = device_api


async def async_map_device_api(hass: HomeAssistant, device_api: DeviceApi) -> Optional[DeviceEntity]:
    # If an exception occurs during the mapping, it will be retried later.
    if not await device_api.check_is_available():
        return None  # Counts as a failure and this mapping will be retried.

    # Retuning a non-None value will result in entity being added to HA.
    return DeviceEntity(hass, device_api)


# Platform setup.
async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
    """Set up switches."""
    device_apis = (
        DeviceApi(host="10.0.1.1"),
        DeviceApi(host="10.0.1.2"),
        DeviceApi(host="10.0.1.3")
    )

    # Will attempt to add all entities now. If there are failures in the mapping,
    # they will be retried later (in the background).
    # This is useful when an integration provides several endpoints from discover.
    # TPLink works in this manner where the integration represents multiple
    # ip devices.
    await async_background_add_entities_retry(
        hass,
        device_apis,
        async_map_device_api,
        async_add_entities
    )

    return True


# Config entry setup.
async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
    async def async_is_custom_api_accessible():
        # API call that could fail sometimes.
        # If the call raises an exception, it will be retried.
        return True

    try:
        # This is useful for confirming a hub is online when setting
        # up the config entry. Smartthings, Vera Hue and many others would benefit.
        await async_foreground_retry(hass, async_is_custom_api_accessible)
    except CustomApiConnectionException:
        raise PlatformNotReady()

    hass.config_entries.async_forward_entry_setup(entry, SENSOR_DOMAIN),
    return True


```

Final thought
These utils are entirely separate but a more intergrated solution is possible by integration with entity_platform.py.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
