### PR TITLE
Measure systemmonitor throughput_network_out/in as megabits

### DIFF
--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     CONF_TYPE,
     DATA_GIBIBYTES,
     DATA_MEBIBYTES,
-    DATA_RATE_MEGABYTES_PER_SECOND,
+    DATA_RATE_MEGABITS_PER_SECOND,
     STATE_OFF,
     STATE_ON,
     UNIT_PERCENTAGE,
@@ -46,13 +46,13 @@ SENSOR_TYPES = {
     "packets_out": ["Packets out", " ", "mdi:server-network", None],
     "throughput_network_in": [
         "Network throughput in",
-        DATA_RATE_MEGABYTES_PER_SECOND,
+        DATA_RATE_MEGABITS_PER_SECOND,
         "mdi:server-network",
         None,
     ],
     "throughput_network_out": [
         "Network throughput out",
-        DATA_RATE_MEGABYTES_PER_SECOND,
+        DATA_RATE_MEGABITS_PER_SECOND,
         "mdi:server-network",
         None,
     ],
@@ -203,7 +203,7 @@ class SystemMonitorSensor(Entity):
                 if self._last_value and self._last_value < counter:
                     self._state = round(
                         (counter - self._last_value)
-                        / 1000 ** 2
+                        / 1000 ** 2 * 8
                         / (now - self._last_update_time).seconds,
                         3,
                     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Users who already have the `systemmonitor` module set up will notice a change in how network throughput is reported. However, these changes still reference variables already available in `const.py` so I don't see anything drastically being broken.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Instead of measuring `throughput_network_out` & `throughout_network_in` as mega**bytes**, I instead feel it makes more sense to measure this is mega**bits**.

Typically network speeds are measured in nbits per second (n being kilo, mega, etc.) [This article](https://www.maketecheasier.com/megabits-vs-megabytes-whats-the-difference/) mentions this under the header "Why Use Bits? Why Not Bytes?".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
