### PR TITLE
Pass config into NAD constructor

### DIFF
--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -208,12 +208,8 @@ class NADtcp(MediaPlayerEntity):
         """Initialize the amplifier."""
         self._name = config[CONF_NAME]
         self._nad_receiver = NADReceiverTCP(config.get(CONF_HOST))
-        self._min_vol = (
-            config[CONF_MIN_VOLUME] + 90
-        ) * 2  # from dB to nad vol (0-200)
-        self._max_vol = (
-            config[CONF_MAX_VOLUME] + 90
-        ) * 2  # from dB to nad vol (0-200)
+        self._min_vol = (config[CONF_MIN_VOLUME] + 90) * 2  # from dB to nad vol (0-200)
+        self._max_vol = (config[CONF_MAX_VOLUME] + 90) * 2  # from dB to nad vol (0-200)
         self._volume_step = config[CONF_VOLUME_STEP]
         self._state = None
         self._mute = None

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -81,25 +81,25 @@ class NAD(MediaPlayerEntity):
         """Initialize the NAD Receiver device."""
         self.config = config
         self._instantiate_nad_receiver()
-        self._min_volume = config.get(CONF_MIN_VOLUME)
-        self._max_volume = config.get(CONF_MAX_VOLUME)
-        self._source_dict = config.get(CONF_SOURCE_DICT)
+        self._min_volume = config[CONF_MIN_VOLUME]
+        self._max_volume = config[CONF_MAX_VOLUME]
+        self._source_dict = config[CONF_SOURCE_DICT]
         self._reverse_mapping = {value: key for key, value in self._source_dict.items()}
 
         self._volume = self._state = self._mute = self._source = None
 
     def _instantiate_nad_receiver(self) -> NADReceiver:
-        if self.config.get(CONF_TYPE) == "RS232":
-            self._nad_receiver = NADReceiver(self.config.get(CONF_SERIAL_PORT))
+        if self.config[CONF_TYPE] == "RS232":
+            self._nad_receiver = NADReceiver(self.config[CONF_SERIAL_PORT])
         else:
             host = self.config.get(CONF_HOST)
-            port = self.config.get(CONF_PORT)
+            port = self.config[CONF_PORT]
             self._nad_receiver = NADReceiverTelnet(host, port)
 
     @property
     def name(self):
         """Return the name of the device."""
-        return self.config.get(CONF_NAME)
+        return self.config[CONF_NAME]
 
     @property
     def state(self):
@@ -206,15 +206,15 @@ class NADtcp(MediaPlayerEntity):
 
     def __init__(self, config):
         """Initialize the amplifier."""
-        self._name = config.get(CONF_NAME)
+        self._name = config[CONF_NAME]
         self._nad_receiver = NADReceiverTCP(config.get(CONF_HOST))
         self._min_vol = (
-            config.get(CONF_MIN_VOLUME) + 90
+            config[CONF_MIN_VOLUME] + 90
         ) * 2  # from dB to nad vol (0-200)
         self._max_vol = (
-            config.get(CONF_MAX_VOLUME) + 90
+            config[CONF_MAX_VOLUME] + 90
         ) * 2  # from dB to nad vol (0-200)
-        self._volume_step = config.get(CONF_VOLUME_STEP)
+        self._volume_step = config[CONF_VOLUME_STEP]
         self._state = None
         self._mute = None
         self._nad_volume = None

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -64,65 +64,42 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NAD platform."""
-    if config.get(CONF_TYPE) == "RS232":
+    if config.get(CONF_TYPE) in ("RS232", "Telnet"):
         add_entities(
-            [
-                NAD(
-                    config.get(CONF_NAME),
-                    NADReceiver(config.get(CONF_SERIAL_PORT)),
-                    config.get(CONF_MIN_VOLUME),
-                    config.get(CONF_MAX_VOLUME),
-                    config.get(CONF_SOURCE_DICT),
-                )
-            ],
-            True,
-        )
-    elif config.get(CONF_TYPE) == "Telnet":
-        add_entities(
-            [
-                NAD(
-                    config.get(CONF_NAME),
-                    NADReceiverTelnet(config.get(CONF_HOST), config.get(CONF_PORT)),
-                    config.get(CONF_MIN_VOLUME),
-                    config.get(CONF_MAX_VOLUME),
-                    config.get(CONF_SOURCE_DICT),
-                )
-            ],
-            True,
+            [NAD(config)], True,
         )
     else:
         add_entities(
-            [
-                NADtcp(
-                    config.get(CONF_NAME),
-                    NADReceiverTCP(config.get(CONF_HOST)),
-                    config.get(CONF_MIN_VOLUME),
-                    config.get(CONF_MAX_VOLUME),
-                    config.get(CONF_VOLUME_STEP),
-                )
-            ],
-            True,
+            [NADtcp(config)], True,
         )
 
 
 class NAD(MediaPlayerEntity):
     """Representation of a NAD Receiver."""
 
-    def __init__(self, name, nad_receiver, min_volume, max_volume, source_dict):
+    def __init__(self, config):
         """Initialize the NAD Receiver device."""
-        self._name = name
-        self._nad_receiver = nad_receiver
-        self._min_volume = min_volume
-        self._max_volume = max_volume
-        self._source_dict = source_dict
+        self.config = config
+        self._instantiate_nad_receiver()
+        self._min_volume = config.get(CONF_MIN_VOLUME)
+        self._max_volume = config.get(CONF_MAX_VOLUME)
+        self._source_dict = config.get(CONF_SOURCE_DICT)
         self._reverse_mapping = {value: key for key, value in self._source_dict.items()}
 
         self._volume = self._state = self._mute = self._source = None
 
+    def _instantiate_nad_receiver(self) -> NADReceiver:
+        if self.config.get(CONF_TYPE) == "RS232":
+            self._nad_receiver = NADReceiver(self.config.get(CONF_SERIAL_PORT))
+        else:
+            host = self.config.get(CONF_HOST)
+            port = self.config.get(CONF_PORT)
+            self._nad_receiver = NADReceiverTelnet(host, port)
+
     @property
     def name(self):
         """Return the name of the device."""
-        return self._name
+        return self.config.get(CONF_NAME)
 
     @property
     def state(self):
@@ -227,13 +204,17 @@ class NAD(MediaPlayerEntity):
 class NADtcp(MediaPlayerEntity):
     """Representation of a NAD Digital amplifier."""
 
-    def __init__(self, name, nad_device, min_volume, max_volume, volume_step):
+    def __init__(self, config):
         """Initialize the amplifier."""
-        self._name = name
-        self._nad_receiver = nad_device
-        self._min_vol = (min_volume + 90) * 2  # from dB to nad vol (0-200)
-        self._max_vol = (max_volume + 90) * 2  # from dB to nad vol (0-200)
-        self._volume_step = volume_step
+        self._name = config.get(CONF_NAME)
+        self._nad_receiver = NADReceiverTCP(config.get(CONF_HOST))
+        self._min_vol = (
+            config.get(CONF_MIN_VOLUME) + 90
+        ) * 2  # from dB to nad vol (0-200)
+        self._max_vol = (
+            config.get(CONF_MAX_VOLUME) + 90
+        ) * 2  # from dB to nad vol (0-200)
+        self._volume_step = config.get(CONF_VOLUME_STEP)
         self._state = None
         self._mute = None
         self._nad_volume = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Unify the various constructors. The nad_receiver library is sadly not very consistent, but at least the telnet and rs232 bits are offering the same API. In order to slowly minimize differences move common code into the constructors instead of assigning it several times.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
