### PR TITLE
Replace importlib_metadata with importlib.metadata on Python 3.8+

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ defusedxml==0.6.0
 distro==1.5.0
 hass-nabucasa==0.34.4
 home-assistant-frontend==20200519.5
-importlib-metadata==1.6.0
+importlib-metadata==1.6.0; python_version<'3.8'
 jinja2>=2.11.1
 netdisco==2.6.0
 pip>=8.0.3

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -8,8 +8,12 @@ import sys
 from typing import Optional
 from urllib.parse import urlparse
 
-from importlib_metadata import PackageNotFoundError, version
 import pkg_resources
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,8 +45,8 @@ def is_installed(package: str) -> bool:
         req = pkg_resources.Requirement.parse(urlparse(package).fragment)
 
     try:
-        return version(req.project_name) in req
-    except PackageNotFoundError:
+        return importlib_metadata.version(req.project_name) in req
+    except importlib_metadata.PackageNotFoundError:
         return False
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ attrs==19.3.0
 bcrypt==3.1.7
 certifi>=2020.4.5.1
 ciso8601==2.1.3
-importlib-metadata==1.6.0
+importlib-metadata==1.6.0; python_version<'3.8'
 jinja2>=2.11.1
 PyJWT==1.7.1
 cryptography==2.9.2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIRES = [
     "bcrypt==3.1.7",
     "certifi>=2020.4.5.1",
     "ciso8601==2.1.3",
-    "importlib-metadata==1.6.0",
+    "importlib-metadata==1.6.0; python_version<'3.8'",
     "jinja2>=2.11.1",
     "PyJWT==1.7.1",
     # PyJWT has loose dependency. We want the latest one.


### PR DESCRIPTION
As of Python3.8 importlib.metadata is the part of stdlib:
https://docs.python.org/3/whatsnew/3.8.html#new-modules

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
