### PR TITLE
Fix fan not checking supported_features

### DIFF
--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -37,12 +37,12 @@ class DemoFan(FanEntity):
         self.hass = hass
         self._supported_features = supported_features
         self._speed = STATE_OFF
-        self.oscillating = None
+        self._oscillating = None
         self._direction = None
         self._name = name
 
         if supported_features & SUPPORT_OSCILLATE:
-            self.oscillating = False
+            self._oscillating = False
         if supported_features & SUPPORT_DIRECTION:
             self._direction = "forward"
 
@@ -89,13 +89,18 @@ class DemoFan(FanEntity):
 
     def oscillate(self, oscillating: bool) -> None:
         """Set oscillation."""
-        self.oscillating = oscillating
+        self._oscillating = oscillating
         self.schedule_update_ha_state()
 
     @property
     def current_direction(self) -> str:
         """Fan direction."""
         return self._direction
+
+    @property
+    def oscillating(self) -> bool:
+        """Oscillating."""
+        return self._oscillating
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -45,12 +45,6 @@ ATTR_SPEED_LIST = "speed_list"
 ATTR_OSCILLATING = "oscillating"
 ATTR_DIRECTION = "direction"
 
-PROP_TO_ATTR = {
-    "speed": ATTR_SPEED,
-    "oscillating": ATTR_OSCILLATING,
-    "current_direction": ATTR_DIRECTION,
-}
-
 
 @bind_hass
 def is_on(hass, entity_id: str) -> bool:

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -167,6 +167,11 @@ class FanEntity(ToggleEntity):
         return None
 
     @property
+    def oscillating(self):
+        """Return whether or not the fan is currently oscillating."""
+        return None
+
+    @property
     def capability_attributes(self):
         """Return capability attributes."""
         if self.supported_features & SUPPORT_SET_SPEED:

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -169,20 +169,24 @@ class FanEntity(ToggleEntity):
     @property
     def capability_attributes(self):
         """Return capability attributes."""
-        return {ATTR_SPEED_LIST: self.speed_list}
+        if self.supported_features & SUPPORT_SET_SPEED:
+            return {ATTR_SPEED_LIST: self.speed_list}
+        return {}
 
     @property
     def state_attributes(self) -> dict:
         """Return optional state attributes."""
         data = {}
+        supported_features = self.supported_features
 
-        for prop, attr in PROP_TO_ATTR.items():
-            if not hasattr(self, prop):
-                continue
+        if supported_features & SUPPORT_DIRECTION:
+            data[ATTR_DIRECTION] = self.current_direction
 
-            value = getattr(self, prop)
-            if value is not None:
-                data[attr] = value
+        if supported_features & SUPPORT_OSCILLATE:
+            data[ATTR_OSCILLATING] = self.oscillating
+
+        if supported_features & SUPPORT_SET_SPEED:
+            data[ATTR_SPEED] = self.speed
 
         return data
 

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -31,7 +31,7 @@ class TestFanEntity(unittest.TestCase):
         assert self.fan.state == "off"
         assert len(self.fan.speed_list) == 0
         assert self.fan.supported_features == 0
-        assert {"speed_list": []} == self.fan.capability_attributes
+        assert {} == self.fan.capability_attributes
         # Test set_speed not required
         self.fan.oscillate(True)
         with pytest.raises(NotImplementedError):

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -31,7 +31,7 @@ class TestFanEntity(unittest.TestCase):
         assert self.fan.state == "off"
         assert len(self.fan.speed_list) == 0
         assert self.fan.supported_features == 0
-        assert {} == self.fan.capability_attributes
+        assert self.fan.capability_attributes == {}
         # Test set_speed not required
         self.fan.oscillate(True)
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the problem that `FanEntity.capability_attributes` and `FanEntity.state_attributes` do not check `supported_features`.

## Docs update:
https://github.com/home-assistant/developers.home-assistant/pull/496
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35232
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
