### PR TITLE
Ability to ignore discovery without unique ID

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -1,4 +1,6 @@
 """Http views to control the config manager."""
+from typing import Any, Dict, Optional
+
 import aiohttp.web_exceptions
 import voluptuous as vol
 import voluptuous_serialize
@@ -312,16 +314,12 @@ async def ignore_config_flow(hass, connection, msg):
         )
         return
 
-    if "unique_id" not in flow["context"]:
-        connection.send_error(
-            msg["id"], "no_unique_id", "Specified flow has no unique ID."
-        )
-        return
+    data: Optional[Dict[str, Any]] = None
+    if "unique_id" in flow["context"]:
+        data = {"unique_id": flow["context"]["unique_id"]}
 
     await hass.config_entries.flow.async_init(
-        flow["handler"],
-        context={"source": config_entries.SOURCE_IGNORE},
-        data={"unique_id": flow["context"]["unique_id"]},
+        flow["handler"], context={"source": config_entries.SOURCE_IGNORE}, data=data,
     )
     connection.send_result(msg["id"])
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -886,9 +886,14 @@ class ConfigFlow(data_entry_flow.FlowHandler):
             if flw["handler"] == self.handler and flw["flow_id"] != self.flow_id
         ]
 
-    async def async_step_ignore(self, user_input: Dict[str, Any]) -> Dict[str, Any]:
+    async def async_step_ignore(
+        self, user_input: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         """Ignore this config flow."""
-        await self.async_set_unique_id(user_input["unique_id"], raise_on_progress=False)
+        if user_input is not None and "unique_id" in user_input:
+            await self.async_set_unique_id(
+                user_input["unique_id"], raise_on_progress=False
+            )
         return self.async_create_entry(title="Ignored", data={})
 
     async def async_step_unignore(self, user_input: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Context

More integrations move towards configuration to the UI. In a lot of cases discovery using HomeKit, SSDP or ZeroConf is added. Which is awesome!

However, a lot of devices don't provide a `unique_id`, which removed the ability to ignore such a discovered integration, such as IKEA Tradfri or ESPHome.

This is annoying towards our users. Some recent example issues raised: #34683 #34561.

### Goal

This PR aims to provide a method to disable discovery for integration altogether if the found discovered item doesn't provide a unique identifier.

### Reasoning

We could implement a unique ID in all config flow... however, that is not a reality as not all devices provide such means for a unique identifier (e.g., ESPHome & IKEA Trafri). 

![image](https://user-images.githubusercontent.com/195327/80311428-e5bc4880-87df-11ea-9a38-ca93d0954b73.png)

![image](https://user-images.githubusercontent.com/195327/80311437-eb199300-87df-11ea-9336-287cd8b00bec.png)

Some suggestions done: Use the MAC address based on IP. However, that would cause issues when using different subnets/VLAN's since you won't get the correct mac.

Other suggestions: Use the hostname. While this might work for the IKEA example, for the ESPHome example, this is configurable/changeable by the user.

Furthermore, we don't require a unique ID to be set. This makes sense, if it a device won't have it... it would exempt those from using a configuration flow.

So that leaves the user, with a discovery he can't ignore. Which we should solve.

### Current status

This PR implements a simple change that, when a discovery is ignored, will use the unique ID to create a config entry with the ignored source, but set the unique ID to None when the unique ID is missing.

I also have the matching frontend change ready for this.

![image](https://user-images.githubusercontent.com/195327/80311403-c2919900-87df-11ea-8c1a-43feba497e54.png)

![image](https://user-images.githubusercontent.com/195327/80311410-ca513d80-87df-11ea-976d-bdc05919930f.png)

Basic frontend change:

![image](https://user-images.githubusercontent.com/195327/80311595-da1d5180-87e0-11ea-8540-97920538b145.png)

(some more changes here, to make the confirmation dialogs distinctive and probably change the "ignore" button to "ignore all" in these cases).

### Missing in this implementation

Currently missing in the part where inside the core we detect this and trigger the abort for the configuration flow. As we should implement this in our core flow context and not be dependent on the integration flow itself. I've been struggling to find a good location for this.

Basically we need to abort the config flow from the core, if:

- The flow is triggered from a discovery source (e.g., HomeKit, SSDP or ZerConf)
- Has a config entry with source == ignored and unique_id is None

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
