### PR TITLE
Add climate turn on support to emulated_hue

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -186,7 +186,6 @@ omit =
     homeassistant/components/emby/media_player.py
     homeassistant/components/emoncms/sensor.py
     homeassistant/components/emoncms_history/*
-    homeassistant/components/emulated_hue/upnp.py
     homeassistant/components/enigma2/media_player.py
     homeassistant/components/enocean/*
     homeassistant/components/enphase_envoy/sensor.py

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -5,6 +5,7 @@ from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import util
+from homeassistant.components.climate.const import HVAC_MODES
 from homeassistant.components.http import real_ip
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import HomeAssistantError
@@ -34,6 +35,7 @@ CONF_ADVERTISE_PORT = "advertise_port"
 CONF_ENTITIES = "entities"
 CONF_ENTITY_HIDDEN = "hidden"
 CONF_ENTITY_NAME = "name"
+CONF_TURN_ON_MODE = "turn_on_mode"
 CONF_EXPOSE_BY_DEFAULT = "expose_by_default"
 CONF_EXPOSED_DOMAINS = "exposed_domains"
 CONF_HOST_IP = "host_ip"
@@ -63,6 +65,7 @@ CONFIG_ENTITY_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_ENTITY_NAME): cv.string,
         vol.Optional(CONF_ENTITY_HIDDEN): cv.boolean,
+        vol.Optional(CONF_TURN_ON_MODE): cv.string,
     }
 )
 
@@ -297,6 +300,17 @@ class Config:
             return True
 
         return False
+
+    def get_turn_on_mode(self, entity_id):
+        """Get turn on mode for climate entities by entity id."""
+        if entity_id in self.entities and CONF_TURN_ON_MODE in self.entities[entity_id]:
+            turn_on_mode = self.entities[entity_id][CONF_TURN_ON_MODE]
+            if turn_on_mode in HVAC_MODES:
+                return turn_on_mode
+
+            _LOGGER.warning("Invalid HVAC mode for %s", entity_id)
+
+        return None
 
 
 def _load_json(filename):

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -305,6 +305,7 @@ class Config:
         """Get turn on mode for climate entities by entity ID."""
         if entity_id in self.entities and CONF_TURN_ON_MODE in self.entities[entity_id]:
             turn_on_mode = self.entities[entity_id][CONF_TURN_ON_MODE]
+            _LOGGER.error(self.hass.states.get(entity_id))
             if turn_on_mode in self.hass.states.get(entity_id)[ATTR_HVAC_MODES]:
                 return turn_on_mode
 

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -305,8 +305,10 @@ class Config:
         """Get turn on mode for climate entities by entity ID."""
         if entity_id in self.entities and CONF_TURN_ON_MODE in self.entities[entity_id]:
             turn_on_mode = self.entities[entity_id][CONF_TURN_ON_MODE]
-            _LOGGER.error(self.hass.states.get(entity_id))
-            if turn_on_mode in self.hass.states.get(entity_id)[ATTR_HVAC_MODES]:
+            if (
+                turn_on_mode
+                in self.hass.states.get(entity_id).attributes[ATTR_HVAC_MODES]
+            ):
                 return turn_on_mode
 
             _LOGGER.warning("HVAC mode not supported by %s", entity_id)

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -5,7 +5,7 @@ from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import util
-from homeassistant.components.climate.const import HVAC_MODES
+from homeassistant.components.climate import ATTR_HVAC_MODES
 from homeassistant.components.http import real_ip
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import HomeAssistantError
@@ -302,13 +302,13 @@ class Config:
         return False
 
     def get_turn_on_mode(self, entity_id):
-        """Get turn on mode for climate entities by entity id."""
+        """Get turn on mode for climate entities by entity ID."""
         if entity_id in self.entities and CONF_TURN_ON_MODE in self.entities[entity_id]:
             turn_on_mode = self.entities[entity_id][CONF_TURN_ON_MODE]
-            if turn_on_mode in HVAC_MODES:
+            if turn_on_mode in self.hass.states.get(entity_id)[ATTR_HVAC_MODES]:
                 return turn_on_mode
 
-            _LOGGER.warning("Invalid HVAC mode for %s", entity_id)
+            _LOGGER.warning("HVAC mode not supported by %s", entity_id)
 
         return None
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -433,15 +433,17 @@ class HueOneLightChangeView(HomeAssistantView):
         # If the requested entity is a climate, set the HVAC mode
         # and the temperature
         elif entity.domain == climate.DOMAIN:
-            if service == SERVICE_TURN_ON:
+            if parsed[STATE_ON]:
                 hvac_mode = config.get_turn_on_mode(entity_id)
                 service = None
 
-            if entity_features & SUPPORT_TARGET_TEMPERATURE:
-                if parsed[STATE_BRIGHTNESS] is not None:
-                    domain = entity.domain
-                    service = SERVICE_SET_TEMPERATURE
-                    data[ATTR_TEMPERATURE] = parsed[STATE_BRIGHTNESS]
+                if entity_features & SUPPORT_TARGET_TEMPERATURE:
+                    if parsed[STATE_BRIGHTNESS] is not None:
+                        domain = entity.domain
+                        service = SERVICE_SET_TEMPERATURE
+                        data[ATTR_TEMPERATURE] = parsed[STATE_BRIGHTNESS]
+                        data[ATTR_HVAC_MODE] = hvac_mode
+                        hvac_mode = None
 
         # If the requested entity is a media player, convert to volume
         elif entity.domain == media_player.DOMAIN:

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -446,13 +446,14 @@ class HueOneLightChangeView(HomeAssistantView):
 
         # If the requested entity is a media player, convert to volume
         elif entity.domain == media_player.DOMAIN:
-            if entity_features & SUPPORT_VOLUME_SET:
-                if parsed[STATE_BRIGHTNESS] is not None:
-                    turn_on_needed = True
-                    domain = entity.domain
-                    service = SERVICE_VOLUME_SET
-                    # Convert 0-100 to 0.0-1.0
-                    data[ATTR_MEDIA_VOLUME_LEVEL] = parsed[STATE_BRIGHTNESS] / 100.0
+            if parsed[STATE_ON]:
+                if entity_features & SUPPORT_VOLUME_SET:
+                    if parsed[STATE_BRIGHTNESS] is not None:
+                        turn_on_needed = True
+                        domain = entity.domain
+                        service = SERVICE_VOLUME_SET
+                        # Convert 0-100 to 0.0-1.0
+                        data[ATTR_MEDIA_VOLUME_LEVEL] = parsed[STATE_BRIGHTNESS] / 100.0
 
         # If the requested entity is a cover, convert to open_cover/close_cover
         # and cover position

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -430,8 +430,8 @@ class HueOneLightChangeView(HomeAssistantView):
             if parsed[STATE_BRIGHTNESS] is not None:
                 data["variables"]["requested_level"] = parsed[STATE_BRIGHTNESS]
 
-        # If the requested entity is a climate, set the HVAC mode
-        # and the temperature
+        # If the requested entity is of climate domain, set the HVAC mode
+        # and convert brightness to temperature
         elif entity.domain == climate.DOMAIN:
             if parsed[STATE_ON]:
                 hvac_mode = config.get_turn_on_mode(entity_id)
@@ -442,7 +442,8 @@ class HueOneLightChangeView(HomeAssistantView):
                         domain = entity.domain
                         service = SERVICE_SET_TEMPERATURE
                         data[ATTR_TEMPERATURE] = parsed[STATE_BRIGHTNESS]
-                        data[ATTR_HVAC_MODE] = hvac_mode
+                        if entity.state == STATE_OFF:
+                            data[ATTR_HVAC_MODE] = hvac_mode
                         hvac_mode = None
 
         # If the requested entity is a media player, convert to volume

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -539,16 +539,6 @@ async def test_put_light_state_climate_with_turn_on_state(hass_hue, hue_client):
         "homeassistant.components.emulated_hue.Config.get_turn_on_mode",
         return_value=climate.const.HVAC_MODE_COOL,
     ):
-        # Turn it on
-        hvac_result = await perform_put_light_state(
-            hass_hue, hue_client, "climate.hvac", True
-        )
-
-        hvac_result_json = await hvac_result.json()
-
-        assert hvac_result.status == 200
-        assert len(hvac_result_json) == 1
-
         # Emulated hue converts 0.0-1.0 to 0-254.
         brightness = 19
         temperature = round(brightness / 254 * 100)
@@ -562,6 +552,16 @@ async def test_put_light_state_climate_with_turn_on_state(hass_hue, hue_client):
 
         assert hvac_result.status == 200
         assert len(hvac_result_json) == 2
+
+        # Separate call for turn on
+        hvac_result = await perform_put_light_state(
+            hass_hue, hue_client, "climate.hvac", True
+        )
+
+        hvac_result_json = await hvac_result.json()
+
+        assert hvac_result.status == 200
+        assert len(hvac_result_json) == 1
 
         hvac = hass_hue.states.get("climate.hvac")
         assert hvac.state == climate.HVAC_MODE_COOL

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -528,12 +528,12 @@ async def test_put_light_state_script(hass, hass_hue, hue_client):
     )
 
 
-async def test_put_light_state_climate_set_state_and_temperature(hass_hue, hue_client):
+async def test_put_light_state_climate(hass_hue, hue_client):
     """Test setting climate state and temperature."""
-    # Turn the climate entity off first
+    # Turn the climate entity on first
     await hass_hue.services.async_call(
         climate.DOMAIN,
-        const.SERVICE_TURN_OFF,
+        const.SERVICE_TURN_ON,
         {const.ATTR_ENTITY_ID: "climate.hvac"},
         blocking=True,
     )

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -530,18 +530,24 @@ async def test_put_light_state_script(hass, hass_hue, hue_client):
 
 async def test_put_light_state_climate(hass_hue, hue_client):
     """Test setting climate state and temperature."""
-    # Turn the climate entity on first
+    # Turn the climate entity off first
     await hass_hue.services.async_call(
         climate.DOMAIN,
-        const.SERVICE_TURN_ON,
+        const.SERVICE_TURN_OFF,
         {const.ATTR_ENTITY_ID: "climate.hvac"},
         blocking=True,
     )
 
-    # Emulated hue converts brightness to temperature
+    # Turn the climate entity on
+    hvac_result = await perform_put_light_state(
+        hass_hue, hue_client, "climate.hvac", True
+    )
+
+    # Convert brightness to temperature
     brightness = 19
     temperature = round(brightness / 254 * 100)
 
+    # Set the brightness
     hvac_result = await perform_put_light_state(
         hass_hue, hue_client, "climate.hvac", True, brightness
     )

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,6 +1,7 @@
 """Test the Emulated Hue component."""
 from unittest.mock import MagicMock, Mock, patch
 
+from homeassistant.components.climate import HVAC_MODES
 from homeassistant.components.emulated_hue import Config
 
 
@@ -115,3 +116,15 @@ def test_config_alexa_entity_id_to_number():
 
     entity_id = conf.number_to_entity_id("light.test")
     assert entity_id == "light.test"
+
+
+def test_config_get_turn_on_mode():
+    """Test getting turn_on_mode from config."""
+    mock_hass = Mock()
+    mock_entity_state = {"hvac_modes": HVAC_MODES}
+    mock_hass.states.get = lambda entity_id: mock_entity_state
+
+    conf = Config(mock_hass, {"entities": {"climate.hvac": {"turn_on_mode": "cool"}}})
+
+    turn_on_mode = conf.get_turn_on_mode("climate.hvac")
+    assert turn_on_mode == "cool"

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -121,7 +121,10 @@ def test_config_alexa_entity_id_to_number():
 def test_config_get_turn_on_mode():
     """Test getting turn_on_mode from config."""
     mock_hass = Mock()
-    mock_entity_state = {"hvac_modes": HVAC_MODES}
+
+    mock_entity_state = Mock()
+    mock_entity_state.attributes = {"hvac_modes": HVAC_MODES}
+
     mock_hass.states.get = lambda entity_id: mock_entity_state
 
     conf = Config(mock_hass, {"entities": {"climate.hvac": {"turn_on_mode": "cool"}}})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for turning on climate entities with the `emulated_hue` component, either by automatically retrieving the last "on" state or defining a fixed one under `entities` configuration in YAML.

This pull request also fixes a problem that would prevent media_player entities of turning off when asked to.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
emulated_hue:
  listen_port: 80
  entities:
    climate.air_conditioner:
      turn_on_state: cool
```

This will make the air conditioner be set to `cool` every time the user asks Alexa to turn it on or to change temperature. If it's not specified, the mode will then be defined to the last state the entity was set to before it was turned off.

If the air conditioner is already on, but in another mode (for example `heat`), it will be set to `turn_on_mode` if the user asks for a single turn on. If the user asks for temperature change, the mode will remain the same.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#13168

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
