### PR TITLE
Some small Monoprice fixes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -240,7 +240,7 @@ homeassistant/components/minecraft_server/* @elmurato
 homeassistant/components/minio/* @tkislan
 homeassistant/components/mobile_app/* @robbiet480
 homeassistant/components/modbus/* @adamchengtkc @janiversen
-homeassistant/components/monoprice/* @etsinko
+homeassistant/components/monoprice/* @etsinko @OnFreund
 homeassistant/components/moon/* @fabaff
 homeassistant/components/mpd/* @fabaff
 homeassistant/components/mqtt/* @home-assistant/core @emontnemery

--- a/homeassistant/components/monoprice/config_flow.py
+++ b/homeassistant/components/monoprice/config_flow.py
@@ -99,7 +99,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 @core.callback
 def _key_for_source(index, source, previous_sources):
     if str(index) in previous_sources:
-        key = vol.Optional(source, default=previous_sources[str(index)])
+        key = vol.Optional(
+            source, description={"suggested_value": previous_sources[str(index)]}
+        )
     else:
         key = vol.Optional(source)
 

--- a/homeassistant/components/monoprice/const.py
+++ b/homeassistant/components/monoprice/const.py
@@ -13,3 +13,6 @@ CONF_SOURCE_6 = "source_6"
 
 SERVICE_SNAPSHOT = "snapshot"
 SERVICE_RESTORE = "restore"
+
+MONOPRICE_OBJECT = "monoprice_object"
+UNDO_UPDATE_LISTENER = "update_update_listener"

--- a/homeassistant/components/monoprice/const.py
+++ b/homeassistant/components/monoprice/const.py
@@ -11,8 +11,11 @@ CONF_SOURCE_4 = "source_4"
 CONF_SOURCE_5 = "source_5"
 CONF_SOURCE_6 = "source_6"
 
+CONF_NOT_FIRST_RUN = "not_first_run"
+
 SERVICE_SNAPSHOT = "snapshot"
 SERVICE_RESTORE = "restore"
 
+FIRST_RUN = "first_run"
 MONOPRICE_OBJECT = "monoprice_object"
 UNDO_UPDATE_LISTENER = "update_update_listener"

--- a/homeassistant/components/monoprice/manifest.json
+++ b/homeassistant/components/monoprice/manifest.json
@@ -3,6 +3,6 @@
   "name": "Monoprice 6-Zone Amplifier",
   "documentation": "https://www.home-assistant.io/integrations/monoprice",
   "requirements": ["pymonoprice==0.3"],
-  "codeowners": ["@etsinko"],
+  "codeowners": ["@etsinko", "@OnFreund"],
   "config_flow": true
 }

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -16,7 +16,13 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import CONF_PORT, STATE_OFF, STATE_ON
 from homeassistant.helpers import config_validation as cv, entity_platform, service
 
-from .const import CONF_SOURCES, DOMAIN, SERVICE_RESTORE, SERVICE_SNAPSHOT
+from .const import (
+    CONF_SOURCES,
+    DOMAIN,
+    MONOPRICE_OBJECT,
+    SERVICE_RESTORE,
+    SERVICE_SNAPSHOT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +64,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Monoprice 6-zone amplifier platform."""
     port = config_entry.data[CONF_PORT]
 
-    monoprice = hass.data[DOMAIN][config_entry.entry_id]
+    monoprice = hass.data[DOMAIN][config_entry.entry_id][MONOPRICE_OBJECT]
 
     sources = _get_sources(config_entry)
 

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -17,6 +17,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.components.monoprice.const import (
+    CONF_NOT_FIRST_RUN,
     CONF_SOURCES,
     DOMAIN,
     SERVICE_RESTORE,
@@ -41,6 +42,7 @@ MOCK_OPTIONS = {CONF_SOURCES: {"2": "two", "4": "four"}}
 
 ZONE_1_ID = "media_player.zone_11"
 ZONE_2_ID = "media_player.zone_12"
+ZONE_7_ID = "media_player.zone_21"
 
 
 class AttrDict(dict):
@@ -100,8 +102,6 @@ async def test_cannot_connect(hass):
         config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        # setup_component(self.hass, DOMAIN, MOCK_CONFIG)
-        # self.hass.async_block_till_done()
         await hass.async_block_till_done()
         assert hass.states.get(ZONE_1_ID) is None
 
@@ -113,8 +113,6 @@ async def _setup_monoprice(hass, monoprice):
         config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        # setup_component(self.hass, DOMAIN, MOCK_CONFIG)
-        # self.hass.async_block_till_done()
         await hass.async_block_till_done()
 
 
@@ -127,8 +125,17 @@ async def _setup_monoprice_with_options(hass, monoprice):
         )
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
-        # setup_component(self.hass, DOMAIN, MOCK_CONFIG)
-        # self.hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+
+async def _setup_monoprice_not_first_run(hass, monoprice):
+    with patch(
+        "homeassistant.components.monoprice.get_monoprice", new=lambda *a: monoprice,
+    ):
+        data = {**MOCK_CONFIG, CONF_NOT_FIRST_RUN: True}
+        config_entry = MockConfigEntry(domain=DOMAIN, data=data)
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
 
@@ -479,3 +486,47 @@ async def test_volume_up_down(hass):
         hass, SERVICE_VOLUME_DOWN, {"entity_id": ZONE_1_ID}
     )
     assert monoprice.zones[11].volume == 37
+
+
+async def test_first_run_with_available_zones(hass):
+    """Test first run with all zones available."""
+    monoprice = MockMonoprice()
+    await _setup_monoprice(hass, monoprice)
+
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entry = registry.async_get(ZONE_7_ID)
+    assert not entry.disabled
+
+
+async def test_first_run_with_failing_zones(hass):
+    """Test first run with failed zones."""
+    monoprice = MockMonoprice()
+
+    with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
+        await _setup_monoprice(hass, monoprice)
+
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entry = registry.async_get(ZONE_1_ID)
+    assert not entry.disabled
+
+    entry = registry.async_get(ZONE_7_ID)
+    assert entry.disabled
+    assert entry.disabled_by == "integration"
+
+
+async def test_not_first_run_with_failing_zone(hass):
+    """Test first run with failed zones."""
+    monoprice = MockMonoprice()
+
+    with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
+        await _setup_monoprice_not_first_run(hass, monoprice)
+
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entry = registry.async_get(ZONE_1_ID)
+    assert not entry.disabled
+
+    entry = registry.async_get(ZONE_7_ID)
+    assert not entry.disabled


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1. Fix unloading of config entry (by unsubscribing to the update listener).
2. Use suggested value (instead of default) for source names, so they can be easily removed in the options flow.
3. Try to automatically detect zones on first run.
4. Don't call `update()` before adding to the entity registry on subsequent runs, to speed boot up and avoid warnings.

Also added myself as a codeowner since over the past few weeks I've basically re-written it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #34035
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13262

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
