### PR TITLE
Use pin value change callback for Arduino sensor

### DIFF
--- a/homeassistant/components/arduino/__init__.py
+++ b/homeassistant/components/arduino/__init__.py
@@ -65,23 +65,32 @@ class ArduinoBoard:
         self._port = port
         self._board = PyMata(self._port, verbose=False)
 
-    def set_mode(self, pin, direction, mode):
+    def set_mode(self, pin, direction, mode, call_back=None):
         """Set the mode and the direction of a given pin."""
         if mode == "analog" and direction == "in":
-            self._board.set_pin_mode(pin, self._board.INPUT, self._board.ANALOG)
+            self._board.set_pin_mode(
+                pin, self._board.INPUT, self._board.ANALOG, call_back
+            )
         elif mode == "analog" and direction == "out":
             self._board.set_pin_mode(pin, self._board.OUTPUT, self._board.ANALOG)
         elif mode == "digital" and direction == "in":
-            self._board.set_pin_mode(pin, self._board.INPUT, self._board.DIGITAL)
+            self._board.set_pin_mode(
+                pin, self._board.INPUT, self._board.DIGITAL, call_back
+            )
         elif mode == "digital" and direction == "out":
             self._board.set_pin_mode(pin, self._board.OUTPUT, self._board.DIGITAL)
         elif mode == "pwm":
             self._board.set_pin_mode(pin, self._board.OUTPUT, self._board.PWM)
 
     def get_analog_inputs(self):
-        """Get the values from the pins."""
+        """Get the analog values from the pins."""
         self._board.capability_query()
         return self._board.get_analog_response_table()
+
+    def get_digital_inputs(self):
+        """Get the digital values from the pins."""
+        self._board.capability_query()
+        return self._board.get_digital_response_table()
 
     def set_digital_out_high(self, pin):
         """Set a given digital pin to high."""

--- a/homeassistant/components/arduino/sensor.py
+++ b/homeassistant/components/arduino/sensor.py
@@ -1,10 +1,11 @@
 """Support for getting information from Arduino pins."""
 import logging
+from threading import Timer
 
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_MODE, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
@@ -14,8 +15,16 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_PINS = "pins"
 CONF_TYPE = "analog"
+PIN_MODE = 0  # This is the PyMata Pin MODE = ANALOG = 2 and DIGITAL = 0x20:
+PIN_NUMBER = 1
+DATA_VALUE = 2
 
-PIN_SCHEMA = vol.Schema({vol.Required(CONF_NAME): cv.string})
+PIN_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Optional(CONF_MODE, default="analog"): vol.In(["analog", "digital"]),
+    }
+)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_PINS): vol.Schema({cv.positive_int: PIN_SCHEMA})}
@@ -30,7 +39,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sensors = []
     for pinnum, pin in pins.items():
-        sensors.append(ArduinoSensor(pin.get(CONF_NAME), pinnum, CONF_TYPE, board))
+        pin_type = pin.get("mode")
+        if not pin_type:
+            pin_type = CONF_TYPE
+        sensors.append(ArduinoSensor(pin.get(CONF_NAME), pinnum, pin_type, board))
     add_entities(sensors)
 
 
@@ -45,8 +57,16 @@ class ArduinoSensor(Entity):
         self.direction = "in"
         self._value = None
 
-        board.set_mode(self._pin, self.direction, self.pin_type)
+        board.set_mode(self._pin, self.direction, self.pin_type, self.cb_value_changed)
         self._board = board
+
+        t = Timer(20.0, self.set_initial_value)
+        t.start()
+
+    @property
+    def should_poll(self):
+        """No need to poll. Sensor receives the update from PyMata."""
+        return False
 
     @property
     def state(self):
@@ -58,6 +78,13 @@ class ArduinoSensor(Entity):
         """Get the name of the sensor."""
         return self._name
 
-    def update(self):
-        """Get the latest value from the pin."""
-        self._value = self._board.get_analog_inputs()[self._pin][1]
+    def cb_value_changed(self, data):
+        """Set the value from the data passed in the callback."""
+        self._value = data[DATA_VALUE]
+        self.async_write_ha_state()
+
+    def set_initial_value(self):
+        """Set the initial value to zero if no value has been received yet."""
+        if self._value is None:
+            self._value = 0
+            self.async_write_ha_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support for digital input added to the Arduino integration.
I also improved the implementation by passing a callback, that will be triggered when a pin value changes, this way the state updates much faster.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  platform: arduino
  pins:
    1:
      name: temperature_sensor
    24:
      name: digital_input
      mode: digital
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

For the Arduino integration a python library PyMata v2.20 is used.
I found an issue with this library that when the initial value of a pin is 0,
then our entity doesn't get notified of this initial value.
So it is only notified when the value is larger than 0.
Therefore I set the initial value to 0, if a value has not been received from PyMata after 20 seconds.
This way the value is None until a value is received or until the 20 seconds have passed.

With the current implementation there is no limit on how fast the input state will update in home assistant, should this be limited? For instance a temperature sensor value can change multiple times a second.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
