### PR TITLE
Add support for Sonos queue

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sonos",
-  "requirements": ["pysonos==0.0.25"],
+  "requirements": ["pysonos==0.0.26"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:ZonePlayer:1"

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -81,6 +81,7 @@ SERVICE_CLEAR_TIMER = "clear_sleep_timer"
 SERVICE_UPDATE_ALARM = "update_alarm"
 SERVICE_SET_OPTION = "set_option"
 SERVICE_PLAY_QUEUE = "play_queue"
+SERVICE_REMOVE_FROM_QUEUE = "remove_from_queue"
 
 ATTR_SLEEP_TIME = "sleep_time"
 ATTR_ALARM_ID = "alarm_id"
@@ -270,6 +271,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         SERVICE_PLAY_QUEUE,
         {vol.Optional(ATTR_QUEUE_POSITION): cv.positive_int},
         "play_queue",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_REMOVE_FROM_QUEUE,
+        {vol.Optional(ATTR_QUEUE_POSITION): cv.positive_int},
+        "remove_from_queue",
     )
 
 
@@ -1229,6 +1236,11 @@ class SonosEntity(MediaPlayerEntity):
     def play_queue(self, queue_position=0):
         """Start playing the queue."""
         self.soco.play_from_queue(queue_position)
+
+    @soco_error()
+    def remove_from_queue(self, queue_position=0):
+        """Remove item from the queue."""
+        self.soco.remove_from_queue(queue_position)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -92,6 +92,9 @@ ATTR_WITH_GROUP = "with_group"
 ATTR_NIGHT_SOUND = "night_sound"
 ATTR_SPEECH_ENHANCE = "speech_enhance"
 ATTR_QUEUE_POSITION = "queue_position"
+ATTR_QUEUE = "queue"
+ATTR_IS_PLAYING_LOCAL_QUEUE = "is_playing_local_queue"
+ATTR_CURRENT_QUEUE_POSITION = "current_queue_position"
 
 UNAVAILABLE_VALUES = {"", "NOT_IMPLEMENTED", None}
 
@@ -363,6 +366,9 @@ class SonosEntity(MediaPlayerEntity):
         self._media_artist = None
         self._media_album_name = None
         self._media_title = None
+        self._queue = []
+        self._is_playing_local_queue = None
+        self._current_queue_position = None
         self._night_sound = None
         self._speech_enhance = None
         self._source_name = None
@@ -507,12 +513,21 @@ class SonosEntity(MediaPlayerEntity):
                 # Skip unknown types
                 _LOGGER.error("Unhandled favorite '%s': %s", fav.title, ex)
 
+    def _set_queue(self):
+        """Set available queue."""
+        self._queue = []
+        if self.soco.is_playing_local_queue:
+            self._is_playing_local_queue = True
+            for item in self.soco.get_queue():
+                self._queue.append(item.title)
+
     def _attach_player(self):
         """Get basic information and add event subscriptions."""
         try:
             self._shuffle = self.soco.shuffle
             self.update_volume()
             self._set_favorites()
+            self._set_queue()
 
             player = self.soco
 
@@ -668,6 +683,9 @@ class SonosEntity(MediaPlayerEntity):
 
         self._media_image_url = track_info.get("album_art")
 
+        if self.soco.is_playing_local_queue:
+            self._current_queue_position = track_info.get("playlist_position")
+
     def update_volume(self, event=None):
         """Update information about currently volume settings."""
         if event:
@@ -765,6 +783,7 @@ class SonosEntity(MediaPlayerEntity):
     def update_content(self, event=None):
         """Update information about available content."""
         self._set_favorites()
+        self._set_queue()
         self.schedule_update_ha_state()
 
     @property
@@ -1221,5 +1240,15 @@ class SonosEntity(MediaPlayerEntity):
 
         if self._speech_enhance is not None:
             attributes[ATTR_SPEECH_ENHANCE] = self._speech_enhance
+
+        if self._queue is not None:
+            attributes[ATTR_QUEUE] = self._queue
+
+        if self._current_queue_position is not None:
+            if int(self._current_queue_position) > 0:
+                attributes[ATTR_CURRENT_QUEUE_POSITION] = self._current_queue_position
+
+        if self._is_playing_local_queue is not None:
+            attributes[ATTR_IS_PLAYING_LOCAL_QUEUE] = self._is_playing_local_queue
 
         return attributes

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -907,7 +907,7 @@ class SonosEntity(MediaPlayerEntity):
             sources += [SOURCE_LINEIN]
         elif "PLAYBAR" in model:
             sources += [SOURCE_LINEIN, SOURCE_TV]
-        elif "BEAM" in model:
+        elif "BEAM" in model or "PLAYBASE" in model:
             sources += [SOURCE_TV]
 
         return sources

--- a/homeassistant/components/sonos/services.yaml
+++ b/homeassistant/components/sonos/services.yaml
@@ -74,3 +74,13 @@ play_queue:
     queue_position:
       description: Position of the song in the queue to start playing from.
       example: "0"
+
+remove_from_queue:
+  description: Removes the first item from the queue.
+  fields:
+    entity_id:
+      description: Name(s) of entities that will remove an item.
+      example: "media_player.living_room_sonos"
+    queue_position:
+      description: Position in the queue to remove.
+      example: "0"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1575,7 +1575,7 @@ pysnmp==4.4.12
 pysoma==0.0.10
 
 # homeassistant.components.sonos
-pysonos==0.0.25
+pysonos==0.0.26
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -629,7 +629,7 @@ pysmartthings==0.7.1
 pysoma==0.0.10
 
 # homeassistant.components.sonos
-pysonos==0.0.25
+pysonos==0.0.26
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds Sonos playbase as a model
Adds Sonos ```queue```, ```current_queue_position``` and ```is_playing_local_queue``` as attributes
Adds a new service to remove songs from queue

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example automation to remove just played song from queue
trigger:
  - platform: state
    entity_id: media_player.kitchen
condition:
  condition: and
  conditions:
    - condition: template
      value_template: >
        {{ trigger.from_state.attributes.current_queue_position | int < trigger.to_state.attributes.current_queue_position | int }}
    - condition: template
      value_template: >
        {{ state_attr('media_player.kitchen', 'is_playing_local_queue') == True }}
action:
  - service: sonos.remove_from_queue
    data_template:
      entity_id: media_player.kitchen
      queue_position: >
        {{ (trigger.from_state.attributes.current_queue_position | int) - 1 }}
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
