### PR TITLE
Store integration type in AirVisual config entry

### DIFF
--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -206,6 +206,19 @@ async def async_migrate_entry(hass, config_entry):
                     data={CONF_API_KEY: config_entry.data[CONF_API_KEY], **geography},
                 )
             )
+    # 2 -> 3: Explicitly store the integration type in the config entry:
+    if version == 2:
+        version = config_entry.version = 3
+
+        if CONF_API_KEY in config_entry.data:
+            integration_type = INTEGRATION_TYPE_GEOGRAPHY
+        else:
+            integration_type = INTEGRATION_TYPE_NODE_PRO
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={**config_entry.data, CONF_INTEGRATION_TYPE: integration_type},
+        )
 
     LOGGER.info("Migration to version %s successful", version)
 

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_CITY,
     CONF_COUNTRY,
     CONF_GEOGRAPHIES,
+    CONF_INTEGRATION_TYPE,
     DATA_CLIENT,
     DOMAIN,
     INTEGRATION_TYPE_GEOGRAPHY,
@@ -140,7 +141,7 @@ async def async_setup_entry(hass, config_entry):
     """Set up AirVisual as config entry."""
     websession = aiohttp_client.async_get_clientsession(hass)
 
-    if CONF_API_KEY in config_entry.data:
+    if config_entry.data[CONF_INTEGRATION_TYPE] == INTEGRATION_TYPE_GEOGRAPHY:
         _standardize_geography_config_entry(hass, config_entry)
         airvisual = AirVisualGeographyData(
             hass,

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -176,6 +176,7 @@ async def async_setup_entry(hass, config_entry):
         # Only geography-based entries have options:
         config_entry.add_update_listener(async_update_options)
     else:
+        _standardize_node_pro_config_entry(hass, config_entry)
         airvisual = AirVisualNodeProData(hass, Client(websession), config_entry)
 
     await airvisual.async_update()

--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 from . import async_get_geography_id
 from .const import (  # pylint: disable=unused-import
     CONF_GEOGRAPHIES,
+    CONF_INTEGRATION_TYPE,
     DOMAIN,
     INTEGRATION_TYPE_GEOGRAPHY,
     INTEGRATION_TYPE_NODE_PRO,
@@ -123,7 +124,8 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 checked_keys.add(user_input[CONF_API_KEY])
 
             return self.async_create_entry(
-                title=f"Cloud API ({geo_id})", data=user_input
+                title=f"Cloud API ({geo_id})",
+                data={**user_input, CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY},
             )
 
     async def async_step_import(self, import_config):
@@ -155,7 +157,8 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_create_entry(
-            title=f"Node/Pro ({user_input[CONF_IP_ADDRESS]})", data=user_input
+            title=f"Node/Pro ({user_input[CONF_IP_ADDRESS]})",
+            data={**user_input, CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_NODE_PRO},
         )
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -31,7 +31,7 @@ from .const import (  # pylint: disable=unused-import
 class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle an AirVisual config flow."""
 
-    VERSION = 3
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     @property

--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -31,7 +31,7 @@ from .const import (  # pylint: disable=unused-import
 class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle an AirVisual config flow."""
 
-    VERSION = 2
+    VERSION = 3
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     @property

--- a/homeassistant/components/airvisual/const.py
+++ b/homeassistant/components/airvisual/const.py
@@ -10,6 +10,7 @@ INTEGRATION_TYPE_NODE_PRO = "AirVisual Node/Pro"
 CONF_CITY = "city"
 CONF_COUNTRY = "country"
 CONF_GEOGRAPHIES = "geographies"
+CONF_INTEGRATION_TYPE = "integration_type"
 
 DATA_CLIENT = "client"
 

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -118,7 +118,6 @@ async def test_migration_1_2(hass):
 
     assert len(config_entries) == 2
 
-    assert config_entries[0].version == 2
     assert config_entries[0].unique_id == "51.528308, -0.3817765"
     assert config_entries[0].title == "Cloud API (51.528308, -0.3817765)"
     assert config_entries[0].data == {
@@ -127,7 +126,6 @@ async def test_migration_1_2(hass):
         CONF_LONGITUDE: -0.3817765,
     }
 
-    assert config_entries[1].version == 2
     assert config_entries[1].unique_id == "35.48847, 137.5263065"
     assert config_entries[1].title == "Cloud API (35.48847, 137.5263065)"
     assert config_entries[1].data == {
@@ -155,7 +153,6 @@ async def test_migration_2_3(hass):
 
     config_entries = hass.config_entries.async_entries(DOMAIN)
 
-    assert config_entries[0].version == 3
     assert config_entries[0].data == {
         CONF_API_KEY: "abcde12345",
         CONF_LATITUDE: 51.528308,

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -136,7 +136,7 @@ async def test_migration_1_2(hass):
 
 
 async def test_migration_2_3(hass):
-    """Test migrating from version 1 to version 2."""
+    """Test migrating from version 2 to version 3."""
     conf = {
         CONF_API_KEY: "abcde12345",
         CONF_LATITUDE: 35.48847,

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -5,6 +5,7 @@ from pyairvisual.errors import InvalidKeyError, NodeProError
 from homeassistant import data_entry_flow
 from homeassistant.components.airvisual import (
     CONF_GEOGRAPHIES,
+    CONF_INTEGRATION_TYPE,
     DOMAIN,
     INTEGRATION_TYPE_GEOGRAPHY,
     INTEGRATION_TYPE_NODE_PRO,
@@ -131,6 +132,32 @@ async def test_migration_1_2(hass):
         CONF_API_KEY: "abcde12345",
         CONF_LATITUDE: 35.48847,
         CONF_LONGITUDE: 137.5263065,
+    }
+
+
+async def test_migration_2_3(hass):
+    """Test migrating from version 1 to version 2."""
+    conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 35.48847,
+        CONF_LONGITUDE: 137.5263065,
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, version=2, unique_id="abcde12345", data=conf
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch("pyairvisual.api.API.nearest_city"):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: conf})
+
+    config_entries = hass.config_entries.async_entries(DOMAIN)
+
+    assert config_entries[0].data == {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+        CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
     }
 
 

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -94,8 +94,8 @@ async def test_node_pro_error(hass):
         assert result["errors"] == {CONF_IP_ADDRESS: "unable_to_connect"}
 
 
-async def test_migration_1_2(hass):
-    """Test migrating from version 1 to version 2."""
+async def test_migration(hass):
+    """Test migrating from version 1 to the current version."""
     conf = {
         CONF_API_KEY: "abcde12345",
         CONF_GEOGRAPHIES: [
@@ -124,6 +124,7 @@ async def test_migration_1_2(hass):
         CONF_API_KEY: "abcde12345",
         CONF_LATITUDE: 51.528308,
         CONF_LONGITUDE: -0.3817765,
+        CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
     }
 
     assert config_entries[1].unique_id == "35.48847, 137.5263065"
@@ -132,31 +133,6 @@ async def test_migration_1_2(hass):
         CONF_API_KEY: "abcde12345",
         CONF_LATITUDE: 35.48847,
         CONF_LONGITUDE: 137.5263065,
-    }
-
-
-async def test_migration_2_3(hass):
-    """Test migrating from version 2 to version 3."""
-    conf = {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 35.48847,
-        CONF_LONGITUDE: 137.5263065,
-    }
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, version=2, unique_id="abcde12345", data=conf
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch("pyairvisual.api.API.nearest_city"):
-        assert await async_setup_component(hass, DOMAIN, {DOMAIN: conf})
-
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-
-    assert config_entries[0].data == {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
         CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
     }
 
@@ -213,6 +189,7 @@ async def test_step_geography(hass):
             CONF_API_KEY: "abcde12345",
             CONF_LATITUDE: 51.528308,
             CONF_LONGITUDE: -0.3817765,
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
         }
 
 
@@ -234,6 +211,7 @@ async def test_step_node_pro(hass):
         assert result["data"] == {
             CONF_IP_ADDRESS: "192.168.1.100",
             CONF_PASSWORD: "my_password",
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_NODE_PRO,
         }
 
 
@@ -258,6 +236,7 @@ async def test_step_import(hass):
             CONF_API_KEY: "abcde12345",
             CONF_LATITUDE: 51.528308,
             CONF_LONGITUDE: -0.3817765,
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
         }
 
 

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -118,6 +118,7 @@ async def test_migration_1_2(hass):
 
     assert len(config_entries) == 2
 
+    assert config_entries[0].version == 2
     assert config_entries[0].unique_id == "51.528308, -0.3817765"
     assert config_entries[0].title == "Cloud API (51.528308, -0.3817765)"
     assert config_entries[0].data == {
@@ -126,6 +127,7 @@ async def test_migration_1_2(hass):
         CONF_LONGITUDE: -0.3817765,
     }
 
+    assert config_entries[1].version == 2
     assert config_entries[1].unique_id == "35.48847, 137.5263065"
     assert config_entries[1].title == "Cloud API (35.48847, 137.5263065)"
     assert config_entries[1].data == {
@@ -153,6 +155,7 @@ async def test_migration_2_3(hass):
 
     config_entries = hass.config_entries.async_entries(DOMAIN)
 
+    assert config_entries[0].version == 3
     assert config_entries[0].data == {
         CONF_API_KEY: "abcde12345",
         CONF_LATITUDE: 51.528308,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR explicitly adds the integration type (Cloud API vs. Node Pro/Unit) to AirVisual config entries. This reduces some too-implicit checks elsewhere and paves the way for future functionality that will need to know what type of integration we have.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
