### PR TITLE
Increase surepetcare default timeout

### DIFF
--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     CONF_ID,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
-    CONF_TIMEOUT,
     CONF_TYPE,
     CONF_USERNAME,
 )
@@ -34,6 +33,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     SPC,
+    SURE_API_TIMEOUT,
     TOPIC_UPDATE,
 )
 
@@ -54,7 +54,6 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [cv.positive_int]
                 ),
                 vol.Optional(CONF_PETS): vol.All(cv.ensure_list, [cv.positive_int]),
-                vol.Optional(CONF_TIMEOUT, default=15): cv.positive_int,
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): cv.time_period,
@@ -82,7 +81,7 @@ async def async_setup(hass, config) -> bool:
             conf[CONF_PASSWORD],
             hass.loop,
             async_get_clientsession(hass),
-            api_timeout=conf[CONF_TIMEOUT],
+            api_timeout=SURE_API_TIMEOUT,
         )
         await surepy.get_data()
     except SurePetcareAuthenticationError:

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -2,7 +2,6 @@
 import logging
 from typing import Any, Dict, List
 
-
 from surepy import (
     SurePetcare,
     SurePetcareAuthenticationError,

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -37,7 +37,6 @@ from .const import (
     TOPIC_UPDATE,
 )
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any, Dict, List
 
+
 from surepy import (
     SurePetcare,
     SurePetcareAuthenticationError,
@@ -14,6 +15,7 @@ from homeassistant.const import (
     CONF_ID,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
+    CONF_TIMEOUT,
     CONF_TYPE,
     CONF_USERNAME,
 )
@@ -35,6 +37,7 @@ from .const import (
     TOPIC_UPDATE,
 )
 
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -51,6 +54,7 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [cv.positive_int]
                 ),
                 vol.Optional(CONF_PETS): vol.All(cv.ensure_list, [cv.positive_int]),
+                vol.Optional(CONF_TIMEOUT, default=15): cv.positive_int,
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): cv.time_period,
@@ -78,6 +82,7 @@ async def async_setup(hass, config) -> bool:
             conf[CONF_PASSWORD],
             hass.loop,
             async_get_clientsession(hass),
+            api_timeout=conf[CONF_TIMEOUT],
         )
         await surepy.get_data()
     except SurePetcareAuthenticationError:

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -8,7 +8,7 @@ from surepy import SureLocationID, SureProductID
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_PRESENCE,
-    BinarySensorDevice,
+    BinarySensorEntity,
 )
 from homeassistant.const import CONF_ID, CONF_TYPE
 from homeassistant.core import callback
@@ -56,7 +56,7 @@ async def async_setup_platform(
     async_add_entities(entities, True)
 
 
-class SurePetcareBinarySensor(BinarySensorDevice):
+class SurePetcareBinarySensor(BinarySensorEntity):
     """A binary sensor implementation for Sure Petcare Entities."""
 
     def __init__(

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -8,7 +8,7 @@ from surepy import SureLocationID, SureProductID
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_PRESENCE,
-    BinarySensorEntity,
+    BinarySensorDevice,
 )
 from homeassistant.const import CONF_ID, CONF_TYPE
 from homeassistant.core import callback
@@ -16,6 +16,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import SurePetcareAPI
 from .const import DATA_SURE_PETCARE, SPC, TOPIC_UPDATE
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ async def async_setup_platform(
     async_add_entities(entities, True)
 
 
-class SurePetcareBinarySensor(BinarySensorEntity):
+class SurePetcareBinarySensor(BinarySensorDevice):
     """A binary sensor implementation for Sure Petcare Entities."""
 
     def __init__(
@@ -105,7 +106,7 @@ class SurePetcareBinarySensor(BinarySensorEntity):
         return None if not self._device_class else self._device_class
 
     @property
-    def unique_id(self: BinarySensorEntity) -> str:
+    def unique_id(self) -> str:
         """Return an unique ID."""
         return f"{self._spc_data['household_id']}-{self._id}"
 
@@ -214,7 +215,7 @@ class DeviceConnectivity(SurePetcareBinarySensor):
         return f"{self._name}_connectivity"
 
     @property
-    def unique_id(self: BinarySensorEntity) -> str:
+    def unique_id(self) -> str:
         """Return an unique ID."""
         return f"{self._spc_data['household_id']}-{self._id}-connectivity"
 

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from . import SurePetcareAPI
 from .const import DATA_SURE_PETCARE, SPC, TOPIC_UPDATE
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/surepetcare/const.py
+++ b/homeassistant/components/surepetcare/const.py
@@ -1,6 +1,7 @@
 """Constants for the Sure Petcare component."""
 from datetime import timedelta
 
+
 DOMAIN = "surepetcare"
 DEFAULT_DEVICE_CLASS = "lock"
 DEFAULT_ICON = "mdi:cat"
@@ -22,6 +23,9 @@ SURE_IDS = "sure_ids"
 
 # platforms
 TOPIC_UPDATE = f"{DOMAIN}_data_update"
+
+# sure petcare api
+SURE_API_TIMEOUT = 15
 
 # flap
 BATTERY_ICON = "mdi:battery"

--- a/homeassistant/components/surepetcare/const.py
+++ b/homeassistant/components/surepetcare/const.py
@@ -1,7 +1,6 @@
 """Constants for the Sure Petcare component."""
 from datetime import timedelta
 
-
 DOMAIN = "surepetcare"
 DEFAULT_DEVICE_CLASS = "lock"
 DEFAULT_ICON = "mdi:cat"

--- a/homeassistant/components/surepetcare/manifest.json
+++ b/homeassistant/components/surepetcare/manifest.json
@@ -3,5 +3,5 @@
   "name": "Sure Petcare",
   "documentation": "https://www.home-assistant.io/integrations/surepetcare",
   "codeowners": ["@benleb"],
-  "requirements": ["surepy==0.2.3"]
+  "requirements": ["surepy==0.2.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1993,7 +1993,7 @@ sucks==0.9.4
 sunwatcher==0.2.1
 
 # homeassistant.components.surepetcare
-surepy==0.2.3
+surepy==0.2.5
 
 # homeassistant.components.swiss_hydrological_data
 swisshydrodata==0.0.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
add timeout parameter and increase default timeout


## Type of change
add timeout parameter and increase default timeout to fix issues mentioned below

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
surepetcare:
  username: YOUR_SURE_PETCARE_LOGIN
  password: YOUR_SURE_PETCARE_PASSWORD
  feeders: [12345, 67890]
  flaps: [13579]
  pets: [24680]
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32583, fixes #33515
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/13235

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
