### PR TITLE
Return emulated hue id for update requests

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -712,9 +712,9 @@ def entity_to_json(config, entity):
     return retval
 
 
-def create_hue_success_response(entity_id, attr, value):
+def create_hue_success_response(entity_number, attr, value):
     """Create a success response for an attribute set on a light."""
-    success_key = f"/lights/{entity_id}/state/{attr}"
+    success_key = f"/lights/{entity_number}/state/{attr}"
     return {"success": {success_key: value}}
 
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -506,7 +506,9 @@ class HueOneLightChangeView(HomeAssistantView):
 
         # Create success responses for all received keys
         json_response = [
-            create_hue_success_response(entity_id, HUE_API_STATE_ON, parsed[STATE_ON])
+            create_hue_success_response(
+                entity_number, HUE_API_STATE_ON, parsed[STATE_ON]
+            )
         ]
 
         for (key, val) in (
@@ -517,7 +519,7 @@ class HueOneLightChangeView(HomeAssistantView):
         ):
             if parsed[key] is not None:
                 json_response.append(
-                    create_hue_success_response(entity_id, val, parsed[key])
+                    create_hue_success_response(entity_number, val, parsed[key])
                 )
 
         return self.json(json_response)

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -9,6 +9,7 @@ import requests
 
 from homeassistant import const, setup
 from homeassistant.components import emulated_hue
+from homeassistant.const import HTTP_OK
 
 from tests.common import get_test_home_assistant, get_test_instance_port
 
@@ -51,7 +52,7 @@ class TestEmulatedHue(unittest.TestCase):
         """Test the description."""
         result = requests.get(BRIDGE_URL_BASE.format("/description.xml"), timeout=5)
 
-        assert result.status_code == 200
+        assert result.status_code == HTTP_OK
         assert "text/xml" in result.headers["content-type"]
 
         # Make sure the XML is parsable
@@ -68,7 +69,7 @@ class TestEmulatedHue(unittest.TestCase):
             BRIDGE_URL_BASE.format("/api"), data=json.dumps(request_json), timeout=5
         )
 
-        assert result.status_code == 200
+        assert result.status_code == HTTP_OK
         assert "application/json" in result.headers["content-type"]
 
         resp_json = result.json()
@@ -87,7 +88,7 @@ class TestEmulatedHue(unittest.TestCase):
             timeout=5,
         )
 
-        assert result.status_code == 200
+        assert result.status_code == HTTP_OK
         assert "application/json" in result.headers["content-type"]
 
         resp_json = result.json()


### PR DESCRIPTION
## Proposed change

There is a bug in emulated_hue where HA-style entity IDs (e.g. "light.kitchen") are returned instead of the corresponding emulated IDs for PUT requests. This PR fixes this issue by always returning the emulated number.

Example: `curl -s -d '{"on":true}' -X PUT http://<emulated_hue_ip>/api/username/lights/1/state`
* Expected: `[{"success": {"/lights/1/state/on": true}}]`
* Actual: `[{"success": {"/lights/light.kitchen/state/on": true}}]`

Additionally, the API tests were only written for the now-deprecated Alexa mode, where HA-style IDs are returned. So this PR also changes the corresponding test to correctly deal with and test for numbers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
