### PR TITLE
Add delay in emulated_hue after PUT

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -1,6 +1,7 @@
 """Support for a Hue API to control Home Assistant."""
 import hashlib
 import logging
+import asyncio
 
 from homeassistant import core
 from homeassistant.components import (
@@ -555,6 +556,12 @@ class HueOneLightChangeView(HomeAssistantView):
                     create_hue_success_response(entity_number, val, parsed[key])
                 )
 
+        """
+        Echo will fetch the state immediately after the PUT method returns.
+        Waiting a short while to allow for the changes to propagate.
+        """
+        await asyncio.sleep(0.1)
+            
         return self.json(json_response)
 
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -1,7 +1,7 @@
 """Support for a Hue API to control Home Assistant."""
+import asyncio
 import hashlib
 import logging
-import asyncio
 
 from homeassistant import core
 from homeassistant.components import (
@@ -224,14 +224,7 @@ class HueFullStateView(HomeAssistantView):
 
         json_response = {
             "lights": create_list_of_entities(self.config, request),
-            "config": {
-                "mac": "00:00:00:00:00:00",
-                "swversion": "01003542",
-                "apiversion": "1.17.0",
-                "whitelist": {HUE_API_USERNAME: {"name": "HASS BRIDGE"}},
-                "ipaddress": f"{self.config.advertise_ip}:{self.config.advertise_port}",
-                "linkbutton": True,
-            },
+            "config": create_config_model(self.config, request),
         }
 
         return self.json(json_response)
@@ -256,14 +249,7 @@ class HueConfigView(HomeAssistantView):
         if username != HUE_API_USERNAME:
             return self.json(UNAUTHORIZED_USER)
 
-        json_response = {
-            "mac": "00:00:00:00:00:00",
-            "swversion": "01003542",
-            "apiversion": "1.17.0",
-            "whitelist": {HUE_API_USERNAME: {"name": "HASS BRIDGE"}},
-            "ipaddress": f"{self.config.advertise_ip}:{self.config.advertise_port}",
-            "linkbutton": True,
-        }
+        json_response = create_config_model(self.config, request)
 
         return self.json(json_response)
 
@@ -556,10 +542,10 @@ class HueOneLightChangeView(HomeAssistantView):
                     create_hue_success_response(entity_number, val, parsed[key])
                 )
 
-        # Echo fetchs the state immediately after the PUT method returns.
-        # Waiting here a short while to allow for the changes to propagate.
-        await asyncio.sleep(0.1)
-            
+        # Echo fetches the state immediately after the PUT method returns.
+        # Waiting for a short time allows the changes to propagate.
+        await asyncio.sleep(0.25)
+
         return self.json(json_response)
 
 
@@ -754,6 +740,18 @@ def create_hue_success_response(entity_number, attr, value):
     """Create a success response for an attribute set on a light."""
     success_key = f"/lights/{entity_number}/state/{attr}"
     return {"success": {success_key: value}}
+
+
+def create_config_model(config, request):
+    """Create a config resource"""
+    return {
+        "mac": "00:00:00:00:00:00",
+        "swversion": "01003542",
+        "apiversion": "1.17.0",
+        "whitelist": {HUE_API_USERNAME: {"name": "HASS BRIDGE"}},
+        "ipaddress": f"{config.advertise_ip}:{config.advertise_port}",
+        "linkbutton": True,
+    }
 
 
 def create_list_of_entities(config, request):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -556,10 +556,8 @@ class HueOneLightChangeView(HomeAssistantView):
                     create_hue_success_response(entity_number, val, parsed[key])
                 )
 
-        """
-        Echo will fetch the state immediately after the PUT method returns.
-        Waiting a short while to allow for the changes to propagate.
-        """
+        # Echo fetchs the state immediately after the PUT method returns.
+        # Waiting here a short while to allow for the changes to propagate.
         await asyncio.sleep(0.1)
             
         return self.json(json_response)

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -743,7 +743,7 @@ def create_hue_success_response(entity_number, attr, value):
 
 
 def create_config_model(config, request):
-    """Create a config resource"""
+    """Create a config resource."""
     return {
         "mac": "00:00:00:00:00:00",
         "swversion": "01003542",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

An Echo device changes the state of the device by submitting a PUT to `/api/{username}/lights/{entity_id}/state`. Immediately after the call, it executes a GET to `/api/{username}/lights/{entity_id}` to validate if the change was successful. 

In many cases the state of the device will not be updated to be reflected in the subsequent GET command. When there is a discrepancy between the state submited and received, Echo would complain with  '/.../ appears to be malfunctioning' announcement. This change introduces a short artificial delay of 250ms before the PUT method returns to allow for the change to successfully propagate, which keeps the Echo device pleased. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

emulated_hue:
   listen_port: 80
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31438 
- This PR is related to issue: #29899
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
