### PR TITLE
Add unique ID to TRADFRI

### DIFF
--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -1,6 +1,5 @@
 """Config flow for Tradfri."""
 import asyncio
-from collections import OrderedDict
 from uuid import uuid4
 
 import async_timeout
@@ -70,7 +69,7 @@ class FlowHandler(config_entries.ConfigFlow):
         else:
             user_input = {}
 
-        fields = OrderedDict()
+        fields = {}
 
         if self._host is None:
             fields[vol.Required(CONF_HOST, default=user_input.get(CONF_HOST))] = str
@@ -83,24 +82,27 @@ class FlowHandler(config_entries.ConfigFlow):
             step_id="auth", data_schema=vol.Schema(fields), errors=errors
         )
 
-    async def async_step_zeroconf(self, user_input):
-        """Handle zeroconf discovery."""
+    async def async_step_homekit(self, user_input):
+        """Handle homekit discovery."""
+        await self.async_set_unique_id(user_input["id"])
+        self._abort_if_unique_id_configured({CONF_HOST: user_input["host"]})
+
         host = user_input["host"]
 
-        # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-        self.context["host"] = host
-
-        if any(host == flow["context"]["host"] for flow in self._async_in_progress()):
-            return self.async_abort(reason="already_in_progress")
-
         for entry in self._async_current_entries():
-            if entry.data[CONF_HOST] == host:
-                return self.async_abort(reason="already_configured")
+            if entry.data[CONF_HOST] != host:
+                continue
+
+            # Backwards compat, we update old entries
+            if not entry.unique_id:
+                self.hass.config_entries.async_update_entry(
+                    entry, unique_id=user_input["id"]
+                )
+
+            return self.async_abort(reason="already_configured")
 
         self._host = host
         return await self.async_step_auth()
-
-    async_step_homekit = async_step_zeroconf
 
     async def async_step_import(self, user_input):
         """Import a config entry."""

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -84,7 +84,7 @@ class FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_homekit(self, user_input):
         """Handle homekit discovery."""
-        await self.async_set_unique_id(user_input["id"])
+        await self.async_set_unique_id(user_input["properties"]["id"])
         self._abort_if_unique_id_configured({CONF_HOST: user_input["host"]})
 
         host = user_input["host"]
@@ -96,7 +96,7 @@ class FlowHandler(config_entries.ConfigFlow):
             # Backwards compat, we update old entries
             if not entry.unique_id:
                 self.hass.config_entries.async_update_entry(
-                    entry, unique_id=user_input["id"]
+                    entry, unique_id=user_input["properties"]["id"]
                 )
 
             return self.async_abort(reason="already_configured")

--- a/homeassistant/components/tradfri/manifest.json
+++ b/homeassistant/components/tradfri/manifest.json
@@ -7,6 +7,5 @@
   "homekit": {
     "models": ["TRADFRI"]
   },
-  "zeroconf": ["_coap._udp.local."],
   "codeowners": ["@ggravlingen"]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -10,9 +10,6 @@ ZEROCONF = {
         "axis",
         "doorbird"
     ],
-    "_coap._udp.local.": [
-        "tradfri"
-    ],
     "_elg._tcp.local.": [
         "elgato"
     ],

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -82,7 +82,7 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
     flow = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": "homekit"},
-        data={"host": "123.123.123.123", "id": "homekit-id"},
+        data={"host": "123.123.123.123", "properties": {"id": "homekit-id"}},
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -230,7 +230,7 @@ async def test_discovery_duplicate_aborted(hass):
     flow = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": "homekit"},
-        data={"host": "new-host", "id": "homekit-id"},
+        data={"host": "new-host", "properties": {"id": "homekit-id"}},
     )
 
     assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -256,7 +256,7 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
     result = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": "homekit"},
-        data={"host": "123.123.123.123", "id": "homekit-id"},
+        data={"host": "123.123.123.123", "properties": {"id": "homekit-id"}},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -264,7 +264,7 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
     result2 = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": "homekit"},
-        data={"host": "123.123.123.123", "id": "homekit-id"},
+        data={"host": "123.123.123.123", "properties": {"id": "homekit-id"}},
     )
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -278,7 +278,7 @@ async def test_discovery_updates_unique_id(hass):
     flow = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": "homekit"},
-        data={"host": "some-host", "id": "homekit-id"},
+        data={"host": "some-host", "properties": {"id": "homekit-id"}},
     )
 
     assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -80,7 +80,9 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
     mock_auth.side_effect = lambda hass, host, code: {"host": host, "gateway_id": "bla"}
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri", context={"source": "zeroconf"}, data={"host": "123.123.123.123"}
+        "tradfri",
+        context={"source": "homekit"},
+        data={"host": "123.123.123.123", "id": "homekit-id"},
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -90,6 +92,7 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
     assert len(mock_entry_setup.mock_calls) == 1
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == "homekit-id"
     assert result["result"].data == {
         "host": "123.123.123.123",
         "gateway_id": "bla",
@@ -218,15 +221,22 @@ async def test_import_connection_legacy_no_groups(
 
 
 async def test_discovery_duplicate_aborted(hass):
-    """Test a duplicate discovery host is ignored."""
-    MockConfigEntry(domain="tradfri", data={"host": "some-host"}).add_to_hass(hass)
+    """Test a duplicate discovery host aborts and updates existing entry."""
+    entry = MockConfigEntry(
+        domain="tradfri", data={"host": "some-host"}, unique_id="homekit-id"
+    )
+    entry.add_to_hass(hass)
 
     flow = await hass.config_entries.flow.async_init(
-        "tradfri", context={"source": "zeroconf"}, data={"host": "some-host"}
+        "tradfri",
+        context={"source": "homekit"},
+        data={"host": "new-host", "id": "homekit-id"},
     )
 
     assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert flow["reason"] == "already_configured"
+
+    assert entry.data["host"] == "new-host"
 
 
 async def test_import_duplicate_aborted(hass):
@@ -244,13 +254,34 @@ async def test_import_duplicate_aborted(hass):
 async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
     """Test a duplicate discovery in progress is ignored."""
     result = await hass.config_entries.flow.async_init(
-        "tradfri", context={"source": "zeroconf"}, data={"host": "123.123.123.123"}
+        "tradfri",
+        context={"source": "homekit"},
+        data={"host": "123.123.123.123", "id": "homekit-id"},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
     result2 = await hass.config_entries.flow.async_init(
-        "tradfri", context={"source": "zeroconf"}, data={"host": "123.123.123.123"}
+        "tradfri",
+        context={"source": "homekit"},
+        data={"host": "123.123.123.123", "id": "homekit-id"},
     )
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+
+
+async def test_discovery_updates_unique_id(hass):
+    """Test a duplicate discovery host aborts and updates existing entry."""
+    entry = MockConfigEntry(domain="tradfri", data={"host": "some-host"},)
+    entry.add_to_hass(hass)
+
+    flow = await hass.config_entries.flow.async_init(
+        "tradfri",
+        context={"source": "homekit"},
+        data={"host": "some-host", "id": "homekit-id"},
+    )
+
+    assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert flow["reason"] == "already_configured"
+
+    assert entry.unique_id == "homekit-id"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add unique ID to TRADFRI config flows.

The only way we can get a unique ID from TRADFRI is via HomeKit discovery. So moving forward we will only rely on HomeKit discovery of TRADFRI. This is great because the zeroconf one was a generic coap service endpoint.

Old config entries are automatically made compatible by updating config entries once discovered.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
