### PR TITLE
Enable setting require_admin for map, logbook and history panels

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -282,10 +282,7 @@ async def async_setup(hass, config):
 
     hass.http.register_view(HistoryPeriodView(filters, use_include_order))
     hass.components.frontend.async_register_built_in_panel(
-        "history",
-        "history",
-        "hass:poll-box",
-        require_admin=CONF_REQUIRE_ADMIN,
+        "history", "history", "hass:poll-box", require_admin=CONF_REQUIRE_ADMIN,
     )
 
     return True

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -29,12 +29,14 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "history"
 CONF_ORDER = "use_include_order"
+CONF_REQUIRE_ADMIN = "require_admin"
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: recorder.FILTER_SCHEMA.extend(
             {vol.Optional(CONF_ORDER, default=False): cv.boolean}
-        )
+        ),
+        vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
     },
     extra=vol.ALLOW_EXTRA,
 )
@@ -278,7 +280,10 @@ async def async_setup(hass, config):
 
     hass.http.register_view(HistoryPeriodView(filters, use_include_order))
     hass.components.frontend.async_register_built_in_panel(
-        "history", "history", "hass:poll-box"
+        "history",
+        "history",
+        "hass:poll-box",
+        require_admin=CONF_REQUIRE_ADMIN,
     )
 
     return True

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -34,9 +34,11 @@ CONF_REQUIRE_ADMIN = "require_admin"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: recorder.FILTER_SCHEMA.extend(
-            {vol.Optional(CONF_ORDER, default=False): cv.boolean}
+            {
+                vol.Optional(CONF_ORDER, default=False): cv.boolean,
+                vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
+            }
         ),
-        vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -45,6 +45,7 @@ ATTR_MESSAGE = "message"
 
 CONF_DOMAINS = "domains"
 CONF_ENTITIES = "entities"
+CONF_REQUIRE_ADMIN = "require_admin"
 CONTINUOUS_DOMAINS = ["proximity", "sensor"]
 
 DOMAIN = "logbook"
@@ -71,6 +72,7 @@ CONFIG_SCHEMA = vol.Schema(
                         ),
                     }
                 ),
+                vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
             }
         )
     },
@@ -138,7 +140,10 @@ async def async_setup(hass, config):
     hass.http.register_view(LogbookView(config.get(DOMAIN, {})))
 
     hass.components.frontend.async_register_built_in_panel(
-        "logbook", "logbook", "hass:format-list-bulleted-type"
+        "logbook",
+        "logbook",
+        "hass:format-list-bulleted-type",
+        require_admin=CONF_REQUIRE_ADMIN,
     )
 
     hass.services.async_register(DOMAIN, "log", log_message, schema=LOG_MESSAGE_SCHEMA)

--- a/homeassistant/components/map/__init__.py
+++ b/homeassistant/components/map/__init__.py
@@ -1,10 +1,29 @@
 """Support for showing device locations."""
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+CONF_REQUIRE_ADMIN = "require_admin"
+
 DOMAIN = "map"
 
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 async def async_setup(hass, config):
     """Register the built-in map panel."""
     hass.components.frontend.async_register_built_in_panel(
-        "map", "map", "hass:tooltip-account"
+        "map",
+        "map",
+        "hass:tooltip-account",
+        require_admin=CONF_REQUIRE_ADMIN,
     )
     return True

--- a/homeassistant/components/map/__init__.py
+++ b/homeassistant/components/map/__init__.py
@@ -10,7 +10,7 @@ DOMAIN = "map"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,}
+            {vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean, }
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/map/__init__.py
+++ b/homeassistant/components/map/__init__.py
@@ -18,6 +18,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+
 async def async_setup(hass, config):
     """Register the built-in map panel."""
     hass.components.frontend.async_register_built_in_panel(

--- a/homeassistant/components/map/__init__.py
+++ b/homeassistant/components/map/__init__.py
@@ -10,9 +10,7 @@ DOMAIN = "map"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
-            }
+            {vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,}
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -22,9 +20,6 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass, config):
     """Register the built-in map panel."""
     hass.components.frontend.async_register_built_in_panel(
-        "map",
-        "map",
-        "hass:tooltip-account",
-        require_admin=CONF_REQUIRE_ADMIN,
+        "map", "map", "hass:tooltip-account", require_admin=CONF_REQUIRE_ADMIN,
     )
     return True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The Lovelace interface enables setting panels to require admin rights of the user to display. While the iframe panel already had this feature enabled, the (default) map, logbook and history panels hadn't. This PR enables setting this (optional) parameter for these panels.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
map:
  require_admin: true

logbook:
  exclude:
    entities:
      - sensor.room_temperature
  require_admin: true

history:
  include: 
    entities:
      - sensor.room_temperature
  require_admin: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13204

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [-] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [n/a] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [n/a] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [n/a] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
