### PR TITLE
Remove configuration.yaml support for WWLLN

### DIFF
--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -2,73 +2,65 @@
 import logging
 
 from aiowwlln import Client
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import CONF_WINDOW, DATA_CLIENT, DEFAULT_RADIUS, DEFAULT_WINDOW, DOMAIN
+from .const import (
+    CONF_WINDOW,
+    DATA_CLIENT,
+    DEFAULT_RADIUS,
+    DEFAULT_WINDOW,
+    DOMAIN,
+    TOPIC_OPTIONS_UPDATE,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_LATITUDE): cv.latitude,
-                vol.Optional(CONF_LONGITUDE): cv.longitude,
-                vol.Optional(CONF_RADIUS, default=DEFAULT_RADIUS): cv.positive_int,
-                vol.Optional(CONF_WINDOW, default=DEFAULT_WINDOW): vol.All(
-                    cv.time_period,
-                    cv.positive_timedelta,
-                    lambda value: value.total_seconds(),
-                    vol.Range(min=DEFAULT_WINDOW.total_seconds()),
-                ),
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
 
 
 async def async_setup(hass, config):
     """Set up the WWLLN component."""
-    if DOMAIN not in config:
-        return True
-
-    conf = config[DOMAIN]
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-        )
-    )
+    hass.data[DOMAIN] = {DATA_CLIENT: {}}
 
     return True
 
 
+@callback
+def _standardize_config_entry(hass, config_entry):
+    """Ensure that config entries have appropriate properties."""
+    entry_updates = {}
+
+    if not config_entry.unique_id:
+        # If the config entry doesn't already have a unique ID, set one:
+        entry_updates[
+            "unique_id"
+        ] = f"{config_entry.data[CONF_LATITUDE], config_entry.data[CONF_LONGITUDE]}"
+    if not config_entry.options:
+        # If the config entry doesn't already have any options set, set defaults:
+        entry_updates["options"] = {
+            CONF_RADIUS: DEFAULT_RADIUS,
+            CONF_WINDOW: DEFAULT_WINDOW,
+        }
+
+    if not entry_updates:
+        return
+
+    hass.config_entries.async_update_entry(config_entry, **entry_updates)
+
+
 async def async_setup_entry(hass, config_entry):
     """Set up the WWLLN as config entry."""
-    if not config_entry.unique_id:
-        hass.config_entries.async_update_entry(
-            config_entry,
-            unique_id=(
-                f"{config_entry.data[CONF_LATITUDE]}, "
-                f"{config_entry.data[CONF_LONGITUDE]}"
-            ),
-        )
-
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][DATA_CLIENT] = {}
+    _standardize_config_entry(hass, config_entry)
 
     websession = aiohttp_client.async_get_clientsession(hass)
-
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = Client(websession)
-
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(config_entry, "geo_location")
     )
+
+    config_entry.add_update_listener(async_update_options)
 
     return True
 
@@ -100,3 +92,10 @@ async def async_migrate_entry(hass, config_entry):
         _LOGGER.info("Migration to version %s successful", version)
 
     return True
+
+
+async def async_update_options(hass, config_entry):
+    """Handle an options update."""
+    async_dispatcher_send(
+        hass, TOPIC_OPTIONS_UPDATE.format(config_entry.unique_id), config_entry.options
+    )

--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -79,14 +79,12 @@ async def async_migrate_entry(hass, config_entry):
     version = config_entry.version
     data = config_entry.data
 
-    default_total_seconds = DEFAULT_WINDOW.total_seconds()
-
     _LOGGER.debug("Migrating from version %s", version)
 
-    # 1 -> 2: Expanding the default window to 1 hour (if needed):
+    # 1 -> 2: Expanding the default window (if needed):
     if version == 1:
-        if data[CONF_WINDOW] < default_total_seconds:
-            data[CONF_WINDOW] = default_total_seconds
+        if data[CONF_WINDOW] < DEFAULT_WINDOW:
+            data[CONF_WINDOW] = DEFAULT_WINDOW
         version = config_entry.version = 2
         hass.config_entries.async_update_entry(config_entry, data=data)
         _LOGGER.info("Migration to version %s successful", version)

--- a/homeassistant/components/wwlln/const.py
+++ b/homeassistant/components/wwlln/const.py
@@ -1,6 +1,4 @@
 """Define constants for the WWLLN integration."""
-from datetime import timedelta
-
 DOMAIN = "wwlln"
 
 CONF_WINDOW = "window"
@@ -8,4 +6,6 @@ CONF_WINDOW = "window"
 DATA_CLIENT = "client"
 
 DEFAULT_RADIUS = 25
-DEFAULT_WINDOW = timedelta(hours=1)
+DEFAULT_WINDOW = 3600
+
+TOPIC_OPTIONS_UPDATE = "wwlln_options_update_{0}"

--- a/homeassistant/components/wwlln/strings.json
+++ b/homeassistant/components/wwlln/strings.json
@@ -5,11 +5,21 @@
         "title": "Fill in your location information.",
         "data": {
           "latitude": "Latitude",
-          "longitude": "Longitude",
-          "radius": "Radius (using your base unit system)"
+          "longitude": "Longitude"
         }
       }
     },
     "abort": { "already_configured": "This location is already registered." }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure WWLLN",
+        "data": {
+          "radius": "The radius to monitor (using your base unit system)",
+          "window": "The number of seconds \"back\" to look for strikes"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/wwlln/translations/en.json
+++ b/homeassistant/components/wwlln/translations/en.json
@@ -7,10 +7,20 @@
             "user": {
                 "data": {
                     "latitude": "Latitude",
-                    "longitude": "Longitude",
-                    "radius": "Radius (using your base unit system)"
+                    "longitude": "Longitude"
                 },
                 "title": "Fill in your location information."
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "radius": "The radius to monitor (using your base unit system)",
+                    "window": "The number of seconds \"back\" to look for strikes"
+                },
+                "title": "Configure WWLLN"
             }
         }
     }

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.components.wwlln import (
     DOMAIN,
     async_setup_entry,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 
 from tests.common import MockConfigEntry
@@ -38,28 +38,6 @@ async def test_show_form(hass):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
-
-
-async def test_step_import(hass):
-    """Test that the import step works."""
-    conf = {
-        CONF_LATITUDE: 39.128712,
-        CONF_LONGITUDE: -104.9812612,
-        CONF_RADIUS: 25,
-    }
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "39.128712, -104.9812612"
-    assert result["data"] == {
-        CONF_LATITUDE: 39.128712,
-        CONF_LONGITUDE: -104.9812612,
-        CONF_RADIUS: 25,
-        CONF_WINDOW: 3600.0,
-    }
 
 
 async def test_step_user(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
WWLLN can no longer be configured via `configuration.yaml`. If you already had it configured in this manner, your configuration options have already been imported and you merely need to remove the `wwlln:` key from `configuration.yaml`.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per [ADR-0010](https://github.com/home-assistant/architecture/blob/master/adr/0010-integration-configuration.md), this PR removes configuration of the WWLLN integration via `configuration.yaml` and moves all configuration (including `radius` and `window` options) to a config entry.

Because existing WWLLN integrations would already have been imported as config entries, I'm electing to rip the band-aid off and not do a deprecation period.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/34812
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13213

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
