### PR TITLE
Update NAD states only when the device is on

### DIFF
--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -185,6 +185,11 @@ class NAD(MediaPlayerEntity):
         """List of available input sources."""
         return sorted(list(self._reverse_mapping.keys()))
 
+    @property
+    def available(self):
+        """Return if device is available."""
+        return self._state is not None
+
     def update(self) -> None:
         """Retrieve latest state."""
         power_state = self._nad_receiver.main_power("?")

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -13,7 +13,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -189,7 +189,7 @@ class NAD(MediaPlayerEntity):
         """Retrieve latest state."""
         power_state = self._nad_receiver.main_power("?")
         if not power_state:
-            self._state = STATE_UNKNOWN
+            self._state = None
             return
         self._state = (
             STATE_ON if self._nad_receiver.main_power("?") == "On" else STATE_OFF

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -187,21 +187,15 @@ class NAD(MediaPlayerEntity):
 
     def update(self):
         """Retrieve latest state."""
-        if self._nad_receiver.main_power("?") == "Off":
-            self._state = STATE_OFF
-        else:
-            self._state = STATE_ON
+        self._state = STATE_ON if self._nad_receiver.main_power("?") == "On" else STATE_OFF
 
-        if self._nad_receiver.main_mute("?") == "Off":
-            self._mute = False
-        else:
-            self._mute = True
-
-        volume = self._nad_receiver.main_volume("?")
-        # Some receivers cannot report the volume, e.g. C 356BEE,
-        # instead they only support stepping the volume up or down
-        self._volume = self.calc_volume(volume) if volume is not None else None
-        self._source = self._source_dict.get(self._nad_receiver.main_source("?"))
+        if self._state == STATE_ON:
+            self._mute = self._nad_receiver.main_mute("?") == "On"
+            volume = self._nad_receiver.main_volume("?")
+            # Some receivers cannot report the volume, e.g. C 356BEE,
+            # instead they only support stepping the volume up or down
+            self._volume = self.calc_volume(volume) if volume is not None else None
+            self._source = self._source_dict.get(self._nad_receiver.main_source("?"))
 
     def calc_volume(self, decibel):
         """

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -13,7 +13,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -185,9 +185,15 @@ class NAD(MediaPlayerEntity):
         """List of available input sources."""
         return sorted(list(self._reverse_mapping.keys()))
 
-    def update(self):
+    def update(self) -> None:
         """Retrieve latest state."""
-        self._state = STATE_ON if self._nad_receiver.main_power("?") == "On" else STATE_OFF
+        power_state = self._nad_receiver.main_power("?")
+        if not power_state:
+            self._state = STATE_UNKNOWN
+            return
+        self._state = (
+            STATE_ON if self._nad_receiver.main_power("?") == "On" else STATE_OFF
+        )
 
         if self._state == STATE_ON:
             self._mute = self._nad_receiver.main_mute("?") == "On"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The nad integration tries to update all states, even when the device is off.

The updates over RS232 actually take time and don't make any sense
when the device is off. My amp does not even reply when it's off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
