### PR TITLE
Add config flow to Netgear

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -639,6 +639,7 @@ omit =
     homeassistant/components/netatmo/webhook.py
     homeassistant/components/netdata/sensor.py
     homeassistant/components/netgear/device_tracker.py
+    homeassistant/components/netgear/router.py
     homeassistant/components/netgear_lte/*
     homeassistant/components/netio/switch.py
     homeassistant/components/neurio_energy/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -306,7 +306,7 @@ homeassistant/components/nest/* @allenporter
 homeassistant/components/netatmo/* @cgtobi
 homeassistant/components/netdata/* @fabaff
 homeassistant/components/netgear/* @hacf-fr @Quentame
-homeassistant/components/nexia/* @ryannazaretian @bdraco
+homeassistant/components/nexia/* @bdraco
 homeassistant/components/nextbus/* @vividboarder
 homeassistant/components/nextcloud/* @meichthys
 homeassistant/components/nightscout/* @marciogranzotto

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -305,7 +305,8 @@ homeassistant/components/ness_alarm/* @nickw444
 homeassistant/components/nest/* @allenporter
 homeassistant/components/netatmo/* @cgtobi
 homeassistant/components/netdata/* @fabaff
-homeassistant/components/nexia/* @bdraco
+homeassistant/components/netgear/* @Quentame
+homeassistant/components/nexia/* @ryannazaretian @bdraco
 homeassistant/components/nextbus/* @vividboarder
 homeassistant/components/nextcloud/* @meichthys
 homeassistant/components/nightscout/* @marciogranzotto

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -305,7 +305,7 @@ homeassistant/components/ness_alarm/* @nickw444
 homeassistant/components/nest/* @allenporter
 homeassistant/components/netatmo/* @cgtobi
 homeassistant/components/netdata/* @fabaff
-homeassistant/components/netgear/* @Quentame
+homeassistant/components/netgear/* @hacf-fr @Quentame
 homeassistant/components/nexia/* @ryannazaretian @bdraco
 homeassistant/components/nextbus/* @vividboarder
 homeassistant/components/nextcloud/* @meichthys

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -1,1 +1,90 @@
-"""The netgear component."""
+"""Support for Netgear routers."""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_EXCLUDE,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN, PLATFORMS
+from .router import NetgearRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+NETGEAR_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT): cv.port,
+        vol.Optional(CONF_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [NETGEAR_SCHEMA]))},
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """Set up the Netgear component."""
+    conf = config.get(DOMAIN)
+
+    if conf is None:
+        return True
+
+    for netgear_conf in conf:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=netgear_conf,
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Set up Netgear component."""
+    router = NetgearRouter(hass, entry)
+    await router.setup()
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.unique_id] = router
+
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN][entry.unique_id].unload()
+        hass.data[DOMAIN].pop(entry.unique_id)
+
+    return unload_ok

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -56,7 +56,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Set up Netgear component."""
     router = NetgearRouter(hass, entry)
-    await router.setup()
+    await router.async_setup()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.unique_id] = router
@@ -80,7 +80,7 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
         )
     )
     if unload_ok:
-        hass.data[DOMAIN][entry.unique_id].unload()
+        await hass.data[DOMAIN][entry.unique_id].async_unload()
         hass.data[DOMAIN].pop(entry.unique_id)
 
     return unload_ok

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -6,8 +6,6 @@ import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
-    CONF_DEVICES,
-    CONF_EXCLUDE,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
@@ -29,8 +27,6 @@ NETGEAR_SCHEMA = vol.Schema(
         vol.Optional(CONF_SSL, default=False): cv.boolean,
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -46,7 +46,9 @@ async def async_setup(hass, config):
     for netgear_conf in conf:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": SOURCE_IMPORT}, data=netgear_conf,
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=netgear_conf,
             )
         )
 
@@ -82,5 +84,7 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     if unload_ok:
         await hass.data[DOMAIN][entry.unique_id].async_unload()
         hass.data[DOMAIN].pop(entry.unique_id)
+        if not hass.data[DOMAIN]:
+            hass.data.pop(DOMAIN)
 
     return unload_ok

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -11,6 +11,11 @@ from .router import NetgearRouter
 _LOGGER = logging.getLogger(__name__)
 
 
+async def async_setup(hass, config):
+    """Set up Netgear integration."""
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Set up Netgear component."""
     router = NetgearRouter(hass, entry)

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -2,57 +2,13 @@
 import asyncio
 import logging
 
-import voluptuous as vol
-
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_USERNAME,
-)
-from homeassistant.helpers import config_validation as cv
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import DOMAIN, PLATFORMS
 from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
-
-NETGEAR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT): cv.port,
-        vol.Optional(CONF_SSL, default=False): cv.boolean,
-        vol.Optional(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-    }
-)
-
-CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [NETGEAR_SCHEMA]))},
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass, config):
-    """Set up the Netgear component."""
-    conf = config.get(DOMAIN)
-
-    if conf is None:
-        return True
-
-    for netgear_conf in conf:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data=netgear_conf,
-            )
-        )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -1,0 +1,169 @@
+"""Config flow to configure the Netgear integration."""
+import asyncio
+import logging
+
+from pynetgear import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_USER, Netgear, autodetect_url
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components import ssdp
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_URL,
+    CONF_USERNAME,
+)
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN  # pylint: disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _discovery_schema_with_defaults(discovery_info):
+    return vol.Schema(_ordered_shared_schema(discovery_info))
+
+
+def _user_schema_with_defaults(user_input):
+    user_schema = {
+        vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str,
+        vol.Optional(CONF_PORT, default=user_input.get(CONF_PORT, "")): int,
+        vol.Optional(CONF_SSL, default=user_input.get(CONF_SSL, False)): bool,
+    }
+    user_schema.update(_ordered_shared_schema(user_input))
+
+    return vol.Schema(user_schema)
+
+
+def _ordered_shared_schema(schema_input):
+    return {
+        vol.Optional(CONF_USERNAME, default=schema_input.get(CONF_USERNAME, "")): str,
+        vol.Required(CONF_PASSWORD, default=schema_input.get(CONF_PASSWORD, "")): str,
+    }
+
+
+class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self):
+        """Initialize the netgear config flow."""
+        self.discovered_conf = {}
+        self.placeholders = {
+            CONF_NAME: "",
+            CONF_HOST: DEFAULT_HOST,
+            CONF_PORT: DEFAULT_PORT,
+            CONF_USERNAME: DEFAULT_USER,
+        }
+
+    async def _show_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user."""
+        if not user_input:
+            user_input = {}
+
+        if self.discovered_conf.get(CONF_URL):
+            user_input.update(self.discovered_conf)
+            step_id = "link"
+            data_schema = _discovery_schema_with_defaults(user_input)
+        else:
+            step_id = "user"
+            data_schema = _user_schema_with_defaults(user_input)
+
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=data_schema,
+            errors=errors or {},
+            description_placeholders=self.placeholders or {},
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        if self.source == config_entries.SOURCE_IMPORT:
+            if not user_input.get(CONF_HOST):
+                url = await self.hass.async_add_executor_job(autodetect_url)
+                self.placeholders[CONF_URL] = url
+
+        elif not self.discovered_conf.get(CONF_URL):
+            return await self.async_step_discover()
+
+        if not user_input:
+            return await self._show_setup_form(user_input, errors)
+
+        url = self.placeholders.get(CONF_URL)
+        host = user_input.get(CONF_HOST)
+        port = user_input.get(CONF_PORT)
+        ssl = user_input.get(CONF_SSL)
+        username = user_input.get(CONF_USERNAME)
+        password = user_input[CONF_PASSWORD]
+
+        try:
+            # Open connection and check authentication
+            api = await self.hass.async_add_executor_job(
+                Netgear, password, host, username, port, ssl, url
+            )
+            if not await self.hass.async_add_executor_job(api.login):
+                raise InvalidAuth
+
+            # Get device infos to check if already configured
+            infos = await self.hass.async_add_executor_job(api.get_info)
+
+        except OSError:
+            _LOGGER.error("Error connecting to the Netgear router at %s", host)
+            errors["base"] = "connection"
+        except InvalidAuth:
+            errors[CONF_USERNAME] = "login"
+        except Exception as exp:  # pylint: disable=broad-except
+            _LOGGER.error(exp)
+            errors[CONF_USERNAME] = "unknown"
+
+        await self.async_set_unique_id(infos["SerialNumber"])
+        self._abort_if_unique_id_configured()
+
+        if errors:
+            return await self._show_setup_form(user_input, errors)
+
+        return self.async_create_entry(
+            title=f"{infos['ModelName']} - {infos['DeviceName']}", data=user_input,
+        )
+
+    async def async_step_discover(self, user_input=None):
+        """Discover host, port and SSL."""
+        if user_input is None:
+            return self.async_show_form(step_id="discover")
+
+        url = await self.hass.async_add_executor_job(autodetect_url)
+        self.discovered_conf[CONF_URL] = url
+        self.placeholders[CONF_URL] = url
+        return await self.async_step_user()
+
+    async def async_step_ssdp(self, discovery_info):
+        """Handle a discovered device."""
+        # brief delay to allow processing the import step first
+        await asyncio.sleep(20)
+
+        await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_SERIAL])
+        self._abort_if_unique_id_configured()
+
+        friendly_name = discovery_info[ssdp.ATTR_UPNP_MODEL_NUMBER]
+        self.discovered_conf[CONF_NAME] = friendly_name
+        self.placeholders[CONF_NAME] = friendly_name
+        return await self.async_step_user()
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        return await self.async_step_user(user_input)
+
+    async def async_step_link(self, user_input):
+        """Link a config entry from discovery."""
+        return await self.async_step_user(user_input)
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -106,7 +106,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Check if already configured
         infos = await self.hass.async_add_executor_job(api.get_info)
-        await self.async_set_unique_id(infos["SerialNumber"])
+        await self.async_set_unique_id(infos["SerialNumber"], raise_on_progress=False)
         self._abort_if_unique_id_configured()
 
         config_data = {

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -131,8 +131,6 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, user_input=None):
         """Import a config entry."""
-        print("import")
-        print(user_input)
         return await self.async_step_user(user_input)
 
     async def async_step_ssdp(self, discovery_info):

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -65,17 +65,15 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if self.placeholders.get(CONF_URL):
             user_input.update({CONF_URL: self.placeholders[CONF_URL]})
-            step_id = "ssdp_confirm"
             data_schema = _discovery_schema_with_defaults(user_input)
         else:
-            step_id = "user"
             data_schema = _user_schema_with_defaults(user_input)
 
         return self.async_show_form(
-            step_id=step_id,
+            step_id="user",
             data_schema=data_schema,
             errors=errors or {},
-            description_placeholders=self.placeholders or {},
+            description_placeholders=self.placeholders,
         )
 
     async def async_step_user(self, user_input=None):
@@ -142,11 +140,4 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.placeholders[
             CONF_URL
         ] = f"http://{urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname}/"
-        return await self.async_step_ssdp_confirm()
-
-    async def async_step_ssdp_confirm(self, user_input=None):
-        """Link a config entry from discovery."""
-        if not user_input:
-            return await self._show_setup_form(user_input)
-
-        return await self.async_step_user(user_input)
+        return await self._show_setup_form()

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -137,7 +137,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         self.placeholders[CONF_NAME] = discovery_info[ssdp.ATTR_UPNP_MODEL_NUMBER]
-        self.placeholders[CONF_URL] = urlparse(
-            discovery_info[ssdp.ATTR_SSDP_LOCATION]
-        ).hostname
+        self.placeholders[
+            CONF_URL
+        ] = f"http://{urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname}/"
         return await self._show_setup_form()

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the Netgear integration."""
-import asyncio
+from urllib.parse import urlparse
 
-from pynetgear import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_USER, Netgear, autodetect_url
+from pynetgear import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_USER
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -15,9 +15,10 @@ from homeassistant.const import (
     CONF_URL,
     CONF_USERNAME,
 )
-from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN  # pylint: disable=unused-import
+from .errors import CannotLoginException
+from .router import async_get_api
 
 
 def _discovery_schema_with_defaults(discovery_info):
@@ -27,7 +28,7 @@ def _discovery_schema_with_defaults(discovery_info):
 def _user_schema_with_defaults(user_input):
     user_schema = {
         vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str,
-        vol.Optional(CONF_PORT, default=user_input.get(CONF_PORT, "")): int,
+        vol.Optional(CONF_PORT, default=user_input.get(CONF_PORT, 0)): int,
         vol.Optional(CONF_SSL, default=user_input.get(CONF_SSL, False)): bool,
     }
     user_schema.update(_ordered_shared_schema(user_input))
@@ -62,7 +63,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             user_input = {}
 
-        if self.placeholders.get(CONF_URL) != "url_not_found":
+        if self.placeholders.get(CONF_URL):
             user_input.update({CONF_URL: self.placeholders[CONF_URL]})
             step_id = "link"
             data_schema = _discovery_schema_with_defaults(user_input)
@@ -84,26 +85,24 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input and not self.placeholders.get(CONF_URL):
             self.placeholders[CONF_URL] = user_input.get(CONF_URL)
 
-        if self.placeholders.get(CONF_URL) is None:
-            return await self.async_step_discover()
-
         if not user_input:
             return await self._show_setup_form(user_input, errors)
 
         url = None
-        if self.placeholders.get(CONF_URL) != "url_not_found":
+        if self.placeholders.get(CONF_URL):
             url = self.placeholders.get(CONF_URL)
         host = user_input.get(CONF_HOST)
         port = user_input.get(CONF_PORT)
         ssl = user_input.get(CONF_SSL)
-        username = user_input.get(CONF_USERNAME) or None
+        username = user_input.get(CONF_USERNAME)
         password = user_input[CONF_PASSWORD]
 
         # Open connection and check authentication
-        api = await self.hass.async_add_executor_job(
-            Netgear, password, None, username, port, ssl, None
-        )
-        if not await self.hass.async_add_executor_job(api.login):
+        try:
+            api = await self.hass.async_add_executor_job(
+                async_get_api, password, host, username, port, ssl, url
+            )
+        except CannotLoginException:
             errors["base"] = "config"
 
         if errors:
@@ -115,9 +114,11 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         config_data = {
-            CONF_USERNAME: username,
             CONF_PASSWORD: password,
         }
+        if username:
+            config_data[CONF_USERNAME] = username
+
         if url:
             config_data[CONF_URL] = url
         else:
@@ -130,39 +131,24 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data=config_data,
         )
 
-    async def async_step_discover(self, user_input=None):
-        """Discover host, port and SSL."""
-        if user_input is None:
-            return self.async_show_form(step_id="discover")
-
-        url = await self.hass.async_add_executor_job(autodetect_url)
-        self.placeholders[CONF_URL] = url or "url_not_found"
-        return await self.async_step_user()
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        return await self.async_step_user(user_input)
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered device."""
-        # brief delay to allow processing the import step first
-        await asyncio.sleep(6)
-
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_SERIAL])
         self._abort_if_unique_id_configured()
 
         self.placeholders[CONF_NAME] = discovery_info[ssdp.ATTR_UPNP_MODEL_NUMBER]
-        self.placeholders[CONF_URL] = discovery_info[ssdp.ATTR_UPNP_PRESENTATION_URL]
-        return await self.async_step_user()
+        self.placeholders[
+            CONF_URL
+        ] = f"http://{urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname}/"
+        return await self.async_step_link()
 
-    async def async_step_import(self, user_input=None):
-        """Import a config entry."""
-        if not user_input.get(CONF_HOST):
-            url = await self.hass.async_add_executor_job(autodetect_url)
-            self.placeholders[CONF_URL] = url or "url_not_found"
-
-        return await self.async_step_user(user_input)
-
-    async def async_step_link(self, user_input):
+    async def async_step_link(self, user_input=None):
         """Link a config entry from discovery."""
+        if not user_input:
+            return await self._show_setup_form(user_input)
+
         return await self.async_step_user(user_input)
-
-
-class InvalidConfig(HomeAssistantError):
-    """Error to indicate there is invalid config."""

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -131,13 +131,13 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import a config entry."""
         return await self.async_step_user(user_input)
 
-    async def async_step_ssdp(self, discovery_info):
-        """Handle a discovered device."""
+    async def async_step_ssdp(self, discovery_info: dict):
+        """Initialize flow from ssdp."""
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_SERIAL])
         self._abort_if_unique_id_configured()
 
         self.placeholders[CONF_NAME] = discovery_info[ssdp.ATTR_UPNP_MODEL_NUMBER]
-        self.placeholders[
-            CONF_URL
-        ] = f"http://{urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname}/"
+        self.placeholders[CONF_URL] = urlparse(
+            discovery_info[ssdp.ATTR_SSDP_LOCATION]
+        ).hostname
         return await self._show_setup_form()

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -135,7 +135,6 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered device."""
-        print("discovery")
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_SERIAL])
         self._abort_if_unique_id_configured()
 

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -65,7 +65,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if self.placeholders.get(CONF_URL):
             user_input.update({CONF_URL: self.placeholders[CONF_URL]})
-            step_id = "link"
+            step_id = "ssdp_confirm"
             data_schema = _discovery_schema_with_defaults(user_input)
         else:
             step_id = "user"
@@ -142,9 +142,9 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.placeholders[
             CONF_URL
         ] = f"http://{urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname}/"
-        return await self.async_step_link()
+        return await self.async_step_ssdp_confirm()
 
-    async def async_step_link(self, user_input=None):
+    async def async_step_ssdp_confirm(self, user_input=None):
         """Link a config entry from discovery."""
         if not user_input:
             return await self._show_setup_form(user_input)

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 
 from .const import DOMAIN  # pylint: disable=unused-import
 from .errors import CannotLoginException
-from .router import async_get_api
+from .router import get_api
 
 
 def _discovery_schema_with_defaults(discovery_info):
@@ -88,9 +88,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             return await self._show_setup_form(user_input, errors)
 
-        url = None
-        if self.placeholders.get(CONF_URL):
-            url = self.placeholders.get(CONF_URL)
+        url = self.placeholders.get(CONF_URL)
         host = user_input.get(CONF_HOST)
         port = user_input.get(CONF_PORT)
         ssl = user_input.get(CONF_SSL)
@@ -100,7 +98,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # Open connection and check authentication
         try:
             api = await self.hass.async_add_executor_job(
-                async_get_api, password, host, username, port, ssl, url
+                get_api, password, host, username, port, ssl, url
             )
         except CannotLoginException:
             errors["base"] = "config"
@@ -133,10 +131,13 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, user_input=None):
         """Import a config entry."""
+        print("import")
+        print(user_input)
         return await self.async_step_user(user_input)
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered device."""
+        print("discovery")
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_SERIAL])
         self._abort_if_unique_id_configured()
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -1,0 +1,50 @@
+"""Netgear component constants."""
+DOMAIN = "netgear"
+
+PLATFORMS = ["device_tracker"]
+
+# Icons
+DEVICE_ICONS = {
+    0: "mdi:access-point-network",  # Router (Orbi ...)
+    1: "mdi:book-open-variant",  # Amazon Kindle
+    2: "mdi:android",  # Android Device
+    3: "mdi:cellphone-android",  # Android Phone
+    4: "mdi:tablet-android",  # Android Tablet
+    5: "mdi:router-wireless",  # Apple Airport Express
+    6: "mdi:disc-player",  # Blu-ray Player
+    7: "mdi:router-network",  # Bridge
+    8: "mdi:play-network",  # Cable STB
+    9: "mdi:camera",  # Camera
+    10: "mdi:router-network",  # Router
+    11: "mdi:play-network",  # DVR
+    12: "mdi:gamepad-variant",  # Gaming Console
+    13: "mdi:desktop-mac",  # iMac
+    14: "mdi:tablet-ipad",  # iPad
+    15: "mdi:tablet-ipad",  # iPad Mini
+    16: "mdi:cellphone-iphone",  # iPhone 5/5S/5C
+    17: "mdi:cellphone-iphone",  # iPhone
+    18: "mdi:ipod",  # iPod Touch
+    19: "mdi:linux",  # Linux PC
+    20: "mdi:apple-finder",  # Mac Mini
+    21: "mdi:desktop-tower",  # Mac Pro
+    22: "mdi:laptop-mac",  # MacBook
+    23: "mdi:play-network",  # Media Device
+    24: "mdi:network",  # Network Device
+    25: "mdi:play-network",  # Other STB
+    26: "mdi:power-plug",  # Powerline
+    27: "mdi:printer",  # Printer
+    28: "mdi:access-point",  # Repeater
+    29: "mdi:play-network",  # Satellite STB
+    30: "mdi:scanner",  # Scanner
+    31: "mdi:play-network",  # SlingBox
+    32: "mdi:cellphone",  # Smart Phone
+    33: "mdi:nas",  # Storage (NAS)
+    34: "mdi:switch",  # Switch
+    35: "mdi:television",  # TV
+    36: "mdi:tablet",  # Tablet
+    37: "mdi:desktop-classic",  # UNIX PC
+    38: "mdi:desktop-tower-monitor",  # Windows PC
+    39: "mdi:laptop-windows",  # Surface
+    40: "mdi:access-point-network",  # Wifi Extender
+    41: "mdi:apple-airplay",  # Apple TV
+}

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -1,170 +1,141 @@
 """Support for Netgear routers."""
 import logging
-from pprint import pformat
+from typing import Dict
 
-from pynetgear import Netgear
-import voluptuous as vol
+from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
+from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.typing import HomeAssistantType
 
-from homeassistant.components.device_tracker import (
-    DOMAIN,
-    PLATFORM_SCHEMA,
-    DeviceScanner,
-)
-from homeassistant.const import (
-    CONF_DEVICES,
-    CONF_EXCLUDE,
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_USERNAME,
-)
-import homeassistant.helpers.config_validation as cv
+from .const import DEVICE_ICONS, DOMAIN
+from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_APS = "accesspoints"
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_HOST, default=""): cv.string,
-        vol.Optional(CONF_SSL, default=False): cv.boolean,
-        vol.Optional(CONF_USERNAME, default=""): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_PORT): cv.port,
-        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_APS, default=[]): vol.All(cv.ensure_list, [cv.string]),
-    }
-)
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up device tracker for Netgear component."""
+    router = hass.data[DOMAIN][entry.unique_id]
+    tracked = set()
 
+    @callback
+    def update_router():
+        """Update the values of the router."""
+        add_entities(router, async_add_entities, tracked)
 
-def get_scanner(hass, config):
-    """Validate the configuration and returns a Netgear scanner."""
-    info = config[DOMAIN]
-    host = info[CONF_HOST]
-    ssl = info[CONF_SSL]
-    username = info[CONF_USERNAME]
-    password = info[CONF_PASSWORD]
-    port = info.get(CONF_PORT)
-    devices = info[CONF_DEVICES]
-    excluded_devices = info[CONF_EXCLUDE]
-    accesspoints = info[CONF_APS]
+    router.listeners.append(
+        async_dispatcher_connect(hass, router.signal_device_new, update_router)
+    )
 
-    api = Netgear(password, host, username, port, ssl)
-    scanner = NetgearDeviceScanner(api, devices, excluded_devices, accesspoints)
-
-    _LOGGER.debug("Logging in")
-
-    results = scanner.get_attached_devices()
-
-    if results is not None:
-        scanner.last_results = results
-    else:
-        _LOGGER.error("Failed to Login")
-        return None
-
-    return scanner
+    update_router()
 
 
-class NetgearDeviceScanner(DeviceScanner):
-    """Queries a Netgear wireless router using the SOAP-API."""
+@callback
+def add_entities(router, async_add_entities, tracked):
+    """Add new tracker entities from the router."""
+    new_tracked = []
 
-    def __init__(
-        self,
-        api,
-        devices,
-        excluded_devices,
-        accesspoints,
-    ):
-        """Initialize the scanner."""
-        self.tracked_devices = devices
-        self.excluded_devices = excluded_devices
-        self.tracked_accesspoints = accesspoints
-        self.last_results = []
-        self._api = api
+    for mac, device in router.devices.items():
+        if mac in tracked:
+            continue
 
-    def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        self._update_info()
+        new_tracked.append(NetgearDevice(router, device))
+        tracked.add(mac)
 
-        devices = []
+    if new_tracked:
+        async_add_entities(new_tracked, True)
 
-        for dev in self.last_results:
-            tracked = (
-                not self.tracked_devices
-                or dev.mac in self.tracked_devices
-                or dev.name in self.tracked_devices
+
+class NetgearDevice(ScannerEntity):
+    """Representation of a Netgear device."""
+
+    def __init__(self, router: NetgearRouter, device: Dict[str, any]) -> None:
+        """Initialize a Netgear device."""
+        self._router = router
+        self._name = device["name"]
+        self._mac = device["mac"]
+        self._manufacturer = device["device_model"]
+        self._icon = icon_for_device(device)
+        self._active = True
+        self._attrs = {}
+
+    def update(self) -> None:
+        """Update the Netgear device."""
+        device = self._router.devices[self._mac]
+        self._active = device["active"]
+        self._attrs = {
+            "link_type": device["type"],
+            "link_rate": device["link_rate"],
+            "signal_strength": device["signal"],
+        }
+        if not self._active:
+            self._attrs = {}
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._mac
+
+    @property
+    def name(self) -> str:
+        """Return the name."""
+        return self._name
+
+    @property
+    def is_connected(self):
+        """Return true if the device is connected to the network."""
+        return self._active
+
+    @property
+    def source_type(self) -> str:
+        """Return the source type."""
+        return SOURCE_TYPE_ROUTER
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self) -> Dict[str, any]:
+        """Return the attributes."""
+        return self._attrs
+
+    @property
+    def device_info(self) -> Dict[str, any]:
+        """Return the device information."""
+        return {
+            "connections": {(CONNECTION_NETWORK_MAC, self._mac)},
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "manufacturer": self._manufacturer,
+        }
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False
+
+    async def async_on_demand_update(self):
+        """Update state."""
+        self.async_schedule_update_ha_state(True)
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_device_update,
+                self.async_on_demand_update,
             )
-            tracked = tracked and (
-                not self.excluded_devices
-                or not (
-                    dev.mac in self.excluded_devices
-                    or dev.name in self.excluded_devices
-                )
-            )
-            if tracked:
-                devices.append(dev.mac)
-                if (
-                    self.tracked_accesspoints
-                    and dev.conn_ap_mac in self.tracked_accesspoints
-                ):
-                    devices.append(f"{dev.mac}_{dev.conn_ap_mac}")
+        )
 
-        return devices
 
-    def get_device_name(self, device):
-        """Return the name of the given device or the MAC if we don't know."""
-        parts = device.split("_")
-        mac = parts[0]
-        ap_mac = None
-        if len(parts) > 1:
-            ap_mac = parts[1]
-
-        name = None
-        for dev in self.last_results:
-            if dev.mac == mac:
-                name = dev.name
-                break
-
-        if not name or name == "--":
-            name = mac
-
-        if ap_mac:
-            ap_name = "Router"
-            for dev in self.last_results:
-                if dev.mac == ap_mac:
-                    ap_name = dev.name
-                    break
-
-            return f"{name} on {ap_name}"
-
-        return name
-
-    def _update_info(self):
-        """Retrieve latest information from the Netgear router.
-
-        Returns boolean if scanning successful.
-        """
-        _LOGGER.debug("Scanning")
-
-        results = self.get_attached_devices()
-
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("Scan result: \n%s", pformat(results))
-
-        if results is None:
-            _LOGGER.warning("Error scanning devices")
-
-        self.last_results = results or []
-
-    def get_attached_devices(self):
-        """List attached devices with pynetgear.
-
-        The v2 method takes more time and is more heavy on the router
-        so we only use it if we need connected AP info.
-        """
-        if self.tracked_accesspoints:
-            return self._api.get_attached_devices_2()
-
-        return self._api.get_attached_devices()
+def icon_for_device(device) -> str:
+    """Return the device icon from his type."""
+    return DEVICE_ICONS.get(device["device_type"], "mdi:help-network")

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -64,7 +64,8 @@ class NetgearDeviceEntity(ScannerEntity):
         self._active = True
         self._attrs = {}
 
-    async def async_update(self) -> None:
+    @callback
+    def update_device(self) -> None:
         """Update the Netgear device."""
         device = self._router.devices[self._mac]
         self._active = device["active"]
@@ -76,8 +77,7 @@ class NetgearDeviceEntity(ScannerEntity):
         if not self._active:
             self._attrs = {}
 
-        if self.entity_id:
-            self.async_write_ha_state()
+        self.async_write_ha_state()
 
     @property
     def unique_id(self) -> str:
@@ -128,7 +128,7 @@ class NetgearDeviceEntity(ScannerEntity):
         """Register state update callback."""
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass, self._router.signal_device_update, self.async_update,
+                self.hass, self._router.signal_device_update, self.update_device,
             )
         )
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -64,7 +64,7 @@ class NetgearDeviceEntity(ScannerEntity):
         self._active = True
         self._attrs = {}
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Update the Netgear device."""
         device = self._router.devices[self._mac]
         self._active = device["active"]
@@ -75,6 +75,9 @@ class NetgearDeviceEntity(ScannerEntity):
         }
         if not self._active:
             self._attrs = {}
+
+        if self.entity_id:
+            self.async_write_ha_state()
 
     @property
     def unique_id(self) -> str:
@@ -121,17 +124,11 @@ class NetgearDeviceEntity(ScannerEntity):
         """No polling needed."""
         return False
 
-    async def async_on_demand_update(self):
-        """Update state."""
-        self.async_schedule_update_ha_state(True)
-
     async def async_added_to_hass(self):
         """Register state update callback."""
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass,
-                self._router.signal_device_update,
-                self.async_on_demand_update,
+                self.hass, self._router.signal_device_update, self.async_update,
             )
         )
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -114,7 +114,6 @@ class NetgearDeviceEntity(ScannerEntity):
         """Return the device information."""
         return {
             "connections": {(CONNECTION_NETWORK_MAC, self._mac)},
-            "identifiers": {(DOMAIN, self.unique_id)},
             "name": self.name,
             "manufacturer": self._manufacturer,
         }

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -44,15 +44,15 @@ def add_entities(router, async_add_entities, tracked):
         if mac in tracked:
             continue
 
-        new_tracked.append(NetgearDevice(router, device))
+        new_tracked.append(NetgearDeviceEntity(router, device))
         tracked.add(mac)
 
     if new_tracked:
         async_add_entities(new_tracked, True)
 
 
-class NetgearDevice(ScannerEntity):
-    """Representation of a Netgear device."""
+class NetgearDeviceEntity(ScannerEntity):
+    """Representation of a device connected to a Netgear router."""
 
     def __init__(self, router: NetgearRouter, device: Dict[str, any]) -> None:
         """Initialize a Netgear device."""
@@ -88,7 +88,7 @@ class NetgearDevice(ScannerEntity):
 
     @property
     def is_connected(self):
-        """Return true if the device is connected to the network."""
+        """Return true if the device is connected to the router."""
         return self._active
 
     @property

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -60,7 +60,7 @@ class NetgearDeviceEntity(ScannerEntity):
         self._name = device["name"]
         self._mac = device["mac"]
         self._manufacturer = device["device_model"]
-        self._icon = icon_for_device(device)
+        self._icon = DEVICE_ICONS.get(device["device_type"], "mdi:help-network")
         self._active = True
         self._attrs = {}
 
@@ -127,11 +127,8 @@ class NetgearDeviceEntity(ScannerEntity):
         """Register state update callback."""
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass, self._router.signal_device_update, self.update_device,
+                self.hass,
+                self._router.signal_device_update,
+                self.update_device,
             )
         )
-
-
-def icon_for_device(device) -> str:
-    """Return the device icon from his type."""
-    return DEVICE_ICONS.get(device["device_type"], "mdi:help-network")

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -39,7 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_scanner(hass, config, async_add_entities, discovery_info=None):
+async def async_get_scanner(hass, config):
     """Import Netgear configuration from YAML."""
     hass.async_create_task(
         hass.config_entries.flow.async_init(

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -54,7 +54,7 @@ async def async_get_scanner(hass, config):
         "please remove it from configuration.yaml. Loading Netgear via platform setup is now deprecated."
     )
 
-    return True
+    return None
 
 
 async def async_setup_entry(

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -32,8 +32,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PORT): cv.port,
-    },
-    extra=vol.ALLOW_EXTRA,
+        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_APS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+    }
 )
 
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -2,10 +2,20 @@
 import logging
 from typing import Dict
 
-from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SOURCE_TYPE_ROUTER
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+)
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
@@ -14,6 +24,31 @@ from .const import DEVICE_ICONS, DOMAIN
 from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_SSL): cv.boolean,
+        vol.Optional(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_PORT): cv.port,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Import Netgear configuration from YAML."""
+    _LOGGER.warning(
+        "Loading Netgear via platform setup is deprecated. Please remove it from your configuration."
+    )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=config,
+        )
+    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -37,11 +37,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_scanner(hass, config, async_add_entities, discovery_info=None):
     """Import Netgear configuration from YAML."""
-    _LOGGER.warning(
-        "Loading Netgear via platform setup is deprecated. Please remove it from your configuration."
-    )
     hass.async_create_task(
         hass.config_entries.flow.async_init(
             DOMAIN,
@@ -49,6 +46,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             data=config,
         )
     )
+
+    _LOGGER.warning(
+        "Your Netgear configuration has been imported into the UI, "
+        "please remove it from configuration.yaml. Loading Netgear via platform setup is now deprecated."
+    )
+
+    return True
 
 
 async def async_setup_entry(

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -8,6 +8,8 @@ from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SOURCE_TYPE
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_EXCLUDE,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
@@ -24,6 +26,8 @@ from .const import DEVICE_ICONS, DOMAIN
 from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_APS = "accesspoints"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -51,7 +51,8 @@ async def async_get_scanner(hass, config):
 
     _LOGGER.warning(
         "Your Netgear configuration has been imported into the UI, "
-        "please remove it from configuration.yaml. Loading Netgear via platform setup is now deprecated."
+        "please remove it from configuration.yaml. "
+        "Loading Netgear via platform setup is now deprecated"
     )
 
     return None

--- a/homeassistant/components/netgear/errors.py
+++ b/homeassistant/components/netgear/errors.py
@@ -1,0 +1,10 @@
+"""Errors for the Netgear component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class NetgearException(HomeAssistantError):
+    """Base class for Netgear exceptions."""
+
+
+class CannotLoginException(NetgearException):
+    """Unable to login to the router."""

--- a/homeassistant/components/netgear/manifest.json
+++ b/homeassistant/components/netgear/manifest.json
@@ -2,6 +2,13 @@
   "domain": "netgear",
   "name": "NETGEAR",
   "documentation": "https://www.home-assistant.io/integrations/netgear",
-  "requirements": ["pynetgear==0.6.1"],
-  "codeowners": []
+  "requirements": ["pynetgear==0.7.0"],
+  "codeowners": ["@Quentame"],
+  "config_flow": true,
+  "ssdp": [
+    {
+      "manufacturer": "NETGEAR, Inc.",
+      "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
+    }
+  ]
 }

--- a/homeassistant/components/netgear/manifest.json
+++ b/homeassistant/components/netgear/manifest.json
@@ -3,7 +3,7 @@
   "name": "NETGEAR",
   "documentation": "https://www.home-assistant.io/integrations/netgear",
   "requirements": ["pynetgear==0.7.0"],
-  "codeowners": ["@Quentame"],
+  "codeowners": ["@hacf-fr", "@Quentame"],
   "config_flow": true,
   "ssdp": [
     {

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -1,0 +1,126 @@
+"""Represent the Netgear router and its devices."""
+from datetime import timedelta
+import logging
+from typing import Dict
+
+from pynetgear import Netgear
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_EXCLUDE,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+)
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+
+class NetgearRouter:
+    """Representation of a Netgear router."""
+
+    def __init__(self, hass: HomeAssistantType, entry: ConfigEntry) -> None:
+        """Initialize a Netgear router."""
+        self.hass = hass
+        self._host = entry.data.get(CONF_HOST)
+        self._port = entry.data.get(CONF_PORT)
+        self._ssl = entry.data.get(CONF_SSL)
+        self._username = entry.data.get(CONF_USERNAME)
+        self._password = entry.data[CONF_PASSWORD]
+        self._tracked_devices = entry.data.get(CONF_DEVICES)
+        self._excluded_devices = entry.data.get(CONF_EXCLUDE)
+
+        self._api: Netgear = None
+        self._attrs = {}
+
+        self.devices: Dict[str, any] = {}
+
+        self._unsub_dispatcher = None
+        self.listeners = []
+
+    async def setup(self) -> None:
+        """Set up a Netgear router."""
+        self._api = await self.hass.async_add_executor_job(
+            Netgear, self._password, self._host, self._username, self._port, self._ssl
+        )
+
+        try:
+            await self.hass.async_add_executor_job(self._api.login)
+        except OSError:
+            _LOGGER.exception("Failed to connect to Netgear")
+            return ConfigEntryNotReady
+
+        await self.update_devices()
+        self._unsub_dispatcher = async_track_time_interval(
+            self.hass, self.update_devices, SCAN_INTERVAL
+        )
+
+    def unload(self) -> None:
+        """Unload a Netgear router."""
+        self._unsub_dispatcher()
+        self._unsub_dispatcher = None
+
+    async def update_devices(self, now=None) -> None:
+        """Update Netgear devices."""
+        new_device = False
+        ntg_devices: Dict[str, any] = await self.hass.async_add_executor_job(
+            self._api.get_attached_devices_2
+        )
+
+        for device in self.devices.values():
+            device["active"] = False
+
+        for ntg_device in ntg_devices:
+            device_mac = ntg_device.mac
+
+            if not ntg_device.link_rate:
+                continue
+
+            tracked = (
+                not self._tracked_devices
+                or ntg_device.mac in self._tracked_devices
+                or ntg_device.name in self._tracked_devices
+            )
+            tracked = tracked and (
+                not self._excluded_devices
+                or not (
+                    ntg_device.mac in self._excluded_devices
+                    or ntg_device.name in self._excluded_devices
+                )
+            )
+
+            if not tracked:
+                continue
+
+            if not self.devices.get(device_mac):
+                new_device = True
+
+            self.devices[device_mac] = ntg_device._asdict()
+            self.devices[device_mac]["active"] = True
+            _LOGGER.warning(self.devices[device_mac])
+
+        async_dispatcher_send(self.hass, self.signal_device_update)
+
+        if new_device:
+            async_dispatcher_send(self.hass, self.signal_device_new)
+
+    @property
+    def signal_device_new(self) -> str:
+        """Event specific per Netgear entry to signal new device."""
+        return f"{DOMAIN}-{self._host}-device-new"
+
+    @property
+    def signal_device_update(self) -> str:
+        """Event specific per Netgear entry to signal updates in devices."""
+        return f"{DOMAIN}-{self._host}-device-update"

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -6,8 +6,6 @@ from pynetgear import Netgear
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_DEVICES,
-    CONF_EXCLUDE,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
@@ -36,8 +34,6 @@ class NetgearRouter:
         self._ssl = entry.data.get(CONF_SSL)
         self._username = entry.data.get(CONF_USERNAME)
         self._password = entry.data[CONF_PASSWORD]
-        self._tracked_devices = entry.data.get(CONF_DEVICES)
-        self._excluded_devices = entry.data.get(CONF_EXCLUDE)
 
         self._api: Netgear = None
         self._attrs = {}
@@ -85,22 +81,6 @@ class NetgearRouter:
             device_mac = ntg_device.mac
 
             if not ntg_device.link_rate:
-                continue
-
-            tracked = (
-                not self._tracked_devices
-                or ntg_device.mac in self._tracked_devices
-                or ntg_device.name in self._tracked_devices
-            )
-            tracked = tracked and (
-                not self._excluded_devices
-                or not (
-                    ntg_device.mac in self._excluded_devices
-                    or ntg_device.name in self._excluded_devices
-                )
-            )
-
-            if not tracked:
                 continue
 
             if not self.devices.get(device_mac):

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -43,7 +43,7 @@ class NetgearRouter:
         self._unsub_dispatcher = None
         self.listeners = []
 
-    async def setup(self) -> None:
+    async def async_setup(self) -> None:
         """Set up a Netgear router."""
         self._api = await self.hass.async_add_executor_job(
             Netgear,
@@ -57,17 +57,17 @@ class NetgearRouter:
 
         await self.hass.async_add_executor_job(self._api.login)
 
-        await self.update_devices()
+        await self.async_update_devices()
         self._unsub_dispatcher = async_track_time_interval(
-            self.hass, self.update_devices, SCAN_INTERVAL
+            self.hass, self.async_update_devices, SCAN_INTERVAL
         )
 
-    def unload(self) -> None:
+    async def async_unload(self) -> None:
         """Unload a Netgear router."""
         self._unsub_dispatcher()
         self._unsub_dispatcher = None
 
-    async def update_devices(self, now=None) -> None:
+    async def async_update_devices(self, now=None) -> None:
         """Update Netgear devices."""
         new_device = False
         ntg_devices: Dict[str, any] = await self.hass.async_add_executor_job(

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -23,8 +23,7 @@ from .errors import CannotLoginException
 SCAN_INTERVAL = timedelta(seconds=30)
 
 
-async def async_get_api(
-    hass: HomeAssistantType,
+def get_api(
     password: str,
     host: str = None,
     username: str = None,
@@ -65,7 +64,7 @@ class NetgearRouter:
     async def async_setup(self) -> None:
         """Set up a Netgear router."""
         self._api = await self.hass.async_add_executor_job(
-            async_get_api,
+            get_api,
             self._password,
             self._host,
             self._username,

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -73,9 +73,9 @@ class NetgearRouter:
             self._url,
         )
 
-        await self.async_update_devices()
+        await self.async_update_device_trackers()
         self._unsub_dispatcher = async_track_time_interval(
-            self.hass, self.async_update_devices, SCAN_INTERVAL
+            self.hass, self.async_update_device_trackers, SCAN_INTERVAL
         )
 
     async def async_unload(self) -> None:
@@ -83,7 +83,7 @@ class NetgearRouter:
         self._unsub_dispatcher()
         self._unsub_dispatcher = None
 
-    async def async_update_devices(self, now=None) -> None:
+    async def async_update_device_trackers(self, now=None) -> None:
         """Update Netgear devices."""
         new_device = False
         ntg_devices: Dict[str, any] = await self.hass.async_add_executor_job(

--- a/homeassistant/components/netgear/strings.json
+++ b/homeassistant/components/netgear/strings.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Netgear",
+        "description": "Default host: {host}\n Default port: {port}\n Default username: {username}",
+        "data": {
+          "host": "Host (Optional)",
+          "port": "Port (Optional)",
+          "ssl": "Use SSL (Optional)",
+          "username": "Username (Optional)",
+          "password": "Password"
+        }
+      },
+      "link": {
+        "title": "Netgear",
+        "description": "Do you want to setup router {name} ({url})?\n Default username: {username}",
+        "data": {
+          "username": "Username (Optional)",
+          "password": "Password"
+        }
+      },
+      "discover": {
+        "title": "Netgear: discovery",
+        "description": "Submit to try to discover your router host, port and SSL"
+      }
+    },
+    "error": {
+      "connection": "Connection error: please check your host, password & ssl",
+      "login": "Login error: please check your username & password",
+      "unknown": "Unknown error: please check logs to get more details"
+    },
+    "abort": {
+      "already_configured": "Host already configured"
+    }
+  }
+}

--- a/homeassistant/components/netgear/strings.json
+++ b/homeassistant/components/netgear/strings.json
@@ -26,9 +26,7 @@
       }
     },
     "error": {
-      "connection": "Connection error: please check your host, password & ssl",
-      "login": "Login error: please check your username & password",
-      "unknown": "Unknown error: please check logs to get more details"
+      "config": "Connection or login error: please check your configuration"
     },
     "abort": {
       "already_configured": "Host already configured"

--- a/homeassistant/components/netgear/strings.json
+++ b/homeassistant/components/netgear/strings.json
@@ -5,19 +5,19 @@
         "title": "Netgear",
         "description": "Default host: {host}\n Default port: {port}\n Default username: {username}",
         "data": {
-          "host": "Host (Optional)",
-          "port": "Port (Optional)",
-          "ssl": "Use SSL (Optional)",
-          "username": "Username (Optional)",
-          "password": "Password"
+          "host": "[%key:common::config_flow::data::host%] (Optional)",
+          "port": "[%key:common::config_flow::data::port%] (Optional)",
+          "ssl": "[%key:common::config_flow::data::ssl%]",
+          "username": "[%key:common::config_flow::data::username%] (Optional)",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       },
       "link": {
         "title": "Netgear",
         "description": "Do you want to setup router {name} ({url})?\n Default username: {username}",
         "data": {
-          "username": "Username (Optional)",
-          "password": "Password"
+          "username": "[%key:common::config_flow::data::username%] (Optional)",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },

--- a/homeassistant/components/netgear/strings.json
+++ b/homeassistant/components/netgear/strings.json
@@ -19,10 +19,6 @@
           "username": "Username (Optional)",
           "password": "Password"
         }
-      },
-      "discover": {
-        "title": "Netgear: discovery",
-        "description": "Submit to try to discover your router host, port and SSL"
       }
     },
     "error": {

--- a/homeassistant/components/netgear/translations/en.json
+++ b/homeassistant/components/netgear/translations/en.json
@@ -1,0 +1,37 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Host already configured"
+        },
+        "error": {
+            "connection": "Connection error: please check your host, password & ssl",
+            "login": "Login error: please check your username & password",
+            "unknown": "Unknown error: please check logs to get more details"
+        },
+        "step": {
+            "discover": {
+                "description": "Submit to try to discover your router host, port and SSL",
+                "title": "Netgear: discovery"
+            },
+            "link": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username (Optional)"
+                },
+                "description": "Do you want to setup router {name} ({url})?\n Default username: {username}",
+                "title": "Netgear"
+            },
+            "user": {
+                "data": {
+                    "host": "Host (Optional)",
+                    "password": "Password",
+                    "port": "Port (Optional)",
+                    "ssl": "Use SSL (Optional)",
+                    "username": "Username (Optional)"
+                },
+                "description": "Default host: {host}\n Default port: {port}\n Default username: {username}",
+                "title": "Netgear"
+            }
+        }
+    }
+}

--- a/homeassistant/components/netgear/translations/en.json
+++ b/homeassistant/components/netgear/translations/en.json
@@ -4,9 +4,7 @@
             "already_configured": "Host already configured"
         },
         "error": {
-            "connection": "Connection error: please check your host, password & ssl",
-            "login": "Login error: please check your username & password",
-            "unknown": "Unknown error: please check logs to get more details"
+            "config": "Connection or login error: please check your configuration"
         },
         "step": {
             "discover": {

--- a/homeassistant/components/netgear/translations/en.json
+++ b/homeassistant/components/netgear/translations/en.json
@@ -7,10 +7,6 @@
             "config": "Connection or login error: please check your configuration"
         },
         "step": {
-            "discover": {
-                "description": "Submit to try to discover your router host, port and SSL",
-                "title": "Netgear: discovery"
-            },
             "link": {
                 "data": {
                     "password": "Password",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -149,6 +149,7 @@ FLOWS = [
     "neato",
     "nest",
     "netatmo",
+    "netgear",
     "nexia",
     "nightscout",
     "notion",

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -136,6 +136,12 @@ SSDP = {
             "manufacturer": "konnected.io"
         }
     ],
+    "netgear": [
+        {
+            "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+            "manufacturer": "NETGEAR, Inc."
+        }
+    ],
     "roku": [
         {
             "deviceType": "urn:roku-com:device:player:1-0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1561,7 +1561,7 @@ pynanoleaf==0.0.5
 pynello==2.0.3
 
 # homeassistant.components.netgear
-pynetgear==0.6.1
+pynetgear==0.7.0
 
 # homeassistant.components.netio
 pynetio==0.1.9.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -829,6 +829,9 @@ pymysensors==0.20.1
 # homeassistant.components.nuki
 pynuki==1.3.8
 
+# homeassistant.components.netgear
+pynetgear==0.7.0
+
 # homeassistant.components.nut
 pynut2==2.1.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -826,11 +826,11 @@ pymyq==3.0.4
 # homeassistant.components.mysensors
 pymysensors==0.20.1
 
-# homeassistant.components.nuki
-pynuki==1.3.8
-
 # homeassistant.components.netgear
 pynetgear==0.7.0
+
+# homeassistant.components.nuki
+pynuki==1.3.8
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/tests/components/netgear/__init__.py
+++ b/tests/components/netgear/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Netgear component."""

--- a/tests/components/netgear/conftest.py
+++ b/tests/components/netgear/conftest.py
@@ -1,0 +1,11 @@
+"""Configure Netgear tests."""
+import pytest
+
+from tests.async_mock import patch
+
+
+@pytest.fixture(name="bypass_setup", autouse=True)
+def bypass_setup_fixture():
+    """Mock component setup."""
+    with patch("homeassistant.components.netgear.async_setup_entry", return_value=True):
+        yield

--- a/tests/components/netgear/conftest.py
+++ b/tests/components/netgear/conftest.py
@@ -8,7 +8,7 @@ import pytest
 def bypass_setup_fixture():
     """Mock component setup."""
     with patch(
-        "homeassistant.components.netgear.device_tracker.async_setup_scanner",
-        return_value=True,
+        "homeassistant.components.netgear.device_tracker.async_get_scanner",
+        return_value=None,
     ):
         yield

--- a/tests/components/netgear/conftest.py
+++ b/tests/components/netgear/conftest.py
@@ -1,11 +1,14 @@
 """Configure Netgear tests."""
-import pytest
+from unittest.mock import patch
 
-from tests.async_mock import patch
+import pytest
 
 
 @pytest.fixture(name="bypass_setup", autouse=True)
 def bypass_setup_fixture():
     """Mock component setup."""
-    with patch("homeassistant.components.netgear.async_setup_entry", return_value=True):
+    with patch(
+        "homeassistant.components.netgear.device_tracker.async_setup_scanner",
+        return_value=True,
+    ):
         yield

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -1,0 +1,298 @@
+"""Tests for the Netgear config flow."""
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+
+from homeassistant import data_entry_flow
+from homeassistant.components import ssdp
+from homeassistant.components.netgear.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_SSDP, SOURCE_USER
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_URL,
+    CONF_USERNAME,
+)
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+URL = "http://routerlogin.net"
+SERIAL = "5ER1AL0000001"
+
+ROUTER_INFOS = {
+    "Description": "Netgear Smart Wizard 3.0, specification 1.6 version",
+    "SignalStrength": "-4",
+    "SmartAgentversion": "3.0",
+    "FirewallVersion": "net-wall 2.0",
+    "VPNVersion": None,
+    "OthersoftwareVersion": "N/A",
+    "Hardwareversion": "N/A",
+    "Otherhardwareversion": "N/A",
+    "FirstUseDate": "Sunday, 30 Sep 2007 01:10:03",
+    "DeviceMode": "0",
+    "ModelName": "RBR20",
+    "SerialNumber": SERIAL,
+    "Firmwareversion": "V2.3.5.26",
+    "DeviceName": "Desk",
+    "DeviceNameUserSet": "true",
+    "FirmwareDLmethod": "HTTPS",
+    "FirmwareLastUpdate": "2019_10.5_18:42:58",
+    "FirmwareLastChecked": "2020_5.3_1:33:0",
+    "DeviceModeCapability": "0;1",
+}
+TITLE = f"{ROUTER_INFOS['ModelName']} - {ROUTER_INFOS['DeviceName']}"
+
+HOST = "10.0.0.1"
+SERIAL_2 = "5ER1AL0000002"
+PORT = 80
+SSL = False
+USERNAME = "Home_Assistant"
+PASSWORD = "password"
+
+
+@pytest.fixture(name="autodetect_url")
+def mock_controller_autodetect_url():
+    """Mock a successful autodetect."""
+    with patch(
+        "homeassistant.components.netgear.config_flow.autodetect_url"
+    ) as service_mock:
+        service_mock.return_value = URL
+        yield service_mock
+
+
+@pytest.fixture(name="autodetect_url_not_found")
+def mock_controller_autodetect_url_not_found():
+    """Mock a non successful autodetect."""
+    with patch(
+        "homeassistant.components.netgear.config_flow.autodetect_url"
+    ) as service_mock:
+        service_mock.return_value = None
+        yield service_mock
+
+
+@pytest.fixture(name="service")
+def mock_controller_service():
+    """Mock a successful service."""
+    with patch("homeassistant.components.netgear.config_flow.Netgear") as service_mock:
+        service_mock.return_value.get_info = Mock(return_value=ROUTER_INFOS)
+        yield service_mock
+
+
+@pytest.fixture(name="service_failed")
+def mock_controller_service_failed():
+    """Mock a failed service."""
+    with patch("homeassistant.components.netgear.config_flow.Netgear") as service_mock:
+        service_mock.return_value.login = Mock(return_value=None)
+        service_mock.return_value.get_info = Mock(return_value=None)
+        yield service_mock
+
+
+async def _discover_step_user(hass):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "discover"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    return result
+
+
+async def test_discover(hass, autodetect_url, service):
+    """Test discover step."""
+    result = await _discover_step_user(hass)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "link"
+
+
+async def test_user_required(hass, autodetect_url, service):
+    """Test user step."""
+    result = await _discover_step_user(hass)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "link"
+
+    # test with required only
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == SERIAL
+    assert result["title"] == TITLE
+    assert result["data"].get(CONF_URL) == URL
+    assert result["data"].get(CONF_HOST) is None
+    assert result["data"].get(CONF_PORT) is None
+    assert result["data"].get(CONF_SSL) is None
+    assert result["data"].get(CONF_USERNAME) is None
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+
+
+async def test_user_url_not_found(hass, autodetect_url_not_found, service):
+    """Test user step while autodetect_url did not find url."""
+    result = await _discover_step_user(hass)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # Have to provide all config
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_SSL: SSL,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == SERIAL
+    assert result["title"] == TITLE
+    assert result["data"].get(CONF_URL) is None
+    assert result["data"].get(CONF_HOST) == HOST
+    assert result["data"].get(CONF_PORT) == PORT
+    assert result["data"].get(CONF_SSL) == SSL
+    assert result["data"].get(CONF_USERNAME) == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+
+
+async def test_import_required(hass, autodetect_url, service):
+    """Test import step, with required config only."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == SERIAL
+    assert result["title"] == TITLE
+    assert result["data"].get(CONF_URL) == URL
+    assert result["data"].get(CONF_HOST) is None
+    assert result["data"].get(CONF_PORT) is None
+    assert result["data"].get(CONF_SSL) is None
+    assert result["data"].get(CONF_USERNAME) is None
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+
+
+async def test_import_required_login_failed(hass, autodetect_url, service_failed):
+    """Test import step, with required config only, while wrong password."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "link"
+    assert result["errors"] == {"base": "config"}
+
+
+async def test_import_all(hass, autodetect_url, service):
+    """Test import step, with all config provided."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_SSL: SSL,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == SERIAL
+    assert result["title"] == TITLE
+    assert result["data"].get(CONF_URL) is None
+    assert result["data"].get(CONF_HOST) == HOST
+    assert result["data"].get(CONF_PORT) == PORT
+    assert result["data"].get(CONF_SSL) == SSL
+    assert result["data"].get(CONF_USERNAME) == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+
+
+async def test_import_all_connection_failed(hass, autodetect_url, service_failed):
+    """Test import step, with all config provided, while wrong host."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_SSL: SSL,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "config"}
+
+
+async def test_abort_if_already_setup(hass, autodetect_url, service):
+    """Test we abort if the router is already setup."""
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_PASSWORD: PASSWORD}, unique_id=SERIAL,
+    ).add_to_hass(hass)
+
+    # Should fail, same SERIAL (import)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD},
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+    # Should fail, same SERIAL (flow)
+    result = await _discover_step_user(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: PASSWORD},
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_form_ssdp_already_configured(hass):
+    """Test ssdp abort when the router is already configured."""
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_PASSWORD: PASSWORD}, unique_id=SERIAL,
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data={
+            ssdp.ATTR_SSDP_LOCATION: "http://10.0.0.1:5555/rootDesc.xml",
+            ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
+            ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
+            ssdp.ATTR_UPNP_SERIAL: SERIAL,
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_form_ssdp(hass, autodetect_url, service):
+    """Test ssdp step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data={
+            ssdp.ATTR_SSDP_LOCATION: "http://10.0.0.1:5555/rootDesc.xml",
+            ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
+            ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
+            ssdp.ATTR_UPNP_SERIAL: SERIAL,
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "link"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == SERIAL
+    assert result["title"] == TITLE
+    assert result["data"].get(CONF_URL) == URL
+    assert result["data"].get(CONF_HOST) is None
+    assert result["data"].get(CONF_PORT) is None
+    assert result["data"].get(CONF_SSL) is None
+    assert result["data"].get(CONF_USERNAME) is None
+    assert result["data"][CONF_PASSWORD] == PASSWORD

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -230,12 +230,16 @@ async def test_import_all_connection_failed(hass, autodetect_url, service_failed
 async def test_abort_if_already_setup(hass, autodetect_url, service):
     """Test we abort if the router is already setup."""
     MockConfigEntry(
-        domain=DOMAIN, data={CONF_PASSWORD: PASSWORD}, unique_id=SERIAL,
+        domain=DOMAIN,
+        data={CONF_PASSWORD: PASSWORD},
+        unique_id=SERIAL,
     ).add_to_hass(hass)
 
     # Should fail, same SERIAL (import)
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD},
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_PASSWORD: PASSWORD},
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
@@ -243,7 +247,8 @@ async def test_abort_if_already_setup(hass, autodetect_url, service):
     # Should fail, same SERIAL (flow)
     result = await _discover_step_user(hass)
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_PASSWORD: PASSWORD},
+        result["flow_id"],
+        {CONF_PASSWORD: PASSWORD},
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
@@ -252,7 +257,9 @@ async def test_abort_if_already_setup(hass, autodetect_url, service):
 async def test_form_ssdp_already_configured(hass):
     """Test ssdp abort when the router is already configured."""
     MockConfigEntry(
-        domain=DOMAIN, data={CONF_PASSWORD: PASSWORD}, unique_id=SERIAL,
+        domain=DOMAIN,
+        data={CONF_PASSWORD: PASSWORD},
+        unique_id=SERIAL,
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -72,20 +72,11 @@ def mock_controller_service_failed():
         yield service_mock
 
 
-async def _discover_step_user(hass):
+async def test_user(hass, service):
+    """Test user step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "discover"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    return result
-
-
-async def test_user(hass, service):
-    """Test user step."""
-    result = await _discover_step_user(hass)
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
@@ -128,7 +119,7 @@ async def test_import_required(hass, autodetect_url, service):
 
 
 async def test_import_required_login_failed(hass, autodetect_url, service_failed):
-    """Test import step, with required config only, while wrong password."""
+    """Test import step, with required config only, while wrong password or connection issue."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD}
     )
@@ -197,7 +188,12 @@ async def test_abort_if_already_setup(hass, autodetect_url, service):
     assert result["reason"] == "already_configured"
 
     # Should fail, same SERIAL (flow)
-    result = await _discover_step_user(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_PASSWORD: PASSWORD},

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -55,26 +55,6 @@ USERNAME = "Home_Assistant"
 PASSWORD = "password"
 
 
-@pytest.fixture(name="autodetect_url")
-def mock_controller_autodetect_url():
-    """Mock a successful autodetect."""
-    with patch(
-        "homeassistant.components.netgear.config_flow.autodetect_url"
-    ) as service_mock:
-        service_mock.return_value = URL
-        yield service_mock
-
-
-@pytest.fixture(name="autodetect_url_not_found")
-def mock_controller_autodetect_url_not_found():
-    """Mock a non successful autodetect."""
-    with patch(
-        "homeassistant.components.netgear.config_flow.autodetect_url"
-    ) as service_mock:
-        service_mock.return_value = None
-        yield service_mock
-
-
 @pytest.fixture(name="service")
 def mock_controller_service():
     """Mock a successful service."""
@@ -103,36 +83,8 @@ async def _discover_step_user(hass):
     return result
 
 
-async def test_discover(hass, autodetect_url, service):
-    """Test discover step."""
-    result = await _discover_step_user(hass)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
-
-
-async def test_user_required(hass, autodetect_url, service):
+async def test_user(hass, service):
     """Test user step."""
-    result = await _discover_step_user(hass)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
-
-    # test with required only
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_PASSWORD: PASSWORD}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["result"].unique_id == SERIAL
-    assert result["title"] == TITLE
-    assert result["data"].get(CONF_URL) == URL
-    assert result["data"].get(CONF_HOST) is None
-    assert result["data"].get(CONF_PORT) is None
-    assert result["data"].get(CONF_SSL) is None
-    assert result["data"].get(CONF_USERNAME) is None
-    assert result["data"][CONF_PASSWORD] == PASSWORD
-
-
-async def test_user_url_not_found(hass, autodetect_url_not_found, service):
-    """Test user step while autodetect_url did not find url."""
     result = await _discover_step_user(hass)
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -58,7 +58,7 @@ PASSWORD = "password"
 @pytest.fixture(name="service")
 def mock_controller_service():
     """Mock a successful service."""
-    with patch("homeassistant.components.netgear.config_flow.Netgear") as service_mock:
+    with patch("homeassistant.components.netgear.router.Netgear") as service_mock:
         service_mock.return_value.get_info = Mock(return_value=ROUTER_INFOS)
         yield service_mock
 
@@ -66,7 +66,7 @@ def mock_controller_service():
 @pytest.fixture(name="service_failed")
 def mock_controller_service_failed():
     """Mock a failed service."""
-    with patch("homeassistant.components.netgear.config_flow.Netgear") as service_mock:
+    with patch("homeassistant.components.netgear.router.Netgear") as service_mock:
         service_mock.return_value.login = Mock(return_value=None)
         service_mock.return_value.get_info = Mock(return_value=None)
         yield service_mock

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -245,7 +245,7 @@ async def test_ssdp(hass, service):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
-    assert result["data"].get(CONF_URL) == HOST
+    assert result["data"].get(CONF_URL) == f"http://{HOST}/"
     assert result["data"].get(CONF_HOST) is None
     assert result["data"].get(CONF_PORT) is None
     assert result["data"].get(CONF_SSL) is None

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -100,10 +100,9 @@ async def test_user(hass, service):
     assert result["data"].get(CONF_SSL) == SSL
     assert result["data"].get(CONF_USERNAME) == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["placeholders"][CONF_URL] is None
 
 
-async def test_import_required(hass, autodetect_url, service):
+async def test_import_required(hass, service):
     """Test import step, with required config only."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD}
@@ -111,16 +110,15 @@ async def test_import_required(hass, autodetect_url, service):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
-    assert result["data"].get(CONF_URL) == URL
+    assert result["data"].get(CONF_URL) is None
     assert result["data"].get(CONF_HOST) is None
     assert result["data"].get(CONF_PORT) is None
     assert result["data"].get(CONF_SSL) is None
     assert result["data"].get(CONF_USERNAME) is None
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["placeholders"][CONF_URL] is None
 
 
-async def test_import_required_login_failed(hass, autodetect_url, service_failed):
+async def test_import_required_login_failed(hass, service_failed):
     """Test import step, with required config only, while wrong password or connection issue."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD}
@@ -128,10 +126,9 @@ async def test_import_required_login_failed(hass, autodetect_url, service_failed
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "config"}
-    assert result["placeholders"][CONF_URL] is None
 
 
-async def test_import_all(hass, autodetect_url, service):
+async def test_import_all(hass, service):
     """Test import step, with all config provided."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -153,10 +150,9 @@ async def test_import_all(hass, autodetect_url, service):
     assert result["data"].get(CONF_SSL) == SSL
     assert result["data"].get(CONF_USERNAME) == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["placeholders"][CONF_URL] is None
 
 
-async def test_import_all_connection_failed(hass, autodetect_url, service_failed):
+async def test_import_all_connection_failed(hass, service_failed):
     """Test import step, with all config provided, while wrong host."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -172,10 +168,9 @@ async def test_import_all_connection_failed(hass, autodetect_url, service_failed
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "config"}
-    assert result["placeholders"][CONF_URL] is None
 
 
-async def test_abort_if_already_setup(hass, autodetect_url, service):
+async def test_abort_if_already_setup(hass, service):
     """Test we abort if the router is already setup."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -191,7 +186,6 @@ async def test_abort_if_already_setup(hass, autodetect_url, service):
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
-    assert result["placeholders"][CONF_URL] is None
 
     # Should fail, same SERIAL (flow)
     result = await hass.config_entries.flow.async_init(
@@ -206,10 +200,9 @@ async def test_abort_if_already_setup(hass, autodetect_url, service):
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
-    assert result["placeholders"][CONF_URL] is None
 
 
-async def test_form_ssdp_already_configured(hass):
+async def test_ssdp_already_configured(hass):
     """Test ssdp abort when the router is already configured."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -229,10 +222,9 @@ async def test_form_ssdp_already_configured(hass):
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
-    assert result["placeholders"][CONF_URL] == f"http://{HOST}"
 
 
-async def test_form_ssdp(hass, autodetect_url, service):
+async def test_ssdp(hass, service):
     """Test ssdp step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -253,10 +245,9 @@ async def test_form_ssdp(hass, autodetect_url, service):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
-    assert result["data"].get(CONF_URL) == URL
+    assert result["data"].get(CONF_URL) == HOST
     assert result["data"].get(CONF_HOST) is None
     assert result["data"].get(CONF_PORT) is None
     assert result["data"].get(CONF_SSL) is None
     assert result["data"].get(CONF_USERNAME) is None
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["placeholders"][CONF_URL] == f"http://{HOST}"

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -100,6 +100,7 @@ async def test_user(hass, service):
     assert result["data"].get(CONF_SSL) == SSL
     assert result["data"].get(CONF_USERNAME) == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["placeholders"][CONF_URL] is None
 
 
 async def test_import_required(hass, autodetect_url, service):
@@ -116,6 +117,7 @@ async def test_import_required(hass, autodetect_url, service):
     assert result["data"].get(CONF_SSL) is None
     assert result["data"].get(CONF_USERNAME) is None
     assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["placeholders"][CONF_URL] is None
 
 
 async def test_import_required_login_failed(hass, autodetect_url, service_failed):
@@ -124,8 +126,9 @@ async def test_import_required_login_failed(hass, autodetect_url, service_failed
         DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_PASSWORD: PASSWORD}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "config"}
+    assert result["placeholders"][CONF_URL] is None
 
 
 async def test_import_all(hass, autodetect_url, service):
@@ -150,6 +153,7 @@ async def test_import_all(hass, autodetect_url, service):
     assert result["data"].get(CONF_SSL) == SSL
     assert result["data"].get(CONF_USERNAME) == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["placeholders"][CONF_URL] is None
 
 
 async def test_import_all_connection_failed(hass, autodetect_url, service_failed):
@@ -168,6 +172,7 @@ async def test_import_all_connection_failed(hass, autodetect_url, service_failed
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "config"}
+    assert result["placeholders"][CONF_URL] is None
 
 
 async def test_abort_if_already_setup(hass, autodetect_url, service):
@@ -186,6 +191,7 @@ async def test_abort_if_already_setup(hass, autodetect_url, service):
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
+    assert result["placeholders"][CONF_URL] is None
 
     # Should fail, same SERIAL (flow)
     result = await hass.config_entries.flow.async_init(
@@ -200,6 +206,7 @@ async def test_abort_if_already_setup(hass, autodetect_url, service):
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
+    assert result["placeholders"][CONF_URL] is None
 
 
 async def test_form_ssdp_already_configured(hass):
@@ -222,6 +229,7 @@ async def test_form_ssdp_already_configured(hass):
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
+    assert result["placeholders"][CONF_URL] == f"http://{HOST}"
 
 
 async def test_form_ssdp(hass, autodetect_url, service):
@@ -237,7 +245,7 @@ async def test_form_ssdp(hass, autodetect_url, service):
         },
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
+    assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_PASSWORD: PASSWORD}
@@ -251,3 +259,4 @@ async def test_form_ssdp(hass, autodetect_url, service):
     assert result["data"].get(CONF_SSL) is None
     assert result["data"].get(CONF_USERNAME) is None
     assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["placeholders"][CONF_URL] == f"http://{HOST}"


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Add config flow to Netgear + SSDP discovery

The `accesspoints`, `devices` and `exclude` config are not used anymore.

~Requires merge of MatMaul/pynetgear#80 and MatMaul/pynetgear#81~ (merged and released)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#13300

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
