### PR TITLE
WIP - Add else branch to condition in scripts

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -961,16 +961,16 @@ CONDITION_SCHEMA: vol.Schema = key_value_schemas(
     },
 )
 
-def with_else(value):
-    v = dict(value)
-    if 'else' in v:
-        del v['else']
-    v2 = CONDITION_SCHEMA(v)
-    if 'else' in value:
-        v2['else'] = SCRIPT_SCHEMA(value['else'])
-    return v2
-
-CONDITION_SCHEMA_WITH_ELSE: vol.Schema = with_else
+BRANCH_SCHEMA = vol.Schema({
+        vol.Optional(CONF_ALIAS): string,
+        vol.Required("branch"): vol.All(
+            ensure_list, [{
+                vol.Optional("if"): CONDITION_SCHEMA,
+                vol.Required("sequence"): lambda v: SCRIPT_SCHEMA(v),
+                }]
+            ),
+    }
+)
 
 _SCRIPT_DELAY_SCHEMA = vol.Schema(
     {
@@ -1027,6 +1027,9 @@ def determine_script_action(action: dict) -> str:
     if CONF_SCENE in action:
         return SCRIPT_ACTION_ACTIVATE_SCENE
 
+    if "branch" in action:
+        return "branch"
+
     return SCRIPT_ACTION_CALL_SERVICE
 
 
@@ -1035,9 +1038,10 @@ ACTION_TYPE_SCHEMAS: Dict[str, Callable[[Any], dict]] = {
     SCRIPT_ACTION_DELAY: _SCRIPT_DELAY_SCHEMA,
     SCRIPT_ACTION_WAIT_TEMPLATE: _SCRIPT_WAIT_TEMPLATE_SCHEMA,
     SCRIPT_ACTION_FIRE_EVENT: EVENT_SCHEMA,
-    SCRIPT_ACTION_CHECK_CONDITION: CONDITION_SCHEMA_WITH_ELSE,
+    SCRIPT_ACTION_CHECK_CONDITION: CONDITION_SCHEMA,
     SCRIPT_ACTION_DEVICE_AUTOMATION: DEVICE_ACTION_SCHEMA,
     SCRIPT_ACTION_ACTIVATE_SCENE: _SCRIPT_SCENE_SCHEMA,
+    "branch": BRANCH_SCHEMA,
 }
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -961,6 +961,17 @@ CONDITION_SCHEMA: vol.Schema = key_value_schemas(
     },
 )
 
+def with_else(value):
+    v = dict(value)
+    if 'else' in v:
+        del v['else']
+    v2 = CONDITION_SCHEMA(v)
+    if 'else' in value:
+        v2['else'] = SCRIPT_SCHEMA(value['else'])
+    return v2
+
+CONDITION_SCHEMA_WITH_ELSE: vol.Schema = with_else
+
 _SCRIPT_DELAY_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_ALIAS): string,
@@ -1024,7 +1035,7 @@ ACTION_TYPE_SCHEMAS: Dict[str, Callable[[Any], dict]] = {
     SCRIPT_ACTION_DELAY: _SCRIPT_DELAY_SCHEMA,
     SCRIPT_ACTION_WAIT_TEMPLATE: _SCRIPT_WAIT_TEMPLATE_SCHEMA,
     SCRIPT_ACTION_FIRE_EVENT: EVENT_SCHEMA,
-    SCRIPT_ACTION_CHECK_CONDITION: CONDITION_SCHEMA,
+    SCRIPT_ACTION_CHECK_CONDITION: CONDITION_SCHEMA_WITH_ELSE,
     SCRIPT_ACTION_DEVICE_AUTOMATION: DEVICE_ACTION_SCHEMA,
     SCRIPT_ACTION_ACTIVATE_SCENE: _SCRIPT_SCENE_SCHEMA,
 }

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -311,6 +311,9 @@ class _ScriptRunBase(ABC):
         check = config(self._hass, self._variables)
         self._log("Test condition %s: %s", self._script.last_action, check)
         if not check:
+            if self._action.get("else", False):
+                for _, self._action in enumerate(self._action.get("else")):
+                    await self._async_step(log_exceptions=False)
             raise _StopScript
 
     def _log(self, msg, *args, level=logging.INFO):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the main takeaway from [The future of YAML](https://www.home-assistant.io/blog/2020/04/14/the-future-of-yaml/) is that yaml is *not* going away, we should make it more suitable for where we're using it, e.g. scripts and automations.

~~This is a first step along that road, and adds branching in the form of an `else` option for `condition` steps.~~~
Other steps may comprise adding script-local variables and loops.

Absolute MVP for now. PR for discussion.

Remaining work:
- [ ] Reasonable variable names
- [ ] Better type checking
- [X] Make sure it works for both legacy and non-legacy scripts
- [ ] Tests
- [ ] GUI script editor support
- [ ] Documentation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

This example is deprecated
```yaml
# Example configuration.yaml
script:
  my_branching_script:
  sequence:
    - condition: state
      entity_id: light.bed_light
      state: 'on'
      else:
        - service: system_log.write
          data:
            message: Light is off
    - service: system_log.write
      data:
        message: Light is on
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
