### PR TITLE
0.109.5

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -188,6 +188,7 @@ class ModbusHub:
                 bytesize=self._config_bytesize,
                 parity=self._config_parity,
                 timeout=self._config_timeout,
+                retry_on_empty=True,
             )
         elif self._config_type == "rtuovertcp":
             self._client = ModbusTcpClient(

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -273,10 +273,12 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
     def _read_register(self) -> Optional[int]:
         try:
             if self._register_type == CALL_TYPE_REGISTER_INPUT:
-                result = self._hub.read_input_registers(self._slave, self._register, 1)
+                result = self._hub.read_input_registers(
+                    self._slave, self._verify_register, 1
+                )
             else:
                 result = self._hub.read_holding_registers(
-                    self._slave, self._register, 1
+                    self._slave, self._verify_register, 1
                 )
         except ConnectionException:
             self._available = False

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -196,7 +196,14 @@ class Notion:
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)
         for attr, result in zip(tasks, results):
             if isinstance(result, NotionError):
-                _LOGGER.error("There was an error while updating %s: %s", attr, result)
+                _LOGGER.error(
+                    "There was a Notion error while updating %s: %s", attr, result
+                )
+                continue
+            if isinstance(result, Exception):
+                _LOGGER.error(
+                    "There was an unknown error while updating %s: %s", attr, result
+                )
                 continue
 
             holding_pen = getattr(self, attr)

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -259,4 +259,6 @@ class SamsungTVWSBridge(SamsungTVBridge):
             except ConnectionFailure:
                 self._notify_callback()
                 raise
+            except WebSocketException:
+                self._remote = None
         return self._remote

--- a/homeassistant/components/sms/__init__.py
+++ b/homeassistant/components/sms/__init__.py
@@ -17,7 +17,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass, config):
+def setup(hass, config):
     """Configure Gammu state machine."""
     conf = config[DOMAIN]
     device = conf.get(CONF_DEVICE)

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -199,12 +199,20 @@ class UnifiOptionsFlowHandler(config_entries.OptionsFlow):
             self.options.update(user_input)
             return await self.async_step_client_control()
 
-        ssids = list(self.controller.api.wlans) + [
-            f"{wlan.name}{wlan.name_combine_suffix}"
-            for wlan in self.controller.api.wlans.values()
-            if not wlan.name_combine_enabled
-        ]
-        ssid_filter = {ssid: ssid for ssid in sorted(ssids)}
+        ssids = (
+            set(self.controller.api.wlans)
+            | {
+                f"{wlan.name}{wlan.name_combine_suffix}"
+                for wlan in self.controller.api.wlans.values()
+                if not wlan.name_combine_enabled
+            }
+            | {
+                wlan["name"]
+                for ap in self.controller.api.devices.values()
+                for wlan in ap.raw.get("wlan_overrides", [])
+            }
+        )
+        ssid_filter = {ssid: ssid for ssid in sorted(list(ssids))}
 
         return self.async_show_form(
             step_id="device_tracker",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 109
-PATCH_VERSION = "4"
+PATCH_VERSION = "5"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -33,6 +33,29 @@ from tests.common import MockConfigEntry
 
 CLIENTS = [{"mac": "00:00:00:00:00:01"}]
 
+DEVICES = [
+    {
+        "board_rev": 21,
+        "device_id": "mock-id",
+        "ip": "10.0.1.1",
+        "last_seen": 0,
+        "mac": "00:00:00:00:01:01",
+        "model": "U7PG2",
+        "name": "access_point",
+        "state": 1,
+        "type": "uap",
+        "version": "4.0.80.10875",
+        "wlan_overrides": [
+            {
+                "name": "SSID 3",
+                "radio": "na",
+                "radio_name": "wifi1",
+                "wlan_id": "012345678910111213141516",
+            },
+        ],
+    }
+]
+
 WLANS = [
     {"name": "SSID 1"},
     {"name": "SSID 2", "name_combine_enabled": False, "name_combine_suffix": "_IOT"},
@@ -319,7 +342,7 @@ async def test_flow_fails_unknown_problem(hass, aioclient_mock):
 async def test_option_flow(hass):
     """Test config flow options."""
     controller = await setup_unifi_integration(
-        hass, clients_response=CLIENTS, wlans_response=WLANS
+        hass, clients_response=CLIENTS, devices_response=DEVICES, wlans_response=WLANS
     )
 
     result = await hass.config_entries.options.async_init(
@@ -335,7 +358,7 @@ async def test_option_flow(hass):
             CONF_TRACK_CLIENTS: False,
             CONF_TRACK_WIRED_CLIENTS: False,
             CONF_TRACK_DEVICES: False,
-            CONF_SSID_FILTER: ["SSID 1", "SSID 2_IOT"],
+            CONF_SSID_FILTER: ["SSID 1", "SSID 2_IOT", "SSID 3"],
             CONF_DETECTION_TIME: 100,
         },
     )
@@ -360,7 +383,7 @@ async def test_option_flow(hass):
         CONF_TRACK_CLIENTS: False,
         CONF_TRACK_WIRED_CLIENTS: False,
         CONF_TRACK_DEVICES: False,
-        CONF_SSID_FILTER: ["SSID 1", "SSID 2_IOT"],
+        CONF_SSID_FILTER: ["SSID 1", "SSID 2_IOT", "SSID 3"],
         CONF_DETECTION_TIME: 100,
         CONF_IGNORE_WIRED_BUG: False,
         CONF_POE_CLIENTS: False,


### PR DESCRIPTION
- Add retry on empty modbus messages for serial protocol ([@janiversen] - [#34678]) ([modbus docs])
- Change Modbus switch to use verify_register when defined ([@janiversen] - [#34679]) ([modbus docs])
- Catch samsungtv timeout exception ([@escoand] - [#35205]) ([samsungtv docs])
- Broader Notion exception handling ([@bachya] - [#35265]) ([notion docs])
- UniFi - Support SSID filter of SSIDs from access points with extra configuration ([@Kane610] - [#35295]) ([unifi docs])
- Fix SMS doing I/O in event loop ([@balloob] - [#35313]) ([sms docs])

[#34678]: https://github.com/home-assistant/core/pull/34678
[#34679]: https://github.com/home-assistant/core/pull/34679
[#35205]: https://github.com/home-assistant/core/pull/35205
[#35265]: https://github.com/home-assistant/core/pull/35265
[#35295]: https://github.com/home-assistant/core/pull/35295
[#35313]: https://github.com/home-assistant/core/pull/35313
[@Kane610]: https://github.com/Kane610
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@escoand]: https://github.com/escoand
[@janiversen]: https://github.com/janiversen
[modbus docs]: https://www.home-assistant.io/integrations/modbus/
[notion docs]: https://www.home-assistant.io/integrations/notion/
[samsungtv docs]: https://www.home-assistant.io/integrations/samsungtv/
[sms docs]: https://www.home-assistant.io/integrations/sms/
[unifi docs]: https://www.home-assistant.io/integrations/unifi/