### PR TITLE
Fix restoring isy994 brightness with no previous state

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -196,6 +196,7 @@ homeassistant/components/ipp/* @ctalkington
 homeassistant/components/iqvia/* @bachya
 homeassistant/components/irish_rail_transport/* @ttroy50
 homeassistant/components/islamic_prayer_times/* @engrbm87
+homeassistant/components/isy994/* @bdraco
 homeassistant/components/izone/* @Swamp-Ig
 homeassistant/components/jewish_calendar/* @tsvi
 homeassistant/components/juicenet/* @jesserockz

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -3,11 +3,14 @@ import logging
 from typing import Callable
 
 from homeassistant.components.light import DOMAIN, SUPPORT_BRIGHTNESS, LightEntity
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
 from . import ISY994_NODES, ISYDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_LAST_BRIGHTNESS = "last_brightness"
 
 
 def setup_platform(
@@ -21,7 +24,7 @@ def setup_platform(
     add_entities(devices)
 
 
-class ISYLightDevice(ISYDevice, LightEntity):
+class ISYLightDevice(ISYDevice, LightEntity, RestoreEntity):
     """Representation of an ISY994 light device."""
 
     def __init__(self, node) -> None:
@@ -56,7 +59,7 @@ class ISYLightDevice(ISYDevice, LightEntity):
     # pylint: disable=arguments-differ
     def turn_on(self, brightness=None, **kwargs) -> None:
         """Send the turn on command to the ISY994 light device."""
-        if brightness is None and self._last_brightness is not None:
+        if brightness is None and self._last_brightness:
             brightness = self._last_brightness
         if not self._node.on(val=brightness):
             _LOGGER.debug("Unable to turn on light")
@@ -65,3 +68,22 @@ class ISYLightDevice(ISYDevice, LightEntity):
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS
+
+    @property
+    def device_state_attributes(self):
+        """Return the light attributes."""
+        return {ATTR_LAST_BRIGHTNESS: self._last_brightness}
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last_brightness on restart."""
+        await super().async_added_to_hass()
+
+        last_state = await self.async_get_last_state()
+        if not last_state:
+            return
+
+        if (
+            ATTR_LAST_BRIGHTNESS in last_state.attributes
+            and last_state.attributes[ATTR_LAST_BRIGHTNESS]
+        ):
+            self._last_brightness = last_state.attributes[ATTR_LAST_BRIGHTNESS]

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -30,6 +30,7 @@ class ISYLightDevice(ISYDevice, LightEntity, RestoreEntity):
     def __init__(self, node) -> None:
         """Initialize the ISY994 light device."""
         super().__init__(node)
+        self._last_brightness = None
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -77,7 +77,7 @@ class ISYLightDevice(ISYDevice, LightEntity, RestoreEntity):
         """Restore last_brightness on restart."""
         await super().async_added_to_hass()
 
-        self._last_brightness = self.brightness
+        self._last_brightness = self.brightness or 255
         last_state = await self.async_get_last_state()
         if not last_state:
             return

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -30,7 +30,6 @@ class ISYLightDevice(ISYDevice, LightEntity, RestoreEntity):
     def __init__(self, node) -> None:
         """Initialize the ISY994 light device."""
         super().__init__(node)
-        self._last_brightness = self.brightness
 
     @property
     def is_on(self) -> bool:
@@ -78,6 +77,7 @@ class ISYLightDevice(ISYDevice, LightEntity, RestoreEntity):
         """Restore last_brightness on restart."""
         await super().async_added_to_hass()
 
+        self._last_brightness = self.brightness
         last_state = await self.async_get_last_state()
         if not last_state:
             return

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,5 +3,5 @@
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
   "requirements": ["PyISY==1.1.2"],
-  "codeowners": []
+  "codeowners": ["@bdraco"]
 }


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix restoring isy994 brightness with no previous state
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34967
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
