### PR TITLE
Fix py38 tests

### DIFF
--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -1,6 +1,5 @@
 """Test Google Smart Home."""
-from unittest.mock import Mock, patch
-
+from asynctest import Mock, patch
 import pytest
 
 from homeassistant.components import camera
@@ -31,7 +30,6 @@ from . import BASIC_CONFIG, MockConfig
 
 from tests.common import (
     mock_area_registry,
-    mock_coro,
     mock_device_registry,
     mock_registry,
 )
@@ -790,9 +788,7 @@ async def test_query_disconnect(hass):
     config = MockConfig(hass=hass)
     config.async_enable_report_state()
     assert config._unsub_report_state is not None
-    with patch.object(
-        config, "async_disconnect_agent_user", side_effect=mock_coro
-    ) as mock_disconnect:
+    with patch.object(config, "async_disconnect_agent_user") as mock_disconnect:
         result = await sh.async_handle_message(
             hass,
             config,

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -262,6 +262,8 @@ async def test_query_message(hass):
         },
     }
 
+    await hass.async_block_till_done()
+
     assert len(events) == 4
     assert events[0].event_type == EVENT_QUERY_RECEIVED
     assert events[0].data == {
@@ -811,7 +813,7 @@ async def test_trait_execute_adding_query_data(hass):
 
     with patch(
         "homeassistant.components.camera.async_request_stream",
-        return_value=mock_coro("/api/streams/bla"),
+        return_value="/api/streams/bla",
     ):
         result = await sh.async_handle_message(
             hass,

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -28,11 +28,7 @@ from homeassistant.setup import async_setup_component
 
 from . import BASIC_CONFIG, MockConfig
 
-from tests.common import (
-    mock_area_registry,
-    mock_device_registry,
-    mock_registry,
-)
+from tests.common import mock_area_registry, mock_device_registry, mock_registry
 
 REQ_ID = "ff36a3cc-ec34-11e6-b1a0-64510650abcf"
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1,7 +1,8 @@
 """Tests for the Google Assistant traits."""
 import logging
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
+from asynctest import patch
 import pytest
 
 from homeassistant.components import (
@@ -117,7 +118,7 @@ async def test_camera_stream(hass):
 
     with patch(
         "homeassistant.components.camera.async_request_stream",
-        return_value=mock_coro("/api/streams/bla"),
+        return_value="/api/streams/bla",
     ):
         await trt.execute(trait.COMMAND_GET_CAMERA_STREAM, BASIC_DATA, {}, {})
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -46,7 +46,7 @@ from homeassistant.util import color
 
 from . import BASIC_CONFIG, MockConfig
 
-from tests.common import async_mock_service, mock_coro
+from tests.common import async_mock_service
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/ps4/conftest.py
+++ b/tests/components/ps4/conftest.py
@@ -1,6 +1,5 @@
 """Test configuration for PS4."""
 from asynctest import patch
-
 import pytest
 
 

--- a/tests/components/ps4/conftest.py
+++ b/tests/components/ps4/conftest.py
@@ -1,0 +1,23 @@
+"""Test configuration for PS4."""
+from asynctest import patch
+
+import pytest
+
+
+@pytest.fixture
+def patch_load_json():
+    """Prevent load JSON being used."""
+    with patch("homeassistant.components.ps4.load_json", return_value={}) as mock_load:
+        yield mock_load
+
+
+@pytest.fixture
+def patch_save_json():
+    """Prevent save JSON being used."""
+    with patch("homeassistant.components.ps4.save_json") as mock_save:
+        yield mock_save
+
+
+@pytest.fixture(autouse=True)
+def patch_io(patch_load_json, patch_save_json):
+    """Prevent PS4 doing I/O."""

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -1,5 +1,5 @@
 """Define tests for the PlayStation 4 config flow."""
-from unittest.mock import patch
+from asynctest import patch
 
 from pyps4_2ndscreen.errors import CredentialTimeout
 
@@ -21,7 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.util import location
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import MockConfigEntry
 
 MOCK_TITLE = "PlayStation 4"
 MOCK_CODE = 12345678
@@ -313,7 +313,7 @@ async def test_0_pin(hass):
         "pyps4_2ndscreen.Helper.has_devices", return_value=[{"host-ip": MOCK_HOST}]
     ), patch(
         "homeassistant.components.ps4.config_flow.location.async_detect_location_info",
-        return_value=mock_coro(MOCK_LOCATION),
+        return_value=MOCK_LOCATION,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], MOCK_AUTO

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -1,6 +1,5 @@
 """Define tests for the PlayStation 4 config flow."""
 from asynctest import patch
-
 from pyps4_2ndscreen.errors import CredentialTimeout
 
 from homeassistant import data_entry_flow

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -1,5 +1,5 @@
 """Tests for the PS4 Integration."""
-from unittest.mock import MagicMock, patch
+from asynctest import MagicMock, patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import ps4
@@ -29,7 +29,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.util import location
 
-from tests.common import MockConfigEntry, mock_coro, mock_registry
+from tests.common import MockConfigEntry, mock_registry
 
 MOCK_HOST = "192.168.0.1"
 MOCK_NAME = "test_ps4"
@@ -119,8 +119,8 @@ async def test_creating_entry_sets_up_media_player(hass):
     mock_flow = "homeassistant.components.ps4.PlayStation4FlowHandler.async_step_user"
     with patch(
         "homeassistant.components.ps4.media_player.async_setup_entry",
-        return_value=mock_coro(True),
-    ) as mock_setup, patch(mock_flow, return_value=mock_coro(MOCK_FLOW_RESULT)):
+        return_value=True,
+    ) as mock_setup, patch(mock_flow, return_value=MOCK_FLOW_RESULT):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -152,10 +152,10 @@ async def test_config_flow_entry_migrate(hass):
 
     with patch(
         "homeassistant.util.location.async_detect_location_info",
-        return_value=mock_coro(MOCK_LOCATION),
+        return_value=MOCK_LOCATION,
     ), patch(
         "homeassistant.helpers.entity_registry.async_get_registry",
-        return_value=mock_coro(mock_e_registry),
+        return_value=mock_e_registry,
     ):
         await ps4.async_migrate_entry(hass, mock_entry)
 
@@ -281,7 +281,7 @@ async def test_send_command(hass):
     assert mock_entity.entity_id == f"media_player.{MOCK_NAME}"
 
     # Test that all commands call service function.
-    with patch(mock_func, return_value=mock_coro(True)) as mock_service:
+    with patch(mock_func, return_value=True) as mock_service:
         for mock_command in COMMANDS:
             await hass.services.async_call(
                 DOMAIN,

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -1,5 +1,5 @@
 """Tests for the PS4 media player platform."""
-from unittest.mock import MagicMock, patch
+from asynctest import MagicMock, patch
 
 from pyps4_2ndscreen.credential import get_ddp_message
 
@@ -35,7 +35,7 @@ from homeassistant.const import (
 )
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, mock_coro, mock_device_registry, mock_registry
+from tests.common import MockConfigEntry, mock_device_registry, mock_registry
 
 MOCK_CREDS = "123412341234abcd12341234abcd12341234abcd12341234abcd12341234abcd"
 MOCK_NAME = "ha_ps4_name"
@@ -123,7 +123,6 @@ MOCK_DATA = {CONF_TOKEN: MOCK_CREDS, "devices": [MOCK_DEVICE]}
 MOCK_CONFIG = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA, entry_id=MOCK_ENTRY_ID)
 
 MOCK_LOAD = "homeassistant.components.ps4.media_player.load_games"
-MOCK_SAVE = "homeassistant.components.ps4.save_json"
 
 
 async def setup_mock_component(hass, entry=None):
@@ -137,9 +136,7 @@ async def setup_mock_component(hass, entry=None):
 
     mock_entry.add_to_hass(hass)
 
-    # Don't use an actual file.
-    with patch(MOCK_LOAD, return_value={}), patch(MOCK_SAVE, side_effect=MagicMock()):
-        await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
     await hass.async_block_till_done()
 
@@ -150,7 +147,7 @@ async def setup_mock_component(hass, entry=None):
     return mock_entity_id
 
 
-async def mock_ddp_response(hass, mock_status_data, games=None):
+async def mock_ddp_response(hass, mock_status_data):
     """Mock raw UDP response from device."""
     mock_protocol = hass.data[PS4_DATA].protocol
 
@@ -159,14 +156,8 @@ async def mock_ddp_response(hass, mock_status_data, games=None):
     mock_status_header = f"{mock_code} {mock_status}"
     mock_response = get_ddp_message(mock_status_header, mock_status_data).encode()
 
-    if games is None:
-        games = {}
-
-    with patch(MOCK_LOAD, return_value=games), patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
-        mock_protocol.datagram_received(mock_response, (MOCK_HOST, MOCK_RANDOM_PORT))
-        await hass.async_block_till_done()
+    mock_protocol.datagram_received(mock_response, (MOCK_HOST, MOCK_RANDOM_PORT))
+    await hass.async_block_till_done()
 
 
 async def test_media_player_is_setup_correctly_with_entry(hass):
@@ -187,8 +178,7 @@ async def test_state_standby_is_set(hass):
     """Test that state is set to standby."""
     mock_entity_id = await setup_mock_component(hass)
 
-    with patch(MOCK_SAVE, side_effect=MagicMock()):
-        await mock_ddp_response(hass, MOCK_STATUS_STANDBY)
+    await mock_ddp_response(hass, MOCK_STATUS_STANDBY)
 
     assert hass.states.get(mock_entity_id).state == STATE_STANDBY
 
@@ -201,9 +191,7 @@ async def test_state_playing_is_set(hass):
         "pyps4.Ps4Async.async_get_ps_store_data",
     )
 
-    with patch(mock_func, return_value=mock_coro(None)), patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
+    with patch(mock_func, return_value=None):
         await mock_ddp_response(hass, MOCK_STATUS_PLAYING)
 
     assert hass.states.get(mock_entity_id).state == STATE_PLAYING
@@ -213,8 +201,7 @@ async def test_state_idle_is_set(hass):
     """Test that state is set to idle."""
     mock_entity_id = await setup_mock_component(hass)
 
-    with patch(MOCK_SAVE, side_effect=MagicMock()):
-        await mock_ddp_response(hass, MOCK_STATUS_IDLE)
+    await mock_ddp_response(hass, MOCK_STATUS_IDLE)
 
     assert hass.states.get(mock_entity_id).state == STATE_IDLE
 
@@ -240,9 +227,7 @@ async def test_media_attributes_are_fetched(hass):
     mock_result.cover_art = MOCK_TITLE_ART_URL
     mock_result.game_type = "game"
 
-    with patch(mock_func, return_value=mock_coro(mock_result)) as mock_fetch, patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
+    with patch(mock_func, return_value=mock_result) as mock_fetch:
         await mock_ddp_response(hass, MOCK_STATUS_PLAYING)
 
     mock_state = hass.states.get(mock_entity_id)
@@ -258,19 +243,17 @@ async def test_media_attributes_are_fetched(hass):
     assert mock_attrs.get(ATTR_MEDIA_CONTENT_TYPE) == MOCK_TITLE_TYPE
 
 
-async def test_media_attributes_are_loaded(hass):
+async def test_media_attributes_are_loaded(hass, patch_load_json):
     """Test that media attributes are loaded."""
     mock_entity_id = await setup_mock_component(hass)
-    mock_data = {MOCK_TITLE_ID: MOCK_GAMES_DATA_LOCKED}
-    mock_func = "{}{}".format(
-        "homeassistant.components.ps4.media_player.",
-        "pyps4.Ps4Async.async_get_ps_store_data",
-    )
+    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA_LOCKED}
 
-    with patch(mock_func, return_value=mock_coro(None)) as mock_fetch, patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
-        await mock_ddp_response(hass, MOCK_STATUS_PLAYING, mock_data)
+    with patch(
+        "homeassistant.components.ps4.media_player."
+        "pyps4.Ps4Async.async_get_ps_store_data",
+        return_value=None,
+    ) as mock_fetch:
+        await mock_ddp_response(hass, MOCK_STATUS_PLAYING)
 
     mock_state = hass.states.get(mock_entity_id)
     mock_attrs = dict(mock_state.attributes)
@@ -372,9 +355,7 @@ async def test_turn_on(hass):
         "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.wakeup"
     )
 
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
+    with patch(mock_func) as mock_call:
         await hass.services.async_call(
             "media_player", "turn_on", {ATTR_ENTITY_ID: mock_entity_id}
         )
@@ -390,9 +371,7 @@ async def test_turn_off(hass):
         "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.standby"
     )
 
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
+    with patch(mock_func) as mock_call:
         await hass.services.async_call(
             "media_player", "turn_off", {ATTR_ENTITY_ID: mock_entity_id}
         )
@@ -408,9 +387,7 @@ async def test_media_pause(hass):
         "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.remote_control"
     )
 
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
+    with patch(mock_func) as mock_call:
         await hass.services.async_call(
             "media_player", "media_pause", {ATTR_ENTITY_ID: mock_entity_id}
         )
@@ -426,9 +403,7 @@ async def test_media_stop(hass):
         "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.remote_control"
     )
 
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
+    with patch(mock_func) as mock_call:
         await hass.services.async_call(
             "media_player", "media_stop", {ATTR_ENTITY_ID: mock_entity_id}
         )
@@ -437,46 +412,34 @@ async def test_media_stop(hass):
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source(hass):
+async def test_select_source(hass, patch_load_json):
     """Test that select source service calls function with title."""
-    mock_data = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
-    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE), patch(
-        MOCK_LOAD, return_value=mock_data
-    ):
+    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
         mock_entity_id = await setup_mock_component(hass)
 
-    mock_func = "{}{}".format(
-        "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.start_title"
-    )
-
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
+    with patch("pyps4_2ndscreen.ps4.Ps4Async.start_title") as mock_call, patch(
+        "homeassistant.components.ps4.media_player.PS4Device.async_update"
     ):
         # Test with title name.
         await hass.services.async_call(
             "media_player",
             "select_source",
             {ATTR_ENTITY_ID: mock_entity_id, ATTR_INPUT_SOURCE: MOCK_TITLE_NAME},
+            blocking=True,
         )
-        await hass.async_block_till_done()
 
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source_caps(hass):
+async def test_select_source_caps(hass, patch_load_json):
     """Test that select source service calls function with upper case title."""
-    mock_data = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
-    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE), patch(
-        MOCK_LOAD, return_value=mock_data
-    ):
+    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
         mock_entity_id = await setup_mock_component(hass)
 
-    mock_func = "{}{}".format(
-        "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.start_title"
-    )
-
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
+    with patch("pyps4_2ndscreen.ps4.Ps4Async.start_title") as mock_call, patch(
+        "homeassistant.components.ps4.media_player.PS4Device.async_update"
     ):
         # Test with title name in caps.
         await hass.services.async_call(
@@ -486,34 +449,28 @@ async def test_select_source_caps(hass):
                 ATTR_ENTITY_ID: mock_entity_id,
                 ATTR_INPUT_SOURCE: MOCK_TITLE_NAME.upper(),
             },
+            blocking=True,
         )
-        await hass.async_block_till_done()
 
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source_id(hass):
+async def test_select_source_id(hass, patch_load_json):
     """Test that select source service calls function with Title ID."""
-    mock_data = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
-    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE), patch(
-        MOCK_LOAD, return_value=mock_data
-    ):
+    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
         mock_entity_id = await setup_mock_component(hass)
 
-    mock_func = "{}{}".format(
-        "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.start_title"
-    )
-
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
+    with patch("pyps4_2ndscreen.ps4.Ps4Async.start_title") as mock_call, patch(
+        "homeassistant.components.ps4.media_player.PS4Device.async_update"
     ):
         # Test with title ID.
         await hass.services.async_call(
             "media_player",
             "select_source",
             {ATTR_ENTITY_ID: mock_entity_id, ATTR_INPUT_SOURCE: MOCK_TITLE_ID},
+            blocking=True,
         )
-        await hass.async_block_till_done()
 
     assert len(mock_call.mock_calls) == 1
 
@@ -521,17 +478,14 @@ async def test_select_source_id(hass):
 async def test_ps4_send_command(hass):
     """Test that ps4 send command service calls function."""
     mock_entity_id = await setup_mock_component(hass)
-    mock_func = "{}{}".format(
-        "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.remote_control"
-    )
 
-    with patch(mock_func, return_value=MagicMock()) as mock_call, patch(
-        MOCK_SAVE, side_effect=MagicMock()
-    ):
+    with patch("pyps4_2ndscreen.ps4.Ps4Async.remote_control") as mock_call:
         await hass.services.async_call(
-            DOMAIN, "send_command", {ATTR_ENTITY_ID: mock_entity_id, ATTR_COMMAND: "ps"}
+            DOMAIN,
+            "send_command",
+            {ATTR_ENTITY_ID: mock_entity_id, ATTR_COMMAND: "ps"},
+            blocking=True,
         )
-        await hass.async_block_till_done()
 
     assert len(mock_call.mock_calls) == 1
 

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -1,6 +1,5 @@
 """Tests for the PS4 media player platform."""
 from asynctest import MagicMock, patch
-
 from pyps4_2ndscreen.credential import get_ddp_message
 
 from homeassistant.components import ps4

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,6 +1,5 @@
 """Test Zeroconf component setup process."""
-from unittest.mock import patch
-
+from asynctest import patch
 import pytest
 from zeroconf import ServiceInfo, ServiceStateChange
 
@@ -75,7 +74,7 @@ async def test_setup(hass, mock_zeroconf):
     expected_flow_calls = 0
     for matching_components in zc_gen.ZEROCONF.values():
         expected_flow_calls += len(matching_components)
-    assert len(mock_config_flow.mock_calls) == expected_flow_calls * 2
+    assert len(mock_config_flow.mock_calls) == expected_flow_calls
 
 
 async def test_homekit_match_partial_space(hass, mock_zeroconf):
@@ -91,7 +90,7 @@ async def test_homekit_match_partial_space(hass, mock_zeroconf):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    assert len(mock_config_flow.mock_calls) == 2
+    assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "lifx"
 
 
@@ -110,7 +109,7 @@ async def test_homekit_match_partial_dash(hass, mock_zeroconf):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    assert len(mock_config_flow.mock_calls) == 2
+    assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "rachio"
 
 
@@ -127,7 +126,7 @@ async def test_homekit_match_full(hass, mock_zeroconf):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    assert len(mock_config_flow.mock_calls) == 2
+    assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix all tests that broke under 3.8 in #34654 that I could locally reproduce.

Digging into core tests now.

It's either a timing issue (add a block till done) or some edge cases when mocking coroutines. Getting rid of mock_coro and using `patch` from `asynctest` fixes it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
