### PR TITLE
Update pydaikin to 2.0.0

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -5,19 +5,18 @@ import logging
 
 from aiohttp import ClientConnectionError
 from async_timeout import timeout
-from pydaikin.appliance import Appliance
+from pydaikin.daikin_base import Appliance
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_HOSTS
+from homeassistant.const import CONF_HOST, CONF_HOSTS, CONF_PASSWORD
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import Throttle
 
 from . import config_flow  # noqa: F401
-from .const import TIMEOUT
+from .const import CONF_KEY, CONF_UUID, TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +61,13 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Establish connection with Daikin."""
     conf = entry.data
-    daikin_api = await daikin_api_setup(hass, conf[CONF_HOST])
+    daikin_api = await daikin_api_setup(
+        hass,
+        conf[CONF_HOST],
+        conf.get(CONF_KEY),
+        conf.get(CONF_UUID),
+        conf.get(CONF_PASSWORD),
+    )
     if not daikin_api:
         return False
     hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: daikin_api})
@@ -87,14 +92,15 @@ async def async_unload_entry(hass, config_entry):
     return True
 
 
-async def daikin_api_setup(hass, host):
+async def daikin_api_setup(hass, host, key, uuid, password):
     """Create a Daikin instance only once."""
 
     session = hass.helpers.aiohttp_client.async_get_clientsession()
     try:
         with timeout(TIMEOUT):
-            device = Appliance(host, session)
-            await device.init()
+            device = await Appliance.factory(
+                host, session, key=key, uuid=uuid, password=password
+            )
     except asyncio.TimeoutError:
         _LOGGER.debug("Connection to %s timed out", host)
         raise ConfigEntryNotReady
@@ -116,8 +122,8 @@ class DaikinApi:
     def __init__(self, device):
         """Initialize the Daikin Handle."""
         self.device = device
-        self.name = device.values["name"]
-        self.ip_address = device.ip
+        self.name = device.values.get("name", "Daikin AC")
+        self.ip_address = device.device_ip
         self._available = True
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -136,19 +142,13 @@ class DaikinApi:
         return self._available
 
     @property
-    def mac(self):
-        """Return mac-address of device."""
-        return self.device.values.get(CONNECTION_NETWORK_MAC)
-
-    @property
     def device_info(self):
         """Return a device description for device registry."""
         info = self.device.values
         return {
-            "connections": {(CONNECTION_NETWORK_MAC, self.mac)},
-            "identifieres": self.mac,
+            "identifieres": self.device.mac,
             "manufacturer": "Daikin",
             "model": info.get("model"),
             "name": info.get("name"),
-            "sw_version": info.get("ver").replace("_", "."),
+            "sw_version": info.get("ver", "").replace("_", "."),
         }

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -1,7 +1,6 @@
 """Support for the Daikin HVAC."""
 import logging
 
-from pydaikin import appliance
 import voluptuous as vol
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
@@ -96,12 +95,7 @@ class DaikinClimate(ClimateEntity):
         self._list = {
             ATTR_HVAC_MODE: list(HA_STATE_TO_DAIKIN),
             ATTR_FAN_MODE: self._api.device.fan_rate,
-            ATTR_SWING_MODE: list(
-                map(
-                    str.title,
-                    appliance.daikin_values(HA_ATTR_TO_DAIKIN[ATTR_SWING_MODE]),
-                )
-            ),
+            ATTR_SWING_MODE: self._api.device.swing_modes,
         }
 
         self._supported_features = SUPPORT_TARGET_TEMPERATURE
@@ -156,7 +150,7 @@ class DaikinClimate(ClimateEntity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._api.mac
+        return self._api.device.mac
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/daikin/config_flow.py
+++ b/homeassistant/components/daikin/config_flow.py
@@ -45,13 +45,13 @@ class FlowHandler(config_entries.ConfigFlow):
         """Create device."""
 
         # BRP07Cxx devices needs uuid together with key
-        if key is not None and key != "":
+        if key:
             uuid = str(uuid4())
         else:
             uuid = None
             key = None
 
-        if password == "":
+        if not password:
             password = None
 
         try:

--- a/homeassistant/components/daikin/config_flow.py
+++ b/homeassistant/components/daikin/config_flow.py
@@ -1,16 +1,17 @@
 """Config flow for the Daikin platform."""
 import asyncio
 import logging
+from uuid import uuid4
 
 from aiohttp import ClientError
 from async_timeout import timeout
-from pydaikin.appliance import Appliance
+from pydaikin.daikin_base import Appliance
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
-from .const import KEY_IP, KEY_MAC, TIMEOUT
+from .const import CONF_KEY, CONF_UUID, KEY_IP, KEY_MAC, TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,24 +23,43 @@ class FlowHandler(config_entries.ConfigFlow):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    async def _create_entry(self, host, mac):
+    async def _create_entry(self, host, mac, key=None, uuid=None, password=None):
         """Register new entry."""
         # Check if mac already is registered
         for entry in self._async_current_entries():
             if entry.data[KEY_MAC] == mac:
                 return self.async_abort(reason="already_configured")
 
-        return self.async_create_entry(title=host, data={CONF_HOST: host, KEY_MAC: mac})
+        return self.async_create_entry(
+            title=host,
+            data={
+                CONF_HOST: host,
+                KEY_MAC: mac,
+                CONF_KEY: key,
+                CONF_UUID: uuid,
+                CONF_PASSWORD: password,
+            },
+        )
 
-    async def _create_device(self, host):
+    async def _create_device(self, host, key=None, password=None):
         """Create device."""
 
+        # BRP07Cxx devices needs uuid together with key
+        if key is not None and not "":
+            uuid = str(uuid4())
+        else:
+            uuid = None
+            key = None
+
         try:
-            device = Appliance(
-                host, self.hass.helpers.aiohttp_client.async_get_clientsession()
-            )
             with timeout(TIMEOUT):
-                await device.init()
+                device = await Appliance.factory(
+                    host,
+                    self.hass.helpers.aiohttp_client.async_get_clientsession(),
+                    key=key,
+                    uuid=uuid,
+                    password=password,
+                )
         except asyncio.TimeoutError:
             return self.async_abort(reason="device_timeout")
         except ClientError:
@@ -49,16 +69,27 @@ class FlowHandler(config_entries.ConfigFlow):
             _LOGGER.exception("Unexpected error creating device")
             return self.async_abort(reason="device_fail")
 
-        mac = device.values.get("mac")
-        return await self._create_entry(host, mac)
+        mac = device.mac
+        return await self._create_entry(host, mac, key, uuid, password)
 
     async def async_step_user(self, user_input=None):
         """User initiated config flow."""
         if user_input is None:
             return self.async_show_form(
-                step_id="user", data_schema=vol.Schema({vol.Required(CONF_HOST): str})
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_HOST): str,
+                        vol.Optional(CONF_KEY): str,
+                        vol.Optional(CONF_PASSWORD): str,
+                    }
+                ),
             )
-        return await self._create_device(user_input[CONF_HOST])
+        return await self._create_device(
+            user_input[CONF_HOST],
+            user_input.get(CONF_KEY),
+            user_input.get(CONF_PASSWORD),
+        )
 
     async def async_step_import(self, user_input):
         """Import a config entry."""

--- a/homeassistant/components/daikin/config_flow.py
+++ b/homeassistant/components/daikin/config_flow.py
@@ -23,7 +23,7 @@ class FlowHandler(config_entries.ConfigFlow):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    async def _create_entry(self, host, mac, key=None, uuid=None, password=None):
+    def _create_entry(self, host, mac, key=None, uuid=None, password=None):
         """Register new entry."""
         # Check if mac already is registered
         for entry in self._async_current_entries():
@@ -73,7 +73,7 @@ class FlowHandler(config_entries.ConfigFlow):
             return self.async_abort(reason="device_fail")
 
         mac = device.mac
-        return await self._create_entry(host, mac, key, uuid, password)
+        return self._create_entry(host, mac, key, uuid, password)
 
     async def async_step_user(self, user_input=None):
         """User initiated config flow."""
@@ -104,4 +104,4 @@ class FlowHandler(config_entries.ConfigFlow):
     async def async_step_discovery(self, user_input):
         """Initialize step from discovery."""
         _LOGGER.info("Discovered device: %s", user_input)
-        return await self._create_entry(user_input[KEY_IP], user_input[KEY_MAC])
+        return self._create_entry(user_input[KEY_IP], user_input[KEY_MAC])

--- a/homeassistant/components/daikin/config_flow.py
+++ b/homeassistant/components/daikin/config_flow.py
@@ -45,11 +45,14 @@ class FlowHandler(config_entries.ConfigFlow):
         """Create device."""
 
         # BRP07Cxx devices needs uuid together with key
-        if key is not None and not "":
+        if key is not None and key != "":
             uuid = str(uuid4())
         else:
             uuid = None
             key = None
+
+        if password == "":
+            password = None
 
         try:
             with timeout(TIMEOUT):

--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -23,6 +23,9 @@ SENSOR_TYPES = {
     },
 }
 
+CONF_KEY = "key"
+CONF_UUID = "uuid"
+
 KEY_MAC = "mac"
 KEY_IP = "ip"
 

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -3,7 +3,7 @@
   "name": "Daikin AC",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
-  "requirements": ["pydaikin==1.6.3"],
+  "requirements": ["pydaikin==2.0.0"],
   "codeowners": ["@fredrike"],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/daikin/sensor.py
+++ b/homeassistant/components/daikin/sensor.py
@@ -40,7 +40,7 @@ class DaikinClimateSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return f"{self._api.mac}-{self._device_attribute}"
+        return f"{self._api.device.mac}-{self._device_attribute}"
 
     @property
     def icon(self):

--- a/homeassistant/components/daikin/strings.json
+++ b/homeassistant/components/daikin/strings.json
@@ -4,7 +4,11 @@
       "user": {
         "title": "Configure Daikin AC",
         "description": "Enter IP address of your Daikin AC.",
-        "data": { "host": "Host" }
+        "data": {
+          "host": "Host",
+          "key": "Authentication key (only used by BRP072C/Zena devices)",
+          "password": "Device password (only used by SKYFi devices)"
+        } 
       }
     },
     "abort": {

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -43,7 +43,7 @@ class DaikinZoneSwitch(ToggleEntity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return f"{self._api.mac}-zone{self._zone_id}"
+        return f"{self._api.device.mac}-zone{self._zone_id}"
 
     @property
     def icon(self):

--- a/homeassistant/components/daikin/translations/en.json
+++ b/homeassistant/components/daikin/translations/en.json
@@ -8,7 +8,9 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "Host"
+                    "host": "Host",
+                    "key": "Authentication key (only used by BRP072C/Zena devices)",
+                    "password": "Device password (only used by SKYFi devices)"
                 },
                 "description": "Enter IP address of your Daikin AC.",
                 "title": "Configure Daikin AC"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1242,7 +1242,7 @@ pycsspeechtts==1.0.3
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-pydaikin==1.6.3
+pydaikin==2.0.0
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -512,7 +512,7 @@ pychromecast==5.0.0
 pycoolmasternet==0.0.4
 
 # homeassistant.components.daikin
-pydaikin==1.6.3
+pydaikin==2.0.0
 
 # homeassistant.components.deconz
 pydeconz==70

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.components.daikin import config_flow
 from homeassistant.components.daikin.const import KEY_IP, KEY_MAC
 from homeassistant.const import CONF_HOST
 
-from tests.async_mock import patch
+from tests.async_mock import PropertyMock, patch
 from tests.common import MockConfigEntry
 
 MAC = "AABBCCDDEEFF"
@@ -27,13 +27,13 @@ def init_config_flow(hass):
 def mock_daikin():
     """Mock pydaikin."""
 
-    async def mock_daikin_init():
+    async def mock_daikin_factory(*args, **kwargs):
         """Mock the init function in pydaikin."""
-        pass
+        return Appliance
 
     with patch("homeassistant.components.daikin.config_flow.Appliance") as Appliance:
-        Appliance().values.get.return_value = "AABBCCDDEEFF"
-        Appliance().init = mock_daikin_init
+        type(Appliance).mac = PropertyMock(return_value="AABBCCDDEEFF")
+        Appliance.factory = mock_daikin_factory
         yield Appliance
 
 
@@ -95,7 +95,7 @@ async def test_discovery(hass, mock_daikin):
 async def test_device_abort(hass, mock_daikin, s_effect, reason):
     """Test device abort."""
     flow = init_config_flow(hass)
-    mock_daikin.side_effect = s_effect
+    mock_daikin.factory.side_effect = s_effect
 
     result = await flow.async_step_user({CONF_HOST: HOST})
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -33,7 +33,7 @@ def mock_daikin():
 
     with patch("homeassistant.components.daikin.config_flow.Appliance") as Appliance:
         type(Appliance).mac = PropertyMock(return_value="AABBCCDDEEFF")
-        Appliance.factory = mock_daikin_factory
+        Appliance.factory.side_effect = mock_daikin_factory
         yield Appliance
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update pydaikin to version 2.0.0.

pydaikin v2.0.0 adds support for:

- Energy monitoring (added in pr #34391) 
- Daikin devices using the BRP072C module
- Daikin devices using the SKYFi protocol

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

I'm planning to decommission`configuration.yaml` as not all settings is available trough that atm and bc: https://www.home-assistant.io/blog/2020/04/14/the-future-of-yaml/. But as that will be a breaking change it will be a separate PR.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13199

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
