### PR TITLE
deCONZ - Add support for "Window covering controller"

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -37,7 +37,7 @@ ATTR_ON = "on"
 ATTR_VALVE = "valve"
 
 DAMPERS = ["Level controllable output"]
-WINDOW_COVERS = ["Window covering device"]
+WINDOW_COVERS = ["Window covering device", "Window covering controller"]
 COVER_TYPES = DAMPERS + WINDOW_COVERS
 
 POWER_PLUGS = ["On/Off light", "On/Off plug-in unit", "Smart plug"]

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -41,6 +41,14 @@ COVERS = {
         "modelid": "Not zigbee spec",
         "uniqueid": "00:00:00:00:00:00:00:03-00",
     },
+    "5": {
+        "id": "Window covering controller id",
+        "name": "Window covering controller",
+        "type": "Window covering controller",
+        "state": {"bri": 254, "on": True, "reachable": True},
+        "modelid": "Motor controller",
+        "uniqueid": "00:00:00:00:00:00:00:04-00",
+    },
 }
 
 
@@ -71,7 +79,8 @@ async def test_cover(hass):
     assert "cover.window_covering_device" in gateway.deconz_ids
     assert "cover.unsupported_cover" not in gateway.deconz_ids
     assert "cover.deconz_old_brightness_cover" in gateway.deconz_ids
-    assert len(hass.states.async_all()) == 4
+    assert "cover.window_covering_controller" in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 5
 
     level_controllable_cover = hass.states.get("cover.level_controllable_cover")
     assert level_controllable_cover.state == "open"


### PR DESCRIPTION
Some window cover devices such as Sunricher SR-ZG9080A are identified in deconz as "Window covering controller".
We need to include this device type in const.py to be integrated as type "cover" in home-assistant.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some window cover devices such as Sunricher SR-ZG9080A are identified in deconz as "Window covering controller".
We need to include this device type in const.py to be integrated as type "cover" in home-assistant.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
