### PR TITLE
Sort minecraft_server players_online sensor's players_list

### DIFF
--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -197,6 +197,7 @@ class MinecraftServer:
             if status_response.players.sample is not None:
                 for player in status_response.players.sample:
                     self.players_list.append(player.name)
+                self.players_list.sort()
 
             # Inform user once about successful update if necessary.
             if self._last_status_request_failed:


### PR DESCRIPTION
Sort the players_list attribute of the minecraft_server players_online sensor in order to eliminate uneccessary state updates and ease comparisons in state changes.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `minecraft_server` sensor `players_online` writes its state frequently.
The HA documentation says that a `state` object's `last_updated` property will not change if a state is written that contains the same `state` and `attributes`.
The `minecraft_server` `players_online` sensor's `players_list` attribute is often ordered differently with the same set of players (i.e. not sorted), and this triggers the `last_updated` of the state to change.
Additionally, a sorted list will make comparisons and other operations easier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
automations:
  - id: '1588369803164'
    alias: Minecraft status
    description: ''
    trigger:
    - entity_id: sensor.minecraft_shipyard_players_online
      platform: state
    condition:
    - condition: template
      value_template: '{{ trigger.from_state.last_updated != trigger.to_state.last_updated }}'
    action:
    - data_template:
        title: Minecraft Shipyard
        message: >
          {{ states(''sensor.minecraft_shipyard_players_online'') }} players online
          {%- if states(''sensor.minecraft_shipyard_players_online'') != "0" -%}
          \n
          {%- for player in state_attr(''sensor.minecraft_shipyard_players_online'',''players_list'') -%} 
          {{ player }}{% if not loop.last %}, {% endif %}
          {%- endfor -%}
          {%- endif -%}
      service: notify.notification_target
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
