### PR TITLE
Stop requiring home-assistant authentication for meraki

### DIFF
--- a/tests/components/meraki/test_device_tracker.py
+++ b/tests/components/meraki/test_device_tracker.py
@@ -47,20 +47,20 @@ async def test_invalid_or_missing_data(mock_device_tracker_conf, meraki_client):
 
     req = await meraki_client.post(URL, data=b"{}")
     text = await req.json()
-    assert req.status == 422
-    assert text["message"] == "No secret"
+    assert req.status == 401
+    assert text["message"] == "Invalid secret"
+
+    data = {"version": "2.0", "secret": "invalid"}
+    req = await meraki_client.post(URL, data=json.dumps(data))
+    text = await req.json()
+    assert req.status == 401
+    assert text["message"] == "Invalid secret"
 
     data = {"version": "1.0", "secret": "secret"}
     req = await meraki_client.post(URL, data=json.dumps(data))
     text = await req.json()
     assert req.status == 422
     assert text["message"] == "Invalid version"
-
-    data = {"version": "2.0", "secret": "invalid"}
-    req = await meraki_client.post(URL, data=json.dumps(data))
-    text = await req.json()
-    assert req.status == 422
-    assert text["message"] == "Invalid secret"
 
     data = {"version": "2.0", "secret": "secret", "type": "InvalidType"}
     req = await meraki_client.post(URL, data=json.dumps(data))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None

## Proposed change
The Meraki Scanning API is configured with a shared secret that are part of every request the Meraki Cloud makes to configured receivers.

As such we can allow requests to this integration to go without authentication by homeassistant.

It's worth noting that the GET method returns a static value that should not be considered a secret and thus it is ok not to be protected. Validation serves to ensure that the receiver you are configuring in the Meraki Dashboard is ready to receive requests.

This change also refactors the secret validation logic slightly to improve readability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13187

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

