### PR TITLE
Add support for custom media_type in mediaroom

### DIFF
--- a/homeassistant/components/mediaroom/media_player.py
+++ b/homeassistant/components/mediaroom/media_player.py
@@ -200,15 +200,17 @@ class MediaroomDevice(MediaPlayerDevice):
         )
         if media_type == MEDIA_TYPE_CHANNEL:
             if not media_id.isdigit():
-                _LOGGER.error("media_id must be a channel number")
+                _LOGGER.error(
+                    "Invalid media_id %s: Must be a channel number", media_id
+                )
                 return
             media_id = int(media_id)
         elif media_type == MEDIA_TYPE_MEDIAROOM:
             if media_id not in COMMANDS:
-                _LOGGER.error("media_id is not a valid command")
+                _LOGGER.error("Invalid media_id %s: Must be a command", media_id)
                 return
         else:
-            _LOGGER.error("invalid media type")
+            _LOGGER.error("Invalid media type %s", media_type)
             return
 
         try:

--- a/homeassistant/components/mediaroom/media_player.py
+++ b/homeassistant/components/mediaroom/media_player.py
@@ -200,9 +200,7 @@ class MediaroomDevice(MediaPlayerDevice):
         )
         if media_type == MEDIA_TYPE_CHANNEL:
             if not media_id.isdigit():
-                _LOGGER.error(
-                    "Invalid media_id %s: Must be a channel number", media_id
-                )
+                _LOGGER.error("Invalid media_id %s: Must be a channel number", media_id)
                 return
             media_id = int(media_id)
         elif media_type == MEDIA_TYPE_MEDIAROOM:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for a custom media_type in the mediaroom component. This allows for more control options of the media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Example of the new functionality added in the play_media service:
```yaml
- service: media_player.play_media
  data:
    entity_id: media_player.mediaroom_box
    media_content_id: Up
    media_content_type: mediaroom
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [https://github.com/home-assistant/developers.home-assistant/pull/470](https://github.com/home-assistant/developers.home-assistant/pull/470)
- Link to documentation pull request: [https://github.com/home-assistant/home-assistant.io/pull/13182](https://github.com/home-assistant/home-assistant.io/pull/13182)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
