### PR TITLE
Provide zeroconf option to bind to only the default interface

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -5,6 +5,7 @@ import socket
 
 import voluptuous as vol
 from zeroconf import (
+    InterfaceChoice,
     NonUniqueNameException,
     ServiceBrowser,
     ServiceInfo,
@@ -20,6 +21,7 @@ from homeassistant.const import (
     __version__,
 )
 from homeassistant.generated.zeroconf import HOMEKIT, ZEROCONF
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,12 +36,29 @@ ATTR_PROPERTIES = "properties"
 ZEROCONF_TYPE = "_home-assistant._tcp.local."
 HOMEKIT_TYPE = "_hap._tcp.local."
 
-CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+CONF_DEFAULT_INTERFACE = "default_interface"
+DEFAULT_DEFAULT_INTERFACE = False
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(
+                    CONF_DEFAULT_INTERFACE, default=DEFAULT_DEFAULT_INTERFACE
+                ): cv.boolean
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 def setup(hass, config):
     """Set up Zeroconf and make Home Assistant discoverable."""
-    zeroconf = Zeroconf()
+    if config.get(CONF_DEFAULT_INTERFACE):
+        zeroconf = Zeroconf(interfaces=InterfaceChoice.Default)
+    else:
+        zeroconf = Zeroconf()
     zeroconf_name = f"{hass.config.location_name}.{ZEROCONF_TYPE}"
 
     params = {

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,8 +1,9 @@
 """Test Zeroconf component setup process."""
 import pytest
-from zeroconf import ServiceInfo, ServiceStateChange
+from zeroconf import InterfaceChoice, ServiceInfo, ServiceStateChange
 
 from homeassistant.components import zeroconf
+from homeassistant.components.zeroconf import CONF_DEFAULT_INTERFACE
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.setup import async_setup_component
 
@@ -76,6 +77,19 @@ async def test_setup(hass, mock_zeroconf):
     for matching_components in zc_gen.ZEROCONF.values():
         expected_flow_calls += len(matching_components)
     assert len(mock_config_flow.mock_calls) == expected_flow_calls
+
+
+async def test_setup_with_default_interface(hass, mock_zeroconf):
+    """Test default interface config."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "ServiceBrowser", side_effect=service_update_mock
+    ):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(
+            hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_DEFAULT_INTERFACE: True}}
+        )
+
+    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
 
 
 async def test_homekit_match_partial_space(hass, mock_zeroconf):


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
By default zeroconf binds to every interface.  If you have many NICs, virtual network devices (docker containers running that each create a virtual network), zeroconf will create listeners on each one of them or fail to startup as seen in #33437 (and https://github.com/ikalchev/HAP-python/issues/160).  

A similar option has been added to `HomeKit` to address this issue for `homekit` users : https://www.home-assistant.io/integrations/homekit/#zeroconf_default_interface

Additionally this compounds the existing performance issues because the same data is potentially coming in on multiple interfaces.  

```
Collecting samples from 'python3 -m homeassistant --config /config' (python v3.7.6)
Total Samples 10
GIL: 40.00%, Active: 200.00%, Threads: 143

  %Own   %Total  OwnTime  TotalTime  Function (filename:line)                                                                                                                                                 
 60.00%  60.00%   0.060s    0.060s   handle_read (zeroconf/__init__.py:1277)
 30.00%  30.00%   0.030s    0.030s   run (zeroconf/__init__.py:1223)
  3.33%   3.33%   0.030s    0.030s   entries (zeroconf/__init__.py:1185)
```

Before (listening on all 4 interfaces):
```
python3 3446 root   42u     IPv4           61056704       0t0      UDP *:mdns 
python3 3446 root   43u     IPv4           61056706       0t0      UDP *:mdns 
python3 3446 root   44u     IPv4           61056707       0t0      UDP *:mdns 
python3 3446 root   46u     IPv4           61056708       0t0      UDP *:mdns 
```

With `default_interface: True` (listening on default interface only):
```
python3 3446 root   42u     IPv4           61056704       0t0      UDP *:mdns 
```

I've been manually patching `zeroconf` to work inside containers that have
network devices that cause startup to fail because they can't be used by
`zeroconf`.  


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
