### PR TITLE
Add missing async_block_till_done to homekit

### DIFF
--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -133,6 +133,7 @@ async def test_setup_auto_start_disabled(hass):
     homekit.status = STATUS_READY
 
     await hass.services.async_call(DOMAIN, SERVICE_HOMEKIT_START, blocking=True)
+    await hass.async_block_till_done()
     assert homekit.async_start.called is True
 
     # Test start call with driver started
@@ -141,6 +142,7 @@ async def test_setup_auto_start_disabled(hass):
     homekit.status = STATUS_STOPPED
 
     await hass.services.async_call(DOMAIN, SERVICE_HOMEKIT_START, blocking=True)
+    await hass.async_block_till_done()
     assert homekit.async_start.called is False
 
 
@@ -326,6 +328,7 @@ async def test_homekit_start(hass, hk_driver, debounce_patcher):
     ) as hk_driver_start:
         await homekit.async_start()
 
+    await hass.async_block_till_done()
     mock_add_acc.assert_called_with(state)
     mock_setup_msg.assert_called_with(hass, pin, ANY)
     hk_driver_add_acc.assert_called_with(homekit.bridge)
@@ -335,6 +338,7 @@ async def test_homekit_start(hass, hk_driver, debounce_patcher):
     # Test start() if already started
     hk_driver_start.reset_mock()
     await homekit.async_start()
+    await hass.async_block_till_done()
     assert not hk_driver_start.called
 
 
@@ -362,6 +366,7 @@ async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, debounce_p
     ) as hk_driver_start:
         await homekit.async_start()
 
+    await hass.async_block_till_done()
     mock_setup_msg.assert_called_with(hass, pin, ANY)
     hk_driver_add_acc.assert_called_with(homekit.bridge)
     assert hk_driver_start.called
@@ -370,6 +375,7 @@ async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, debounce_p
     # Test start() if already started
     hk_driver_start.reset_mock()
     await homekit.async_start()
+    await hass.async_block_till_done()
     assert not hk_driver_start.called
 
 
@@ -508,6 +514,7 @@ async def test_homekit_finds_linked_batteries(
         "pyhap.accessory_driver.AccessoryDriver.start"
     ):
         await homekit.async_start()
+    await hass.async_block_till_done()
 
     mock_get_acc.assert_called_with(
         hass,


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add missing async_block_till_done to homekit

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
