### PR TITLE
Clean up device registry if entity registry updates

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -21,7 +21,7 @@ class Debouncer:
         """Initialize debounce.
 
         immediate: indicate if the function needs to be called right away and
-                   wait 0.3s until executing next invocation.
+                   wait <cooldown> until executing next invocation.
         function: optional and can be instantiated later.
         """
         self.hass = hass

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1,15 +1,21 @@
 """Provide a way to connect entities belonging to one device."""
 from collections import OrderedDict
 import logging
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 import uuid
 
 import attr
 
-from homeassistant.core import callback
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import Event, callback
+from homeassistant.loader import bind_hass
 
+from .debounce import Debouncer
 from .singleton import singleton
 from .typing import HomeAssistantType
+
+if TYPE_CHECKING:
+    from . import entity_registry
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 
@@ -21,6 +27,7 @@ EVENT_DEVICE_REGISTRY_UPDATED = "device_registry_updated"
 STORAGE_KEY = "core.device_registry"
 STORAGE_VERSION = 1
 SAVE_DELAY = 10
+CLEANUP_DELAY = 10
 
 CONNECTION_NETWORK_MAC = "mac"
 CONNECTION_UPNP = "upnp"
@@ -285,6 +292,8 @@ class DeviceRegistry:
 
     async def async_load(self):
         """Load the device registry."""
+        async_setup_cleanup(self.hass, self)
+
         data = await self._store.async_load()
 
         devices = OrderedDict()
@@ -347,16 +356,8 @@ class DeviceRegistry:
     @callback
     def async_clear_config_entry(self, config_entry_id: str) -> None:
         """Clear config entry from registry entries."""
-        remove = []
-        for dev_id, device in self.devices.items():
-            if device.config_entries == {config_entry_id}:
-                remove.append(dev_id)
-            else:
-                self._async_update_device(
-                    dev_id, remove_config_entry_id=config_entry_id
-                )
-        for dev_id in remove:
-            self.async_remove_device(dev_id)
+        for device in list(self.devices.values()):
+            self._async_update_device(device.id, remove_config_entry_id=config_entry_id)
 
     @callback
     def async_clear_area_id(self, area_id: str) -> None:
@@ -390,3 +391,69 @@ def async_entries_for_config_entry(
         for device in registry.devices.values()
         if config_entry_id in device.config_entries
     ]
+
+
+@callback
+def async_cleanup(
+    hass: HomeAssistantType,
+    dev_reg: DeviceRegistry,
+    ent_reg: "entity_registry.EntityRegistry",
+) -> None:
+    """Clean up device registry."""
+    # Find all devices that are no longer referenced in the entity registry.
+    referenced = {entry.device_id for entry in ent_reg.entities.values()}
+    orphan = set(dev_reg.devices) - referenced
+
+    for dev_id in orphan:
+        dev_reg.async_remove_device(dev_id)
+
+    # Find all referenced config entries that no longer exist
+    # This shouldn't happen but have not been able to track down the bug :(
+    config_entry_ids = {entry.entry_id for entry in hass.config_entries.async_entries()}
+
+    for device in list(dev_reg.devices.values()):
+        for config_entry_id in device.config_entries:
+            if config_entry_id not in config_entry_ids:
+                dev_reg.async_update_device(
+                    device.id, remove_config_entry_id=config_entry_id
+                )
+
+
+@callback
+def async_setup_cleanup(hass: HomeAssistantType, dev_reg: DeviceRegistry) -> None:
+    """Clean up device registry when entities removed."""
+    from . import entity_registry
+
+    async def cleanup():
+        """Cleanup."""
+        ent_reg = await entity_registry.async_get_registry(hass)
+        async_cleanup(hass, dev_reg, ent_reg)
+
+    debounced_cleanup = Debouncer(
+        hass, _LOGGER, cooldown=CLEANUP_DELAY, immediate=False, function=cleanup
+    )
+
+    async def entity_registry_changed(event: Event) -> None:
+        """Handle entity updated or removed."""
+        if (
+            event.data["action"] == "update"
+            and "device_id" not in event.data["changes"]
+        ) or event.data["action"] == "create":
+            return
+
+        await debounced_cleanup.async_call()
+
+    if hass.is_running:
+        hass.bus.async_listen(
+            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED, entity_registry_changed
+        )
+        return
+
+    async def startup_clean(event: Event) -> None:
+        """Clean up on startup."""
+        hass.bus.async_listen(
+            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED, entity_registry_changed
+        )
+        await debounced_cleanup.async_call()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, startup_clean)

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -8,7 +8,6 @@ import attr
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import Event, callback
-from homeassistant.loader import bind_hass
 
 from .debounce import Debouncer
 from .singleton import singleton
@@ -422,7 +421,7 @@ def async_cleanup(
 @callback
 def async_setup_cleanup(hass: HomeAssistantType, dev_reg: DeviceRegistry) -> None:
     """Clean up device registry when entities removed."""
-    from . import entity_registry
+    from . import entity_registry  # pylint: disable=import-outside-toplevel
 
     async def cleanup():
         """Cleanup."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After startup or when entity registry entries are removed or their device ID is updated, schedule a cleanup of the device registry.

Devices will be removed if:
 - no entities reference them
 - no config entries reference them

That last one is actually a bug, because config entry removal is supposed to do this but somehow it can happen that devices end up referring to a non-existing config entry. I have been unable to track it down but it ends up breaking random things like device automations.

Note: The logic in this PR to remove devices without config entries was modified by https://github.com/home-assistant/core/pull/35977

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
