### PR TITLE
Improve stability of homekit media players

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -164,13 +164,12 @@ def get_accessory(hass, driver, state, aid, config):
 
     elif state.domain == "media_player":
         device_class = state.attributes.get(ATTR_DEVICE_CLASS)
-        feature_list = config.get(CONF_FEATURE_LIST)
+        feature_list = config.get(CONF_FEATURE_LIST, [])
 
         if device_class == DEVICE_CLASS_TV:
             a_type = "TelevisionMediaPlayer"
-        else:
-            if feature_list and validate_media_player_features(state, feature_list):
-                a_type = "MediaPlayer"
+        elif validate_media_player_features(state, feature_list):
+            a_type = "MediaPlayer"
 
     elif state.domain == "sensor":
         device_class = state.attributes.get(ATTR_DEVICE_CLASS)

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -64,6 +64,7 @@ from .const import (
     SERV_TELEVISION,
     SERV_TELEVISION_SPEAKER,
 )
+from .util import get_media_player_features
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,10 +84,12 @@ MEDIA_PLAYER_KEYS = {
     # 15: "Information",
 }
 
+# Names may not contain special characters
+# or emjoi (/ is a special character for Apple)
 MODE_FRIENDLY_NAME = {
     FEATURE_ON_OFF: "Power",
-    FEATURE_PLAY_PAUSE: "Play/Pause",
-    FEATURE_PLAY_STOP: "Play/Stop",
+    FEATURE_PLAY_PAUSE: "Play-Pause",
+    FEATURE_PLAY_STOP: "Play-Stop",
     FEATURE_TOGGLE_MUTE: "Mute",
 }
 
@@ -105,7 +108,9 @@ class MediaPlayer(HomeAccessory):
             FEATURE_PLAY_STOP: None,
             FEATURE_TOGGLE_MUTE: None,
         }
-        feature_list = self.config[CONF_FEATURE_LIST]
+        feature_list = self.config.get(
+            CONF_FEATURE_LIST, get_media_player_features(state)
+        )
 
         if FEATURE_ON_OFF in feature_list:
             name = self.generate_service_name(FEATURE_ON_OFF)
@@ -213,7 +218,7 @@ class MediaPlayer(HomeAccessory):
                 self.chars[FEATURE_PLAY_STOP].set_value(hk_state)
 
         if self.chars[FEATURE_TOGGLE_MUTE]:
-            current_state = new_state.attributes.get(ATTR_MEDIA_VOLUME_MUTED)
+            current_state = bool(new_state.attributes.get(ATTR_MEDIA_VOLUME_MUTED))
             _LOGGER.debug(
                 '%s: Set current state for "toggle_mute" to %s',
                 self.entity_id,
@@ -239,9 +244,7 @@ class TelevisionMediaPlayer(HomeAccessory):
         # Add additional characteristics if volume or input selection supported
         self.chars_tv = []
         self.chars_speaker = []
-        features = self.hass.states.get(self.entity_id).attributes.get(
-            ATTR_SUPPORTED_FEATURES, 0
-        )
+        features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         if features & (SUPPORT_PLAY | SUPPORT_PAUSE):
             self.chars_tv.append(CHAR_REMOTE_KEY)
@@ -252,7 +255,8 @@ class TelevisionMediaPlayer(HomeAccessory):
             if features & SUPPORT_VOLUME_SET:
                 self.chars_speaker.append(CHAR_VOLUME)
 
-        if features & SUPPORT_SELECT_SOURCE:
+        source_list = state.attributes.get(ATTR_INPUT_SOURCE_LIST, [])
+        if source_list and features & SUPPORT_SELECT_SOURCE:
             self.support_select_source = True
 
         serv_tv = self.add_preload_service(SERV_TELEVISION, self.chars_tv)
@@ -297,9 +301,7 @@ class TelevisionMediaPlayer(HomeAccessory):
                 )
 
         if self.support_select_source:
-            self.sources = self.hass.states.get(self.entity_id).attributes.get(
-                ATTR_INPUT_SOURCE_LIST, []
-            )
+            self.sources = source_list
             self.char_input_source = serv_tv.configure_char(
                 CHAR_ACTIVE_IDENTIFIER, setter_callback=self.set_input_source
             )
@@ -379,14 +381,13 @@ class TelevisionMediaPlayer(HomeAccessory):
         hk_state = 0
         if current_state not in ("None", STATE_OFF, STATE_UNKNOWN):
             hk_state = 1
-
         _LOGGER.debug("%s: Set current active state to %s", self.entity_id, hk_state)
         if self.char_active.value != hk_state:
             self.char_active.set_value(hk_state)
 
         # Set mute state
         if CHAR_VOLUME_SELECTOR in self.chars_speaker:
-            current_mute_state = new_state.attributes.get(ATTR_MEDIA_VOLUME_MUTED)
+            current_mute_state = bool(new_state.attributes.get(ATTR_MEDIA_VOLUME_MUTED))
             _LOGGER.debug(
                 "%s: Set current mute state to %s", self.entity_id, current_mute_state,
             )
@@ -394,20 +395,16 @@ class TelevisionMediaPlayer(HomeAccessory):
                 self.char_mute.set_value(current_mute_state)
 
         # Set active input
-        if self.support_select_source:
+        if self.support_select_source and self.sources:
             source_name = new_state.attributes.get(ATTR_INPUT_SOURCE)
-            if self.sources:
-                _LOGGER.debug(
-                    "%s: Set current input to %s", self.entity_id, source_name
+            _LOGGER.debug("%s: Set current input to %s", self.entity_id, source_name)
+            if source_name in self.sources:
+                index = self.sources.index(source_name)
+                if self.char_input_source.value != index:
+                    self.char_input_source.set_value(index)
+            else:
+                _LOGGER.warning(
+                    "%s: Sources out of sync. Restart Home Assistant", self.entity_id,
                 )
-                if source_name in self.sources:
-                    index = self.sources.index(source_name)
-                    if self.char_input_source.value != index:
-                        self.char_input_source.set_value(index)
-                else:
-                    _LOGGER.warning(
-                        "%s: Sources out of sync. Restart Home Assistant",
-                        self.entity_id,
-                    )
-                    if self.char_input_source.value != 0:
-                        self.char_input_source.set_value(0)
+                if self.char_input_source.value != 0:
+                    self.char_input_source.set_value(0)

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -369,6 +369,26 @@ async def test_media_player_television_basic(hass, hk_driver, events, caplog):
     assert not caplog.messages or "Error" not in caplog.messages[-1]
 
 
+async def test_media_player_television_supports_source_select_no_sources(
+    hass, hk_driver, events, caplog
+):
+    """Test if basic tv that supports source select but is missing a source list."""
+    entity_id = "media_player.television"
+
+    # Supports turn_on', 'turn_off'
+    hass.states.async_set(
+        entity_id,
+        None,
+        {ATTR_DEVICE_CLASS: DEVICE_CLASS_TV, ATTR_SUPPORTED_FEATURES: 3469},
+    )
+    await hass.async_block_till_done()
+    acc = TelevisionMediaPlayer(hass, hk_driver, "MediaPlayer", entity_id, 2, None)
+    await acc.run_handler()
+    await hass.async_block_till_done()
+
+    assert acc.support_select_source is False
+
+
 async def test_tv_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -23,6 +23,7 @@ from homeassistant.components.homekit.const import (
 from homeassistant.components.homekit.util import (
     HomeKitSpeedMapping,
     SpeedRange,
+    cleanup_name_for_homekit,
     convert_to_float,
     density_to_air_quality,
     dismiss_setup_message,
@@ -175,6 +176,19 @@ def test_convert_to_float():
     assert convert_to_float(12.4) == 12.4
     assert convert_to_float(STATE_UNKNOWN) is None
     assert convert_to_float(None) is None
+
+
+def test_cleanup_name_for_homekit():
+    """Ensure name sanitize works as expected."""
+
+    assert cleanup_name_for_homekit("abc") == "abc"
+    assert cleanup_name_for_homekit("a b c") == "a b c"
+    assert cleanup_name_for_homekit("ab_c") == "ab c"
+    assert (
+        cleanup_name_for_homekit('ab!@#$%^&*()-=":.,><?//\\ frog')
+        == "ab--#---&----- -.,------ frog"
+    )
+    assert cleanup_name_for_homekit("の日本_語文字セット") == "の日本 語文字セット"
 
 
 def test_temperature_to_homekit():


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve stability of homekit media players

* Prevent invalid names from causing homekit crashes

* We were creating switches with "Play/Pause" in the name
and "/" is an invalid name character

* Avoid setting up TV inputs when there are no sources
as it causes a crash on iOS 12

* Auto detect media player features when they
are not configured

* Two places in `media_player.py` were setting the
value to `None` when it should be a `bool`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34914
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
