### PR TITLE
Allow flows to know if user is in advanced mode

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -253,6 +253,16 @@ class FlowHandler:
     # Set by developer
     VERSION = 1
 
+    @property
+    def source(self) -> Optional[str]:
+        """Source that initialized the flow."""
+        return self.context.get("source", None)
+
+    @property
+    def show_advanced_options(self) -> bool:
+        """If we should show advanced options."""
+        return self.context.get("show_advanced_options", False)
+
     @callback
     def async_show_form(
         self,

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -49,7 +49,13 @@ class FlowManagerIndexView(_BaseFlowManagerView):
     """View to create config flows."""
 
     @RequestDataValidator(
-        vol.Schema({vol.Required("handler"): vol.Any(str, list)}, extra=vol.ALLOW_EXTRA)
+        vol.Schema(
+            {
+                vol.Required("handler"): vol.Any(str, list),
+                vol.Optional("show_advanced_options", default=False): cv.boolean,
+            },
+            extra=vol.ALLOW_EXTRA,
+        )
     )
     async def post(self, request, data):
         """Handle a POST request."""
@@ -60,7 +66,11 @@ class FlowManagerIndexView(_BaseFlowManagerView):
 
         try:
             result = await self._flow_mgr.async_init(
-                handler, context={"source": config_entries.SOURCE_USER}
+                handler,
+                context={
+                    "source": config_entries.SOURCE_USER,
+                    "show_advanced_options": data["show_advanced_options"],
+                },
             )
         except data_entry_flow.UnknownHandler:
             return self.json_message("Invalid handler specified", HTTP_NOT_FOUND)

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -141,13 +141,17 @@ async def test_initialize_flow(hass, client):
             return self.async_show_form(
                 step_id="user",
                 data_schema=schema,
-                description_placeholders={"url": "https://example.com"},
+                description_placeholders={
+                    "url": "https://example.com",
+                    "show_advanced_options": self.show_advanced_options,
+                },
                 errors={"username": "Should be unique."},
             )
 
     with patch.dict(HANDLERS, {"test": TestFlow}):
         resp = await client.post(
-            "/api/config/config_entries/flow", json={"handler": "test"}
+            "/api/config/config_entries/flow",
+            json={"handler": "test", "show_advanced_options": True},
         )
 
     assert resp.status == 200
@@ -163,7 +167,10 @@ async def test_initialize_flow(hass, client):
             {"name": "username", "required": True, "type": "string"},
             {"name": "password", "required": True, "type": "string"},
         ],
-        "description_placeholders": {"url": "https://example.com"},
+        "description_placeholders": {
+            "url": "https://example.com",
+            "show_advanced_options": True,
+        },
         "errors": {"username": "Should be unique."},
     }
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -26,7 +26,6 @@ def manager():
 
             flow = handler()
             flow.init_step = context.get("init_step", "init")
-            flow.source = context.get("source")
             return flow
 
         async def async_finish_flow(self, flow, result):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow specifying in a config flow if the user is interested in advanced options.

Frontend: https://github.com/home-assistant/frontend/pull/5612

CC @jjlawren 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
