### PR TITLE
Set up config entries in parallel

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -201,8 +201,12 @@ async def _async_setup_component(
     await asyncio.sleep(0)
     await hass.config_entries.flow.async_wait_init_flow_finish(domain)
 
-    for entry in hass.config_entries.async_entries(domain):
-        await entry.async_setup(hass, integration=integration)
+    await asyncio.gather(
+        *[
+            entry.async_setup(hass, integration=integration)
+            for entry in hass.config_entries.async_entries(domain)
+        ]
+    )
 
     hass.config.components.add(domain)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,13 +1,15 @@
 """Test component/platform setup."""
 # pylint: disable=protected-access
+import asyncio
 import logging
 import os
 import threading
-from unittest import mock
 
+from asynctest import Mock, patch
+import pytest
 import voluptuous as vol
 
-from homeassistant import setup
+from homeassistant import config_entries, setup
 import homeassistant.config as config_util
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
@@ -19,6 +21,7 @@ from homeassistant.helpers.config_validation import (
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
+    MockConfigEntry,
     MockModule,
     MockPlatform,
     assert_setup_component,
@@ -32,6 +35,19 @@ ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
 VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def mock_handlers():
+    """Mock config flows."""
+
+    class MockFlowHandler(config_entries.ConfigFlow):
+        """Define a mock flow handler."""
+
+        VERSION = 1
+
+    with patch.dict(config_entries.HANDLERS, {"comp": MockFlowHandler}):
+        yield
 
 
 class TestSetup:
@@ -239,7 +255,7 @@ class TestSetup:
 
     def test_component_not_double_initialized(self):
         """Test we do not set up a component twice."""
-        mock_setup = mock.MagicMock(return_value=True)
+        mock_setup = Mock(return_value=True)
 
         mock_integration(self.hass, MockModule("comp", setup=mock_setup))
 
@@ -251,7 +267,7 @@ class TestSetup:
         assert setup.setup_component(self.hass, "comp", {})
         assert not mock_setup.called
 
-    @mock.patch("homeassistant.util.package.install_package", return_value=False)
+    @patch("homeassistant.util.package.install_package", return_value=False)
     def test_component_not_installed_if_requirement_fails(self, mock_install):
         """Component setup should fail if requirement can't install."""
         self.hass.config.skip_pip = False
@@ -350,7 +366,7 @@ class TestSetup:
             {"valid": True}, extra=vol.PREVENT_EXTRA
         )
 
-        mock_setup = mock.MagicMock(spec_set=True)
+        mock_setup = Mock(spec_set=True)
 
         mock_entity_platform(
             self.hass,
@@ -469,7 +485,7 @@ async def test_component_cannot_depend_config(hass):
 async def test_component_warn_slow_setup(hass):
     """Warn we log when a component setup takes a long time."""
     mock_integration(hass, MockModule("test_component1"))
-    with mock.patch.object(hass.loop, "call_later", mock.MagicMock()) as mock_call:
+    with patch.object(hass.loop, "call_later") as mock_call:
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert result
         assert mock_call.called
@@ -488,7 +504,7 @@ async def test_platform_no_warn_slow(hass):
     mock_integration(
         hass, MockModule("test_component1", platform_schema=PLATFORM_SCHEMA)
     )
-    with mock.patch.object(hass.loop, "call_later", mock.MagicMock()) as mock_call:
+    with patch.object(hass.loop, "call_later") as mock_call:
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert result
         assert not mock_call.called
@@ -524,7 +540,30 @@ async def test_when_setup_already_loaded(hass):
 
 async def test_setup_import_blows_up(hass):
     """Test that we handle it correctly when importing integration blows up."""
-    with mock.patch(
+    with patch(
         "homeassistant.loader.Integration.get_component", side_effect=ValueError
     ):
         assert not await setup.async_setup_component(hass, "sun", {})
+
+
+async def test_parallel_entry_setup(hass):
+    """Test config entries are set up in parallel."""
+    MockConfigEntry(domain="comp", data={"value": 1}).add_to_hass(hass)
+    MockConfigEntry(domain="comp", data={"value": 2}).add_to_hass(hass)
+
+    calls = []
+
+    async def mock_async_setup_entry(hass, entry):
+        """Mock setting up an entry."""
+        calls.append(entry.data["value"])
+        await asyncio.sleep(0)
+        calls.append(entry.data["value"])
+        return True
+
+    mock_integration(
+        hass, MockModule("comp", async_setup_entry=mock_async_setup_entry,),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+    await setup.async_setup_component(hass, "comp", {})
+
+    assert calls == [1, 2, 1, 2]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set up config entries in parallel. It's up to async methods to make sure they do proper locking. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
