### PR TITLE
Use web map service for Environment Canada radar

### DIFF
--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -17,12 +17,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_STATION = "station"
-ATTR_LOCATION = "location"
-ATTR_UPDATED = "updated"
-
 CONF_ATTRIBUTION = "Data provided by Environment Canada"
-CONF_STATION = "station"
 CONF_LOOP = "loop"
 CONF_PRECIP_TYPE = "precip_type"
 
@@ -30,12 +25,11 @@ MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(minutes=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_LOOP, default=True): cv.boolean,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_STATION): cv.matches_regex(r"^C[A-Z]{4}$|^[A-Z]{3}$"),
         vol.Inclusive(CONF_LATITUDE, "latlon"): cv.latitude,
         vol.Inclusive(CONF_LONGITUDE, "latlon"): cv.longitude,
-        vol.Optional(CONF_PRECIP_TYPE): ["RAIN", "SNOW"],
+        vol.Optional(CONF_LOOP, default=True): cv.boolean,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_PRECIP_TYPE): ["rain", "snow"],
     }
 )
 
@@ -43,16 +37,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Environment Canada camera."""
 
-    if config.get(CONF_STATION):
-        radar_object = ECRadar(
-            station_id=config[CONF_STATION], precip_type=config.get(CONF_PRECIP_TYPE)
-        )
-    else:
-        lat = config.get(CONF_LATITUDE, hass.config.latitude)
-        lon = config.get(CONF_LONGITUDE, hass.config.longitude)
-        radar_object = ECRadar(coordinates=(lat, lon))
+    lat = config.get(CONF_LATITUDE, hass.config.latitude)
+    lon = config.get(CONF_LONGITUDE, hass.config.longitude)
+    precip_type = config.get(CONF_PRECIP_TYPE, None)
+    name = config.get(CONF_NAME) or "Environment Canada Radar"
 
-    add_devices([ECCamera(radar_object, config.get(CONF_NAME))], True)
+    radar_object = ECRadar(coordinates=(lat, lon),
+                           precip_type=precip_type)
+
+    add_devices([ECCamera(radar_object, name)], True)
 
 
 class ECCamera(Camera):
@@ -76,20 +69,14 @@ class ECCamera(Camera):
     @property
     def name(self):
         """Return the name of the camera."""
-        if self.camera_name is not None:
-            return self.camera_name
-        return " ".join([self.radar_object.station_name, "Radar"])
+        return self.camera_name
 
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
         attr = {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            ATTR_LOCATION: self.radar_object.station_name,
-            ATTR_STATION: self.radar_object.station_code,
-            ATTR_UPDATED: self.timestamp,
         }
-
         return attr
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -99,4 +86,4 @@ class ECCamera(Camera):
             self.image = self.radar_object.get_loop()
         else:
             self.image = self.radar_object.get_latest_frame()
-        self.timestamp = self.radar_object.timestamp.isoformat()
+        self.timestamp = datetime.datetime.now().isoformat()

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -42,8 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     precip_type = config.get(CONF_PRECIP_TYPE, None)
     name = config.get(CONF_NAME) or "Environment Canada Radar"
 
-    radar_object = ECRadar(coordinates=(lat, lon),
-                           precip_type=precip_type)
+    radar_object = ECRadar(coordinates=(lat, lon), precip_type=precip_type)
 
     add_devices([ECCamera(radar_object, name)], True)
 
@@ -74,9 +73,7 @@ class ECCamera(Camera):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-        }
+        attr = {ATTR_ATTRIBUTION: CONF_ATTRIBUTION}
         return attr
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -2,6 +2,6 @@
   "domain": "environment_canada",
   "name": "Environment Canada",
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
-  "requirements": ["env_canada==0.0.35"],
+  "requirements": ["env_canada==0.0.36"],
   "codeowners": ["@michaeldavie"]
 }

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -2,6 +2,6 @@
   "domain": "environment_canada",
   "name": "Environment Canada",
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
-  "requirements": ["env_canada==0.0.36"],
+  "requirements": ["env_canada==0.0.37"],
   "codeowners": ["@michaeldavie"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,7 +514,7 @@ enocean==0.50
 enturclient==0.2.1
 
 # homeassistant.components.environment_canada
-env_canada==0.0.35
+env_canada==0.0.36
 
 # homeassistant.components.envirophat
 # envirophat==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,7 +514,7 @@ enocean==0.50
 enturclient==0.2.1
 
 # homeassistant.components.environment_canada
-env_canada==0.0.36
+env_canada==0.0.37
 
 # homeassistant.components.envirophat
 # envirophat==0.0.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Radar location must be specified by latitude / longitude; station ID is no longer supported.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the use of web scraping.
Uses web map service to dynamically build radar imagery.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
camera:
  - platform: environment_canada
    latitude: 50
    longitude: -100
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/michaeldavie/env_canada/issues/17
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13175

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
