### PR TITLE
Update KNX integration to xknx 0.11.3

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -4,15 +4,20 @@ import logging
 import voluptuous as vol
 from xknx import XKNX
 from xknx.devices import ActionCallback, DateTime, DateTimeBroadcastType, ExposeSensor
+from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import XKNXException
 from xknx.io import DEFAULT_MCAST_PORT, ConnectionConfig, ConnectionType
-from xknx.knx import AddressFilter, DPTArray, DPTBinary, GroupAddress, Telegram
+from xknx.telegram import AddressFilter, GroupAddress, Telegram
 
 from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_HOST,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
@@ -35,6 +40,8 @@ CONF_KNX_STATE_UPDATER = "state_updater"
 CONF_KNX_RATE_LIMIT = "rate_limit"
 CONF_KNX_EXPOSE = "expose"
 CONF_KNX_EXPOSE_TYPE = "type"
+CONF_KNX_EXPOSE_ATTRIBUTE = "attribute"
+CONF_KNX_EXPOSE_DEFAULT = "default"
 CONF_KNX_EXPOSE_ADDRESS = "address"
 
 SERVICE_KNX_SEND = "send"
@@ -57,6 +64,8 @@ EXPOSE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_KNX_EXPOSE_TYPE): cv.string,
         vol.Optional(CONF_ENTITY_ID): cv.entity_id,
+        vol.Optional(CONF_KNX_EXPOSE_ATTRIBUTE): cv.string,
+        vol.Optional(CONF_KNX_EXPOSE_DEFAULT): cv.match_all,
         vol.Required(CONF_KNX_EXPOSE_ADDRESS): cv.string,
     }
 )
@@ -244,6 +253,8 @@ class KNXModule:
         for to_expose in self.config[DOMAIN][CONF_KNX_EXPOSE]:
             expose_type = to_expose.get(CONF_KNX_EXPOSE_TYPE)
             entity_id = to_expose.get(CONF_ENTITY_ID)
+            attribute = to_expose.get(CONF_KNX_EXPOSE_ATTRIBUTE)
+            default = to_expose.get(CONF_KNX_EXPOSE_DEFAULT)
             address = to_expose.get(CONF_KNX_EXPOSE_ADDRESS)
             if expose_type in ["time", "date", "datetime"]:
                 exposure = KNXExposeTime(self.xknx, expose_type, address)
@@ -251,7 +262,13 @@ class KNXModule:
                 self.exposures.append(exposure)
             else:
                 exposure = KNXExposeSensor(
-                    self.hass, self.xknx, expose_type, entity_id, address
+                    self.hass,
+                    self.xknx,
+                    expose_type,
+                    entity_id,
+                    attribute,
+                    default,
+                    address,
                 )
                 exposure.async_register()
                 self.exposures.append(exposure)
@@ -325,23 +342,26 @@ class KNXExposeTime:
 class KNXExposeSensor:
     """Object to Expose Home Assistant entity to KNX bus."""
 
-    def __init__(self, hass, xknx, expose_type, entity_id, address):
+    def __init__(self, hass, xknx, expose_type, entity_id, attribute, default, address):
         """Initialize of Expose class."""
         self.hass = hass
         self.xknx = xknx
         self.type = expose_type
         self.entity_id = entity_id
+        self.expose_attribute = attribute
+        self.expose_default = default
         self.address = address
         self.device = None
 
     @callback
     def async_register(self):
         """Register listener."""
+        if self.expose_attribute is not None:
+            _name = self.entity_id + "__" + self.expose_attribute
+        else:
+            _name = self.entity_id
         self.device = ExposeSensor(
-            self.xknx,
-            name=self.entity_id,
-            group_address=self.address,
-            value_type=self.type,
+            self.xknx, name=_name, group_address=self.address, value_type=self.type,
         )
         self.xknx.devices.add(self.device)
         async_track_state_change(self.hass, self.entity_id, self._async_entity_changed)
@@ -350,13 +370,31 @@ class KNXExposeSensor:
         """Handle entity change."""
         if new_state is None:
             return
-        if new_state.state == "unknown":
+        if new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             return
 
-        if self.type == "binary":
-            if new_state.state == "on":
-                await self.device.set(True)
-            elif new_state.state == "off":
-                await self.device.set(False)
+        if self.expose_attribute is not None:
+            new_attribute = new_state.attributes.get(self.expose_attribute)
+            if old_state is not None:
+                old_attribute = old_state.attributes.get(self.expose_attribute)
+                if old_attribute == new_attribute:
+                    # don't send same value sequentially
+                    return
+            await self._async_set_knx_value(new_attribute)
         else:
-            await self.device.set(new_state.state)
+            await self._async_set_knx_value(new_state.state)
+
+    async def _async_set_knx_value(self, value):
+        """Set new value on xknx ExposeSensor."""
+        if value is None:
+            if self.expose_default is None:
+                return
+            value = self.expose_default
+
+        if self.type == "binary":
+            if value == STATE_ON:
+                value = True
+            elif value == STATE_OFF:
+                value = False
+
+        await self.device.set(value)

--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -124,6 +124,10 @@ class KNXBinarySensor(BinarySensorEntity):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -116,6 +116,10 @@ class KNXCover(CoverEntity):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -162,6 +162,10 @@ class KNXLight(LightEntity):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,6 +2,6 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.11.2"],
+  "requirements": ["xknx==0.11.3"],
   "codeowners": ["@Julius2342"]
 }

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -77,6 +77,10 @@ class KNXSensor(Entity):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Update the state from KNX."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -73,6 +73,10 @@ class KNXSwitch(SwitchEntity):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2167,7 +2167,7 @@ xboxapi==0.1.1
 xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
-xknx==0.11.2
+xknx==0.11.3
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates xknx requirement of knx integration to 0.11.3

- added a lot of DPT definitions now useable as sensor type
- add expose attribute function (eg. expose brightness of a light) and expose default value
- default climate havc_mode to "heat" if modes are not supported (https://github.com/home-assistant/core/issues/30204#issuecomment-617485750)
- support `update_entity` service call
- bugfixes from [xknx 0.11.3](https://github.com/XKNX/xknx/releases/tag/0.11.3)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32394
- This PR is related to issue: #30204 (may fix it)
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13277

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
