### PR TITLE
Plex discovery on demand

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -4,6 +4,7 @@ import logging
 
 from aiohttp import web_response
 import plexapi.exceptions
+from plexapi.gdm import GDM
 from plexauth import PlexAuth
 import requests.exceptions
 import voluptuous as vol
@@ -60,6 +61,18 @@ def configured_servers(hass):
         entry.data[CONF_SERVER_IDENTIFIER]
         for entry in hass.config_entries.async_entries(DOMAIN)
     }
+
+
+async def async_discover(hass):
+    """Scan for available Plex servers."""
+    gdm = GDM()
+    await hass.async_add_executor_job(gdm.scan)
+    for server_data in gdm.entries:
+        await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DISCOVERY},
+            data=server_data,
+        )
 
 
 class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -265,6 +278,19 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import from Plex configuration."""
         _LOGGER.debug("Imported Plex configuration")
         return await self.async_step_server_validate(import_config)
+
+    async def async_step_discovery(self, discovery_info):
+        """Handle GDM discovery."""
+        machine_identifier = discovery_info["data"]["Resource-Identifier"]
+        await self.async_set_unique_id(machine_identifier)
+        self._abort_if_unique_id_configured()
+        host = f"{discovery_info['from'][0]}:{discovery_info['data']['Port']}"
+        name = discovery_info["data"]["Name"]
+        self.context["title_placeholders"] = {  # pylint: disable=no-member
+            "host": host,
+            "name": name,
+        }
+        return await self.async_step_user()
 
     async def async_step_plex_website_auth(self):
         """Begin external auth flow on Plex website."""

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -70,7 +70,7 @@ async def async_discover(hass):
     for server_data in gdm.entries:
         await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": config_entries.SOURCE_DISCOVERY},
+            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
             data=server_data,
         )
 
@@ -279,7 +279,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Imported Plex configuration")
         return await self.async_step_server_validate(import_config)
 
-    async def async_step_discovery(self, discovery_info):
+    async def async_step_integration_discovery(self, discovery_info):
         """Handle GDM discovery."""
         machine_identifier = discovery_info["data"]["Resource-Identifier"]
         await self.async_set_unique_id(machine_identifier)

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name} ({host})",
     "step": {
       "user": {
         "title": "Plex Media Server",

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -22,6 +22,7 @@ _UNDEF: dict = {}
 
 SOURCE_DISCOVERY = "discovery"
 SOURCE_IMPORT = "import"
+SOURCE_INTEGRATION_DISCOVERY = "integration_discovery"
 SOURCE_SSDP = "ssdp"
 SOURCE_USER = "user"
 SOURCE_ZEROCONF = "zeroconf"

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -8,6 +8,32 @@ from homeassistant.const import CONF_URL
 
 from .const import DEFAULT_DATA, MOCK_SERVERS, MOCK_USERS
 
+GDM_PAYLOAD = [
+    {
+        "data": {
+            "Content-Type": "plex/media-server",
+            "Name": "plextest",
+            "Port": "32400",
+            "Resource-Identifier": "1234567890123456789012345678901234567890",
+            "Updated-At": "157762684800",
+            "Version": "1.0",
+        },
+        "from": ("1.2.3.4", 32414),
+    }
+]
+
+
+class MockGDM:
+    """Mock a GDM instance."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.entries = GDM_PAYLOAD
+
+    def scan(self):
+        """Mock the scan call."""
+        pass
+
 
 class MockResource:
     """Mock a PlexAccount resource."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Plex does not support the standard protocols for discovery (SSDP, zeroconf) and the legacy `netdisco` discovery didn't provide a unique ID. The underlying library now supports GDM discovery which can be triggered by a call to the integration.

This PR doesn't add any code that's directly called yet, but sets up the ability to trigger discovery on demand during onboarding.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
