### PR TITLE
Use a future for mock coro

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -744,7 +744,12 @@ def patch_yaml_files(files_dict, endswith=True):
 
 def mock_coro(return_value=None, exception=None):
     """Return a coro that returns a value or raise an exception."""
-    return mock_coro_func(return_value, exception)()
+    fut = asyncio.Future()
+    if exception is not None:
+        fut.set_exception(exception)
+    else:
+        fut.set_result(return_value)
+    return fut
 
 
 def mock_coro_func(return_value=None, exception=None):

--- a/tests/common.py
+++ b/tests/common.py
@@ -752,15 +752,6 @@ def mock_coro(return_value=None, exception=None):
     return fut
 
 
-def mock_coro_func(return_value=None, exception=None):
-    """Return a method to create a coro function that returns a value."""
-
-    if exception:
-        return AsyncMock(side_effect=exception)
-
-    return AsyncMock(return_value=return_value)
-
-
 @contextmanager
 def assert_setup_component(count, domain=None):
     """Collect valid configuration from setup_component.
@@ -841,52 +832,6 @@ def mock_restore_cache(hass, states):
 
     # Patch the singleton task in hass.data to return our new RestoreStateData
     hass.data[key] = hass.async_create_task(get_restore_state_data())
-
-
-class MockDependency:
-    """Decorator to mock install a dependency."""
-
-    def __init__(self, root, *args):
-        """Initialize decorator."""
-        self.root = root
-        self.submodules = args
-
-    def __enter__(self):
-        """Start mocking."""
-
-        def resolve(mock, path):
-            """Resolve a mock."""
-            if not path:
-                return mock
-
-            return resolve(getattr(mock, path[0]), path[1:])
-
-        base = MagicMock()
-        to_mock = {
-            f"{self.root}.{tom}": resolve(base, tom.split("."))
-            for tom in self.submodules
-        }
-        to_mock[self.root] = base
-
-        self.patcher = patch.dict("sys.modules", to_mock)
-        self.patcher.start()
-        return base
-
-    def __exit__(self, *exc):
-        """Stop mocking."""
-        self.patcher.stop()
-        return False
-
-    def __call__(self, func):
-        """Apply decorator."""
-
-        def run_mocked(*args, **kwargs):
-            """Run with mocked dependencies."""
-            with self as base:
-                args = list(args) + [base]
-                func(*args, **kwargs)
-
-        return run_mocked
 
 
 class MockEntity(entity.Entity):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1,5 +1,4 @@
 """Test for smart home alexa support."""
-from unittest.mock import patch
 
 import pytest
 
@@ -39,7 +38,8 @@ from . import (
     reported_properties,
 )
 
-from tests.common import async_mock_service, mock_coro
+from tests.async_mock import patch
+from tests.common import async_mock_service
 
 
 @pytest.fixture
@@ -3831,7 +3831,7 @@ async def test_initialize_camera_stream(hass, mock_camera, mock_stream):
 
     with patch(
         "homeassistant.components.demo.camera.DemoCamera.stream_source",
-        return_value=mock_coro("rtsp://example.local"),
+        return_value="rtsp://example.local",
     ), patch(
         "homeassistant.helpers.network.async_get_external_url",
         return_value="https://mycamerastream.test",

--- a/tests/components/almond/test_init.py
+++ b/tests/components/almond/test_init.py
@@ -1,6 +1,5 @@
 """Tests for Almond set up."""
 from time import time
-from unittest.mock import patch
 
 import pytest
 
@@ -10,7 +9,8 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from tests.common import MockConfigEntry, async_fire_time_changed, mock_coro
+from tests.async_mock import patch
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture(autouse=True)
@@ -34,7 +34,6 @@ async def test_set_up_oauth_remote_url(hass, aioclient_mock):
 
     with patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-        return_value=mock_coro(),
     ):
         assert await async_setup_component(hass, "almond", {})
 
@@ -43,9 +42,7 @@ async def test_set_up_oauth_remote_url(hass, aioclient_mock):
     with patch("homeassistant.components.almond.ALMOND_SETUP_DELAY", 0), patch(
         "homeassistant.helpers.network.async_get_external_url",
         return_value="https://example.nabu.casa",
-    ), patch(
-        "pyalmond.WebAlmondAPI.async_create_device", return_value=mock_coro()
-    ) as mock_create_device:
+    ), patch("pyalmond.WebAlmondAPI.async_create_device") as mock_create_device:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
         async_fire_time_changed(hass, utcnow())
@@ -69,7 +66,6 @@ async def test_set_up_oauth_no_external_url(hass, aioclient_mock):
 
     with patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
-        return_value=mock_coro(),
     ), patch("pyalmond.WebAlmondAPI.async_create_device") as mock_create_device:
         assert await async_setup_component(hass, "almond", {})
 
@@ -104,9 +100,7 @@ async def test_set_up_local(hass, aioclient_mock):
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "pyalmond.WebAlmondAPI.async_create_device", return_value=mock_coro()
-    ) as mock_create_device:
+    with patch("pyalmond.WebAlmondAPI.async_create_device") as mock_create_device:
         assert await async_setup_component(hass, "almond", {})
 
     assert entry.state == config_entries.ENTRY_STATE_LOADED

--- a/tests/components/asuswrt/test_device_tracker.py
+++ b/tests/components/asuswrt/test_device_tracker.py
@@ -1,5 +1,4 @@
 """The tests for the ASUSWRT device tracker platform."""
-from unittest.mock import patch
 
 from homeassistant.components.asuswrt import (
     CONF_DNSMASQ,
@@ -10,13 +9,13 @@ from homeassistant.components.asuswrt import (
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro_func
+from tests.async_mock import AsyncMock, patch
 
 
 async def test_password_or_pub_key_required(hass):
     """Test creating an AsusWRT scanner without a pass or pubkey."""
     with patch("homeassistant.components.asuswrt.AsusWrt") as AsusWrt:
-        AsusWrt().connection.async_connect = mock_coro_func()
+        AsusWrt().connection.async_connect = AsyncMock()
         AsusWrt().is_connected = False
         result = await async_setup_component(
             hass, DOMAIN, {DOMAIN: {CONF_HOST: "fake_host", CONF_USERNAME: "fake_user"}}
@@ -27,7 +26,7 @@ async def test_password_or_pub_key_required(hass):
 async def test_network_unreachable(hass):
     """Test creating an AsusWRT scanner without a pass or pubkey."""
     with patch("homeassistant.components.asuswrt.AsusWrt") as AsusWrt:
-        AsusWrt().connection.async_connect = mock_coro_func(exception=OSError)
+        AsusWrt().connection.async_connect = AsyncMock(side_effect=OSError)
         AsusWrt().is_connected = False
         result = await async_setup_component(
             hass, DOMAIN, {DOMAIN: {CONF_HOST: "fake_host", CONF_USERNAME: "fake_user"}}
@@ -39,10 +38,8 @@ async def test_network_unreachable(hass):
 async def test_get_scanner_with_password_no_pubkey(hass):
     """Test creating an AsusWRT scanner with a password and no pubkey."""
     with patch("homeassistant.components.asuswrt.AsusWrt") as AsusWrt:
-        AsusWrt().connection.async_connect = mock_coro_func()
-        AsusWrt().connection.async_get_connected_devices = mock_coro_func(
-            return_value={}
-        )
+        AsusWrt().connection.async_connect = AsyncMock()
+        AsusWrt().connection.async_get_connected_devices = AsyncMock(return_value={})
         result = await async_setup_component(
             hass,
             DOMAIN,
@@ -62,7 +59,7 @@ async def test_get_scanner_with_password_no_pubkey(hass):
 async def test_specify_non_directory_path_for_dnsmasq(hass):
     """Test creating an AsusWRT scanner with a dnsmasq location which is not a valid directory."""
     with patch("homeassistant.components.asuswrt.AsusWrt") as AsusWrt:
-        AsusWrt().connection.async_connect = mock_coro_func()
+        AsusWrt().connection.async_connect = AsyncMock()
         AsusWrt().is_connected = False
         result = await async_setup_component(
             hass,
@@ -82,10 +79,8 @@ async def test_specify_non_directory_path_for_dnsmasq(hass):
 async def test_interface(hass):
     """Test creating an AsusWRT scanner using interface eth1."""
     with patch("homeassistant.components.asuswrt.AsusWrt") as AsusWrt:
-        AsusWrt().connection.async_connect = mock_coro_func()
-        AsusWrt().connection.async_get_connected_devices = mock_coro_func(
-            return_value={}
-        )
+        AsusWrt().connection.async_connect = AsyncMock()
+        AsusWrt().connection.async_get_connected_devices = AsyncMock(return_value={})
         result = await async_setup_component(
             hass,
             DOMAIN,
@@ -106,7 +101,7 @@ async def test_interface(hass):
 async def test_no_interface(hass):
     """Test creating an AsusWRT scanner using no interface."""
     with patch("homeassistant.components.asuswrt.AsusWrt") as AsusWrt:
-        AsusWrt().connection.async_connect = mock_coro_func()
+        AsusWrt().connection.async_connect = AsyncMock()
         AsusWrt().is_connected = False
         result = await async_setup_component(
             hass,

--- a/tests/components/cast/test_init.py
+++ b/tests/components/cast/test_init.py
@@ -1,19 +1,18 @@
 """Tests for the Cast config flow."""
-from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import cast
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockDependency, mock_coro
+from tests.async_mock import patch
 
 
 async def test_creating_entry_sets_up_media_player(hass):
     """Test setting up Cast loads the media player."""
     with patch(
         "homeassistant.components.cast.media_player.async_setup_entry",
-        return_value=mock_coro(True),
-    ) as mock_setup, MockDependency("pychromecast", "discovery"), patch(
+        return_value=True,
+    ) as mock_setup, patch(
         "pychromecast.discovery.discover_chromecasts", return_value=True
     ):
         result = await hass.config_entries.flow.async_init(
@@ -34,8 +33,8 @@ async def test_creating_entry_sets_up_media_player(hass):
 async def test_configuring_cast_creates_entry(hass):
     """Test that specifying config will create an entry."""
     with patch(
-        "homeassistant.components.cast.async_setup_entry", return_value=mock_coro(True)
-    ) as mock_setup, MockDependency("pychromecast", "discovery"), patch(
+        "homeassistant.components.cast.async_setup_entry", return_value=True
+    ) as mock_setup, patch(
         "pychromecast.discovery.discover_chromecasts", return_value=True
     ):
         await async_setup_component(
@@ -49,8 +48,8 @@ async def test_configuring_cast_creates_entry(hass):
 async def test_not_configuring_cast_not_creates_entry(hass):
     """Test that no config will not create an entry."""
     with patch(
-        "homeassistant.components.cast.async_setup_entry", return_value=mock_coro(True)
-    ) as mock_setup, MockDependency("pychromecast", "discovery"), patch(
+        "homeassistant.components.cast.async_setup_entry", return_value=True
+    ) as mock_setup, patch(
         "pychromecast.discovery.discover_chromecasts", return_value=True
     ):
         await async_setup_component(hass, cast.DOMAIN, {})

--- a/tests/components/cloud/__init__.py
+++ b/tests/components/cloud/__init__.py
@@ -1,18 +1,17 @@
 """Tests for the cloud component."""
-from unittest.mock import patch
 
 from homeassistant.components import cloud
 from homeassistant.components.cloud import const
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro
+from tests.async_mock import AsyncMock, patch
 
 
 async def mock_cloud(hass, config=None):
     """Mock cloud."""
     assert await async_setup_component(hass, cloud.DOMAIN, {"cloud": config or {}})
     cloud_inst = hass.data["cloud"]
-    with patch("hass_nabucasa.Cloud.run_executor", return_value=mock_coro()):
+    with patch("hass_nabucasa.Cloud.run_executor", AsyncMock(return_value=None)):
         await cloud_inst.start()
 
 

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -89,7 +89,7 @@ def patch_sync_helper():
     to_update = []
     to_remove = []
 
-    async def sync_helper(to_upd, to_rem):
+    def sync_helper(to_upd, to_rem):
         to_update.extend([ent_id for ent_id in to_upd if ent_id not in to_update])
         to_remove.extend([ent_id for ent_id in to_rem if ent_id not in to_remove])
         return True

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -1,6 +1,4 @@
 """Test the cloud.iot module."""
-from unittest.mock import MagicMock, patch
-
 from aiohttp import web
 import pytest
 
@@ -12,8 +10,7 @@ from homeassistant.setup import async_setup_component
 
 from . import mock_cloud, mock_cloud_prefs
 
-from tests.async_mock import AsyncMock
-from tests.common import mock_coro
+from tests.async_mock import AsyncMock, MagicMock, patch
 from tests.components.alexa import test_smart_home as test_alexa
 
 
@@ -131,7 +128,7 @@ async def test_handler_google_actions_disabled(hass, mock_cloud_fixture):
     """Test handler Google Actions when user has disabled it."""
     mock_cloud_fixture._prefs[PREF_ENABLE_GOOGLE] = False
 
-    with patch("hass_nabucasa.Cloud.start", return_value=mock_coro()):
+    with patch("hass_nabucasa.Cloud.start"):
         assert await async_setup_component(hass, "cloud", {})
 
     reqid = "5711642932632160983"
@@ -146,7 +143,7 @@ async def test_handler_google_actions_disabled(hass, mock_cloud_fixture):
 
 async def test_webhook_msg(hass):
     """Test webhook msg."""
-    with patch("hass_nabucasa.Cloud.start", return_value=mock_coro()):
+    with patch("hass_nabucasa.Cloud.start"):
         setup = await async_setup_component(hass, "cloud", {"cloud": {}})
         assert setup
     cloud = hass.data["cloud"]

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -1,7 +1,6 @@
 """Test config entries API."""
 
 from collections import OrderedDict
-from unittest.mock import patch
 
 import pytest
 import voluptuous as vol
@@ -13,10 +12,10 @@ from homeassistant.core import callback
 from homeassistant.generated import config_flows
 from homeassistant.setup import async_setup_component
 
+from tests.async_mock import AsyncMock, patch
 from tests.common import (
     MockConfigEntry,
     MockModule,
-    mock_coro_func,
     mock_entity_platform,
     mock_integration,
 )
@@ -228,7 +227,9 @@ async def test_create_account(hass, client):
     """Test a flow that creates an account."""
     mock_entity_platform(hass, "config_flow.test", None)
 
-    mock_integration(hass, MockModule("test", async_setup_entry=mock_coro_func(True)))
+    mock_integration(
+        hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
+    )
 
     class TestFlow(core_ce.ConfigFlow):
         VERSION = 1
@@ -263,7 +264,9 @@ async def test_create_account(hass, client):
 
 async def test_two_step_flow(hass, client):
     """Test we can finish a two step flow."""
-    mock_integration(hass, MockModule("test", async_setup_entry=mock_coro_func(True)))
+    mock_integration(
+        hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
+    )
     mock_entity_platform(hass, "config_flow.test", None)
 
     class TestFlow(core_ce.ConfigFlow):
@@ -320,7 +323,9 @@ async def test_two_step_flow(hass, client):
 
 async def test_continue_flow_unauth(hass, client, hass_admin_user):
     """Test we can't finish a two step flow."""
-    mock_integration(hass, MockModule("test", async_setup_entry=mock_coro_func(True)))
+    mock_integration(
+        hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
+    )
     mock_entity_platform(hass, "config_flow.test", None)
 
     class TestFlow(core_ce.ConfigFlow):
@@ -516,7 +521,9 @@ async def test_options_flow(hass, client):
 
 async def test_two_step_options_flow(hass, client):
     """Test we can finish a two step options flow."""
-    mock_integration(hass, MockModule("test", async_setup_entry=mock_coro_func(True)))
+    mock_integration(
+        hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
+    )
 
     class TestFlow(core_ce.ConfigFlow):
         @staticmethod
@@ -666,7 +673,9 @@ async def test_update_entry_nonexisting(hass, hass_ws_client):
 async def test_ignore_flow(hass, hass_ws_client):
     """Test we can ignore a flow."""
     assert await async_setup_component(hass, "config", {})
-    mock_integration(hass, MockModule("test", async_setup_entry=mock_coro_func(True)))
+    mock_integration(
+        hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
+    )
     mock_entity_platform(hass, "config_flow.test", None)
 
     class TestFlow(core_ce.ConfigFlow):

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -11,7 +11,7 @@ import requests_mock
 from homeassistant.components.darksky import sensor as darksky
 from homeassistant.setup import setup_component
 
-from tests.common import MockDependency, get_test_home_assistant, load_fixture
+from tests.common import get_test_home_assistant, load_fixture
 
 VALID_CONFIG_MINIMAL = {
     "sensor": {
@@ -110,12 +110,11 @@ class TestDarkSkySetup(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    @MockDependency("forecastio")
     @patch(
         "homeassistant.components.darksky.sensor.forecastio.load_forecast",
         new=load_forecastMock,
     )
-    def test_setup_with_config(self, mock_forecastio):
+    def test_setup_with_config(self):
         """Test the platform setup with configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_MINIMAL)
 
@@ -129,12 +128,11 @@ class TestDarkSkySetup(unittest.TestCase):
         state = self.hass.states.get("sensor.dark_sky_summary")
         assert state is None
 
-    @MockDependency("forecastio")
     @patch(
         "homeassistant.components.darksky.sensor.forecastio.load_forecast",
         new=load_forecastMock,
     )
-    def test_setup_with_language_config(self, mock_forecastio):
+    def test_setup_with_language_config(self):
         """Test the platform setup with language configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_LANG_DE)
 
@@ -164,12 +162,11 @@ class TestDarkSkySetup(unittest.TestCase):
         )
         assert not response
 
-    @MockDependency("forecastio")
     @patch(
         "homeassistant.components.darksky.sensor.forecastio.load_forecast",
         new=load_forecastMock,
     )
-    def test_setup_with_alerts_config(self, mock_forecastio):
+    def test_setup_with_alerts_config(self):
         """Test the platform setup with alert configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_ALERTS)
 

--- a/tests/components/emulated_roku/test_binding.py
+++ b/tests/components/emulated_roku/test_binding.py
@@ -14,7 +14,7 @@ from homeassistant.components.emulated_roku.binding import (
     EmulatedRoku,
 )
 
-from tests.common import mock_coro_func
+from tests.async_mock import AsyncMock
 
 
 async def test_events_fired_properly(hass):
@@ -39,7 +39,7 @@ async def test_events_fired_properly(hass):
         nonlocal roku_event_handler
         roku_event_handler = handler
 
-        return Mock(start=mock_coro_func(), close=mock_coro_func())
+        return Mock(start=AsyncMock(), close=AsyncMock())
 
     def listener(event):
         events.append(event)

--- a/tests/components/emulated_roku/test_init.py
+++ b/tests/components/emulated_roku/test_init.py
@@ -4,14 +4,14 @@ from unittest.mock import Mock, patch
 from homeassistant.components import emulated_roku
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro_func
+from tests.async_mock import AsyncMock
 
 
 async def test_config_required_fields(hass):
     """Test that configuration is successful with required fields."""
     with patch.object(emulated_roku, "configured_servers", return_value=[]), patch(
         "homeassistant.components.emulated_roku.binding.EmulatedRokuServer",
-        return_value=Mock(start=mock_coro_func(), close=mock_coro_func()),
+        return_value=Mock(start=AsyncMock(), close=AsyncMock()),
     ):
         assert (
             await async_setup_component(
@@ -36,7 +36,7 @@ async def test_config_already_registered_not_configured(hass):
     """Test that an already registered name causes the entry to be ignored."""
     with patch(
         "homeassistant.components.emulated_roku.binding.EmulatedRokuServer",
-        return_value=Mock(start=mock_coro_func(), close=mock_coro_func()),
+        return_value=Mock(start=AsyncMock(), close=AsyncMock()),
     ) as instantiate, patch.object(
         emulated_roku, "configured_servers", return_value=["Emulated Roku Test"]
     ):
@@ -75,7 +75,7 @@ async def test_setup_entry_successful(hass):
 
     with patch(
         "homeassistant.components.emulated_roku.binding.EmulatedRokuServer",
-        return_value=Mock(start=mock_coro_func(), close=mock_coro_func()),
+        return_value=Mock(start=AsyncMock(), close=AsyncMock()),
     ) as instantiate:
         assert await emulated_roku.async_setup_entry(hass, entry) is True
 
@@ -99,7 +99,7 @@ async def test_unload_entry(hass):
 
     with patch(
         "homeassistant.components.emulated_roku.binding.EmulatedRokuServer",
-        return_value=Mock(start=mock_coro_func(), close=mock_coro_func()),
+        return_value=Mock(start=AsyncMock(), close=AsyncMock()),
     ):
         assert await emulated_roku.async_setup_entry(hass, entry) is True
 

--- a/tests/components/folder_watcher/test_init.py
+++ b/tests/components/folder_watcher/test_init.py
@@ -5,8 +5,6 @@ from unittest.mock import Mock, patch
 from homeassistant.components import folder_watcher
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockDependency
-
 
 async def test_invalid_path_setup(hass):
     """Test that an invalid path is not set up."""
@@ -29,8 +27,7 @@ async def test_valid_path_setup(hass):
         )
 
 
-@MockDependency("watchdog", "events")
-def test_event(mock_watchdog):
+def test_event():
     """Check that Home Assistant events are fired correctly on watchdog event."""
 
     class MockPatternMatchingEventHandler:
@@ -39,17 +36,20 @@ def test_event(mock_watchdog):
         def __init__(self, patterns):
             pass
 
-    mock_watchdog.events.PatternMatchingEventHandler = MockPatternMatchingEventHandler
-    hass = Mock()
-    handler = folder_watcher.create_event_handler(["*"], hass)
-    handler.on_created(
-        Mock(is_directory=False, src_path="/hello/world.txt", event_type="created")
-    )
-    assert hass.bus.fire.called
-    assert hass.bus.fire.mock_calls[0][1][0] == folder_watcher.DOMAIN
-    assert hass.bus.fire.mock_calls[0][1][1] == {
-        "event_type": "created",
-        "path": "/hello/world.txt",
-        "file": "world.txt",
-        "folder": "/hello",
-    }
+    with patch(
+        "homeassistant.components.folder_watcher.PatternMatchingEventHandler",
+        MockPatternMatchingEventHandler,
+    ):
+        hass = Mock()
+        handler = folder_watcher.create_event_handler(["*"], hass)
+        handler.on_created(
+            Mock(is_directory=False, src_path="/hello/world.txt", event_type="created")
+        )
+        assert hass.bus.fire.called
+        assert hass.bus.fire.mock_calls[0][1][0] == folder_watcher.DOMAIN
+        assert hass.bus.fire.mock_calls[0][1][1] == {
+            "event_type": "created",
+            "path": "/hello/world.txt",
+            "file": "world.txt",
+            "folder": "/hello",
+        }

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -15,7 +15,7 @@ from homeassistant.components.http.view import (
 )
 from homeassistant.exceptions import ServiceNotFound, Unauthorized
 
-from tests.common import mock_coro_func
+from tests.async_mock import AsyncMock
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ async def test_handling_unauthorized(mock_request):
     """Test handling unauth exceptions."""
     with pytest.raises(HTTPUnauthorized):
         await request_handler_factory(
-            Mock(requires_auth=False), mock_coro_func(exception=Unauthorized)
+            Mock(requires_auth=False), AsyncMock(side_effect=Unauthorized)
         )(mock_request)
 
 
@@ -46,7 +46,7 @@ async def test_handling_invalid_data(mock_request):
     """Test handling unauth exceptions."""
     with pytest.raises(HTTPBadRequest):
         await request_handler_factory(
-            Mock(requires_auth=False), mock_coro_func(exception=vol.Invalid("yo"))
+            Mock(requires_auth=False), AsyncMock(side_effect=vol.Invalid("yo"))
         )(mock_request)
 
 
@@ -55,5 +55,5 @@ async def test_handling_service_not_found(mock_request):
     with pytest.raises(HTTPInternalServerError):
         await request_handler_factory(
             Mock(requires_auth=False),
-            mock_coro_func(exception=ServiceNotFound("test", "test")),
+            AsyncMock(side_effect=ServiceNotFound("test", "test")),
         )(mock_request)

--- a/tests/components/iqvia/test_config_flow.py
+++ b/tests/components/iqvia/test_config_flow.py
@@ -1,17 +1,8 @@
 """Define tests for the IQVIA config flow."""
-import pytest
-
 from homeassistant import data_entry_flow
 from homeassistant.components.iqvia import CONF_ZIP_CODE, DOMAIN, config_flow
 
-from tests.common import MockConfigEntry, MockDependency
-
-
-@pytest.fixture
-def mock_pyiqvia():
-    """Mock the pyiqvia library."""
-    with MockDependency("pyiqvia") as mock_pyiqvia_:
-        yield mock_pyiqvia_
+from tests.common import MockConfigEntry
 
 
 async def test_duplicate_error(hass):
@@ -26,7 +17,7 @@ async def test_duplicate_error(hass):
     assert result["errors"] == {CONF_ZIP_CODE: "identifier_exists"}
 
 
-async def test_invalid_zip_code(hass, mock_pyiqvia):
+async def test_invalid_zip_code(hass):
     """Test that an invalid ZIP code key throws an error."""
     conf = {CONF_ZIP_CODE: "abcde"}
 
@@ -48,7 +39,7 @@ async def test_show_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_step_import(hass, mock_pyiqvia):
+async def test_step_import(hass):
     """Test that the import step works."""
     conf = {CONF_ZIP_CODE: "12345"}
 
@@ -61,7 +52,7 @@ async def test_step_import(hass, mock_pyiqvia):
     assert result["data"] == {CONF_ZIP_CODE: "12345"}
 
 
-async def test_step_user(hass, mock_pyiqvia):
+async def test_step_user(hass):
     """Test that the user step works."""
     conf = {CONF_ZIP_CODE: "12345"}
 

--- a/tests/components/melissa/test_init.py
+++ b/tests/components/melissa/test_init.py
@@ -1,23 +1,22 @@
 """The test for the Melissa Climate component."""
 from homeassistant.components import melissa
 
-from tests.common import MockDependency, mock_coro_func
+from tests.async_mock import AsyncMock, patch
 
 VALID_CONFIG = {"melissa": {"username": "********", "password": "********"}}
 
 
 async def test_setup(hass):
     """Test setting up the Melissa component."""
-    with MockDependency("melissa") as mocked_melissa:
-        melissa.melissa = mocked_melissa
-        mocked_melissa.AsyncMelissa().async_connect = mock_coro_func()
+    with patch("melissa.AsyncMelissa") as mocked_melissa, patch.object(
+        melissa, "async_load_platform"
+    ):
+        mocked_melissa.return_value.async_connect = AsyncMock()
         await melissa.async_setup(hass, VALID_CONFIG)
 
-        mocked_melissa.AsyncMelissa.assert_called_with(
-            username="********", password="********"
-        )
+        mocked_melissa.assert_called_with(username="********", password="********")
 
         assert melissa.DATA_MELISSA in hass.data
         assert isinstance(
-            hass.data[melissa.DATA_MELISSA], type(mocked_melissa.AsyncMelissa())
+            hass.data[melissa.DATA_MELISSA], type(mocked_melissa.return_value),
         )

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -1,18 +1,18 @@
 """Test config flow."""
-from unittest.mock import patch
 
 import pytest
 
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
 def mock_finish_setup():
     """Mock out the finish setup method."""
     with patch(
-        "homeassistant.components.mqtt.MQTT.async_connect", return_value=mock_coro(True)
+        "homeassistant.components.mqtt.MQTT.async_connect", return_value=True
     ) as mock_finish:
         yield mock_finish
 

--- a/tests/components/reddit/test_sensor.py
+++ b/tests/components/reddit/test_sensor.py
@@ -3,7 +3,6 @@ import copy
 import unittest
 from unittest.mock import patch
 
-from homeassistant.components.reddit import sensor as reddit_sensor
 from homeassistant.components.reddit.sensor import (
     ATTR_BODY,
     ATTR_COMMENTS_NUMBER,
@@ -20,7 +19,7 @@ from homeassistant.components.reddit.sensor import (
 from homeassistant.const import CONF_MAXIMUM, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import setup_component
 
-from tests.common import MockDependency, get_test_home_assistant
+from tests.common import get_test_home_assistant
 
 VALID_CONFIG = {
     "sensor": {
@@ -157,12 +156,10 @@ class TestRedditSetup(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    @MockDependency("praw")
     @patch("praw.Reddit", new=MockPraw)
-    def test_setup_with_valid_config(self, mock_praw):
+    def test_setup_with_valid_config(self):
         """Test the platform setup with Reddit configuration."""
-        with patch.object(reddit_sensor, "praw", mock_praw):
-            setup_component(self.hass, "sensor", VALID_CONFIG)
+        setup_component(self.hass, "sensor", VALID_CONFIG)
 
         state = self.hass.states.get("sensor.reddit_worldnews")
         assert int(state.state) == MOCK_RESULTS_LENGTH
@@ -184,9 +181,8 @@ class TestRedditSetup(unittest.TestCase):
 
         assert state.attributes[CONF_SORT_BY] == "hot"
 
-    @MockDependency("praw")
     @patch("praw.Reddit", new=MockPraw)
-    def test_setup_with_invalid_config(self, mock_praw):
+    def test_setup_with_invalid_config(self):
         """Test the platform setup with invalid Reddit configuration."""
         setup_component(self.hass, "sensor", INVALID_SORT_BY_CONFIG)
         assert not self.hass.states.get("sensor.reddit_worldnews")

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
 
-from tests.common import MockDependency, async_fire_time_changed
+from tests.common import async_fire_time_changed
 
 VALID_CONFIG_MINIMAL = {
     "sensor": {
@@ -110,15 +110,8 @@ class ProfileMock:
         return self.__class__.summary_data
 
 
-@pytest.fixture(autouse=True, name="mock_py17track")
-def fixture_mock_py17track():
-    """Mock py17track dependency."""
-    with MockDependency("py17track"):
-        yield
-
-
 @pytest.fixture(autouse=True, name="mock_client")
-def fixture_mock_client(mock_py17track):
+def fixture_mock_client():
     """Mock py17track client."""
     with mock.patch(
         "homeassistant.components.seventeentrack.sensor.SeventeenTrackClient",

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -16,14 +16,12 @@ from homeassistant.components.tplink.common import (
 from homeassistant.const import CONF_HOST
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, MockDependency, mock_coro
-
-MOCK_PYHS100 = MockDependency("pyHS100")
+from tests.common import MockConfigEntry, mock_coro
 
 
 async def test_creating_entry_tries_discover(hass):
     """Test setting up does discovery."""
-    with MOCK_PYHS100, patch(
+    with patch(
         "homeassistant.components.tplink.async_setup_entry",
         return_value=mock_coro(True),
     ) as mock_setup, patch(
@@ -47,9 +45,7 @@ async def test_creating_entry_tries_discover(hass):
 
 async def test_configuring_tplink_causes_discovery(hass):
     """Test that specifying empty config does discovery."""
-    with MOCK_PYHS100, patch(
-        "homeassistant.components.tplink.common.Discover.discover"
-    ) as discover:
+    with patch("homeassistant.components.tplink.common.Discover.discover") as discover:
         discover.return_value = {"host": 1234}
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
@@ -177,7 +173,7 @@ async def test_is_dimmable(hass):
 
 async def test_configuring_discovery_disabled(hass):
     """Test that discover does not get called when disabled."""
-    with MOCK_PYHS100, patch(
+    with patch(
         "homeassistant.components.tplink.async_setup_entry",
         return_value=mock_coro(True),
     ) as mock_setup, patch(
@@ -226,7 +222,7 @@ async def test_platforms_are_initialized(hass):
 
 async def test_no_config_creates_no_entry(hass):
     """Test for when there is no tplink in config."""
-    with MOCK_PYHS100, patch(
+    with patch(
         "homeassistant.components.tplink.async_setup_entry",
         return_value=mock_coro(True),
     ) as mock_setup:

--- a/tests/components/twilio/test_init.py
+++ b/tests/components/twilio/test_init.py
@@ -5,34 +5,31 @@ from homeassistant import data_entry_flow
 from homeassistant.components import twilio
 from homeassistant.core import callback
 
-from tests.common import MockDependency
-
 
 async def test_config_flow_registers_webhook(hass, aiohttp_client):
     """Test setting up Twilio and sending webhook."""
-    with MockDependency("twilio", "rest"), MockDependency("twilio", "twiml"):
-        with patch("homeassistant.util.get_local_ip", return_value="example.com"):
-            result = await hass.config_entries.flow.async_init(
-                "twilio", context={"source": "user"}
-            )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
+    with patch("homeassistant.util.get_local_ip", return_value="example.com"):
+        result = await hass.config_entries.flow.async_init(
+            "twilio", context={"source": "user"}
+        )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM, result
 
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        webhook_id = result["result"].data["webhook_id"]
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    webhook_id = result["result"].data["webhook_id"]
 
-        twilio_events = []
+    twilio_events = []
 
-        @callback
-        def handle_event(event):
-            """Handle Twilio event."""
-            twilio_events.append(event)
+    @callback
+    def handle_event(event):
+        """Handle Twilio event."""
+        twilio_events.append(event)
 
-        hass.bus.async_listen(twilio.RECEIVED_DATA, handle_event)
+    hass.bus.async_listen(twilio.RECEIVED_DATA, handle_event)
 
-        client = await aiohttp_client(hass.http.app)
-        await client.post(f"/api/webhook/{webhook_id}", data={"hello": "twilio"})
+    client = await aiohttp_client(hass.http.app)
+    await client.post(f"/api/webhook/{webhook_id}", data={"hello": "twilio"})
 
-        assert len(twilio_events) == 1
-        assert twilio_events[0].data["webhook_id"] == webhook_id
-        assert twilio_events[0].data["hello"] == "twilio"
+    assert len(twilio_events) == 1
+    assert twilio_events[0].data["webhook_id"] == webhook_id
+    assert twilio_events[0].data["hello"] == "twilio"

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
-from tests.common import MockDependency, mock_component
+from tests.common import mock_component
 
 NEW_VERSION = "10000.0"
 MOCK_VERSION = "10.0"
@@ -15,13 +15,6 @@ MOCK_HUUID = "abcdefg"
 MOCK_RESPONSE = {"version": "0.15", "release-notes": "https://home-assistant.io"}
 MOCK_CONFIG = {updater.DOMAIN: {"reporting": True}}
 RELEASE_NOTES = "test release notes"
-
-
-@pytest.fixture(autouse=True)
-def mock_distro():
-    """Mock distro dep."""
-    with MockDependency("distro"):
-        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/wake_on_lan/test_init.py
+++ b/tests/components/wake_on_lan/test_init.py
@@ -2,20 +2,17 @@
 import pytest
 import voluptuous as vol
 
-from homeassistant.components import wake_on_lan
 from homeassistant.components.wake_on_lan import DOMAIN, SERVICE_SEND_MAGIC_PACKET
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockDependency
+from tests.async_mock import patch
 
 
 async def test_send_magic_packet(hass):
     """Test of send magic packet service call."""
-    with MockDependency("wakeonlan") as mocked_wakeonlan:
+    with patch("homeassistant.components.wake_on_lan.wakeonlan") as mocked_wakeonlan:
         mac = "aa:bb:cc:dd:ee:ff"
         bc_ip = "192.168.255.255"
-
-        wake_on_lan.wakeonlan = mocked_wakeonlan
 
         await async_setup_component(hass, DOMAIN, {})
 

--- a/tests/components/yandex_transport/test_yandex_transport_sensor.py
+++ b/tests/components/yandex_transport/test_yandex_transport_sensor.py
@@ -8,12 +8,8 @@ import homeassistant.components.sensor as sensor
 from homeassistant.const import CONF_NAME
 import homeassistant.util.dt as dt_util
 
-from tests.common import (
-    MockDependency,
-    assert_setup_component,
-    async_setup_component,
-    load_fixture,
-)
+from tests.async_mock import patch
+from tests.common import assert_setup_component, async_setup_component, load_fixture
 
 REPLY = json.loads(load_fixture("yandex_transport_reply.json"))
 
@@ -21,8 +17,8 @@ REPLY = json.loads(load_fixture("yandex_transport_reply.json"))
 @pytest.fixture
 def mock_requester():
     """Create a mock ya_ma module and YandexMapsRequester."""
-    with MockDependency("ya_ma") as ya_ma:
-        instance = ya_ma.YandexMapsRequester.return_value
+    with patch("ya_ma.YandexMapsRequester") as requester:
+        instance = requester.return_value
         instance.get_stop_info.return_value = REPLY
         yield instance
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def hass(loop, hass_storage, request):
 
     def exc_handle(loop, context):
         """Handle exceptions by rethrowing them, which will fail the test."""
-        exceptions.append(context["exception"])
+        exceptions.append(context.get("exception"))
         orig_exception_handler(loop, context)
 
     exceptions = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def hass(loop, hass_storage, request):
 
     def exc_handle(loop, context):
         """Handle exceptions by rethrowing them, which will fail the test."""
-        exceptions.append(context.get("exception"))
+        exceptions.append(context["exception"])
         orig_exception_handler(loop, context)
 
     exceptions = []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This changes the implementation of `mock_coro` to use an asyncio future instead of AsyncMock.

Last cleanup I do on the tests for async things this week 😆 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
