### PR TITLE
Add ability to ignore myq discovery

### DIFF
--- a/homeassistant/components/myq/config_flow.py
+++ b/homeassistant/components/myq/config_flow.py
@@ -75,6 +75,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # they already have one configured as they can always
             # add a new one via "+"
             return self.async_abort(reason="already_configured")
+        properties = {
+            key.lower(): value for (key, value) in homekit_info["properties"].items()
+        }
+        await self.async_set_unique_id(properties["id"])
         return await self.async_step_user()
 
     async def async_step_import(self, user_input):

--- a/tests/components/myq/test_config_flow.py
+++ b/tests/components/myq/test_config_flow.py
@@ -111,7 +111,9 @@ async def test_form_homekit(hass):
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "homekit"}
+        DOMAIN,
+        context={"source": "homekit"},
+        data={"properties": {"id": "AA:BB:CC:DD:EE:FF"}},
     )
     assert result["type"] == "form"
     assert result["errors"] == {}
@@ -122,6 +124,8 @@ async def test_form_homekit(hass):
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "homekit"}
+        DOMAIN,
+        context={"source": "homekit"},
+        data={"properties": {"id": "AA:BB:CC:DD:EE:FF"}},
     )
     assert result["type"] == "abort"

--- a/tests/components/myq/test_config_flow.py
+++ b/tests/components/myq/test_config_flow.py
@@ -117,7 +117,11 @@ async def test_form_homekit(hass):
     )
     assert result["type"] == "form"
     assert result["errors"] == {}
-    flows_in_progress = hass.config_entries.flow.async_progress()
+    flow = next(
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["flow_id"] == result["flow_id"]
+    )
     assert flows_in_progress[0]["context"]["unique_id"] == "AA:BB:CC:DD:EE:FF"
 
     entry = MockConfigEntry(

--- a/tests/components/myq/test_config_flow.py
+++ b/tests/components/myq/test_config_flow.py
@@ -117,6 +117,8 @@ async def test_form_homekit(hass):
     )
     assert result["type"] == "form"
     assert result["errors"] == {}
+    flows_in_progress = hass.config_entries.flow.async_progress()
+    assert flows_in_progress[0]["context"]["unique_id"] == "AA:BB:CC:DD:EE:FF"
 
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"}

--- a/tests/components/myq/test_config_flow.py
+++ b/tests/components/myq/test_config_flow.py
@@ -122,7 +122,7 @@ async def test_form_homekit(hass):
         for flow in hass.config_entries.flow.async_progress()
         if flow["flow_id"] == result["flow_id"]
     )
-    assert flows_in_progress[0]["context"]["unique_id"] == "AA:BB:CC:DD:EE:FF"
+    assert flow["context"]["unique_id"] == "AA:BB:CC:DD:EE:FF"
 
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"}


### PR DESCRIPTION



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add ability to ignore myq discovery

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
