### PR TITLE
Fix connection problems in the Broadlink integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -90,6 +90,7 @@ omit =
     homeassistant/components/braviatv/const.py
     homeassistant/components/braviatv/media_player.py
     homeassistant/components/broadlink/const.py
+    homeassistant/components/broadlink/device.py
     homeassistant/components/broadlink/remote.py
     homeassistant/components/broadlink/sensor.py
     homeassistant/components/broadlink/switch.py

--- a/homeassistant/components/broadlink/device.py
+++ b/homeassistant/components/broadlink/device.py
@@ -1,0 +1,57 @@
+"""Support for Broadlink devices."""
+from functools import partial
+import logging
+
+from broadlink.exceptions import (
+    AuthorizationError,
+    BroadlinkException,
+    ConnectionClosedError,
+    DeviceOfflineError,
+)
+
+from .const import DEFAULT_RETRY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BroadlinkDevice:
+    """Manages a Broadlink device."""
+
+    def __init__(self, hass, api):
+        """Initialize the device."""
+        self.hass = hass
+        self.api = api
+        self.available = None
+
+    async def async_connect(self):
+        """Connect to the device."""
+        try:
+            await self.hass.async_add_executor_job(self.api.auth)
+        except BroadlinkException as err_msg:
+            if self.available:
+                self.available = False
+                _LOGGER.warning(
+                    "Disconnected from device at %s: %s", self.api.host[0], err_msg
+                )
+            return False
+        else:
+            if not self.available:
+                if self.available is not None:
+                    _LOGGER.warning("Connected to device at %s", self.api.host[0])
+                self.available = True
+            return True
+
+    async def async_request(self, function, *args, **kwargs):
+        """Send a request to the device."""
+        partial_function = partial(function, *args, **kwargs)
+        for attempt in range(DEFAULT_RETRY):
+            try:
+                result = await self.hass.async_add_executor_job(partial_function)
+            except (AuthorizationError, ConnectionClosedError, DeviceOfflineError):
+                if attempt == DEFAULT_RETRY - 1 or not await self.async_connect():
+                    raise
+            else:
+                if not self.available:
+                    self.available = True
+                    _LOGGER.warning("Connected to device at %s", self.api.host[0])
+                return result

--- a/homeassistant/components/broadlink/manifest.json
+++ b/homeassistant/components/broadlink/manifest.json
@@ -2,6 +2,6 @@
   "domain": "broadlink",
   "name": "Broadlink",
   "documentation": "https://www.home-assistant.io/integrations/broadlink",
-  "requirements": ["broadlink==0.13.2"],
+  "requirements": ["broadlink==0.14.0"],
   "codeowners": ["@danielhiversen", "@felipediel"]
 }

--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -4,6 +4,7 @@ from ipaddress import ip_address
 import logging
 
 import broadlink as blk
+from broadlink.exceptions import BroadlinkException
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -18,6 +19,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     UNIT_PERCENTAGE,
 )
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -31,6 +33,7 @@ from .const import (
     RM4_TYPES,
     RM_TYPES,
 )
+from .device import BroadlinkDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,7 +63,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Broadlink device sensors."""
     host = config[CONF_HOST]
     mac_addr = config[CONF_MAC]
@@ -77,11 +80,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         check_sensors = api.check_sensors_raw
 
     api.timeout = timeout
-    broadlink_data = BroadlinkData(api, check_sensors, update_interval)
-    dev = []
-    for variable in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(BroadlinkSensor(name, broadlink_data, variable))
-    add_entities(dev, True)
+    device = BroadlinkDevice(hass, api)
+
+    connected = await device.async_connect()
+    if not connected:
+        raise PlatformNotReady
+
+    broadlink_data = BroadlinkData(device, check_sensors, update_interval)
+    sensors = [
+        BroadlinkSensor(name, broadlink_data, variable)
+        for variable in config[CONF_MONITORED_CONDITIONS]
+    ]
+    async_add_entities(sensors, True)
 
 
 class BroadlinkSensor(Entity):
@@ -91,7 +101,6 @@ class BroadlinkSensor(Entity):
         """Initialize the sensor."""
         self._name = f"{name} {SENSOR_TYPES[sensor_type][0]}"
         self._state = None
-        self._is_available = False
         self._type = sensor_type
         self._broadlink_data = broadlink_data
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
@@ -109,30 +118,29 @@ class BroadlinkSensor(Entity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return self._is_available
+        return self._broadlink_data.device.available
 
     @property
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return self._unit_of_measurement
 
-    def update(self):
+    async def async_update(self):
         """Get the latest data from the sensor."""
-        self._broadlink_data.update()
-        if self._broadlink_data.data is None:
-            self._state = None
-            self._is_available = False
-            return
-        self._state = self._broadlink_data.data[self._type]
-        self._is_available = True
+        await self._broadlink_data.async_update()
+        self._state = (
+            self._broadlink_data.data[self._type]
+            if self._broadlink_data.device.available
+            else None
+        )
 
 
 class BroadlinkData:
     """Representation of a Broadlink data object."""
 
-    def __init__(self, api, check_sensors, interval):
+    def __init__(self, device, check_sensors, interval):
         """Initialize the data object."""
-        self.api = api
+        self.device = device
         self.check_sensors = check_sensors
         self.data = None
         self._schema = vol.Schema(
@@ -144,31 +152,16 @@ class BroadlinkData:
                 vol.Optional("noise"): vol.Any(0, 1, 2),
             }
         )
-        self.update = Throttle(interval)(self._update)
-        if not self._auth():
-            _LOGGER.warning("Failed to connect to device")
+        self.async_update = Throttle(interval)(self._async_fetch_sensor_data)
 
-    def _update(self, retry=3):
+    async def _async_fetch_sensor_data(self):
+        """Fetch sensor data."""
         try:
-            data = self.check_sensors()
-            if data is not None:
-                self.data = self._schema(data)
-                return
-        except OSError as error:
-            if retry < 1:
-                self.data = None
-                _LOGGER.error(error)
-                return
+            data = await self.device.async_request(self.check_sensors)
+        except BroadlinkException:
+            return
+        try:
+            data = self._schema(data)
         except (vol.Invalid, vol.MultipleInvalid):
-            pass  # Continue quietly if device returned malformed data
-        if retry > 0 and self._auth():
-            self._update(retry - 1)
-
-    def _auth(self, retry=3):
-        try:
-            auth = self.api.auth()
-        except OSError:
-            auth = False
-        if not auth and retry > 0:
-            return self._auth(retry - 1)
-        return auth
+            return
+        self.data = data

--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -128,11 +128,10 @@ class BroadlinkSensor(Entity):
     async def async_update(self):
         """Get the latest data from the sensor."""
         await self._broadlink_data.async_update()
-        self._state = (
-            self._broadlink_data.data[self._type]
-            if self._broadlink_data.device.available
-            else None
-        )
+        try:
+            self._state = self._broadlink_data.data[self._type]
+        except TypeError:
+            pass
 
 
 class BroadlinkData:
@@ -152,9 +151,9 @@ class BroadlinkData:
                 vol.Optional("noise"): vol.Any(0, 1, 2),
             }
         )
-        self.async_update = Throttle(interval)(self._async_fetch_sensor_data)
+        self.async_update = Throttle(interval)(self._async_fetch_data)
 
-    async def _async_fetch_sensor_data(self):
+    async def _async_fetch_data(self):
         """Fetch sensor data."""
         try:
             data = await self.device.async_request(self.check_sensors)

--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -153,7 +153,7 @@ class BroadlinkData:
 
     async def _async_fetch_data(self):
         """Fetch sensor data."""
-        for attempt in range(DEFAULT_RETRY):
+        for _ in range(DEFAULT_RETRY):
             try:
                 data = await self.device.async_request(self.check_sensors)
             except BroadlinkException:

--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -166,4 +166,4 @@ class BroadlinkData:
                 self.data = data
                 return
 
-        _LOGGER.debug("Failed to update sensors: Device returned malformed data.")
+        _LOGGER.debug("Failed to update sensors: Device returned malformed data")

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONF_TYPE,
     STATE_ON,
 )
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import Throttle, slugify
@@ -139,9 +140,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     broadlink_device.timeout = config.get(CONF_TIMEOUT)
     try:
-        broadlink_device.auth()
+        auth = broadlink_device.auth()
     except OSError:
+        auth = False
+    if not auth:
         _LOGGER.error("Failed to connect to device")
+        raise PlatformNotReady
 
     add_entities(switches)
 

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -110,12 +110,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if model in RM_TYPES:
         api = blk.rm((host, DEFAULT_PORT), mac_addr, None)
         broadlink_device = BroadlinkDevice(hass, api)
-        hass.add_job(async_setup_service, hass, host, broadlink_device)
+        hass.async_create_task(async_setup_service(hass, host, broadlink_device))
         switches = generate_rm_switches(devices, broadlink_device)
     elif model in RM4_TYPES:
         api = blk.rm4((host, DEFAULT_PORT), mac_addr, None)
         broadlink_device = BroadlinkDevice(hass, api)
-        hass.add_job(async_setup_service, hass, host, broadlink_device)
+        hass.async_create_task(async_setup_service(hass, host, broadlink_device))
         switches = generate_rm_switches(devices, broadlink_device)
     elif model in SP1_TYPES:
         api = blk.sp1((host, DEFAULT_PORT), mac_addr, None)

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -65,15 +65,15 @@ MP1_SWITCH_SLOT_SCHEMA = vol.Schema(
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_SWITCHES, default={}): cv.schema_with_slug_keys(
-            SWITCH_SCHEMA
-        ),
-        vol.Optional(CONF_SLOTS, default={}): MP1_SWITCH_SLOT_SCHEMA,
         vol.Required(CONF_HOST): vol.All(vol.Any(hostname, ip_address), cv.string),
         vol.Required(CONF_MAC): mac_address,
         vol.Optional(CONF_FRIENDLY_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_TYPE, default=DEVICE_TYPES[0]): vol.In(DEVICE_TYPES),
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_SLOTS, default={}): MP1_SWITCH_SLOT_SCHEMA,
+        vol.Optional(CONF_SWITCHES, default={}): cv.schema_with_slug_keys(
+            SWITCH_SCHEMA
+        ),
     }
 )
 
@@ -81,12 +81,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Broadlink switches."""
 
-    devices = config.get(CONF_SWITCHES)
-    slots = config.get("slots", {})
-    host = config.get(CONF_HOST)
-    mac_addr = config.get(CONF_MAC)
-    friendly_name = config.get(CONF_FRIENDLY_NAME)
+    host = config[CONF_HOST]
+    mac_addr = config[CONF_MAC]
+    friendly_name = config[CONF_FRIENDLY_NAME]
     model = config[CONF_TYPE]
+    timeout = config[CONF_TIMEOUT]
+    slots = config[CONF_SLOTS]
+    devices = config[CONF_SWITCHES]
 
     def generate_rm_switches(switches, broadlink_device):
         """Generate RM switches."""
@@ -136,7 +137,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             for i in range(1, 5)
         ]
 
-    api.timeout = config.get(CONF_TIMEOUT)
+    api.timeout = timeout
     connected = await broadlink_device.async_connect()
     if not connected:
         raise PlatformNotReady

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -2,9 +2,9 @@
 from datetime import timedelta
 from ipaddress import ip_address
 import logging
-import socket
 
 import broadlink as blk
+from broadlink.exceptions import BroadlinkException
 import voluptuous as vol
 
 from homeassistant.components.switch import DOMAIN, PLATFORM_SCHEMA, SwitchEntity
@@ -28,7 +28,6 @@ from . import async_setup_service, data_packet, hostname, mac_address
 from .const import (
     DEFAULT_NAME,
     DEFAULT_PORT,
-    DEFAULT_RETRY,
     DEFAULT_TIMEOUT,
     MP1_TYPES,
     RM4_TYPES,
@@ -36,6 +35,7 @@ from .const import (
     SP1_TYPES,
     SP2_TYPES,
 )
+from .device import BroadlinkDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,12 +74,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_FRIENDLY_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_TYPE, default=DEVICE_TYPES[0]): vol.In(DEVICE_TYPES),
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-        vol.Optional(CONF_RETRY, default=DEFAULT_RETRY): cv.positive_int,
     }
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Broadlink switches."""
 
     devices = config.get(CONF_SWITCHES)
@@ -88,7 +87,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     mac_addr = config.get(CONF_MAC)
     friendly_name = config.get(CONF_FRIENDLY_NAME)
     model = config[CONF_TYPE]
-    retry_times = config.get(CONF_RETRY)
 
     def generate_rm_switches(switches, broadlink_device):
         """Generate RM switches."""
@@ -99,7 +97,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 broadlink_device,
                 config.get(CONF_COMMAND_ON),
                 config.get(CONF_COMMAND_OFF),
-                retry_times,
             )
             for object_id, config in switches.items()
         ]
@@ -111,61 +108,53 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return slots[f"slot_{slot}"]
 
     if model in RM_TYPES:
-        broadlink_device = blk.rm((host, DEFAULT_PORT), mac_addr, None)
+        api = blk.rm((host, DEFAULT_PORT), mac_addr, None)
+        broadlink_device = BroadlinkDevice(hass, api)
         hass.add_job(async_setup_service, hass, host, broadlink_device)
         switches = generate_rm_switches(devices, broadlink_device)
     elif model in RM4_TYPES:
-        broadlink_device = blk.rm4((host, DEFAULT_PORT), mac_addr, None)
+        api = blk.rm4((host, DEFAULT_PORT), mac_addr, None)
+        broadlink_device = BroadlinkDevice(hass, api)
         hass.add_job(async_setup_service, hass, host, broadlink_device)
         switches = generate_rm_switches(devices, broadlink_device)
     elif model in SP1_TYPES:
-        broadlink_device = blk.sp1((host, DEFAULT_PORT), mac_addr, None)
-        switches = [BroadlinkSP1Switch(friendly_name, broadlink_device, retry_times)]
+        api = blk.sp1((host, DEFAULT_PORT), mac_addr, None)
+        broadlink_device = BroadlinkDevice(hass, api)
+        switches = [BroadlinkSP1Switch(friendly_name, broadlink_device)]
     elif model in SP2_TYPES:
-        broadlink_device = blk.sp2((host, DEFAULT_PORT), mac_addr, None)
-        switches = [BroadlinkSP2Switch(friendly_name, broadlink_device, retry_times)]
+        api = blk.sp2((host, DEFAULT_PORT), mac_addr, None)
+        broadlink_device = BroadlinkDevice(hass, api)
+        switches = [BroadlinkSP2Switch(friendly_name, broadlink_device)]
     elif model in MP1_TYPES:
-        switches = []
-        broadlink_device = blk.mp1((host, DEFAULT_PORT), mac_addr, None)
-        parent_device = BroadlinkMP1Switch(broadlink_device, retry_times)
-        for i in range(1, 5):
-            slot = BroadlinkMP1Slot(
-                get_mp1_slot_name(friendly_name, i),
-                broadlink_device,
-                i,
-                parent_device,
-                retry_times,
+        api = blk.mp1((host, DEFAULT_PORT), mac_addr, None)
+        broadlink_device = BroadlinkDevice(hass, api)
+        parent_device = BroadlinkMP1Switch(broadlink_device)
+        switches = [
+            BroadlinkMP1Slot(
+                get_mp1_slot_name(friendly_name, i), broadlink_device, i, parent_device,
             )
-            switches.append(slot)
+            for i in range(1, 5)
+        ]
 
-    broadlink_device.timeout = config.get(CONF_TIMEOUT)
-    try:
-        auth = broadlink_device.auth()
-    except OSError:
-        auth = False
-    if not auth:
-        _LOGGER.error("Failed to connect to device")
+    api.timeout = config.get(CONF_TIMEOUT)
+    connected = await broadlink_device.async_connect()
+    if not connected:
         raise PlatformNotReady
 
-    add_entities(switches)
+    async_add_entities(switches)
 
 
 class BroadlinkRMSwitch(SwitchEntity, RestoreEntity):
     """Representation of an Broadlink switch."""
 
-    def __init__(
-        self, name, friendly_name, device, command_on, command_off, retry_times
-    ):
+    def __init__(self, name, friendly_name, device, command_on, command_off):
         """Initialize the switch."""
+        self.device = device
         self.entity_id = f"{DOMAIN}.{slugify(name)}"
         self._name = friendly_name
         self._state = False
         self._command_on = command_on
         self._command_off = command_off
-        self._device = device
-        self._is_available = False
-        self._retry_times = retry_times
-        _LOGGER.debug("_retry_times : %s", self._retry_times)
 
     async def async_added_to_hass(self):
         """Call when entity about to be added to hass."""
@@ -187,7 +176,7 @@ class BroadlinkRMSwitch(SwitchEntity, RestoreEntity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return not self.should_poll or self._is_available
+        return not self.should_poll or self.device.available
 
     @property
     def should_poll(self):
@@ -199,68 +188,53 @@ class BroadlinkRMSwitch(SwitchEntity, RestoreEntity):
         """Return true if device is on."""
         return self._state
 
-    def turn_on(self, **kwargs):
+    async def async_update(self):
+        """Update the state of the device."""
+        if not self.available:
+            await self.device.async_connect()
+
+    async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        if self._sendpacket(self._command_on, self._retry_times):
+        if await self._async_send_packet(self._command_on):
             self._state = True
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Turn the device off."""
-        if self._sendpacket(self._command_off, self._retry_times):
+        if await self._async_send_packet(self._command_off):
             self._state = False
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
-    def _sendpacket(self, packet, retry):
+    async def _async_send_packet(self, packet):
         """Send packet to device."""
         if packet is None:
             _LOGGER.debug("Empty packet")
             return True
         try:
-            self._device.send_data(packet)
-        except (ValueError, OSError) as error:
-            if retry < 1:
-                _LOGGER.error("Error during sending a packet: %s", error)
-                return False
-            if not self._auth(self._retry_times):
-                return False
-            return self._sendpacket(packet, retry - 1)
+            await self.device.async_request(self.device.api.send_data, packet)
+        except BroadlinkException as err_msg:
+            _LOGGER.error("Failed to send packet: %s", err_msg)
+            return False
         return True
-
-    def _auth(self, retry):
-        _LOGGER.debug("_auth : retry=%s", retry)
-        try:
-            auth = self._device.auth()
-        except OSError:
-            auth = False
-            if retry < 1:
-                _LOGGER.error("Timeout during authorization")
-        if not auth and retry > 0:
-            return self._auth(retry - 1)
-        return auth
 
 
 class BroadlinkSP1Switch(BroadlinkRMSwitch):
     """Representation of an Broadlink switch."""
 
-    def __init__(self, friendly_name, device, retry_times):
+    def __init__(self, friendly_name, device):
         """Initialize the switch."""
-        super().__init__(friendly_name, friendly_name, device, None, None, retry_times)
+        super().__init__(friendly_name, friendly_name, device, None, None)
         self._command_on = 1
         self._command_off = 0
         self._load_power = None
 
-    def _sendpacket(self, packet, retry):
+    async def _async_send_packet(self, packet):
         """Send packet to device."""
         try:
-            self._device.set_power(packet)
-        except (socket.timeout, ValueError) as error:
-            if retry < 1:
-                _LOGGER.error("Error during sending a packet: %s", error)
-                return False
-            if not self._auth(self._retry_times):
-                return False
-            return self._sendpacket(packet, retry - 1)
+            await self.device.async_request(self.device.api.set_power, packet)
+        except BroadlinkException as err_msg:
+            _LOGGER.error("Failed to send packet: %s", err_msg)
+            return False
         return True
 
 
@@ -285,37 +259,24 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
         except (ValueError, TypeError):
             return None
 
-    def update(self):
-        """Synchronize state with switch."""
-        self._update(self._retry_times)
-
-    def _update(self, retry):
+    async def async_update(self):
         """Update the state of the device."""
-        _LOGGER.debug("_update : retry=%s", retry)
         try:
-            state = self._device.check_power()
-            load_power = self._device.get_energy()
-        except (socket.timeout, ValueError) as error:
-            if retry < 1:
-                _LOGGER.error("Error during updating the state: %s", error)
-                self._is_available = False
-                return
-            if not self._auth(self._retry_times):
-                return
-            return self._update(retry - 1)
-        if state is None and retry > 0:
-            return self._update(retry - 1)
+            state = await self.device.async_request(self.device.api.check_power)
+            load_power = await self.device.async_request(self.device.api.get_energy)
+        except BroadlinkException as err_msg:
+            _LOGGER.error("Failed to update state: %s", err_msg)
+            return
         self._state = state
         self._load_power = load_power
-        self._is_available = True
 
 
 class BroadlinkMP1Slot(BroadlinkRMSwitch):
     """Representation of a slot of Broadlink switch."""
 
-    def __init__(self, friendly_name, device, slot, parent_device, retry_times):
+    def __init__(self, friendly_name, device, slot, parent_device):
         """Initialize the slot of switch."""
-        super().__init__(friendly_name, friendly_name, device, None, None, retry_times)
+        super().__init__(friendly_name, friendly_name, device, None, None)
         self._command_on = 1
         self._command_off = 0
         self._slot = slot
@@ -326,44 +287,35 @@ class BroadlinkMP1Slot(BroadlinkRMSwitch):
         """Return true if unable to access real state of entity."""
         return False
 
-    def _sendpacket(self, packet, retry):
-        """Send packet to device."""
-        try:
-            self._device.set_power(self._slot, packet)
-        except (socket.timeout, ValueError) as error:
-            if retry < 1:
-                _LOGGER.error("Error during sending a packet: %s", error)
-                self._is_available = False
-                return False
-            if not self._auth(self._retry_times):
-                return False
-            return self._sendpacket(packet, max(0, retry - 1))
-        self._is_available = True
-        return True
-
     @property
     def should_poll(self):
         """Return the polling state."""
         return True
 
-    def update(self):
-        """Trigger update for all switches on the parent device."""
-        self._parent_device.update()
+    async def async_update(self):
+        """Update the state of the device."""
+        await self._parent_device.async_update()
         self._state = self._parent_device.get_outlet_status(self._slot)
-        if self._state is None:
-            self._is_available = False
-        else:
-            self._is_available = True
+
+    async def _async_send_packet(self, packet):
+        """Send packet to device."""
+        try:
+            await self.device.async_request(
+                self.device.api.set_power, self._slot, packet
+            )
+        except BroadlinkException as err_msg:
+            _LOGGER.error("Failed to send packet: %s", err_msg)
+            return False
+        return True
 
 
 class BroadlinkMP1Switch:
     """Representation of a Broadlink switch - To fetch states of all slots."""
 
-    def __init__(self, device, retry_times):
+    def __init__(self, device):
         """Initialize the switch."""
-        self._device = device
+        self.device = device
         self._states = None
-        self._retry_times = retry_times
 
     def get_outlet_status(self, slot):
         """Get status of outlet from cached status list."""
@@ -372,31 +324,10 @@ class BroadlinkMP1Switch:
         return self._states[f"s{slot}"]
 
     @Throttle(TIME_BETWEEN_UPDATES)
-    def update(self):
-        """Fetch new state data for this device."""
-        self._update(self._retry_times)
-
-    def _update(self, retry):
+    async def async_update(self):
         """Update the state of the device."""
         try:
-            states = self._device.check_power()
-        except (socket.timeout, ValueError) as error:
-            if retry < 1:
-                _LOGGER.error("Error during updating the state: %s", error)
-                return
-            if not self._auth(self._retry_times):
-                return
-            return self._update(max(0, retry - 1))
-        if states is None and retry > 0:
-            return self._update(max(0, retry - 1))
+            states = self.device.async_request(self.device.api.check_power)
+        except BroadlinkException as err_msg:
+            _LOGGER.error("Failed to update state: %s", err_msg)
         self._states = states
-
-    def _auth(self, retry):
-        """Authenticate the device."""
-        try:
-            auth = self._device.auth()
-        except OSError:
-            auth = False
-        if not auth and retry > 0:
-            return self._auth(retry - 1)
-        return auth

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -327,7 +327,7 @@ class BroadlinkMP1Switch:
     async def async_update(self):
         """Update the state of the device."""
         try:
-            states = self.device.async_request(self.device.api.check_power)
+            states = await self.device.async_request(self.device.api.check_power)
         except BroadlinkException as err_msg:
             _LOGGER.error("Failed to update state: %s", err_msg)
         self._states = states

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -362,7 +362,7 @@ boto3==1.9.252
 bravia-tv==1.0.2
 
 # homeassistant.components.broadlink
-broadlink==0.13.2
+broadlink==0.14.0
 
 # homeassistant.components.brother
 brother==0.1.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -147,7 +147,7 @@ bomradarloop==0.1.4
 bravia-tv==1.0.2
 
 # homeassistant.components.broadlink
-broadlink==0.13.2
+broadlink==0.14.0
 
 # homeassistant.components.brother
 brother==0.1.14

--- a/tests/components/broadlink/test_init.py
+++ b/tests/components/broadlink/test_init.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.broadlink import async_setup_service, data_packet
 from homeassistant.components.broadlink.const import DOMAIN, SERVICE_LEARN, SERVICE_SEND
+from homeassistant.components.broadlink.device import BroadlinkDevice
 from homeassistant.util.dt import utcnow
 
 DUMMY_IR_PACKET = (
@@ -33,39 +34,37 @@ async def test_padding(hass):
 
 async def test_send(hass):
     """Test send service."""
-    mock_device = MagicMock()
-    mock_device.send_data.return_value = None
+    mock_api = MagicMock()
+    mock_api.send_data.return_value = None
+    device = BroadlinkDevice(hass, mock_api)
 
-    async_setup_service(hass, DUMMY_HOST, mock_device)
-    await hass.async_block_till_done()
-
+    await async_setup_service(hass, DUMMY_HOST, device)
     await hass.services.async_call(
         DOMAIN, SERVICE_SEND, {"host": DUMMY_HOST, "packet": (DUMMY_IR_PACKET)}
     )
     await hass.async_block_till_done()
 
-    assert mock_device.send_data.call_count == 1
-    assert mock_device.send_data.call_args == call(b64decode(DUMMY_IR_PACKET))
+    assert device.api.send_data.call_count == 1
+    assert device.api.send_data.call_args == call(b64decode(DUMMY_IR_PACKET))
 
 
 async def test_learn(hass):
     """Test learn service."""
-    mock_device = MagicMock()
-    mock_device.enter_learning.return_value = None
-    mock_device.check_data.return_value = b64decode(DUMMY_IR_PACKET)
+    mock_api = MagicMock()
+    mock_api.enter_learning.return_value = None
+    mock_api.check_data.return_value = b64decode(DUMMY_IR_PACKET)
+    device = BroadlinkDevice(hass, mock_api)
 
     with patch.object(
         hass.components.persistent_notification, "async_create"
     ) as mock_create:
 
-        async_setup_service(hass, DUMMY_HOST, mock_device)
-        await hass.async_block_till_done()
-
+        await async_setup_service(hass, DUMMY_HOST, device)
         await hass.services.async_call(DOMAIN, SERVICE_LEARN, {"host": DUMMY_HOST})
         await hass.async_block_till_done()
 
-        assert mock_device.enter_learning.call_count == 1
-        assert mock_device.enter_learning.call_args == call()
+        assert device.api.enter_learning.call_count == 1
+        assert device.api.enter_learning.call_args == call()
 
         assert mock_create.call_count == 1
         assert mock_create.call_args == call(
@@ -75,11 +74,12 @@ async def test_learn(hass):
 
 async def test_learn_timeout(hass):
     """Test learn service."""
-    mock_device = MagicMock()
-    mock_device.enter_learning.return_value = None
-    mock_device.check_data.return_value = None
+    mock_api = MagicMock()
+    mock_api.enter_learning.return_value = None
+    mock_api.check_data.return_value = None
+    device = BroadlinkDevice(hass, mock_api)
 
-    async_setup_service(hass, DUMMY_HOST, mock_device)
+    await async_setup_service(hass, DUMMY_HOST, device)
     await hass.async_block_till_done()
 
     now = utcnow()
@@ -93,8 +93,8 @@ async def test_learn_timeout(hass):
         await hass.services.async_call(DOMAIN, SERVICE_LEARN, {"host": DUMMY_HOST})
         await hass.async_block_till_done()
 
-        assert mock_device.enter_learning.call_count == 1
-        assert mock_device.enter_learning.call_args == call()
+        assert device.api.enter_learning.call_count == 1
+        assert device.api.enter_learning.call_args == call()
 
         assert mock_create.call_count == 1
         assert mock_create.call_args == call(

--- a/tests/components/broadlink/test_init.py
+++ b/tests/components/broadlink/test_init.py
@@ -80,7 +80,6 @@ async def test_learn_timeout(hass):
     device = BroadlinkDevice(hass, mock_api)
 
     await async_setup_service(hass, DUMMY_HOST, device)
-    await hass.async_block_till_done()
 
     now = utcnow()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## The problem
Some users are experiencing connection problems with Broadlink devices. The root of these problems is that we are ignoring the error codes that are being sent by the device in its responses.

Let's take a practical example. We need authorization to send a command. If we send a command without being authorized we will receive an authorization error. It's simple to deal with it, we just need to re-authenticate and send the command again. But currently we are not handling this exception. So once the connection is closed for some reason, the user needs to restart Home Assistant to make the device work again.

Here is a [real case](https://github.com/home-assistant/core/issues/32313#issuecomment-620905430). Once @AndroVet's device closes the connection, the device object breaks silently because it doesn't know it has been logged out.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I [updated the library](https://github.com/mjg59/python-broadlink/pull/356) to propagate errors in the response as exceptions. Now we just need to deal with these exceptions in Home Assistant. These are the changes I propose:
- Create a separate class to handle authentication, availability and requests to the device.
- This class will handle any communication errors that may occur and keep availability up to date.
- Import this class in the platforms and use it as a bridge to send requests to the device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32313 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
