### PR TITLE
Don't attempt to set Vizio is_volume_muted property if Vizio API doesn't provide muted state

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -207,7 +207,10 @@ class VizioDevice(MediaPlayerEntity):
         )
         if audio_settings is not None:
             self._volume_level = float(audio_settings["volume"]) / self._max_volume
-            self._is_muted = audio_settings["mute"].lower() == "on"
+            if "mute" in audio_settings:
+                self._is_muted = audio_settings["mute"].lower() == "on"
+            else:
+                self._is_muted = None
 
             if VIZIO_SOUND_MODE in audio_settings:
                 self._supported_commands |= SUPPORT_SELECT_SOUND_MODE

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -132,7 +132,7 @@ class VizioDevice(MediaPlayerEntity):
         self._state = None
         self._volume_level = None
         self._volume_step = config_entry.options[CONF_VOLUME_STEP]
-        self._is_muted = None
+        self._is_volume_muted = None
         self._current_input = None
         self._current_app = None
         self._current_app_config = None
@@ -190,7 +190,7 @@ class VizioDevice(MediaPlayerEntity):
         if not is_on:
             self._state = STATE_OFF
             self._volume_level = None
-            self._is_muted = None
+            self._is_volume_muted = None
             self._current_input = None
             self._available_inputs = None
             self._current_app = None
@@ -208,9 +208,9 @@ class VizioDevice(MediaPlayerEntity):
         if audio_settings is not None:
             self._volume_level = float(audio_settings["volume"]) / self._max_volume
             if "mute" in audio_settings:
-                self._is_muted = audio_settings["mute"].lower() == "on"
+                self._is_volume_muted = audio_settings["mute"].lower() == "on"
             else:
-                self._is_muted = None
+                self._is_volume_muted = None
 
             if VIZIO_SOUND_MODE in audio_settings:
                 self._supported_commands |= SUPPORT_SELECT_SOUND_MODE
@@ -327,7 +327,7 @@ class VizioDevice(MediaPlayerEntity):
     @property
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
-        return self._is_muted
+        return self._is_volume_muted
 
     @property
     def source(self) -> str:
@@ -431,10 +431,10 @@ class VizioDevice(MediaPlayerEntity):
         """Mute the volume."""
         if mute:
             await self._device.mute_on()
-            self._is_muted = True
+            self._is_volume_muted = True
         else:
             await self._device.mute_off()
-            self._is_muted = False
+            self._is_volume_muted = False
 
     async def async_media_previous_track(self) -> None:
         """Send previous channel command."""

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -621,3 +621,26 @@ async def test_setup_with_no_running_app(
         assert attr["source"] == "CAST"
         assert "app_id" not in attr
         assert "app_name" not in attr
+
+
+async def test_setup_tv_without_mute(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_update: pytest.fixture,
+) -> None:
+    """Test Vizio TV entity setup when mute property isn't returned by Vizio API."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_USER_VALID_TV_CONFIG),
+        unique_id=UNIQUE_ID,
+    )
+
+    async with _cm_for_test_setup_without_apps(
+        {"volume": int(MAX_VOLUME[VIZIO_DEVICE_CLASS_TV] / 2)}, STATE_ON,
+    ):
+        await _add_config_entry_to_hass(hass, config_entry)
+
+        attr = _get_attr_and_assert_base_attr(hass, DEVICE_CLASS_TV, STATE_ON)
+        _assert_sources_and_volume(attr, VIZIO_DEVICE_CLASS_TV)
+        assert "sound_mode" not in attr
+        assert "is_volume_muted" not in attr


### PR DESCRIPTION
## Proposed change
PR #32332 added the `is_volume_muted` property for vizio devices starting in 0.107. It was assumed that all devices returned a `mute` property, but according to issue #34730, not all devices return this property resulting in a `KeyError`. This change fixes the issue and supports both devices that have the property and devices that don't.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34730

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
