### PR TITLE
Change unique_id for webostv

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -28,7 +28,6 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.event import async_call_later
 
 from .const import ATTR_SOUND_OUTPUT
 
@@ -139,30 +138,15 @@ async def async_setup_tv_finalize(hass, config, conf, client):
         client.clear_state_update_callbacks()
         await client.disconnect()
 
-    async def async_load_platforms(_):
-        """Load platforms and event listener."""
-        await async_connect(client)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_on_stop)
 
-        if client.connection is None:
-            async_call_later(hass, 60, async_load_platforms)
-            _LOGGER.debug(
-                "No connection could be made with host %s, retrying in 60 seconds",
-                conf.get(CONF_HOST),
-            )
-            return
-
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_on_stop)
-
-        hass.async_create_task(
-            hass.helpers.discovery.async_load_platform(
-                "media_player", DOMAIN, conf, config
-            )
-        )
-        hass.async_create_task(
-            hass.helpers.discovery.async_load_platform("notify", DOMAIN, conf, config)
-        )
-
-    await async_load_platforms(None)
+    await async_connect(client)
+    hass.async_create_task(
+        hass.helpers.discovery.async_load_platform("media_player", DOMAIN, conf, config)
+    )
+    hass.async_create_task(
+        hass.helpers.discovery.async_load_platform("notify", DOMAIN, conf, config)
+    )
 
 
 async def async_request_configuration(hass, config, conf, client):

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -116,7 +116,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         """Initialize the webos device."""
         self._client = client
         self._name = name
-        self._unique_id = client.software_info["device_id"]
+        self._unique_id = client.client_key
         self._customize = customize
         self._on_script = on_script
 

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -42,6 +42,7 @@ def client_fixture():
     ) as mock_client_class:
         client = mock_client_class.return_value
         client.software_info = {"device_id": "a1:b1:c1:d1:e1:f1"}
+        client.client_key = "0123456789"
         yield client
 
 

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -41,7 +41,6 @@ def client_fixture():
         "homeassistant.components.webostv.WebOsClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.connection = True
         client.software_info = {"device_id": "a1:b1:c1:d1:e1:f1"}
         yield client
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
A new `unique_id` is used for `webostv` media players for users running a 0.109.X release. Duplicate entities will be created with new entity IDs and old entities will need to be manually removed.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Summary from [here](https://github.com/home-assistant/core/issues/34877#issuecomment-622030050):

> 1. A `unique_id` property was added to the `media_player` entity which allows it to use the entity registry. (#34147)
> 2. Setting the `unique_id` would fail on startup if the TV was off, since the information wasn't available.
> 3. A change was made to delay setup of the `media_player` entity when the TV was unreachable. (#34656). This means the `media_player` entity isn't available until the TV turns on and we can connect.
> 4. The `media_player.turn_on` service can't be called if an entity doesn't exist so this functionality is currently unavailable.

Since we can't know the MAC address if the device is unavailable, we have either the IP or pairing code available before we connect. This will have the side-effect of creating a new entity if the device is ever reset to factory defaults or unpaired.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
wake_on_lan:

webostv:
    host: 192.168.1.153
    name: LG TV
    turn_on_action:
      service: wake_on_lan.send_magic_packet
      data:
        mac: "a0:6f:aa:9c:57:e2"
    customize:
      sources:
        - 'Amazon Prime Video'
        - hdmi2
        - photovideo
        - livetv
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34877
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
