### PR TITLE
Fix pyload API statusServer doesn't take parameters

### DIFF
--- a/homeassistant/components/pyload/sensor.py
+++ b/homeassistant/components/pyload/sensor.py
@@ -60,7 +60,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     try:
         pyloadapi = PyLoadAPI(api_url=url, username=username, password=password)
-        pyloadapi.update()
     except (
         requests.exceptions.ConnectionError,
         requests.exceptions.HTTPError,
@@ -144,17 +143,12 @@ class PyLoadAPI:
             self.login = requests.post(f"{api_url}login", data=self.payload, timeout=5)
         self.update()
 
-    def post(self, method, params=None):
+    def post(self):
         """Send a POST request and return the response as a dict."""
-        payload = {"method": method}
-
-        if params:
-            payload["params"] = params
-
+        
         try:
             response = requests.post(
                 f"{self.api_url}statusServer",
-                json=payload,
                 cookies=self.login.cookies,
                 headers=self.headers,
                 timeout=5,
@@ -170,4 +164,4 @@ class PyLoadAPI:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update cached response."""
-        self.status = self.post("speed")
+        self.status = self.post()

--- a/homeassistant/components/pyload/sensor.py
+++ b/homeassistant/components/pyload/sensor.py
@@ -145,7 +145,6 @@ class PyLoadAPI:
 
     def post(self):
         """Send a POST request and return the response as a dict."""
-        
         try:
             response = requests.post(
                 f"{self.api_url}statusServer",


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pyload's API method "statusServer" never accepted parameters. A recent update to payload's integrated webserver (which fixed the SSL connection handling) enforced this rule. Therefor the sensor no longer worked.

Remove json payload from API call to statusServer for retrieving current download speed. 
Skip duplicated call to update function.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

no changes
```yaml
sensor:
  - platform: pyload
    host: yourhost.com
    port: 8001
    name: pyLoad
    username: pyload
    password: !secret pyload_login
    ssl: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/pyload/pyload/issues/3622#issuecomment-623175637

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
