### PR TITLE
Add config option to ignore Plex Web clients

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -30,6 +30,7 @@ from .const import (  # pylint: disable=unused-import
     AUTOMATIC_SETUP_STRING,
     CONF_CLIENT_IDENTIFIER,
     CONF_IGNORE_NEW_SHARED_USERS,
+    CONF_IGNORE_PLEX_WEB_CLIENTS,
     CONF_MONITORED_USERS,
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
@@ -329,6 +330,9 @@ class PlexOptionsFlowHandler(config_entries.OptionsFlow):
             self.options[MP_DOMAIN][CONF_IGNORE_NEW_SHARED_USERS] = user_input[
                 CONF_IGNORE_NEW_SHARED_USERS
             ]
+            self.options[MP_DOMAIN][CONF_IGNORE_PLEX_WEB_CLIENTS] = user_input[
+                CONF_IGNORE_PLEX_WEB_CLIENTS
+            ]
 
             account_data = {
                 user: {"enabled": bool(user in user_input[CONF_MONITORED_USERS])}
@@ -372,6 +376,10 @@ class PlexOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required(
                         CONF_IGNORE_NEW_SHARED_USERS,
                         default=plex_server.option_ignore_new_shared_users,
+                    ): bool,
+                    vol.Required(
+                        CONF_IGNORE_PLEX_WEB_CLIENTS,
+                        default=plex_server.option_ignore_plexweb_clients,
                     ): bool,
                 }
             ),

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -30,6 +30,7 @@ CONF_SERVER_IDENTIFIER = "server_id"
 CONF_USE_EPISODE_ART = "use_episode_art"
 CONF_SHOW_ALL_CONTROLS = "show_all_controls"
 CONF_IGNORE_NEW_SHARED_USERS = "ignore_new_shared_users"
+CONF_IGNORE_PLEX_WEB_CLIENTS = "ignore_plex_web_clients"
 CONF_MONITORED_USERS = "monitored_users"
 
 AUTH_CALLBACK_PATH = "/auth/plex/callback"

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -51,7 +51,8 @@
         "data": {
           "use_episode_art": "Use episode art",
           "ignore_new_shared_users": "Ignore new managed/shared users",
-          "monitored_users": "Monitored users"
+          "monitored_users": "Monitored users",
+          "ignore_plex_web_clients": "Ignore Plex Web clients"
         }
       }
     }

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -134,6 +134,7 @@ class MockPlexClient:
         """Initialize the object."""
         self.machineIdentifier = f"client-{index+1}"
         self._baseurl = url
+        self._index = index
 
     def url(self, key):
         """Mock the url method."""
@@ -152,6 +153,8 @@ class MockPlexClient:
     @property
     def product(self):
         """Mock the product attribute."""
+        if self._index == 1:
+            return "Plex Web"
         return "PRODUCT"
 
     @property

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.plex import config_flow
 from homeassistant.components.plex.const import (
     AUTOMATIC_SETUP_STRING,
     CONF_IGNORE_NEW_SHARED_USERS,
+    CONF_IGNORE_PLEX_WEB_CLIENTS,
     CONF_MONITORED_USERS,
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
@@ -428,6 +429,7 @@ async def test_option_flow(hass):
             CONF_MONITORED_USERS: {
                 user: {"enabled": True} for user in mock_plex_server.accounts
             },
+            CONF_IGNORE_PLEX_WEB_CLIENTS: False,
         }
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Each browser a user logs in with to the Plex UI creates a new `media_player` entity. If the user logs out or clears their cookies, the next login creates a new identifier and yet another `media_player` entity. For privacy-conscious users that clear browsing data regularly, this can get very annoying.

All browsers that log into Plex's interface are considered "Plex Web" clients. This config option allows a user to prevent these clients from being added as entities.

As discussed in https://community.home-assistant.io/t/disabling-plex-browser-app-in-ha/185371.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13347

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
