### PR TITLE
Add unique id to esphome config flow

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -111,7 +111,7 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
                 # Backwards compat, we update old entries
                 if not entry.unique_id:
                     self.hass.config_entries.async_update_entry(
-                        entry, unique_id=node_address
+                        entry, unique_id=node_name
                     )
 
                 return self.async_abort(reason="already_configured")

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -5,9 +5,9 @@ from typing import Optional
 from aioesphomeapi import APIClient, APIConnectionError
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import callback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .entry_data import DATA_KEY, RuntimeEntryData

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -1,6 +1,9 @@
 {
   "config": {
-    "abort": { "already_configured": "ESP is already configured" },
+    "abort": {
+      "already_configured": "ESP is already configured",
+      "already_in_progress": "ESP configuration is already in progress"
+    },
     "error": {
       "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address: https://esphomelib.com/esphomeyaml/components/wifi.html#manual-ips",
       "connection_error": "Can't connect to ESP. Please make sure your YAML file contains an 'api:' line.",

--- a/homeassistant/components/esphome/translations/en.json
+++ b/homeassistant/components/esphome/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "ESP is already configured"
+            "already_configured": "ESP is already configured",
+            "already_in_progress": "ESP configuration is already in progress"
         },
         "error": {
             "connection_error": "Can't connect to ESP. Please make sure your YAML file contains an 'api:' line.",

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -262,7 +262,7 @@ async def test_discovery_duplicate_data(hass, mock_client):
     assert result["reason"] == "already_configured"
 
 
-async def test_discovery_updates_unique_id(hass):
+async def test_discovery_updates_unique_id(hass, mock_client):
     """Test a duplicate discovery host aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain="esphome", data={"host": "192.168.43.183", "port": 6053, "password": ""}

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant.components.esphome import DATA_KEY, config_flow
-from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM, RESULT_TYPE_CREATE_ENTRY
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_FORM,
+    RESULT_TYPE_CREATE_ENTRY,
+)
 
 from tests.common import MockConfigEntry, mock_coro
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -171,7 +171,6 @@ async def test_discovery_initiation(hass, mock_client):
 
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "discovery_confirm"
-    assert result["title"] == "ESPHome: test8266"
     assert result["description_placeholders"]["name"] == "test8266"
 
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -269,7 +269,7 @@ async def test_discovery_duplicate_data(hass, mock_client):
         "esphome", data=service_info, context={"source": "zeroconf"}
     )
     assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "already_in_progress"
 
 
 async def test_discovery_updates_unique_id(hass, mock_client):

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -173,9 +173,7 @@ async def test_discovery_initiation(hass, mock_client):
     assert result["step_id"] == "discovery_confirm"
     assert result["description_placeholders"]["name"] == "test8266"
 
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {}
-    )
+    result = await hass.config_entries.flow.async_configure(flow["flow_id"], {})
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "test8266"

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_user_connection_works(hass, mock_client):
 
     result = await flow.async_step_user(user_input={"host": "127.0.0.1", "port": 80})
 
-    assert result["type"] == "create_entry"
+    assert result["type"] == "create_entry"   
     assert result["data"] == {"host": "127.0.0.1", "port": 80, "password": ""}
     assert result["title"] == "test"
     assert len(mock_client.connect.mock_calls) == 1
@@ -176,6 +176,7 @@ async def test_discovery_initiation(hass, mock_client):
     assert result["title"] == "test8266"
     assert result["data"]["host"] == "test8266.local"
     assert result["data"]["port"] == 6053
+    assert result["result"].unique_id == "test8266"
 
 
 async def test_discovery_already_configured_hostname(hass, mock_client):

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -7,8 +7,8 @@ import pytest
 from homeassistant.components.esphome import DATA_KEY, config_flow
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
-    RESULT_TYPE_FORM,
     RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
 )
 
 from tests.common import MockConfigEntry, mock_coro

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_user_connection_works(hass, mock_client):
 
     result = await flow.async_step_user(user_input={"host": "127.0.0.1", "port": 80})
 
-    assert result["type"] == "create_entry"   
+    assert result["type"] == "create_entry"
     assert result["data"] == {"host": "127.0.0.1", "port": 80, "password": ""}
     assert result["title"] == "test"
     assert len(mock_client.connect.mock_calls) == 1

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -194,7 +194,7 @@ async def test_discovery_already_configured_hostname(hass, mock_client):
         "properties": {},
     }
     result = await flow.async_step_zeroconf(user_input=service_info)
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -212,7 +212,7 @@ async def test_discovery_already_configured_ip(hass, mock_client):
         "properties": {"address": "192.168.43.183"},
     }
     result = await flow.async_step_zeroconf(user_input=service_info)
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -234,7 +234,7 @@ async def test_discovery_already_configured_name(hass, mock_client):
         "properties": {"address": "test8266.local"},
     }
     result = await flow.async_step_zeroconf(user_input=service_info)
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -258,7 +258,7 @@ async def test_discovery_duplicate_data(hass, mock_client):
     result = await hass.config_entries.flow.async_init(
         "esphome", data=service_info, context={"source": "zeroconf"}
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
 
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -179,12 +179,11 @@ async def test_discovery_initiation(hass, mock_client):
     mock_client.device_info.return_value = mock_coro(MockDeviceInfo(False, "test8266"))
 
     service_info = {
-        CONF_HOST: "192.168.43.183",
-        CONF_PORT: 6053,
+        "host": "192.168.43.183",
+        "port": 6053,
         "hostname": "test8266.local.",
         "properties": {},
     }
-
     flow = await hass.config_entries.flow.async_init(
         "esphome", context={"source": "zeroconf"}, data=service_info
     )
@@ -216,8 +215,8 @@ async def test_discovery_already_configured_hostname(hass, mock_client):
     entry.add_to_hass(hass)
 
     service_info = {
-        CONF_HOST: "192.168.43.183",
-        CONF_PORT: 6053,
+        "host": "192.168.43.183",
+        "port": 6053,
         "hostname": "test8266.local.",
         "properties": {},
     }
@@ -241,8 +240,8 @@ async def test_discovery_already_configured_ip(hass, mock_client):
     entry.add_to_hass(hass)
 
     service_info = {
-        CONF_HOST: "192.168.43.183",
-        CONF_PORT: 6053,
+        "host": "192.168.43.183",
+        "port": 6053,
         "hostname": "test8266.local.",
         "properties": {"address": "192.168.43.183"},
     }
@@ -269,8 +268,8 @@ async def test_discovery_already_configured_name(hass, mock_client):
     hass.data[DATA_KEY] = {entry.entry_id: mock_entry_data}
 
     service_info = {
-        CONF_HOST: "192.168.43.184",
-        CONF_PORT: 6053,
+        "host": "192.168.43.184",
+        "port": 6053,
         "hostname": "test8266.local.",
         "properties": {"address": "test8266.local"},
     }
@@ -288,8 +287,8 @@ async def test_discovery_already_configured_name(hass, mock_client):
 async def test_discovery_duplicate_data(hass, mock_client):
     """Test discovery aborts if same mDNS packet arrives."""
     service_info = {
-        CONF_HOST: "192.168.43.183",
-        CONF_PORT: 6053,
+        "host": "192.168.43.183",
+        "port": 6053,
         "hostname": "test8266.local.",
         "properties": {"address": "test8266.local"},
     }
@@ -319,8 +318,8 @@ async def test_discovery_updates_unique_id(hass, mock_client):
     entry.add_to_hass(hass)
 
     service_info = {
-        CONF_HOST: "192.168.43.183",
-        CONF_PORT: 6053,
+        "host": "192.168.43.183",
+        "port": 6053,
         "hostname": "test8266.local.",
         "properties": {"address": "test8266.local"},
     }

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -169,9 +169,9 @@ async def test_discovery_initiation(hass, mock_client):
         "esphome", context={"source": "zeroconf"}, data=service_info
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["step_id"] == "discovery_confirm"
-    assert result["description_placeholders"]["name"] == "test8266"
+    assert flow["type"] == RESULT_TYPE_FORM
+    assert flow["step_id"] == "discovery_confirm"
+    assert flow["description_placeholders"]["name"] == "test8266"
 
     result = await hass.config_entries.flow.async_configure(flow["flow_id"], {})
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -173,7 +173,9 @@ async def test_discovery_initiation(hass, mock_client):
     assert flow["step_id"] == "discovery_confirm"
     assert flow["description_placeholders"]["name"] == "test8266"
 
-    result = await hass.config_entries.flow.async_configure(flow["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], user_input={}
+    )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "test8266"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
