### PR TITLE
Prevent homekit fans from going to 100% than speed when turning on

### DIFF
--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -94,13 +94,13 @@ class Fan(HomeAccessory):
         _LOGGER.debug("Fan _set_chars: %s", char_values)
         if CHAR_ACTIVE in char_values:
             if char_values[CHAR_ACTIVE]:
-                is_on = False
-                state = self.hass.states.get(self.entity_id)
-                if state and state.state == STATE_ON:
-                    is_on = True
-                # Only set the state to active if we
-                # did not get a rotation speed or its off
-                if not is_on or CHAR_ROTATION_SPEED not in char_values:
+                # If the device supports set speed we
+                # do not want to turn on as it will take
+                # the fan to 100% than to the desired speed.
+                #
+                # Setting the speed will take care of turning
+                # on the fan if SUPPORT_SET_SPEED is set.
+                if not self.char_speed or CHAR_ROTATION_SPEED not in char_values:
                     self.set_state(1)
             else:
                 # Its off, nothing more to do as setting the

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -419,8 +419,7 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     )
     await hass.async_block_till_done()
     acc.speed_mapping.speed_to_states.assert_called_with(42)
-    assert call_turn_on
-    assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
+    assert not call_turn_on
     assert call_set_speed[0]
     assert call_set_speed[0].data[ATTR_ENTITY_ID] == entity_id
     assert call_set_speed[0].data[ATTR_SPEED] == "ludicrous"
@@ -430,11 +429,11 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     assert call_set_direction[0]
     assert call_set_direction[0].data[ATTR_ENTITY_ID] == entity_id
     assert call_set_direction[0].data[ATTR_DIRECTION] == DIRECTION_REVERSE
-    assert len(events) == 4
+    assert len(events) == 3
 
-    assert events[1].data[ATTR_VALUE] is True
-    assert events[2].data[ATTR_VALUE] == DIRECTION_REVERSE
-    assert events[3].data[ATTR_VALUE] == "ludicrous"
+    assert events[0].data[ATTR_VALUE] is True
+    assert events[1].data[ATTR_VALUE] == DIRECTION_REVERSE
+    assert events[2].data[ATTR_VALUE] == "ludicrous"
 
     hass.states.async_set(
         entity_id,
@@ -482,7 +481,7 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     # and we set a fan speed
     await hass.async_block_till_done()
     acc.speed_mapping.speed_to_states.assert_called_with(42)
-    assert len(events) == 7
+    assert len(events) == 6
     assert call_set_speed[1]
     assert call_set_speed[1].data[ATTR_ENTITY_ID] == entity_id
     assert call_set_speed[1].data[ATTR_SPEED] == "ludicrous"
@@ -526,7 +525,7 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     )
     await hass.async_block_till_done()
 
-    assert len(events) == 8
+    assert len(events) == 7
     assert call_turn_off
     assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
     assert len(call_set_speed) == 2


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent homekit fans from going to 100% than speed when turning on

After auditing all the `fan.py` that `SUPPORT_SET_SPEED`, turn on is a wrapper around setting the speed so we can always avoid sending the turn on when speed is set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34222
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
