### PR TITLE
0.109.4

### DIFF
--- a/homeassistant/components/canary/alarm_control_panel.py
+++ b/homeassistant/components/canary/alarm_control_panel.py
@@ -24,10 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Canary alarms."""
     data = hass.data[DATA_CANARY]
-    devices = []
-
-    for location in data.locations:
-        devices.append(CanaryAlarm(data, location.location_id))
+    devices = [CanaryAlarm(data, location.location_id) for location in data.locations]
 
     add_entities(devices, True)
 

--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -29,6 +29,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Canary sensors."""
+    if discovery_info is not None:
+        return
+
     data = hass.data[DATA_CANARY]
     devices = []
 

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -259,6 +259,9 @@ class HueLight(Light):
         else:
             bri = self.light.state.get("bri")
 
+        if bri is None:
+            return bri
+
         return hue_brightness_to_hass(bri)
 
     @property

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -186,7 +186,7 @@ class IcloudAccount:
             DEVICE_STATUS_CODES.get(list(api_devices)[0][DEVICE_STATUS]) == "pending"
             and not self._retried_fetch
         ):
-            _LOGGER.warning("Pending devices, trying again in 15s")
+            _LOGGER.debug("Pending devices, trying again in 15s")
             self._fetch_interval = 0.25
             self._retried_fetch = True
         else:

--- a/homeassistant/components/icloud/manifest.json
+++ b/homeassistant/components/icloud/manifest.json
@@ -3,6 +3,6 @@
   "name": "Apple iCloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/icloud",
-  "requirements": ["pyicloud==0.9.6.1"],
+  "requirements": ["pyicloud==0.9.7"],
   "codeowners": ["@Quentame"]
 }

--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -40,15 +40,18 @@ def _has_all_unique_bilds(value):
     return value
 
 
-DEVICE_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): str,
-        vol.Required(CONF_BLID): str,
-        vol.Required(CONF_PASSWORD): str,
-        vol.Optional(CONF_CERT, default=DEFAULT_CERT): str,
-        vol.Optional(CONF_CONTINUOUS, default=DEFAULT_CONTINUOUS): bool,
-        vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): int,
-    },
+DEVICE_SCHEMA = vol.All(
+    cv.deprecated(CONF_CERT),
+    vol.Schema(
+        {
+            vol.Required(CONF_HOST): str,
+            vol.Required(CONF_BLID): str,
+            vol.Required(CONF_PASSWORD): str,
+            vol.Optional(CONF_CERT, default=DEFAULT_CERT): str,
+            vol.Optional(CONF_CONTINUOUS, default=DEFAULT_CONTINUOUS): bool,
+            vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): int,
+        },
+    ),
 )
 
 
@@ -92,7 +95,6 @@ async def async_setup_entry(hass, config_entry):
         address=config_entry.data[CONF_HOST],
         blid=config_entry.data[CONF_BLID],
         password=config_entry.data[CONF_PASSWORD],
-        cert_name=config_entry.data[CONF_CERT],
         continuous=config_entry.options[CONF_CONTINUOUS],
         delay=config_entry.options[CONF_DELAY],
     )

--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -40,18 +40,15 @@ def _has_all_unique_bilds(value):
     return value
 
 
-DEVICE_SCHEMA = vol.All(
-    cv.deprecated(CONF_CERT),
-    vol.Schema(
-        {
-            vol.Required(CONF_HOST): str,
-            vol.Required(CONF_BLID): str,
-            vol.Required(CONF_PASSWORD): str,
-            vol.Optional(CONF_CERT, default=DEFAULT_CERT): str,
-            vol.Optional(CONF_CONTINUOUS, default=DEFAULT_CONTINUOUS): bool,
-            vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): int,
-        },
-    ),
+DEVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_BLID): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_CERT, default=DEFAULT_CERT): str,
+        vol.Optional(CONF_CONTINUOUS, default=DEFAULT_CONTINUOUS): bool,
+        vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): int,
+    },
 )
 
 

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -11,11 +11,9 @@ from homeassistant.core import callback
 from . import CannotConnect, async_connect_or_timeout, async_disconnect_or_timeout
 from .const import (
     CONF_BLID,
-    CONF_CERT,
     CONF_CONTINUOUS,
     CONF_DELAY,
     CONF_NAME,
-    DEFAULT_CERT,
     DEFAULT_CONTINUOUS,
     DEFAULT_DELAY,
     ROOMBA_SESSION,
@@ -27,7 +25,6 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_BLID): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Optional(CONF_CERT, default=DEFAULT_CERT): str,
         vol.Optional(CONF_CONTINUOUS, default=DEFAULT_CONTINUOUS): bool,
         vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): int,
     }
@@ -45,7 +42,6 @@ async def validate_input(hass: core.HomeAssistant, data):
         address=data[CONF_HOST],
         blid=data[CONF_BLID],
         password=data[CONF_PASSWORD],
-        cert_name=data[CONF_CERT],
         continuous=data[CONF_CONTINUOUS],
         delay=data[CONF_DELAY],
     )

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -3,7 +3,7 @@
   "name": "iRobot Roomba",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roomba",
-  "requirements": ["roombapy==1.5.2"],
+  "requirements": ["roombapy==1.5.3"],
   "dependencies": [],
   "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"]
 }

--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -8,7 +8,6 @@
           "host": "Hostname or IP Address",
           "blid": "BLID",
           "password": "Password",
-          "certificate": "Certificate",
           "continuous": "Continuous",
           "delay": "Delay"
         }

--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -152,7 +152,7 @@ class SynoNasUtilSensor(SynoNasSensor):
         attr = getattr(self._api.utilisation, self.sensor_type)
         if callable(attr):
             attr = attr()
-        if not attr:
+        if attr is None:
             return None
 
         # Data (RAM)
@@ -173,7 +173,7 @@ class SynoNasStorageSensor(SynoNasSensor):
     def state(self):
         """Return the state."""
         attr = getattr(self._api.storage, self.sensor_type)(self.monitored_device)
-        if not attr:
+        if attr is None:
             return None
 
         # Data (disk space)

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -95,7 +95,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     platform.async_register_entity_service(
         SERVICE_CALIBRATE_METER,
-        {vol.Required(ATTR_VALUE): vol.Coerce(float)},
+        {vol.Required(ATTR_VALUE): vol.Coerce(Decimal)},
         "async_calibrate",
     )
 
@@ -222,7 +222,7 @@ class UtilityMeterSensor(RestoreEntity):
     async def async_calibrate(self, value):
         """Calibrate the Utility Meter with a given value."""
         _LOGGER.debug("Calibrate %s = %s", self._name, value)
-        self._state = Decimal(value)
+        self._state = value
         self.async_write_ha_state()
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -192,11 +192,7 @@ class UnifiVideoCamera(Camera):
 
     def set_motion_detection(self, mode):
         """Set motion detection on or off."""
-
-        if mode is True:
-            set_mode = "motion"
-        else:
-            set_mode = "none"
+        set_mode = "motion" if mode is True else "none"
 
         try:
             self._nvr.set_recordmode(self._uuid, set_mode)
@@ -215,9 +211,7 @@ class UnifiVideoCamera(Camera):
 
     async def stream_source(self):
         """Return the source of the stream."""
-        caminfo = self._nvr.get_camera(self._uuid)
-        channels = caminfo["channels"]
-        for channel in channels:
+        for channel in self._caminfo["channels"]:
             if channel["isRtspEnabled"]:
                 return channel["rtspUris"][0]
 

--- a/homeassistant/components/websocket_api/manifest.json
+++ b/homeassistant/components/websocket_api/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "websocket_api",
-  "name": "Home Asssitant WebSocket API",
+  "name": "Home Assistant WebSocket API",
   "documentation": "https://www.home-assistant.io/integrations/websocket_api",
   "dependencies": ["http"],
   "codeowners": ["@home-assistant/core"],

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 109
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1825,7 +1825,7 @@ rocketchat-API==0.6.1
 roku==4.1.0
 
 # homeassistant.components.roomba
-roombapy==1.5.2
+roombapy==1.5.3
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1342,7 +1342,7 @@ pyhomeworks==0.0.6
 pyialarm==0.3
 
 # homeassistant.components.icloud
-pyicloud==0.9.6.1
+pyicloud==0.9.7
 
 # homeassistant.components.intesishome
 pyintesishome==1.7.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -701,7 +701,7 @@ ring_doorbell==0.6.0
 roku==4.1.0
 
 # homeassistant.components.roomba
-roombapy==1.5.2
+roombapy==1.5.3
 
 # homeassistant.components.yamaha
 rxv==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -537,7 +537,7 @@ pyheos==0.6.0
 pyhomematic==0.1.66
 
 # homeassistant.components.icloud
-pyicloud==0.9.6.1
+pyicloud==0.9.7
 
 # homeassistant.components.ipma
 pyipma==2.0.5

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -5,7 +5,6 @@ from roomba import RoombaConnectionError
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.roomba.const import (
     CONF_BLID,
-    CONF_CERT,
     CONF_CONTINUOUS,
     CONF_DELAY,
     DOMAIN,
@@ -20,7 +19,6 @@ VALID_YAML_CONFIG = {
     CONF_HOST: "1.2.3.4",
     CONF_BLID: "blid",
     CONF_PASSWORD: "password",
-    CONF_CERT: "/etc/ssl/certs/ca-certificates.crt",
     CONF_CONTINUOUS: True,
     CONF_DELAY: 1,
 }
@@ -69,7 +67,6 @@ async def test_form(hass):
     assert result2["result"].unique_id == "blid"
     assert result2["data"] == {
         CONF_BLID: "blid",
-        CONF_CERT: "/etc/ssl/certs/ca-certificates.crt",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: "1.2.3.4",
@@ -131,7 +128,6 @@ async def test_form_import(hass):
     assert result["title"] == "imported_roomba"
     assert result["data"] == {
         CONF_BLID: "blid",
-        CONF_CERT: "/etc/ssl/certs/ca-certificates.crt",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: "1.2.3.4",

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -119,6 +119,17 @@ async def test_state(hass):
     assert state is not None
     assert state.state == "100"
 
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CALIBRATE_METER,
+        {ATTR_ENTITY_ID: "sensor.energy_bill_midpeak", ATTR_VALUE: "0.123"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.energy_bill_midpeak")
+    assert state is not None
+    assert state.state == "0.123"
+
 
 async def test_net_consumption(hass):
     """Test utility sensor state."""


### PR DESCRIPTION
- Fix Synology NAS discovered multiple times ([@Quentame] - [#35094]) ([synology_dsm docs])
- Correct typo Asssitant -> Assistant ([@ludeeus] - [#35117]) ([websocket_api docs])
- Hue: Guard for when there is no brightness ([@balloob] - [#35151]) ([hue docs])
- Bump pyiCloud to 0.9.7 + do not warn when pending devices ([@Quentame] - [#35156]) ([icloud docs])
- Fix Canary KeyError: 'ffmpeg_arguments' ([@frenck] - [#35158]) ([canary docs])
- Fix UVC doing I/O inside the event loop ([@frenck] - [#35169]) ([uvc docs])
- Fix utility_meter calibration with float values ([@dgomes] - [#35186]) ([utility_meter docs])
- Fix Synology DSM sensor to be False or 0 ([@Quentame] - [#35208]) ([synology_dsm docs])

[#35094]: https://github.com/home-assistant/core/pull/35094
[#35117]: https://github.com/home-assistant/core/pull/35117
[#35151]: https://github.com/home-assistant/core/pull/35151
[#35156]: https://github.com/home-assistant/core/pull/35156
[#35158]: https://github.com/home-assistant/core/pull/35158
[#35169]: https://github.com/home-assistant/core/pull/35169
[#35186]: https://github.com/home-assistant/core/pull/35186
[#35208]: https://github.com/home-assistant/core/pull/35208
[@Quentame]: https://github.com/Quentame
[@balloob]: https://github.com/balloob
[@dgomes]: https://github.com/dgomes
[@frenck]: https://github.com/frenck
[@ludeeus]: https://github.com/ludeeus
[canary docs]: https://www.home-assistant.io/integrations/canary/
[hue docs]: https://www.home-assistant.io/integrations/hue/
[icloud docs]: https://www.home-assistant.io/integrations/icloud/
[synology_dsm docs]: https://www.home-assistant.io/integrations/synology_dsm/
[utility_meter docs]: https://www.home-assistant.io/integrations/utility_meter/
[uvc docs]: https://www.home-assistant.io/integrations/uvc/
[websocket_api docs]: https://www.home-assistant.io/integrations/websocket_api/