### PR TITLE
Add full options to serial sensor platform (2)

### DIFF
--- a/homeassistant/components/serial/sensor.py
+++ b/homeassistant/components/serial/sensor.py
@@ -17,9 +17,21 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_SERIAL_PORT = "serial_port"
 CONF_BAUDRATE = "baudrate"
+CONF_BYTESIZE = "bytesize"
+CONF_PARITY = "parity"
+CONF_STOPBITS = "stopbits"
+CONF_XONXOFF = "xonxoff"
+CONF_RTSCTS = "rtscts"
+CONF_DSRDTR = "dsrdtr"
 
 DEFAULT_NAME = "Serial Sensor"
 DEFAULT_BAUDRATE = 9600
+DEFAULT_BYTESIZE = serial_asyncio.serial.EIGHTBITS
+DEFAULT_PARITY = serial_asyncio.serial.PARITY_NONE
+DEFAULT_STOPBITS = serial_asyncio.serial.STOPBITS_ONE
+DEFAULT_XONXOFF = False
+DEFAULT_RTSCTS = False
+DEFAULT_DSRDTR = False
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -27,6 +39,33 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE): cv.positive_int,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_BYTESIZE, default=DEFAULT_BYTESIZE): vol.In(
+            [
+                serial_asyncio.serial.FIVEBITS,
+                serial_asyncio.serial.SIXBITS,
+                serial_asyncio.serial.SEVENBITS,
+                serial_asyncio.serial.EIGHTBITS,
+            ]
+        ),
+        vol.Optional(CONF_PARITY, default=DEFAULT_PARITY): vol.In(
+            [
+                serial_asyncio.serial.PARITY_NONE,
+                serial_asyncio.serial.PARITY_EVEN,
+                serial_asyncio.serial.PARITY_ODD,
+                serial_asyncio.serial.PARITY_MARK,
+                serial_asyncio.serial.PARITY_SPACE,
+            ]
+        ),
+        vol.Optional(CONF_STOPBITS, default=DEFAULT_STOPBITS): vol.In(
+            [
+                serial_asyncio.serial.STOPBITS_ONE,
+                serial_asyncio.serial.STOPBITS_ONE_POINT_FIVE,
+                serial_asyncio.serial.STOPBITS_TWO,
+            ]
+        ),
+        vol.Optional(CONF_XONXOFF, default=DEFAULT_XONXOFF): cv.boolean,
+        vol.Optional(CONF_RTSCTS, default=DEFAULT_RTSCTS): cv.boolean,
+        vol.Optional(CONF_DSRDTR, default=DEFAULT_DSRDTR): cv.boolean,
     }
 )
 
@@ -36,12 +75,29 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     name = config.get(CONF_NAME)
     port = config.get(CONF_SERIAL_PORT)
     baudrate = config.get(CONF_BAUDRATE)
+    bytesize = config.get(CONF_BYTESIZE)
+    parity = config.get(CONF_PARITY)
+    stopbits = config.get(CONF_STOPBITS)
+    xonxoff = config.get(CONF_XONXOFF)
+    rtscts = config.get(CONF_RTSCTS)
+    dsrdtr = config.get(CONF_DSRDTR)
 
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass
 
-    sensor = SerialSensor(name, port, baudrate, value_template)
+    sensor = SerialSensor(
+        name,
+        port,
+        baudrate,
+        bytesize,
+        parity,
+        stopbits,
+        xonxoff,
+        rtscts,
+        dsrdtr,
+        value_template,
+    )
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, sensor.stop_serial_read)
     async_add_entities([sensor], True)
@@ -50,12 +106,30 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class SerialSensor(Entity):
     """Representation of a Serial sensor."""
 
-    def __init__(self, name, port, baudrate, value_template):
+    def __init__(
+        self,
+        name,
+        port,
+        baudrate,
+        bytesize,
+        parity,
+        stopbits,
+        xonxoff,
+        rtscts,
+        dsrdtr,
+        value_template,
+    ):
         """Initialize the Serial sensor."""
         self._name = name
         self._state = None
         self._port = port
         self._baudrate = baudrate
+        self._bytesize = bytesize
+        self._parity = parity
+        self._stopbits = stopbits
+        self._xonxoff = xonxoff
+        self._rtscts = rtscts
+        self._dsrdtr = dsrdtr
         self._serial_loop_task = None
         self._template = value_template
         self._attributes = None
@@ -63,17 +137,46 @@ class SerialSensor(Entity):
     async def async_added_to_hass(self):
         """Handle when an entity is about to be added to Home Assistant."""
         self._serial_loop_task = self.hass.loop.create_task(
-            self.serial_read(self._port, self._baudrate)
+            self.serial_read(
+                self._port,
+                self._baudrate,
+                self._bytesize,
+                self._parity,
+                self._stopbits,
+                self._xonxoff,
+                self._rtscts,
+                self._dsrdtr,
+            )
         )
 
-    async def serial_read(self, device, rate, **kwargs):
+    async def serial_read(
+        self,
+        device,
+        baudrate,
+        bytesize,
+        parity,
+        stopbits,
+        xonxoff,
+        rtscts,
+        dsrdtr,
+        **kwargs,
+    ):
         """Read the data from the port."""
         logged_error = False
         while True:
             try:
                 reader, _ = await serial_asyncio.open_serial_connection(
-                    url=device, baudrate=rate, **kwargs
+                    url=device,
+                    baudrate=baudrate,
+                    bytesize=bytesize,
+                    parity=parity,
+                    stopbits=stopbits,
+                    xonxoff=xonxoff,
+                    rtscts=rtscts,
+                    dsrdtr=dsrdtr,
+                    **kwargs,
                 )
+
             except SerialException as exc:
                 if not logged_error:
                     _LOGGER.exception(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve Serial sensor platform with full options for configuring the serial port.
bytesize, parity, stopbits, xonxoff, rtscts, dsrdtr.

The default values are unchanged so it is 100% compatible with previous config.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: serial
    serial_port: /dev/ttyACM0
    baudrate : 9600
    bytesize: 8
    parity: "N"
    stopbits: 1
    xonxoff: false 
    rtscts: false
    dsrdtr: false
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13221

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
