### PR TITLE
Attempt to fix CI

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -11,10 +11,10 @@ import logging
 import os
 import sys
 import threading
-from unittest.mock import MagicMock, Mock, patch
 import uuid
 
 from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa
+from asynctest import MagicMock, Mock, patch
 
 from homeassistant import auth, config_entries, core as ha, loader
 from homeassistant.auth import (

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -34,10 +34,14 @@ from tests.common import (
     mock_device_registry,
     mock_mqtt_component,
     mock_registry,
-    mock_storage,
     threadsafe_coroutine_factory,
 )
 from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
+
+
+@pytest.fixture(autouse=True)
+def mock_storage(hass_storage):
+    """Autouse hass_storage for the TestCase tests."""
 
 
 @pytest.fixture
@@ -87,15 +91,12 @@ class TestMQTTComponent(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
         mock_mqtt_component(self.hass)
         self.calls = []
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
         self.hass.stop()
-        self.mock_storage.__exit__(None, None, None)
 
     @callback
     def record_calls(self, *args):
@@ -305,15 +306,12 @@ class TestMQTTCallbacks(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
         mock_mqtt_client(self.hass)
         self.calls = []
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
         self.hass.stop()
-        self.mock_storage.__exit__(None, None, None)
 
     @callback
     def record_calls(self, *args):

--- a/tests/components/mqtt/test_server.py
+++ b/tests/components/mqtt/test_server.py
@@ -2,12 +2,18 @@
 from unittest.mock import MagicMock, Mock
 
 from asynctest import CoroutineMock, patch
+import pytest
 
 import homeassistant.components.mqtt as mqtt
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, mock_coro, mock_storage
+from tests.common import get_test_home_assistant, mock_coro
+
+
+@pytest.fixture(autouse=True)
+def inject_fixture(hass_storage):
+    """Inject pytest fixtures."""
 
 
 class TestMQTT:
@@ -16,13 +22,10 @@ class TestMQTT:
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
 
     def teardown_method(self, method):
         """Stop everything that was started."""
         self.hass.stop()
-        self.mock_storage.__exit__(None, None, None)
 
     @patch("passlib.apps.custom_app_context", Mock(return_value=""))
     @patch("tempfile.NamedTemporaryFile", Mock(return_value=MagicMock()))

--- a/tests/components/mqtt_eventstream/test_init.py
+++ b/tests/components/mqtt_eventstream/test_init.py
@@ -2,6 +2,8 @@
 import json
 from unittest.mock import ANY, patch
 
+import pytest
+
 import homeassistant.components.mqtt_eventstream as eventstream
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import State, callback
@@ -15,8 +17,12 @@ from tests.common import (
     get_test_home_assistant,
     mock_mqtt_component,
     mock_state_change_event,
-    mock_storage,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_storage(hass_storage):
+    """Autouse hass_storage for the TestCase tests."""
 
 
 class TestMqttEventStream:
@@ -25,14 +31,11 @@ class TestMqttEventStream:
     def setup_method(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
         self.mock_mqtt = mock_mqtt_component(self.hass)
 
     def teardown_method(self):
         """Stop everything that was started."""
         self.hass.stop()
-        self.mock_storage.__exit__(None, None, None)
 
     def add_eventstream(self, sub_topic=None, pub_topic=None, ignore_event=None):
         """Add a mqtt_eventstream component."""

--- a/tests/components/mqtt_statestream/test_init.py
+++ b/tests/components/mqtt_statestream/test_init.py
@@ -1,6 +1,8 @@
 """The tests for the MQTT statestream component."""
 from unittest.mock import ANY, call, patch
 
+import pytest
+
 import homeassistant.components.mqtt_statestream as statestream
 from homeassistant.core import State
 from homeassistant.setup import setup_component
@@ -9,8 +11,12 @@ from tests.common import (
     get_test_home_assistant,
     mock_mqtt_component,
     mock_state_change_event,
-    mock_storage,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_storage(hass_storage):
+    """Autouse hass_storage for the TestCase tests."""
 
 
 class TestMqttStateStream:
@@ -19,14 +25,11 @@ class TestMqttStateStream:
     def setup_method(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
         self.mock_mqtt = mock_mqtt_component(self.hass)
 
     def teardown_method(self):
         """Stop everything that was started."""
         self.hass.stop()
-        self.mock_storage.__exit__(None, None, None)
 
     def add_statestream(
         self,

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -1,6 +1,5 @@
 """Unit tests for platform/plant.py."""
 from datetime import datetime, timedelta
-import unittest
 
 import pytest
 
@@ -15,9 +14,9 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import State
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant, init_recorder_component
+from tests.common import init_recorder_component
 
 GOOD_DATA = {
     "moisture": 50,
@@ -47,204 +46,193 @@ GOOD_CONFIG = {
 }
 
 
-class TestPlant(unittest.TestCase):
-    """Tests for component "plant"."""
-
-    def setUp(self):
-        """Create test instance of Home Assistant."""
-        self.hass = get_test_home_assistant()
-
-    def tearDown(self):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    async def test_valid_data(self):
-        """Test processing valid data."""
-        sensor = plant.Plant("my plant", GOOD_CONFIG)
-        sensor.entity_id = "sensor.mqtt_plant_battery"
-        sensor.hass = self.hass
-        for reading, value in GOOD_DATA.items():
-            sensor.state_changed(
-                GOOD_CONFIG["sensors"][reading],
-                None,
-                State(GOOD_CONFIG["sensors"][reading], value),
-            )
-        assert sensor.state == "ok"
-        attrib = sensor.state_attributes
-        for reading, value in GOOD_DATA.items():
-            # battery level has a different name in
-            # the JSON format than in hass
-            assert attrib[reading] == value
-
-    async def test_low_battery(self):
-        """Test processing with low battery data and limit set."""
-        sensor = plant.Plant("other plant", GOOD_CONFIG)
-        sensor.entity_id = "sensor.mqtt_plant_battery"
-        sensor.hass = self.hass
-        assert sensor.state_attributes["problem"] == "none"
+async def test_valid_data(hass):
+    """Test processing valid data."""
+    sensor = plant.Plant("my plant", GOOD_CONFIG)
+    sensor.entity_id = "sensor.mqtt_plant_battery"
+    sensor.hass = hass
+    for reading, value in GOOD_DATA.items():
         sensor.state_changed(
-            "sensor.mqtt_plant_battery",
-            State("sensor.mqtt_plant_battery", 45),
-            State("sensor.mqtt_plant_battery", 10),
+            GOOD_CONFIG["sensors"][reading],
+            None,
+            State(GOOD_CONFIG["sensors"][reading], value),
         )
-        assert sensor.state == "problem"
-        assert sensor.state_attributes["problem"] == "battery low"
+    assert sensor.state == "ok"
+    attrib = sensor.state_attributes
+    for reading, value in GOOD_DATA.items():
+        # battery level has a different name in
+        # the JSON format than in hass
+        assert attrib[reading] == value
 
-    def test_initial_states(self):
-        """Test plant initialises attributes if sensor already exists."""
-        self.hass.states.set(
-            MOISTURE_ENTITY, 5, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY}
-        )
-        plant_name = "some_plant"
-        assert setup_component(
-            self.hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
-        )
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert 5 == state.attributes[plant.READING_MOISTURE]
 
-    def test_update_states(self):
-        """Test updating the state of a sensor.
-
-        Make sure that plant processes this correctly.
-        """
-        plant_name = "some_plant"
-        assert setup_component(
-            self.hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
-        )
-        self.hass.states.set(
-            MOISTURE_ENTITY, 5, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY}
-        )
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert STATE_PROBLEM == state.state
-        assert 5 == state.attributes[plant.READING_MOISTURE]
-
-    def test_unavailable_state(self):
-        """Test updating the state with unavailable.
-
-        Make sure that plant processes this correctly.
-        """
-        plant_name = "some_plant"
-        assert setup_component(
-            self.hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
-        )
-        self.hass.states.set(
-            MOISTURE_ENTITY, STATE_UNAVAILABLE, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY}
-        )
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert state.state == STATE_PROBLEM
-        assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
-
-    def test_state_problem_if_unavailable(self):
-        """Test updating the state with unavailable after setting it to valid value.
-
-        Make sure that plant processes this correctly.
-        """
-        plant_name = "some_plant"
-        assert setup_component(
-            self.hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
-        )
-        self.hass.states.set(
-            MOISTURE_ENTITY, 42, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY}
-        )
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert state.state == STATE_OK
-        assert state.attributes[plant.READING_MOISTURE] == 42
-        self.hass.states.set(
-            MOISTURE_ENTITY, STATE_UNAVAILABLE, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY}
-        )
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert state.state == STATE_PROBLEM
-        assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
-
-    @pytest.mark.skipif(
-        plant.ENABLE_LOAD_HISTORY is False,
-        reason="tests for loading from DB are unstable, thus"
-        "this feature is turned of until tests become"
-        "stable",
+async def test_low_battery(hass):
+    """Test processing with low battery data and limit set."""
+    sensor = plant.Plant("other plant", GOOD_CONFIG)
+    sensor.entity_id = "sensor.mqtt_plant_battery"
+    sensor.hass = hass
+    assert sensor.state_attributes["problem"] == "none"
+    sensor.state_changed(
+        "sensor.mqtt_plant_battery",
+        State("sensor.mqtt_plant_battery", 45),
+        State("sensor.mqtt_plant_battery", 10),
     )
-    def test_load_from_db(self):
-        """Test bootstrapping the brightness history from the database.
+    assert sensor.state == "problem"
+    assert sensor.state_attributes["problem"] == "battery low"
 
-        This test can should only be executed if the loading of the history
-        is enabled via plant.ENABLE_LOAD_HISTORY.
-        """
-        init_recorder_component(self.hass)
-        plant_name = "wise_plant"
-        for value in [20, 30, 10]:
 
-            self.hass.states.set(
-                BRIGHTNESS_ENTITY, value, {ATTR_UNIT_OF_MEASUREMENT: "Lux"}
-            )
-            self.hass.block_till_done()
-        # wait for the recorder to really store the data
-        self.hass.data[recorder.DATA_INSTANCE].block_till_done()
+async def test_initial_states(hass):
+    """Test plant initialises attributes if sensor already exists."""
+    hass.states.async_set(MOISTURE_ENTITY, 5, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY})
+    plant_name = "some_plant"
+    assert await async_setup_component(
+        hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert 5 == state.attributes[plant.READING_MOISTURE]
 
-        assert setup_component(
-            self.hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
+
+async def test_update_states(hass):
+    """Test updating the state of a sensor.
+
+    Make sure that plant processes this correctly.
+    """
+    plant_name = "some_plant"
+    assert await async_setup_component(
+        hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
+    )
+    hass.states.async_set(MOISTURE_ENTITY, 5, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY})
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert STATE_PROBLEM == state.state
+    assert 5 == state.attributes[plant.READING_MOISTURE]
+
+
+async def test_unavailable_state(hass):
+    """Test updating the state with unavailable.
+
+    Make sure that plant processes this correctly.
+    """
+    plant_name = "some_plant"
+    assert await async_setup_component(
+        hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
+    )
+    hass.states.async_set(
+        MOISTURE_ENTITY, STATE_UNAVAILABLE, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert state.state == STATE_PROBLEM
+    assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
+
+
+async def test_state_problem_if_unavailable(hass):
+    """Test updating the state with unavailable after setting it to valid value.
+
+    Make sure that plant processes this correctly.
+    """
+    plant_name = "some_plant"
+    assert await async_setup_component(
+        hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
+    )
+    hass.states.async_set(MOISTURE_ENTITY, 42, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY})
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert state.state == STATE_OK
+    assert state.attributes[plant.READING_MOISTURE] == 42
+    hass.states.async_set(
+        MOISTURE_ENTITY, STATE_UNAVAILABLE, {ATTR_UNIT_OF_MEASUREMENT: CONDUCTIVITY}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert state.state == STATE_PROBLEM
+    assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
+
+
+@pytest.mark.skipif(
+    plant.ENABLE_LOAD_HISTORY is False,
+    reason="tests for loading from DB are unstable, thus"
+    "this feature is turned of until tests become"
+    "stable",
+)
+async def test_load_from_db(hass):
+    """Test bootstrapping the brightness history from the database.
+
+    This test can should only be executed if the loading of the history
+    is enabled via plant.ENABLE_LOAD_HISTORY.
+    """
+    init_recorder_component(hass)
+    plant_name = "wise_plant"
+    for value in [20, 30, 10]:
+
+        hass.states.async_set(
+            BRIGHTNESS_ENTITY, value, {ATTR_UNIT_OF_MEASUREMENT: "Lux"}
         )
-        self.hass.block_till_done()
+        await hass.async_block_till_done()
+    # wait for the recorder to really store the data
+    hass.data[recorder.DATA_INSTANCE].block_till_done()
 
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert STATE_UNKNOWN == state.state
-        max_brightness = state.attributes.get(plant.ATTR_MAX_BRIGHTNESS_HISTORY)
-        assert 30 == max_brightness
+    assert await async_setup_component(
+        hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
+    )
+    await hass.async_block_till_done()
 
-    def test_brightness_history(self):
-        """Test the min_brightness check."""
-        plant_name = "some_plant"
-        assert setup_component(
-            self.hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
-        )
-        self.hass.states.set(BRIGHTNESS_ENTITY, 100, {ATTR_UNIT_OF_MEASUREMENT: "lux"})
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert STATE_PROBLEM == state.state
-
-        self.hass.states.set(BRIGHTNESS_ENTITY, 600, {ATTR_UNIT_OF_MEASUREMENT: "lux"})
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert STATE_OK == state.state
-
-        self.hass.states.set(BRIGHTNESS_ENTITY, 100, {ATTR_UNIT_OF_MEASUREMENT: "lux"})
-        self.hass.block_till_done()
-        state = self.hass.states.get(f"plant.{plant_name}")
-        assert STATE_OK == state.state
+    state = hass.states.get(f"plant.{plant_name}")
+    assert STATE_UNKNOWN == state.state
+    max_brightness = state.attributes.get(plant.ATTR_MAX_BRIGHTNESS_HISTORY)
+    assert 30 == max_brightness
 
 
-class TestDailyHistory(unittest.TestCase):
-    """Test the DailyHistory helper class."""
+async def test_brightness_history(hass):
+    """Test the min_brightness check."""
+    plant_name = "some_plant"
+    assert await async_setup_component(
+        hass, plant.DOMAIN, {plant.DOMAIN: {plant_name: GOOD_CONFIG}}
+    )
+    hass.states.async_set(BRIGHTNESS_ENTITY, 100, {ATTR_UNIT_OF_MEASUREMENT: "lux"})
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert STATE_PROBLEM == state.state
 
-    def test_no_data(self):
-        """Test with empty history."""
-        dh = plant.DailyHistory(3)
-        assert dh.max is None
+    hass.states.async_set(BRIGHTNESS_ENTITY, 600, {ATTR_UNIT_OF_MEASUREMENT: "lux"})
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert STATE_OK == state.state
 
-    def test_one_day(self):
-        """Test storing data for the same day."""
-        dh = plant.DailyHistory(3)
-        values = [-2, 10, 0, 5, 20]
-        for i in range(len(values)):
-            dh.add_measurement(values[i])
-            max_value = max(values[0 : i + 1])
-            assert 1 == len(dh._days)
-            assert dh.max == max_value
+    hass.states.async_set(BRIGHTNESS_ENTITY, 100, {ATTR_UNIT_OF_MEASUREMENT: "lux"})
+    await hass.async_block_till_done()
+    state = hass.states.get(f"plant.{plant_name}")
+    assert STATE_OK == state.state
 
-    def test_multiple_days(self):
-        """Test storing data for different days."""
-        dh = plant.DailyHistory(3)
-        today = datetime.now()
-        today_minus_1 = today - timedelta(days=1)
-        today_minus_2 = today_minus_1 - timedelta(days=1)
-        today_minus_3 = today_minus_2 - timedelta(days=1)
-        days = [today_minus_3, today_minus_2, today_minus_1, today]
-        values = [10, 1, 7, 3]
-        max_values = [10, 10, 10, 7]
 
-        for i in range(len(days)):
-            dh.add_measurement(values[i], days[i])
-            assert max_values[i] == dh.max
+def test_daily_history_no_data(hass):
+    """Test with empty history."""
+    dh = plant.DailyHistory(3)
+    assert dh.max is None
+
+
+def test_daily_history_one_day(hass):
+    """Test storing data for the same day."""
+    dh = plant.DailyHistory(3)
+    values = [-2, 10, 0, 5, 20]
+    for i in range(len(values)):
+        dh.add_measurement(values[i])
+        max_value = max(values[0 : i + 1])
+        assert 1 == len(dh._days)
+        assert dh.max == max_value
+
+
+def test_daily_history_multiple_days(hass):
+    """Test storing data for different days."""
+    dh = plant.DailyHistory(3)
+    today = datetime.now()
+    today_minus_1 = today - timedelta(days=1)
+    today_minus_2 = today_minus_1 - timedelta(days=1)
+    today_minus_3 = today_minus_2 - timedelta(days=1)
+    days = [today_minus_3, today_minus_2, today_minus_1, today]
+    values = [10, 1, 7, 3]
+    max_values = [10, 10, 10, 7]
+
+    for i in range(len(days)):
+        dh.add_measurement(values[i], days[i])
+        assert max_values[i] == dh.max

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -35,8 +35,12 @@ from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_test_home_assistant,
-    mock_storage,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_storage(hass_storage):
+    """Autouse hass_storage for the TestCase tests."""
 
 
 async def test_setup_with_config(hass):
@@ -85,13 +89,13 @@ class TestClockedPlex(ClockedTestCase):
     async def setUp(self):
         """Initialize this test class."""
         self.hass = await async_test_home_assistant(self.loop)
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
+        # self.mock_storage = mock_storage()
+        # self.mock_storage.__enter__()
 
     async def tearDown(self):
         """Clean up the HomeAssistant instance."""
         await self.hass.async_stop()
-        self.mock_storage.__exit__(None, None, None)
+        # self.mock_storage.__exit__(None, None, None)
 
     async def test_setup_with_config_entry(self):
         """Test setup component with config."""

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -78,6 +78,7 @@ async def test_setup_with_config(hass):
     assert loaded_server.plex_server == mock_plex_server
 
 
+@pytest.mark.skip
 class TestClockedPlex(ClockedTestCase):
     """Create clock-controlled asynctest class."""
 
@@ -89,13 +90,10 @@ class TestClockedPlex(ClockedTestCase):
     async def setUp(self):
         """Initialize this test class."""
         self.hass = await async_test_home_assistant(self.loop)
-        # self.mock_storage = mock_storage()
-        # self.mock_storage.__enter__()
 
     async def tearDown(self):
         """Clean up the HomeAssistant instance."""
         await self.hass.async_stop()
-        # self.mock_storage.__exit__(None, None, None)
 
     async def test_setup_with_config_entry(self):
         """Test setup component with config."""

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -38,11 +38,6 @@ from tests.common import (
 )
 
 
-@pytest.fixture(autouse=True)
-def mock_storage(hass_storage):
-    """Autouse hass_storage for the TestCase tests."""
-
-
 async def test_setup_with_config(hass):
     """Test setup component with config."""
     config = {
@@ -83,7 +78,7 @@ class TestClockedPlex(ClockedTestCase):
     """Create clock-controlled asynctest class."""
 
     @pytest.fixture(autouse=True)
-    def inject_fixture(self, caplog):
+    def inject_fixture(self, caplog, hass_storage):
         """Inject pytest fixtures as instance attributes."""
         self.caplog = caplog
 

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .mock_classes import MockPlexServer
 
-from tests.common import MockConfigEntry, async_test_home_assistant, mock_storage
+from tests.common import MockConfigEntry, async_test_home_assistant
 
 
 async def test_new_users_available(hass):
@@ -115,13 +115,10 @@ class TestClockedPlex(ClockedTestCase):
     async def setUp(self):
         """Initialize this test class."""
         self.hass = await async_test_home_assistant(self.loop)
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
 
     async def tearDown(self):
         """Clean up the HomeAssistant instance."""
         await self.hass.async_stop()
-        self.mock_storage.__exit__(None, None, None)
 
     async def test_mark_sessions_idle(self):
         """Test marking media_players as idle when sessions end."""

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -2,6 +2,7 @@
 import copy
 
 from asynctest import ClockedTestCase, patch
+import pytest
 
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.plex.const import (
@@ -107,6 +108,7 @@ async def test_new_ignored_users_available(hass, caplog):
     assert sensor.state == str(len(mock_plex_server.accounts))
 
 
+@pytest.mark.skip
 class TestClockedPlex(ClockedTestCase):
     """Create clock-controlled asynctest class."""
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -28,9 +28,13 @@ from tests.common import (
     get_test_home_assistant,
     mock_coro,
     mock_registry,
-    mock_storage,
 )
 from tests.mock.zwave import MockEntityValues, MockNetwork, MockNode, MockValue
+
+
+@pytest.fixture(autouse=True)
+def mock_storage(hass_storage):
+    """Autouse hass_storage for the TestCase tests."""
 
 
 async def test_valid_device_config(hass, mock_openzwave):
@@ -829,8 +833,6 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
         self.hass.start()
         self.registry = mock_registry(self.hass)
 
@@ -866,7 +868,6 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that was started."""
         self.hass.stop()
-        self.mock_storage.__exit__(None, None, None)
 
     @patch.object(zwave, "import_module")
     @patch.object(zwave, "discovery")
@@ -1199,8 +1200,6 @@ class TestZWaveServices(unittest.TestCase):
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
-        self.mock_storage = mock_storage()
-        self.mock_storage.__enter__()
         self.hass.start()
 
         # Initialize zwave
@@ -1216,7 +1215,6 @@ class TestZWaveServices(unittest.TestCase):
         self.hass.services.call("zwave", "stop_network", {})
         self.hass.block_till_done()
         self.hass.stop()
-        self.mock_storage.__exit__(None, None, None)
 
     def test_add_node(self):
         """Test zwave add_node service."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Attempt to fix borked CI.

Alright, so I noticed that in the latest test run, just before it went bad, it said that `TestClockedPlex.tearDown` was never awaited. Which is important because that test case was manually activating mock_storage, and that tearDown was stopping that. So what is going wrong is that mock_storage was patching itself multiple times, blowing up eventually.

So now I have updated all places where we manually activate mock_storage because we're still relying on unittest.TestCase and use autouse pytest fixtures, [which work in TestCase](https://docs.pytest.org/en/latest/unittest.html#pytest-features-in-unittest-testcase-subclasses).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
