### PR TITLE
New configuration flow for ZHA integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -860,7 +860,6 @@ omit =
     homeassistant/components/zengge/light.py
     homeassistant/components/zeroconf/*
     homeassistant/components/zestimate/sensor.py
-    homeassistant/components/zha/__init__.py
     homeassistant/components/zha/api.py
     homeassistant/components/zha/core/channels/*
     homeassistant/components/zha/core/const.py

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -161,19 +161,17 @@ async def async_migrate_entry(
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:
-        config_entry.data = {
+        data = {
             CONF_RADIO_TYPE: config_entry.data[CONF_RADIO_TYPE],
             CONF_DEVICE: {CONF_DEVICE_PATH: config_entry.data[CONF_USB_PATH]},
         }
 
         baudrate = hass.data[DATA_ZHA].get(DATA_ZHA_CONFIG, {}).get(CONF_BAUDRATE)
-        if (
-            config_entry.data[CONF_RADIO_TYPE] != RadioType.deconz
-            and baudrate in BAUD_RATES
-        ):
-            config_entry.data[CONF_DEVICE][CONF_BAUDRATE] = baudrate
+        if data[CONF_RADIO_TYPE] != RadioType.deconz and baudrate in BAUD_RATES:
+            data[CONF_DEVICE][CONF_BAUDRATE] = baudrate
 
         config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data=data)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -54,7 +54,6 @@ CONFIG_SCHEMA = vol.Schema(
                 cv.deprecated(CONF_RADIO_TYPE, invalidation_version="0.112"),
                 ZHA_CONFIG_SCHEMA,
             ),
-            extra=vol.ALLOW_EXTRA,
         ),
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -71,23 +71,10 @@ async def async_setup(hass, config):
     """Set up ZHA from config."""
     hass.data[DATA_ZHA] = {}
 
-    if DOMAIN not in config:
-        return True
+    if DOMAIN in config:
+        conf = config[DOMAIN]
+        hass.data[DATA_ZHA][DATA_ZHA_CONFIG] = conf
 
-    conf = config[DOMAIN]
-    hass.data[DATA_ZHA][DATA_ZHA_CONFIG] = conf
-
-    if not hass.config_entries.async_entries(DOMAIN):
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_IMPORT},
-                data={
-                    CONF_DEVICE: conf[CONF_DEVICE],
-                    CONF_RADIO_TYPE: conf[CONF_RADIO_TYPE].value,
-                },
-            )
-        )
     return True
 
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -54,15 +54,6 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         schema = vol.Schema({vol.Required(CONF_DEVICE_PATH): vol.In(list_of_ports)})
         return self.async_show_form(step_id="user", data_schema=schema)
 
-    async def async_step_import(self, import_info):
-        """Handle a zha config import."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
-        return self.async_create_entry(
-            title=import_info[CONF_DEVICE][CONF_DEVICE_PATH], data=import_info
-        )
-
     async def async_step_pick_radio(self, user_input=None):
         """Select radio type."""
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -22,7 +22,7 @@ from .core.registries import RADIO_TYPES
 class ZhaFlowHandler(config_entries.ConfigFlow):
     """Handle a config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -52,7 +52,7 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             dev_path = await self.hass.async_add_executor_job(
                 get_serial_by_id, port.device
             )
-            auto_detected_data = await self.detect_radios(dev_path)
+            auto_detected_data = await detect_radios(dev_path)
             if auto_detected_data is not None:
                 title = f"{port.description}, s/n: {port.serial_number or 'n/a'}"
                 title += f" - {port.manufacturer}" if port.manufacturer else ""
@@ -106,16 +106,16 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    @staticmethod
-    async def detect_radios(dev_path: str) -> Optional[Dict[str, Any]]:
-        """Probe all radio types on the device port."""
-        for radio in RadioType.list():
-            app_cls = RADIO_TYPES[radio][CONTROLLER]
-            dev_config = app_cls.SCHEMA_DEVICE({CONF_DEVICE_PATH: dev_path})
-            if await app_cls.probe(dev_config):
-                return {CONF_RADIO_TYPE: radio, CONF_DEVICE: dev_config}
 
-        return None
+async def detect_radios(dev_path: str) -> Optional[Dict[str, Any]]:
+    """Probe all radio types on the device port."""
+    for radio in RadioType.list():
+        app_cls = RADIO_TYPES[radio][CONTROLLER]
+        dev_config = app_cls.SCHEMA_DEVICE({CONF_DEVICE_PATH: dev_path})
+        if await app_cls.probe(dev_config):
+            return {CONF_RADIO_TYPE: radio, CONF_DEVICE: dev_config}
+
+    return None
 
 
 def get_serial_by_id(dev_path: str) -> str:

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -1,59 +1,58 @@
 """Config flow for ZHA."""
-import asyncio
-from collections import OrderedDict
-import os
+from typing import Any, Dict, Optional
 
+import serial.tools.list_ports
 import voluptuous as vol
-from zigpy.config import CONF_DATABASE, CONF_DEVICE, CONF_DEVICE_PATH
+from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
 from homeassistant import config_entries
 
-from .core.const import (
-    CONF_RADIO_TYPE,
-    CONTROLLER,
-    DEFAULT_DATABASE_NAME,
-    DOMAIN,
-    RadioType,
-)
+from .core.const import CONF_RADIO_TYPE, CONTROLLER, DOMAIN, RadioType
 from .core.registries import RADIO_TYPES
 
+CONF_MANUAL_PATH = "Enter Manually"
 
-@config_entries.HANDLERS.register(DOMAIN)
-class ZhaFlowHandler(config_entries.ConfigFlow):
+
+class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    def __init__(self):
+        """Initialize flow instance."""
+        self._device_path = None
+        self._radio_type = None
 
     async def async_step_user(self, user_input=None):
         """Handle a zha config flow start."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
-        errors = {}
-
-        fields = OrderedDict()
-        fields[vol.Required(CONF_DEVICE_PATH)] = str
-        fields[vol.Optional(CONF_RADIO_TYPE, default="ezsp")] = vol.In(RadioType.list())
+        ports = serial.tools.list_ports.comports()
+        list_of_ports = [
+            f"{p}, s/n: {p.serial_number} - {p.manufacturer}" for p in ports
+        ]
+        list_of_ports.append(CONF_MANUAL_PATH)
 
         if user_input is not None:
-            database = os.path.join(self.hass.config.config_dir, DEFAULT_DATABASE_NAME)
-            test = await check_zigpy_connection(
-                user_input[CONF_DEVICE_PATH], user_input[CONF_RADIO_TYPE], database
-            )
-            if test:
-                return self.async_create_entry(
-                    title=user_input[CONF_DEVICE_PATH],
-                    data={
-                        CONF_DEVICE: {CONF_DEVICE_PATH: user_input[CONF_DEVICE_PATH]},
-                        CONF_RADIO_TYPE: user_input[CONF_RADIO_TYPE],
-                    },
-                )
-            errors["base"] = "cannot_connect"
+            user_selection = user_input[CONF_DEVICE_PATH]
+            if user_selection == CONF_MANUAL_PATH:
+                return await self.async_step_pick_radio()
 
-        return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(fields), errors=errors
-        )
+            dev_path = ports[list_of_ports.index(user_selection)].device
+            auto_detected_data = await self.detect_radios(dev_path)
+            if auto_detected_data is not None:
+                return self.async_create_entry(
+                    title=user_selection, data=auto_detected_data,
+                )
+
+            # did not detect anything
+            self._device_path = dev_path
+            return await self.async_step_pick_radio()
+
+        schema = vol.Schema({vol.Required(CONF_DEVICE_PATH): vol.In(list_of_ports)})
+        return self.async_show_form(step_id="user", data_schema=schema)
 
     async def async_step_import(self, import_info):
         """Handle a zha config import."""
@@ -64,21 +63,50 @@ class ZhaFlowHandler(config_entries.ConfigFlow):
             title=import_info[CONF_DEVICE][CONF_DEVICE_PATH], data=import_info
         )
 
+    async def async_step_pick_radio(self, user_input=None):
+        """Select radio type."""
 
-async def check_zigpy_connection(usb_path, radio_type, database_path):
-    """Test zigpy radio connection."""
-    try:
-        controller_application = RADIO_TYPES[radio_type][CONTROLLER]
-    except KeyError:
-        return False
-    try:
-        config = controller_application.SCHEMA(
-            {CONF_DEVICE: {CONF_DEVICE_PATH: usb_path}, CONF_DATABASE: database_path}
+        if user_input is not None:
+            self._radio_type = user_input[CONF_RADIO_TYPE]
+            return await self.async_step_port_config()
+
+        schema = {vol.Required(CONF_RADIO_TYPE): vol.In(sorted(RadioType.list()))}
+        return self.async_show_form(
+            step_id="pick_radio", data_schema=vol.Schema(schema),
         )
-        controller = await asyncio.wait_for(
-            controller_application.new(config), timeout=30
+
+    async def async_step_port_config(self, user_input=None):
+        """Enter port settings specific for this type of radio."""
+        errors = {}
+        app_cls = RADIO_TYPES[self._radio_type][CONTROLLER]
+
+        if user_input is not None:
+            self._device_path = user_input.get(CONF_DEVICE_PATH)
+            if await app_cls.probe(user_input):
+                return self.async_create_entry(
+                    title=user_input[CONF_DEVICE_PATH],
+                    data={CONF_DEVICE: user_input, CONF_RADIO_TYPE: self._radio_type},
+                )
+            errors["base"] = "cannot_connect"
+
+        schema = {
+            vol.Required(
+                CONF_DEVICE_PATH, default=self._device_path or vol.UNDEFINED
+            ): str
+        }
+        return self.async_show_form(
+            step_id="port_config",
+            data_schema=app_cls.SCHEMA_DEVICE.extend(schema),
+            errors=errors,
         )
-        await controller.shutdown()
-    except Exception:  # pylint: disable=broad-except
-        return False
-    return True
+
+    @staticmethod
+    async def detect_radios(dev_path: str) -> Optional[Dict[str, Any]]:
+        """Probe all radio types on the device port."""
+        for radio in RadioType.list():
+            app_cls = RADIO_TYPES[radio][CONTROLLER]
+            dev_config = app_cls.SCHEMA_DEVICE({CONF_DEVICE_PATH: dev_path})
+            if await app_cls.probe(dev_config):
+                return {CONF_RADIO_TYPE: radio, CONF_DEVICE: dev_config}
+
+        return None

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -29,9 +29,11 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
-        ports = serial.tools.list_ports.comports()
+        ports = serial.tools.list_ports.comports(include_links=False)
         list_of_ports = [
-            f"{p}, s/n: {p.serial_number} - {p.manufacturer}" for p in ports
+            f"{p}, s/n: {p.serial_number or 'n/a'}"
+            + (f" - {p.manufacturer}" if p.manufacturer else "")
+            for p in ports
         ]
         list_of_ports.append(CONF_MANUAL_PATH)
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -9,6 +9,8 @@ from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 from homeassistant import config_entries
 
 from .core.const import (  # pylint:disable=unused-import
+    CONF_BAUDRATE,
+    CONF_FLOWCONTROL,
     CONF_RADIO_TYPE,
     CONTROLLER,
     DOMAIN,
@@ -17,6 +19,10 @@ from .core.const import (  # pylint:disable=unused-import
 from .core.registries import RADIO_TYPES
 
 CONF_MANUAL_PATH = "Enter Manually"
+SUPPORTED_PORT_SETTINGS = (
+    CONF_BAUDRATE,
+    CONF_FLOWCONTROL,
+)
 
 
 class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -100,10 +106,16 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_DEVICE_PATH, default=self._device_path or vol.UNDEFINED
             ): str
         }
+        radio_schema = app_cls.SCHEMA_DEVICE.schema
+        if isinstance(radio_schema, vol.Schema):
+            radio_schema = radio_schema.schema
+
+        for param, value in radio_schema.items():
+            if param in SUPPORTED_PORT_SETTINGS:
+                schema[param] = value
+
         return self.async_show_form(
-            step_id="port_config",
-            data_schema=app_cls.SCHEMA_DEVICE.extend(schema),
-            errors=errors,
+            step_id="port_config", data_schema=vol.Schema(schema), errors=errors,
         )
 
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -8,7 +8,12 @@ from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
 from homeassistant import config_entries
 
-from .core.const import CONF_RADIO_TYPE, CONTROLLER, DOMAIN, RadioType
+from .core.const import (  # pylint:disable=unused-import
+    CONF_RADIO_TYPE,
+    CONTROLLER,
+    DOMAIN,
+    RadioType,
+)
 from .core.registries import RADIO_TYPES
 
 CONF_MANUAL_PATH = "Enter Manually"

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -94,6 +94,7 @@ CONF_DEVICE_CONFIG = "device_config"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
+CONF_ZIGPY = "zigpy_config"
 CONTROLLER = "controller"
 
 DATA_DEVICE_CONFIG = "zha_device_config"

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -259,7 +259,6 @@ ZHA_GW_MSG_GROUP_REMOVED = "group_removed"
 ZHA_GW_MSG_LOG_ENTRY = "log_entry"
 ZHA_GW_MSG_LOG_OUTPUT = "log_output"
 ZHA_GW_MSG_RAW_INIT = "raw_device_initialized"
-ZHA_GW_RADIO = "radio"
 ZHA_GW_RADIO_DESCRIPTION = "radio_description"
 
 EFFECT_BLINK = 0x00

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -146,11 +146,11 @@ POWER_BATTERY_OR_UNKNOWN = "Battery or Unknown"
 class RadioType(enum.Enum):
     """Possible options for radio type."""
 
-    deconz = "deconz"
     ezsp = "ezsp"
+    deconz = "deconz"
     ti_cc = "ti_cc"
-    xbee = "xbee"
     zigate = "zigate"
+    xbee = "xbee"
 
     @classmethod
     def list(cls):

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -2,6 +2,8 @@
 import enum
 import logging
 
+from zigpy.config import CONF_DEVICE_PATH  # noqa: F401 # pylint: disable=unused-import
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.cover import DOMAIN as COVER
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
@@ -92,6 +94,7 @@ CONF_BAUDRATE = "baudrate"
 CONF_DATABASE = "database_path"
 CONF_DEVICE_CONFIG = "device_config"
 CONF_ENABLE_QUIRKS = "enable_quirks"
+CONF_FLOWCONTROL = "flow_control"
 CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
 CONF_ZIGPY = "zigpy_config"

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -10,6 +10,7 @@ import traceback
 from typing import List, Optional
 
 from serial import SerialException
+from zigpy.config import CONF_DEVICE
 import zigpy.device as zigpy_dev
 
 from homeassistant.components.system_log import LogEntry, _figure_out_source
@@ -33,10 +34,9 @@ from .const import (
     ATTR_NWK,
     ATTR_SIGNATURE,
     ATTR_TYPE,
-    CONF_BAUDRATE,
     CONF_DATABASE,
     CONF_RADIO_TYPE,
-    CONF_USB_PATH,
+    CONF_ZIGPY,
     CONTROLLER,
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
@@ -52,7 +52,6 @@ from .const import (
     DEBUG_LEVEL_ORIGINAL,
     DEBUG_LEVELS,
     DEBUG_RELAY_LOGGERS,
-    DEFAULT_BAUDRATE,
     DEFAULT_DATABASE_NAME,
     DOMAIN,
     SIGNAL_ADD_ENTITIES,
@@ -74,7 +73,6 @@ from .const import (
     ZHA_GW_MSG_LOG_ENTRY,
     ZHA_GW_MSG_LOG_OUTPUT,
     ZHA_GW_MSG_RAW_INIT,
-    ZHA_GW_RADIO,
     ZHA_GW_RADIO_DESCRIPTION,
 )
 from .device import DeviceStatus, ZHADevice
@@ -125,43 +123,35 @@ class ZHAGateway:
         self.ha_device_registry = await get_dev_reg(self._hass)
         self.ha_entity_registry = await get_ent_reg(self._hass)
 
-        usb_path = self._config_entry.data.get(CONF_USB_PATH)
-        baudrate = self._config.get(CONF_BAUDRATE, DEFAULT_BAUDRATE)
-        radio_type = self._config_entry.data.get(CONF_RADIO_TYPE)
+        radio_type = self._config_entry.data[CONF_RADIO_TYPE]
 
-        radio_details = RADIO_TYPES[radio_type]
-        radio = radio_details[ZHA_GW_RADIO]()
-        self.radio_description = radio_details[ZHA_GW_RADIO_DESCRIPTION]
+        app_controller_cls = RADIO_TYPES[radio_type][CONTROLLER]
+        self.radio_description = RADIO_TYPES[radio_type][ZHA_GW_RADIO_DESCRIPTION]
+
+        app_config = self._config.get(CONF_ZIGPY, {})
+        database = self._config.get(
+            CONF_DATABASE,
+            os.path.join(self._hass.config.config_dir, DEFAULT_DATABASE_NAME),
+        )
+        app_config[CONF_DATABASE] = database
+        app_config[CONF_DEVICE] = self._config_entry.data[CONF_DEVICE]
+
+        app_config = app_controller_cls.SCHEMA(app_config)
         try:
-            await radio.connect(usb_path, baudrate)
-        except (SerialException, OSError) as exception:
-            _LOGGER.error("Couldn't open serial port for ZHA: %s", str(exception))
-            raise ConfigEntryNotReady
+            self.application_controller = await app_controller_cls.new(
+                app_config, auto_form=True, start_radio=True
+            )
+        except (asyncio.TimeoutError, SerialException, OSError) as exception:
+            _LOGGER.error(
+                "Couldn't start %s coordinator",
+                self.radio_description,
+                exc_info=exception,
+            )
+            raise ConfigEntryNotReady from exception
 
-        if CONF_DATABASE in self._config:
-            database = self._config[CONF_DATABASE]
-        else:
-            database = os.path.join(self._hass.config.config_dir, DEFAULT_DATABASE_NAME)
-
-        self.application_controller = radio_details[CONTROLLER](radio, database)
         apply_application_controller_patch(self)
         self.application_controller.add_listener(self)
         self.application_controller.groups.add_listener(self)
-
-        try:
-            res = await self.application_controller.startup(auto_form=True)
-            if res is False:
-                await self.application_controller.shutdown()
-                raise ConfigEntryNotReady
-        except asyncio.TimeoutError as exception:
-            _LOGGER.error(
-                "Couldn't start %s coordinator",
-                radio_details[ZHA_GW_RADIO_DESCRIPTION],
-                exc_info=exception,
-            )
-            radio.close()
-            raise ConfigEntryNotReady from exception
-
         self._hass.data[DATA_ZHA][DATA_ZHA_GATEWAY] = self
         self._hass.data[DATA_ZHA][DATA_ZHA_BRIDGE_ID] = str(
             self.application_controller.ieee

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -3,18 +3,13 @@ import collections
 from typing import Callable, Dict, List, Set, Tuple, Union
 
 import attr
-import bellows.ezsp
 import bellows.zigbee.application
 import zigpy.profiles.zha
 import zigpy.profiles.zll
 import zigpy.zcl as zcl
-import zigpy_cc.api
 import zigpy_cc.zigbee.application
-import zigpy_deconz.api
 import zigpy_deconz.zigbee.application
-import zigpy_xbee.api
 import zigpy_xbee.zigbee.application
-import zigpy_zigate.api
 import zigpy_zigate.zigbee.application
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
@@ -28,7 +23,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH
 
 # importing channels updates registries
 from . import channels as zha_channels  # noqa: F401 pylint: disable=unused-import
-from .const import CONTROLLER, ZHA_GW_RADIO, ZHA_GW_RADIO_DESCRIPTION, RadioType
+from .const import CONTROLLER, ZHA_GW_RADIO_DESCRIPTION, RadioType
 from .decorators import CALLABLE_T, DictRegistry, SetRegistry
 from .typing import ChannelType
 
@@ -131,27 +126,22 @@ CLIENT_CHANNELS_REGISTRY = DictRegistry()
 
 RADIO_TYPES = {
     RadioType.deconz.name: {
-        ZHA_GW_RADIO: zigpy_deconz.api.Deconz,
         CONTROLLER: zigpy_deconz.zigbee.application.ControllerApplication,
         ZHA_GW_RADIO_DESCRIPTION: "Deconz",
     },
     RadioType.ezsp.name: {
-        ZHA_GW_RADIO: bellows.ezsp.EZSP,
         CONTROLLER: bellows.zigbee.application.ControllerApplication,
         ZHA_GW_RADIO_DESCRIPTION: "EZSP",
     },
     RadioType.ti_cc.name: {
-        ZHA_GW_RADIO: zigpy_cc.api.API,
         CONTROLLER: zigpy_cc.zigbee.application.ControllerApplication,
         ZHA_GW_RADIO_DESCRIPTION: "TI CC",
     },
     RadioType.xbee.name: {
-        ZHA_GW_RADIO: zigpy_xbee.api.XBee,
         CONTROLLER: zigpy_xbee.zigbee.application.ControllerApplication,
         ZHA_GW_RADIO_DESCRIPTION: "XBee",
     },
     RadioType.zigate.name: {
-        ZHA_GW_RADIO: zigpy_zigate.api.ZiGate,
         CONTROLLER: zigpy_zigate.zigbee.application.ControllerApplication,
         ZHA_GW_RADIO_DESCRIPTION: "ZiGate",
     },

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,13 +4,14 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
-    "bellows-homeassistant==0.15.2",
+    "bellows==0.16.1",
+    "pyserial==3.4",
     "zha-quirks==0.0.38",
-    "zigpy-cc==0.3.1",
-    "zigpy-deconz==0.8.1",
-    "zigpy-homeassistant==0.19.0",
-    "zigpy-xbee-homeassistant==0.11.0",
-    "zigpy-zigate==0.5.1"
+    "zigpy-cc==0.4.2",
+    "zigpy-deconz==0.9.1",
+    "zigpy==0.20.1",
+    "zigpy-xbee==0.12.1",
+    "zigpy-zigate==0.6.1"
   ],
   "codeowners": ["@dmulcahey", "@adminiuga"]
 }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -3,9 +3,21 @@
     "step": {
       "user": {
         "title": "ZHA",
+        "data": { "path": "Serial Device Path" },
+        "description": "Select serial port for Zigbee radio"
+      },
+      "pick_radio": {
+        "data": { "radio_type": "Radio Type" },
+        "title": "Radio Type",
+        "description": "Pick a type of your Zigbee radio"
+      },
+      "port_config": {
+        "title": "Settings",
+        "description": "Enter port specific settings",
         "data": {
-          "radio_type": "Radio Type",
-          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+          "path": "Serial device path",
+          "baudrate": "port speed",
+          "flow_control": "data flow control"
         }
       }
     },

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -7,11 +7,27 @@
             "cannot_connect": "Unable to connect to ZHA device."
         },
         "step": {
+            "pick_radio": {
+                "data": {
+                    "radio_type": "Radio Type"
+                },
+                "description": "Pick a type of your Zigbee radio",
+                "title": "Radio Type"
+            },
+            "port_config": {
+                "data": {
+                    "baudrate": "port speed",
+                    "flow_control": "data flow control",
+                    "path": "Serial device path"
+                },
+                "description": "Enter port specific settings",
+                "title": "Settings"
+            },
             "user": {
                 "data": {
-                    "radio_type": "Radio Type",
-                    "usb_path": "USB Device Path"
+                    "path": "Serial Device Path"
                 },
+                "description": "Select serial port for Zigbee radio",
                 "title": "ZHA"
             }
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -327,7 +327,7 @@ beautifulsoup4==4.9.0
 beewi_smartclim==0.0.7
 
 # homeassistant.components.zha
-bellows-homeassistant==0.15.2
+bellows==0.16.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.7.5
@@ -1557,6 +1557,7 @@ pysensibo==1.0.3
 pyserial-asyncio==0.4
 
 # homeassistant.components.acer_projector
+# homeassistant.components.zha
 pyserial==3.4
 
 # homeassistant.components.sesame
@@ -2217,19 +2218,19 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-cc==0.3.1
+zigpy-cc==0.4.2
 
 # homeassistant.components.zha
-zigpy-deconz==0.8.1
+zigpy-deconz==0.9.1
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.19.0
+zigpy-xbee==0.12.1
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.11.0
+zigpy-zigate==0.6.1
 
 # homeassistant.components.zha
-zigpy-zigate==0.5.1
+zigpy==0.20.1
 
 # homeassistant.components.zoneminder
 zm-py==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -141,7 +141,7 @@ axis==25
 base36==0.1.1
 
 # homeassistant.components.zha
-bellows-homeassistant==0.15.2
+bellows==0.16.1
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.2
@@ -634,6 +634,10 @@ pyps4-2ndscreen==1.0.7
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93
 
+# homeassistant.components.acer_projector
+# homeassistant.components.zha
+pyserial==3.4
+
 # homeassistant.components.signal_messenger
 pysignalclirestapi==0.3.4
 
@@ -857,16 +861,16 @@ zeroconf==0.26.0
 zha-quirks==0.0.38
 
 # homeassistant.components.zha
-zigpy-cc==0.3.1
+zigpy-cc==0.4.2
 
 # homeassistant.components.zha
-zigpy-deconz==0.8.1
+zigpy-deconz==0.9.1
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.19.0
+zigpy-xbee==0.12.1
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.11.0
+zigpy-zigate==0.6.1
 
 # homeassistant.components.zha
-zigpy-zigate==0.5.1
+zigpy==0.20.1

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 import zigpy
 from zigpy.application import ControllerApplication
+import zigpy.config
 import zigpy.group
 import zigpy.types
 
@@ -49,12 +50,11 @@ def zigpy_radio():
 async def config_entry_fixture(hass):
     """Fixture representing a config entry."""
     entry = MockConfigEntry(
-        version=1,
+        version=2,
         domain=zha_const.DOMAIN,
         data={
-            zha_const.CONF_BAUDRATE: zha_const.DEFAULT_BAUDRATE,
+            zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: "/dev/ttyUSB0"},
             zha_const.CONF_RADIO_TYPE: "MockRadio",
-            zha_const.CONF_USB_PATH: "/dev/ttyUSB0",
         },
     )
     entry.add_to_hass(hass)
@@ -65,9 +65,13 @@ async def config_entry_fixture(hass):
 def setup_zha(hass, config_entry, zigpy_app_controller, zigpy_radio):
     """Set up ZHA component."""
     zha_config = {zha_const.CONF_ENABLE_QUIRKS: False}
+    app_ctrl = mock.MagicMock()
+    app_ctrl.new = CoroutineMock(return_value=zigpy_app_controller)
+    app_ctrl.SCHEMA = zigpy.config.CONFIG_SCHEMA
+    app_ctrl.SCHEMA_DEVICE = zigpy.config.SCHEMA_DEVICE
 
     radio_details = {
-        zha_const.CONTROLLER: mock.MagicMock(return_value=zigpy_app_controller),
+        zha_const.CONTROLLER: app_ctrl,
         zha_const.ZHA_GW_RADIO_DESCRIPTION: "mock radio",
     }
 

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -66,7 +66,7 @@ def setup_zha(hass, config_entry, zigpy_app_controller, zigpy_radio):
     """Set up ZHA component."""
     zha_config = {zha_const.CONF_ENABLE_QUIRKS: False}
     app_ctrl = mock.MagicMock()
-    app_ctrl.new = CoroutineMock(return_value=zigpy_app_controller)
+    app_ctrl.new = tests.async_mock.AsyncMock(return_value=zigpy_app_controller)
     app_ctrl.SCHEMA = zigpy.config.CONFIG_SCHEMA
     app_ctrl.SCHEMA_DEVICE = zigpy.config.SCHEMA_DEVICE
 

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -67,7 +67,6 @@ def setup_zha(hass, config_entry, zigpy_app_controller, zigpy_radio):
     zha_config = {zha_const.CONF_ENABLE_QUIRKS: False}
 
     radio_details = {
-        zha_const.ZHA_GW_RADIO: mock.MagicMock(return_value=zigpy_radio),
         zha_const.CONTROLLER: mock.MagicMock(return_value=zigpy_app_controller),
         zha_const.ZHA_GW_RADIO_DESCRIPTION: "mock radio",
     }

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -29,9 +29,6 @@ def com_port():
 )
 async def test_user_flow(hass):
     """Test user flow."""
-    flow = config_flow.ZhaFlowHandler()
-    flow.hass = hass
-
     port = com_port()
     port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -2,7 +2,7 @@
 from unittest import mock
 
 from homeassistant.components.zha import config_flow
-from homeassistant.components.zha.core.const import CONTROLLER, DOMAIN, ZHA_GW_RADIO
+from homeassistant.components.zha.core.const import CONTROLLER, DOMAIN
 import homeassistant.components.zha.core.registries
 
 import tests.async_mock
@@ -80,19 +80,17 @@ async def test_check_zigpy_connection():
 
     mock_radio = tests.async_mock.MagicMock()
     mock_radio.connect = tests.async_mock.AsyncMock()
-    radio_cls = tests.async_mock.MagicMock(return_value=mock_radio)
 
     bad_radio = tests.async_mock.MagicMock()
     bad_radio.connect = tests.async_mock.AsyncMock(side_effect=Exception)
-    bad_radio_cls = tests.async_mock.MagicMock(return_value=bad_radio)
 
     mock_ctrl = tests.async_mock.MagicMock()
     mock_ctrl.startup = tests.async_mock.AsyncMock()
     mock_ctrl.shutdown = tests.async_mock.AsyncMock()
     ctrl_cls = tests.async_mock.MagicMock(return_value=mock_ctrl)
     new_radios = {
-        mock.sentinel.radio: {ZHA_GW_RADIO: radio_cls, CONTROLLER: ctrl_cls},
-        mock.sentinel.bad_radio: {ZHA_GW_RADIO: bad_radio_cls, CONTROLLER: ctrl_cls},
+        mock.sentinel.radio: {CONTROLLER: ctrl_cls},
+        mock.sentinel.bad_radio: {CONTROLLER: ctrl_cls},
     }
 
     with mock.patch.dict(

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -7,6 +7,9 @@ import zigpy.config
 
 from homeassistant.components.zha import config_flow
 from homeassistant.components.zha.core.const import CONF_RADIO_TYPE, CONTROLLER, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_SOURCE
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
 
 from tests.async_mock import AsyncMock, MagicMock, patch, sentinel
 from tests.common import MockConfigEntry
@@ -24,47 +27,66 @@ def com_port():
 
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch.object(
+    config_flow,
+    "detect_radios",
+    AsyncMock(return_value={CONF_RADIO_TYPE: "test_radio"}),
+)
 async def test_user_flow(hass):
-    """Test user flow."""
-
-    flow = config_flow.ZhaFlowHandler()
-    flow.hass = hass
+    """Test user flow -- radio detected."""
 
     port = com_port()
     port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
 
-    with patch.object(
-        flow, "detect_radios", return_value=sentinel.data,
-    ):
-        result = await flow.async_step_user(
-            user_input={zigpy.config.CONF_DEVICE_PATH: port_select}
-        )
-    assert result["type"] == "create_entry"
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={zigpy.config.CONF_DEVICE_PATH: port_select},
+    )
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"].startswith(port.description)
-    assert result["data"] is sentinel.data
+    assert result["data"] == {CONF_RADIO_TYPE: "test_radio"}
 
-    with patch.object(
-        flow, "detect_radios", return_value=None,
-    ):
-        result = await flow.async_step_user(
-            user_input={zigpy.config.CONF_DEVICE_PATH: port_select}
-        )
 
-    assert result["type"] == "form"
+@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch.object(
+    config_flow, "detect_radios", AsyncMock(return_value=None),
+)
+async def test_user_flow_not_detected(hass):
+    """Test user flow, radio not detected."""
+
+    port = com_port()
+    port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={zigpy.config.CONF_DEVICE_PATH: port_select},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "pick_radio"
 
-    await flow.async_step_user()
+
+async def test_user_flow_show_form(hass):
+    """Test user step form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
 
 
 async def test_user_flow_manual(hass):
     """Test user flow manual entry."""
-    flow = config_flow.ZhaFlowHandler()
-    flow.hass = hass
 
-    result = await flow.async_step_user(
-        user_input={zigpy.config.CONF_DEVICE_PATH: config_flow.CONF_MANUAL_PATH}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={zigpy.config.CONF_DEVICE_PATH: config_flow.CONF_MANUAL_PATH},
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "pick_radio"
 
 
@@ -74,7 +96,7 @@ async def test_pick_radio_flow(hass):
     flow.hass = hass
 
     result = await flow.async_step_pick_radio({CONF_RADIO_TYPE: "ezsp"})
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "port_config"
 
     await flow.async_step_pick_radio()
@@ -97,11 +119,8 @@ async def test_probe_radios(hass):
     app_ctrl_cls.SCHEMA_DEVICE = zigpy.config.SCHEMA_DEVICE
     app_ctrl_cls.probe = AsyncMock(side_effect=(True, False))
 
-    flow = config_flow.ZhaFlowHandler()
-    flow.hass = hass
-
     with patch.dict(config_flow.RADIO_TYPES, {"ezsp": {CONTROLLER: app_ctrl_cls}}):
-        res = await flow.detect_radios("/dev/null")
+        res = await config_flow.detect_radios("/dev/null")
         assert app_ctrl_cls.probe.await_count == 1
         assert res[CONF_RADIO_TYPE] == "ezsp"
         assert zigpy.config.CONF_DEVICE in res
@@ -109,7 +128,7 @@ async def test_probe_radios(hass):
             res[zigpy.config.CONF_DEVICE][zigpy.config.CONF_DEVICE_PATH] == "/dev/null"
         )
 
-        res = await flow.detect_radios("/dev/null")
+        res = await config_flow.detect_radios("/dev/null")
         assert res is None
 
 
@@ -127,7 +146,7 @@ async def test_user_port_config_fail(hass):
         result = await flow.async_step_port_config(
             {zigpy.config.CONF_DEVICE_PATH: "/dev/ttyUSB33"}
         )
-        assert result["type"] == "form"
+        assert result["type"] == RESULT_TYPE_FORM
         assert result["step_id"] == "port_config"
         assert result["errors"]["base"] == "cannot_connect"
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -24,8 +24,8 @@ def com_port():
     return port
 
 
-@mock.patch(
-    "serial.tools.list_ports.comports", mock.MagicMock(return_value=[com_port()])
+@patch(
+    "serial.tools.list_ports.comports", return_value=[com_port()]
 )
 async def test_user_flow(hass):
     """Test user flow."""

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1,8 +1,8 @@
 """Tests for ZHA config flow."""
 
 import os
-from unittest import mock
 
+from asynctest import mock
 import serial.tools.list_ports
 import zigpy.config
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -9,7 +9,7 @@ import zigpy.config
 from homeassistant.components.zha import config_flow
 from homeassistant.components.zha.core.const import CONF_RADIO_TYPE, CONTROLLER, DOMAIN
 
-import tests.async_mock
+from tests.async_mock import AsyncMock, MagicMock, patch, sentinel
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -1,0 +1,69 @@
+"""Tests for ZHA integration init."""
+
+import pytest
+from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
+
+import homeassistant.components.zha
+from homeassistant.components.zha.core.const import (
+    CONF_BAUDRATE,
+    CONF_RADIO_TYPE,
+    CONF_USB_PATH,
+    DOMAIN,
+)
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+DATA_RADIO_TYPE = "deconz"
+DATA_PORT_PATH = "/dev/serial/by-id/FTDI_USB__-__Serial_Cable_12345678-if00-port0"
+
+
+@pytest.fixture
+def config_entry_v1(hass):
+    """Config entry version 1 fixture."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_RADIO_TYPE: DATA_RADIO_TYPE, CONF_USB_PATH: DATA_PORT_PATH},
+        version=1,
+    )
+
+
+@pytest.mark.parametrize("config", ({}, {DOMAIN: {}}))
+async def test_migration_from_v1_no_baudrate(hass, config_entry_v1, config):
+    """Test migration of config entry from v1."""
+    assert await async_setup_component(hass, DOMAIN, config)
+    await homeassistant.components.zha.async_migrate_entry(hass, config_entry_v1)
+
+    assert config_entry_v1.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
+    assert CONF_DEVICE in config_entry_v1.data
+    assert config_entry_v1.data[CONF_DEVICE][CONF_DEVICE_PATH] == DATA_PORT_PATH
+    assert CONF_BAUDRATE not in config_entry_v1.data[CONF_DEVICE]
+    assert CONF_USB_PATH not in config_entry_v1.data
+    assert config_entry_v1.version == 2
+
+
+async def test_migration_from_v1_with_baudrate(hass, config_entry_v1):
+    """Test migration of config entry from v1 with baudrate in config."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_BAUDRATE: 115200}})
+    await homeassistant.components.zha.async_migrate_entry(hass, config_entry_v1)
+
+    assert config_entry_v1.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
+    assert CONF_DEVICE in config_entry_v1.data
+    assert config_entry_v1.data[CONF_DEVICE][CONF_DEVICE_PATH] == DATA_PORT_PATH
+    assert CONF_USB_PATH not in config_entry_v1.data
+    assert CONF_BAUDRATE in config_entry_v1.data[CONF_DEVICE]
+    assert config_entry_v1.data[CONF_DEVICE][CONF_BAUDRATE] == 115200
+    assert config_entry_v1.version == 2
+
+
+async def test_migration_from_v1_wrong_baudrate(hass, config_entry_v1):
+    """Test migration of config entry from v1 with wrong baudrate."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_BAUDRATE: 115222}})
+    await homeassistant.components.zha.async_migrate_entry(hass, config_entry_v1)
+
+    assert config_entry_v1.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
+    assert CONF_DEVICE in config_entry_v1.data
+    assert config_entry_v1.data[CONF_DEVICE][CONF_DEVICE_PATH] == DATA_PORT_PATH
+    assert CONF_USB_PATH not in config_entry_v1.data
+    assert CONF_BAUDRATE not in config_entry_v1.data[CONF_DEVICE]
+    assert config_entry_v1.version == 2

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -3,7 +3,6 @@
 import pytest
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
-import homeassistant.components.zha
 from homeassistant.components.zha.core.const import (
     CONF_BAUDRATE,
     CONF_RADIO_TYPE,
@@ -12,6 +11,7 @@ from homeassistant.components.zha.core.const import (
 )
 from homeassistant.setup import async_setup_component
 
+from tests.async_mock import AsyncMock, patch
 from tests.common import MockConfigEntry
 
 DATA_RADIO_TYPE = "deconz"
@@ -29,10 +29,11 @@ def config_entry_v1(hass):
 
 
 @pytest.mark.parametrize("config", ({}, {DOMAIN: {}}))
+@patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_migration_from_v1_no_baudrate(hass, config_entry_v1, config):
     """Test migration of config entry from v1."""
+    config_entry_v1.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, config)
-    await homeassistant.components.zha.async_migrate_entry(hass, config_entry_v1)
 
     assert config_entry_v1.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
     assert CONF_DEVICE in config_entry_v1.data
@@ -42,10 +43,11 @@ async def test_migration_from_v1_no_baudrate(hass, config_entry_v1, config):
     assert config_entry_v1.version == 2
 
 
+@patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_migration_from_v1_with_baudrate(hass, config_entry_v1):
     """Test migration of config entry from v1 with baudrate in config."""
+    config_entry_v1.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_BAUDRATE: 115200}})
-    await homeassistant.components.zha.async_migrate_entry(hass, config_entry_v1)
 
     assert config_entry_v1.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
     assert CONF_DEVICE in config_entry_v1.data
@@ -56,10 +58,11 @@ async def test_migration_from_v1_with_baudrate(hass, config_entry_v1):
     assert config_entry_v1.version == 2
 
 
+@patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_migration_from_v1_wrong_baudrate(hass, config_entry_v1):
     """Test migration of config entry from v1 with wrong baudrate."""
+    config_entry_v1.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_BAUDRATE: 115222}})
-    await homeassistant.components.zha.async_migrate_entry(hass, config_entry_v1)
 
     assert config_entry_v1.data[CONF_RADIO_TYPE] == DATA_RADIO_TYPE
     assert CONF_DEVICE in config_entry_v1.data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
**Yes**.
The following:
- `usb_path`
- `baudrate`
- `radio_type`

configuration options for ZHA integration in `configuration.yaml` are deprecated and will be removed in `0.112.0`

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate manual ZHA configuration (Radio type and serial port settings) via yaml, while also trying to make integration configuration a bit more user friendly. In the new flow system presents a drop down of all available serial ports and user has to pick the right one:
![image](https://user-images.githubusercontent.com/5826160/80930320-da898f80-8d80-11ea-8678-758dd8942a87.png)

For USB connected devices, there is going to be some extra information to narrow the choice
![image](https://user-images.githubusercontent.com/5826160/80930379-39e79f80-8d81-11ea-8a5e-d1454e18a23f.png)

Once selected, the flow would try to detect the radio type automatically, which should take about 15s as it tries all radio types in sequence: `EZSP`, `Deconz`, `TI_CC` (ZNP), `Zigate`, `Xbee`

If successful, it's all done:
![image](https://user-images.githubusercontent.com/5826160/80930474-d90c9700-8d81-11ea-8cc8-afdd2f5f7fe0.png)

If none of the probe succeeds (e.g. Elelabs radios decided to change the default baudrate to 115200 for ezsp) then the "manual configuration" kicks in and user has to pick the `radio type` 
![image](https://user-images.githubusercontent.com/5826160/80930546-3c96c480-8d82-11ea-8d66-1a3b81df13fa.png)

And based on the radio type, user will be presented with settings specific for that radio type, as some radios don't care about "baudrate", or some radios may use a different "data flow control", Schema for this forms comes from the Radio and allows advanced radio configuration without any HA code modification. However ATM 99% should be covered by automatic radio detection, assuming user picks the right port. 
![image](https://user-images.githubusercontent.com/5826160/80930699-2d644680-8d83-11ea-92b1-ab72a2ca8d62.png)


Since this PR deprecates manual radio configuration via `.yaml`, the following options are deprecated in `0.112`

- `usb_path`
- `baudrate`
- `radio_type`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] https://github.com/home-assistant/home-assistant.io/pull/13279

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
