### PR TITLE
Move life360 I/O out of event loop in config flow

### DIFF
--- a/homeassistant/components/life360/config_flow.py
+++ b/homeassistant/components/life360/config_flow.py
@@ -47,8 +47,8 @@ class Life360ConfigFlow(config_entries.ConfigFlow):
             try:
                 # pylint: disable=no-value-for-parameter
                 vol.Email()(self._username)
-                authorization = self._api.get_authorization(
-                    self._username, self._password
+                authorization = await self.hass.async_add_executor_job(
+                    self._api.get_authorization, self._username, self._password
                 )
             except vol.Invalid:
                 errors[CONF_USERNAME] = "invalid_username"
@@ -89,7 +89,9 @@ class Life360ConfigFlow(config_entries.ConfigFlow):
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
         try:
-            authorization = self._api.get_authorization(username, password)
+            authorization = await self.hass.async_add_executor_job(
+                self._api.get_authorization, username, password
+            )
         except LoginError:
             _LOGGER.error("Invalid credentials for %s", username)
             return self.async_abort(reason="invalid_credentials")


### PR DESCRIPTION
## Proposed change
Life360 config flow performed I/O in the event loop. This change fixes that.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35163

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
