### PR TITLE
Songpal code and test improvement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -679,8 +679,6 @@ omit =
     homeassistant/components/somfy/*
     homeassistant/components/somfy_mylink/*
     homeassistant/components/sonarr/sensor.py
-    homeassistant/components/songpal/__init__.py
-    homeassistant/components/songpal/media_player.py
     homeassistant/components/sonos/*
     homeassistant/components/sony_projector/switch.py
     homeassistant/components/spc/*

--- a/homeassistant/components/songpal/manifest.json
+++ b/homeassistant/components/songpal/manifest.json
@@ -10,5 +10,6 @@
       "st": "urn:schemas-sony-com:service:ScalarWebAPI:1",
       "manufacturer": "Sony Corporation"
     }
-  ]
+  ],
+  "quality_scale": "gold"
 }

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -77,8 +77,8 @@ async def async_setup_entry(
         _LOGGER.debug("Unable to get methods from songpal: %s", ex)
         raise PlatformNotReady
 
-    songpal_device = SongpalDevice(name, device)
-    async_add_entities([songpal_device], True)
+    songpal_entity = SongpalEntity(name, device)
+    async_add_entities([songpal_entity], True)
 
     platform = entity_platform.current_platform.get()
     platform.async_register_entity_service(
@@ -88,7 +88,7 @@ async def async_setup_entry(
     )
 
 
-class SongpalDevice(MediaPlayerEntity):
+class SongpalEntity(MediaPlayerEntity):
     """Class representing a Songpal device."""
 
     def __init__(self, name, device, poll=False):

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -78,10 +78,6 @@ async def async_setup_entry(
     name = config_entry.data[CONF_NAME]
     endpoint = config_entry.data[CONF_ENDPOINT]
 
-    if endpoint in hass.data[DOMAIN]:
-        _LOGGER.debug("The endpoint exists already, skipping setup.")
-        return
-
     device = SongpalDevice(name, endpoint)
     try:
         await device.initialize()

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -49,6 +49,8 @@ SUPPORT_SONGPAL = (
     | SUPPORT_TURN_OFF
 )
 
+INITIAL_RETRY_DELAY = 10
+
 
 async def async_setup_platform(
     hass: HomeAssistantType, config: dict, async_add_entities, discovery_info=None
@@ -160,7 +162,7 @@ class SongpalEntity(MediaPlayerEntity):
 
             # Try to reconnect forever, a successful reconnect will initialize
             # the websocket connection again.
-            delay = 10
+            delay = INITIAL_RETRY_DELAY
             while not self._available:
                 _LOGGER.debug("Trying to reconnect in %s seconds", delay)
                 await asyncio.sleep(delay)

--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -121,7 +121,6 @@ class SongpalDevice(MediaPlayerEntity):
 
     async def async_will_remove_from_hass(self):
         """Run when entity will be removed from hass."""
-        self.hass.data[DOMAIN].pop(self._endpoint)
         await self.dev.stop_listen_notifications()
 
     async def async_activate_websocket(self):

--- a/tests/components/songpal/__init__.py
+++ b/tests/components/songpal/__init__.py
@@ -1,1 +1,96 @@
 """Test the songpal integration."""
+from songpal import SongpalException
+
+from homeassistant.components.songpal.const import CONF_ENDPOINT
+from homeassistant.const import CONF_NAME
+
+from tests.async_mock import AsyncMock, MagicMock, patch
+
+FRIENDLY_NAME = "friendly name"
+HOST = "0.0.0.0"
+ENDPOINT = f"http://{HOST}:10000/sony"
+MODEL = "model"
+MAC = "mac"
+SW_VERSION = "sw_ver"
+
+CONF_DATA = {
+    CONF_NAME: FRIENDLY_NAME,
+    CONF_ENDPOINT: ENDPOINT,
+}
+
+
+def _create_mocked_device(throw_exception=False):
+    mocked_device = MagicMock()
+
+    type(mocked_device).get_supported_methods = AsyncMock(
+        side_effect=SongpalException("Unable to do POST request: ")
+        if throw_exception
+        else None
+    )
+
+    interface_info = MagicMock()
+    interface_info.modelName = MODEL
+    type(mocked_device).get_interface_information = AsyncMock(
+        return_value=interface_info
+    )
+
+    sys_info = MagicMock()
+    sys_info.macAddr = MAC
+    sys_info.version = SW_VERSION
+    type(mocked_device).get_system_info = AsyncMock(return_value=sys_info)
+
+    volume1 = MagicMock()
+    volume1.maxVolume = 100
+    volume1.minVolume = 0
+    volume1.volume = 50
+    volume1.is_muted = False
+    volume1.set_volume = AsyncMock()
+    volume1.set_mute = AsyncMock()
+    mocked_device.volume1 = volume1
+    type(mocked_device).get_volume_information = AsyncMock(return_value=[volume1])
+
+    power = MagicMock()
+    power.status = True
+    type(mocked_device).get_power = AsyncMock(return_value=power)
+
+    input1 = MagicMock()
+    input1.title = "title1"
+    input1.uri = "uri1"
+    input1.active = False
+    input1.activate = AsyncMock()
+    mocked_device.input1 = input1
+    input2 = MagicMock()
+    input2.title = "title2"
+    input2.uri = "uri2"
+    input2.active = True
+    type(mocked_device).get_inputs = AsyncMock(return_value=[input1, input2])
+
+    type(mocked_device).set_power = AsyncMock()
+    type(mocked_device).set_sound_settings = AsyncMock()
+    type(mocked_device).listen_notifications = AsyncMock()
+    type(mocked_device).stop_listen_notifications = AsyncMock()
+
+    notification_callbacks = {}
+    mocked_device.notification_callbacks = notification_callbacks
+
+    def _on_notification(name, callback):
+        notification_callbacks[name] = callback
+
+    type(mocked_device).on_notification = MagicMock(side_effect=_on_notification)
+    type(mocked_device).clear_notification_callbacks = MagicMock()
+
+    return mocked_device
+
+
+def _patch_config_flow_device(mocked_device):
+    return patch(
+        "homeassistant.components.songpal.config_flow.Device",
+        return_value=mocked_device,
+    )
+
+
+def _patch_media_player_device(mocked_device):
+    return patch(
+        "homeassistant.components.songpal.media_player.Device",
+        return_value=mocked_device,
+    )

--- a/tests/components/songpal/__init__.py
+++ b/tests/components/songpal/__init__.py
@@ -6,7 +6,8 @@ from homeassistant.const import CONF_NAME
 
 from tests.async_mock import AsyncMock, MagicMock, patch
 
-FRIENDLY_NAME = "friendly name"
+FRIENDLY_NAME = "name"
+ENTITY_ID = f"media_player.{FRIENDLY_NAME}"
 HOST = "0.0.0.0"
 ENDPOINT = f"http://{HOST}:10000/sony"
 MODEL = "model"
@@ -46,8 +47,15 @@ def _create_mocked_device(throw_exception=False):
     volume1.is_muted = False
     volume1.set_volume = AsyncMock()
     volume1.set_mute = AsyncMock()
+    volume2 = MagicMock()
+    volume2.maxVolume = 100
+    volume2.minVolume = 0
+    volume2.volume = 20
+    volume2.is_muted = True
     mocked_device.volume1 = volume1
-    type(mocked_device).get_volume_information = AsyncMock(return_value=[volume1])
+    type(mocked_device).get_volume_information = AsyncMock(
+        return_value=[volume1, volume2]
+    )
 
     power = MagicMock()
     power.status = True

--- a/tests/components/songpal/test_config_flow.py
+++ b/tests/components/songpal/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the songpal config flow."""
 import copy
 
-from asynctest import MagicMock, patch
 from songpal import SongpalException
 from songpal.containers import InterfaceInfo
 
@@ -15,6 +14,7 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
+from tests.async_mock import MagicMock, patch
 from tests.common import MockConfigEntry
 
 UDN = "uuid:1234"

--- a/tests/components/songpal/test_config_flow.py
+++ b/tests/components/songpal/test_config_flow.py
@@ -1,9 +1,6 @@
 """Test the songpal config flow."""
 import copy
 
-from songpal import SongpalException
-from songpal.containers import InterfaceInfo
-
 from homeassistant.components import ssdp
 from homeassistant.components.songpal.const import CONF_ENDPOINT, DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_SSDP, SOURCE_USER
@@ -14,14 +11,20 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-from tests.async_mock import MagicMock, patch
+from . import (
+    CONF_DATA,
+    ENDPOINT,
+    FRIENDLY_NAME,
+    HOST,
+    MODEL,
+    _create_mocked_device,
+    _patch_config_flow_device,
+)
+
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 UDN = "uuid:1234"
-FRIENDLY_NAME = "friendly name"
-HOST = "0.0.0.0"
-ENDPOINT = f"http://{HOST}:10000/sony"
-MODEL = "model"
 
 SSDP_DATA = {
     ssdp.ATTR_UPNP_UDN: UDN,
@@ -35,58 +38,18 @@ SSDP_DATA = {
     },
 }
 
-CONF_DATA = {
-    CONF_NAME: FRIENDLY_NAME,
-    CONF_ENDPOINT: ENDPOINT,
-}
-
-
-async def _async_return_value():
-    pass
-
-
-def _get_supported_methods(throw_exception):
-    def get_supported_methods():
-        if throw_exception:
-            raise SongpalException("Unable to do POST request: ")
-        return _async_return_value()
-
-    return get_supported_methods
-
-
-async def _get_interface_information():
-    return InterfaceInfo(
-        productName="product name",
-        modelName=MODEL,
-        productCategory="product category",
-        interfaceVersion="interface version",
-        serverName="server name",
-    )
-
-
-def _create_mocked_device(throw_exception=False):
-    mocked_device = MagicMock()
-    type(mocked_device).get_supported_methods = MagicMock(
-        side_effect=_get_supported_methods(throw_exception)
-    )
-    type(mocked_device).get_interface_information = MagicMock(
-        side_effect=_get_interface_information
-    )
-    return mocked_device
-
-
-def _patch_config_flow_device(mocked_device):
-    return patch(
-        "homeassistant.components.songpal.config_flow.Device",
-        return_value=mocked_device,
-    )
-
 
 def _flow_next(hass, flow_id):
     return next(
         flow
         for flow in hass.config_entries.flow.async_progress()
         if flow["flow_id"] == flow_id
+    )
+
+
+def _patch_setup():
+    return patch(
+        "homeassistant.components.songpal.async_setup_entry", return_value=True,
     )
 
 
@@ -104,19 +67,20 @@ async def test_flow_ssdp(hass):
     flow = _flow_next(hass, result["flow_id"])
     assert flow["context"]["unique_id"] == UDN
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == FRIENDLY_NAME
-    assert result["data"] == CONF_DATA
+    with _patch_setup():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == FRIENDLY_NAME
+        assert result["data"] == CONF_DATA
 
 
 async def test_flow_user(hass):
     """Test working user initialized flow."""
     mocked_device = _create_mocked_device()
 
-    with _patch_config_flow_device(mocked_device):
+    with _patch_config_flow_device(mocked_device), _patch_setup():
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER},
         )
@@ -143,7 +107,7 @@ async def test_flow_import(hass):
     """Test working import flow."""
     mocked_device = _create_mocked_device()
 
-    with _patch_config_flow_device(mocked_device):
+    with _patch_config_flow_device(mocked_device), _patch_setup():
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=CONF_DATA
         )
@@ -153,6 +117,22 @@ async def test_flow_import(hass):
 
     mocked_device.get_supported_methods.assert_called_once()
     mocked_device.get_interface_information.assert_not_called()
+
+
+async def test_flow_import_without_name(hass):
+    """Test import flow without optional name."""
+    mocked_device = _create_mocked_device()
+
+    with _patch_config_flow_device(mocked_device), _patch_setup():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_ENDPOINT: ENDPOINT}
+        )
+        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == MODEL
+        assert result["data"] == {CONF_NAME: MODEL, CONF_ENDPOINT: ENDPOINT}
+
+    mocked_device.get_supported_methods.assert_called_once()
+    mocked_device.get_interface_information.assert_called_once()
 
 
 def _create_mock_config_entry(hass):

--- a/tests/components/songpal/test_init.py
+++ b/tests/components/songpal/test_init.py
@@ -1,0 +1,66 @@
+"""Tests songpal setup."""
+from homeassistant.components import songpal
+from homeassistant.setup import async_setup_component
+
+from . import (
+    CONF_DATA,
+    _create_mocked_device,
+    _patch_config_flow_device,
+    _patch_media_player_device,
+)
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+def _patch_media_setup():
+    """Patch media_player.async_setup_entry."""
+
+    async def _async_return():
+        return True
+
+    return patch(
+        "homeassistant.components.songpal.media_player.async_setup_entry",
+        side_effect=_async_return,
+    )
+
+
+async def test_setup_empty(hass):
+    """Test setup without any configuration."""
+    with _patch_media_setup() as setup:
+        assert await async_setup_component(hass, songpal.DOMAIN, {}) is True
+        await hass.async_block_till_done()
+    setup.assert_not_called()
+
+
+async def test_setup(hass):
+    """Test setup the platform."""
+    mocked_device = _create_mocked_device()
+
+    with _patch_config_flow_device(mocked_device), _patch_media_setup() as setup:
+        assert (
+            await async_setup_component(
+                hass, songpal.DOMAIN, {songpal.DOMAIN: [CONF_DATA]}
+            )
+            is True
+        )
+        await hass.async_block_till_done()
+    mocked_device.get_supported_methods.assert_called_once()
+    setup.assert_called_once()
+
+
+async def test_unload(hass):
+    """Test unload entity."""
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
+    mocked_device = _create_mocked_device()
+
+    with _patch_config_flow_device(mocked_device), _patch_media_player_device(
+        mocked_device
+    ):
+        assert await async_setup_component(hass, songpal.DOMAIN, {}) is True
+        await hass.async_block_till_done()
+    mocked_device.listen_notifications.assert_called_once()
+    assert await songpal.async_unload_entry(hass, entry)
+    await hass.async_block_till_done()
+    mocked_device.stop_listen_notifications.assert_called_once()

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -1,5 +1,6 @@
 """Test songpal media_player."""
-import pytest
+from datetime import timedelta
+
 from songpal import (
     ConnectChange,
     ContentChange,
@@ -8,24 +9,23 @@ from songpal import (
     VolumeChange,
 )
 
-from homeassistant.components import songpal
+from homeassistant.components import media_player, songpal
 from homeassistant.components.songpal.const import SET_SOUND_SETTING
 from homeassistant.components.songpal.media_player import (
     STATE_OFF,
     STATE_ON,
     SUPPORT_SONGPAL,
-    SongpalDevice,
-    async_setup_entry,
 )
-from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from . import (
     CONF_DATA,
     CONF_ENDPOINT,
     CONF_NAME,
     ENDPOINT,
+    ENTITY_ID,
     FRIENDLY_NAME,
     MAC,
     MODEL,
@@ -35,7 +35,12 @@ from . import (
 )
 
 from tests.async_mock import AsyncMock, MagicMock, call, patch
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def _get_attributes(hass):
+    state = hass.states.get(ENTITY_ID)
+    return state.as_dict()["attributes"]
 
 
 async def test_setup_platform(hass):
@@ -44,9 +49,9 @@ async def test_setup_platform(hass):
     with _patch_media_player_device(mocked_device):
         await async_setup_component(
             hass,
-            "media_player",
+            media_player.DOMAIN,
             {
-                "media_player": [
+                media_player.DOMAIN: [
                     {
                         "platform": songpal.DOMAIN,
                         CONF_NAME: FRIENDLY_NAME,
@@ -59,118 +64,137 @@ async def test_setup_platform(hass):
 
     # No device is set up
     mocked_device.assert_not_called()
+    all_states = hass.states.async_all()
+    assert len(all_states) == 0
 
 
 async def test_setup_failed(hass):
     """Test failed to set up the entity."""
     mocked_device = _create_mocked_device(throw_exception=True)
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
-    mocked_add_entity = MagicMock()
+    entry.add_to_hass(hass)
 
-    with _patch_media_player_device(mocked_device), pytest.raises(PlatformNotReady):
-        await async_setup_entry(hass, entry, mocked_add_entity)
-    mocked_add_entity.assert_not_called()
+    logger_warning = MagicMock()
+    logger_error = MagicMock()
+    with patch("logging.Logger.warning", side_effect=logger_warning), patch(
+        "logging.Logger.error", side_effect=logger_error
+    ):
+        with _patch_media_player_device(mocked_device):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+        all_states = hass.states.async_all()
+        assert len(all_states) == 0
+        assert logger_warning.call_count == 2
+        logger_warning.reset_mock()
+
+        utcnow = dt_util.utcnow()
+        type(mocked_device).get_supported_methods = AsyncMock()
+        with _patch_media_player_device(mocked_device):
+            async_fire_time_changed(hass, utcnow + timedelta(seconds=30))
+            await hass.async_block_till_done()
+        all_states = hass.states.async_all()
+        assert len(all_states) == 1
+        logger_warning.assert_not_called()
+        logger_error.assert_not_called()
 
 
-async def test_properties(hass):
-    """Test property values."""
+async def test_state(hass):
+    """Test state of the entity."""
     mocked_device = _create_mocked_device()
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
 
-    songpal_device = SongpalDevice(FRIENDLY_NAME, mocked_device)
-    songpal_device.hass = hass
-    await songpal_device.async_update()
-    await hass.async_block_till_done()
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    assert songpal_device.should_poll is False
-    assert songpal_device.name == FRIENDLY_NAME
-    assert songpal_device.unique_id == MAC
-    assert songpal_device.device_info == {
-        "connections": {(dr.CONNECTION_NETWORK_MAC, MAC)},
-        "identifiers": {(songpal.DOMAIN, MAC)},
-        "manufacturer": "Sony Corporation",
-        "name": FRIENDLY_NAME,
-        "sw_version": SW_VERSION,
-        "model": MODEL,
-    }
-    assert songpal_device.available is True
-    assert songpal_device.source_list == ["title1", "title2"]
-    assert songpal_device.state == STATE_ON
-    assert songpal_device.source == "title2"
-    assert songpal_device.volume_level == 0.5
-    assert songpal_device.is_volume_muted is False
-    assert songpal_device.supported_features == SUPPORT_SONGPAL
+    state = hass.states.get(ENTITY_ID)
+    assert state.name == FRIENDLY_NAME
+    assert state.state == STATE_ON
+    attributes = state.as_dict()["attributes"]
+    assert attributes["volume_level"] == 0.5
+    assert attributes["is_volume_muted"] is False
+    assert attributes["source_list"] == ["title1", "title2"]
+    assert attributes["source"] == "title2"
+    assert attributes["supported_features"] == SUPPORT_SONGPAL
 
-    # no volume
-    type(mocked_device).get_volume_information = AsyncMock(return_value=[])
-    await songpal_device.async_update()
-    assert songpal_device.available is False
-
-    # multiple volumes
-    volume1 = mocked_device.volume1
-    volume2 = MagicMock()
-    type(mocked_device).get_volume_information = AsyncMock(
-        return_value=[volume1, volume2]
+    device_registry = await dr.async_get_registry(hass)
+    device = device_registry.async_get_device(
+        identifiers={(songpal.DOMAIN, MAC)}, connections={}
     )
-    await songpal_device.async_update()
-    assert songpal_device.available is True
-    assert songpal_device._volume_control == volume1  # pylint: disable=protected-access
+    assert device.connections == {(dr.CONNECTION_NETWORK_MAC, MAC)}
+    assert device.manufacturer == "Sony Corporation"
+    assert device.name == FRIENDLY_NAME
+    assert device.sw_version == SW_VERSION
+    assert device.model == MODEL
 
-    # exception
-    type(mocked_device).get_power = AsyncMock(side_effect=SongpalException("exception"))
-    await songpal_device.async_update()
-    assert songpal_device.available is False
+    entity_registry = await er.async_get_registry(hass)
+    entity = entity_registry.async_get(ENTITY_ID)
+    assert entity.unique_id == MAC
 
 
-async def test_methods(hass):
-    """Test method calls."""
+async def test_services(hass):
+    """Test services."""
     mocked_device = _create_mocked_device()
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
 
-    songpal_device = SongpalDevice(FRIENDLY_NAME, mocked_device)
-    songpal_device.hass = hass
-    await songpal_device.async_update()
-    await hass.async_block_till_done()
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    await songpal_device.async_select_source("none")
-    mocked_device.input1.activate.assert_not_called()
-    await songpal_device.async_select_source("title1")
-    mocked_device.input1.activate.assert_called_once()
+    async def _call(service, **argv):
+        await hass.services.async_call(
+            media_player.DOMAIN,
+            service,
+            {"entity_id": ENTITY_ID, **argv},
+            blocking=True,
+        )
 
-    await songpal_device.async_set_volume_level(0.6)
-    await songpal_device.async_volume_up()
-    await songpal_device.async_volume_down()
+    await _call(media_player.SERVICE_TURN_ON)
+    await _call(media_player.SERVICE_TURN_OFF)
+    await _call(media_player.SERVICE_TOGGLE)
+    assert mocked_device.set_power.call_count == 3
+    mocked_device.set_power.assert_has_calls([call(True), call(False), call(False)])
+
+    await _call(media_player.SERVICE_VOLUME_SET, volume_level=0.6)
+    await _call(media_player.SERVICE_VOLUME_UP)
+    await _call(media_player.SERVICE_VOLUME_DOWN)
     assert mocked_device.volume1.set_volume.call_count == 3
     mocked_device.volume1.set_volume.assert_has_calls(
         [call(60), call("+1"), call("-1")]
     )
 
-    await songpal_device.async_turn_on()
-    await songpal_device.async_turn_off()
-    assert mocked_device.set_power.call_count == 2
-    mocked_device.set_power.assert_has_calls([call(True), call(False)])
-
-    await songpal_device.async_mute_volume(True)
+    await _call(media_player.SERVICE_VOLUME_MUTE, is_volume_muted=True)
     mocked_device.volume1.set_mute.assert_called_once_with(True)
 
-
-async def test_services(hass):
-    """Test custom services."""
-    MockConfigEntry(
-        domain=songpal.DOMAIN, data={CONF_NAME: "d1", CONF_ENDPOINT: ENDPOINT}
-    ).add_to_hass(hass)
-    mocked_device = _create_mocked_device()
-
-    with _patch_media_player_device(mocked_device):
-        await async_setup_component(hass, songpal.DOMAIN, {})
-        await hass.async_block_till_done()
+    await _call(media_player.SERVICE_SELECT_SOURCE, source="none")
+    mocked_device.input1.activate.assert_not_called()
+    await _call(media_player.SERVICE_SELECT_SOURCE, source="title1")
+    mocked_device.input1.activate.assert_called_once()
 
     await hass.services.async_call(
         songpal.DOMAIN,
         SET_SOUND_SETTING,
-        {"entity_id": "media_player.d1", "name": "name", "value": "value"},
+        {"entity_id": ENTITY_ID, "name": "name", "value": "value"},
         blocking=True,
     )
     mocked_device.set_sound_settings.assert_called_once_with("name", "value")
     mocked_device.set_sound_settings.reset_mock()
+
+    mocked_device2 = _create_mocked_device()
+    sys_info = MagicMock()
+    sys_info.macAddr = "mac2"
+    sys_info.version = SW_VERSION
+    type(mocked_device2).get_system_info = AsyncMock(return_value=sys_info)
+    entry2 = MockConfigEntry(
+        domain=songpal.DOMAIN, data={CONF_NAME: "d2", CONF_ENDPOINT: ENDPOINT}
+    )
+    entry2.add_to_hass(hass)
+    with _patch_media_player_device(mocked_device2):
+        await hass.config_entries.async_setup(entry2.entry_id)
+        await hass.async_block_till_done()
+
     await hass.services.async_call(
         songpal.DOMAIN,
         SET_SOUND_SETTING,
@@ -178,18 +202,18 @@ async def test_services(hass):
         blocking=True,
     )
     mocked_device.set_sound_settings.assert_called_once_with("name", "value")
+    mocked_device2.set_sound_settings.assert_called_once_with("name", "value")
 
 
 async def test_websocket_events(hass):
     """Test websocket events."""
     mocked_device = _create_mocked_device()
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
 
-    songpal_device = SongpalDevice(FRIENDLY_NAME, mocked_device)
-    songpal_device.hass = hass
-    songpal_device.async_write_ha_state = MagicMock()
-    songpal_device.async_update_ha_state = AsyncMock()
-    await songpal_device.async_update()
-    await hass.async_block_till_done()
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     mocked_device.listen_notifications.assert_called_once()
     assert mocked_device.on_notification.call_count == 4
@@ -200,38 +224,64 @@ async def test_websocket_events(hass):
     volume_change.mute = True
     volume_change.volume = 20
     await notification_callbacks[VolumeChange](volume_change)
-    assert songpal_device.is_volume_muted is True
-    assert songpal_device.volume_level == 0.2
-    songpal_device.async_write_ha_state.assert_called_once()
-    songpal_device.async_write_ha_state.reset_mock()
+    attributes = _get_attributes(hass)
+    assert attributes["is_volume_muted"] is True
+    assert attributes["volume_level"] == 0.2
 
     content_change = MagicMock()
     content_change.is_input = False
     content_change.uri = "uri1"
     await notification_callbacks[ContentChange](content_change)
-    assert songpal_device.source == "title2"
-    songpal_device.async_write_ha_state.assert_not_called()
+    assert _get_attributes(hass)["source"] == "title2"
     content_change.is_input = True
     await notification_callbacks[ContentChange](content_change)
-    assert songpal_device.source == "title1"
-    songpal_device.async_write_ha_state.assert_called_once()
-    songpal_device.async_write_ha_state.reset_mock()
+    assert _get_attributes(hass)["source"] == "title1"
 
     power_change = MagicMock()
     power_change.status = False
     await notification_callbacks[PowerChange](power_change)
-    assert songpal_device.state == STATE_OFF
-    songpal_device.async_write_ha_state.assert_called_once()
-    songpal_device.async_write_ha_state.reset_mock()
+    assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
     connect_change = MagicMock()
     connect_change.exception = "disconnected"
-
-    async def _mocked_sleep(delay):
-        songpal_device._available = True  # pylint: disable=protected-access
-
-    with patch("asyncio.sleep", side_effect=_mocked_sleep) as sleep:
+    with patch("asyncio.sleep", side_effect=AsyncMock()) as sleep:
         await notification_callbacks[ConnectChange](connect_change)
     sleep.assert_called_once()
     mocked_device.clear_notification_callbacks.assert_called_once()
-    songpal_device.async_update_ha_state.assert_called_once_with(force_refresh=True)
+
+
+async def test_disconnected(hass):
+    """Test disconnected behavior."""
+    mocked_device = _create_mocked_device()
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
+
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    logger_warning = MagicMock()
+    logger_error = MagicMock()
+    connect_change = MagicMock()
+    connect_change.exception = "disconnected"
+    type(mocked_device).get_supported_methods = AsyncMock(
+        side_effect=SongpalException("disconnected")
+    )
+    notification_callbacks = mocked_device.notification_callbacks
+
+    async def _mocked_sleep(delay):
+        if delay == 10:  # first sleep
+            logger_warning.assert_called_once()
+            logger_warning.reset_mock()
+        elif delay == 20:  # second sleep
+            logger_warning.assert_not_called()
+            type(mocked_device).get_supported_methods = AsyncMock()
+        else:
+            assert False  # should never be here
+
+    with patch("asyncio.sleep", side_effect=_mocked_sleep), patch(
+        "logging.Logger.warning", side_effect=logger_warning
+    ), patch("logging.Logger.error", side_effect=logger_error):
+        await notification_callbacks[ConnectChange](connect_change)
+    logger_warning.assert_called_once()
+    logger_error.assert_not_called()

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -76,9 +76,10 @@ async def test_properties(hass):
     """Test property values."""
     mocked_device = _create_mocked_device()
 
-    with _patch_media_player_device(mocked_device):
-        songpal_device = SongpalDevice(FRIENDLY_NAME, ENDPOINT)
-        await songpal_device.initialize()
+    songpal_device = SongpalDevice(FRIENDLY_NAME, mocked_device)
+    songpal_device.hass = hass
+    await songpal_device.async_update()
+    await hass.async_block_till_done()
 
     assert songpal_device.should_poll is False
     assert songpal_device.name == FRIENDLY_NAME
@@ -91,12 +92,6 @@ async def test_properties(hass):
         "sw_version": SW_VERSION,
         "model": MODEL,
     }
-    assert songpal_device.available is False
-
-    songpal_device.hass = hass
-    await songpal_device.async_update()
-    await hass.async_block_till_done()
-
     assert songpal_device.available is True
     assert songpal_device.source_list == ["title1", "title2"]
     assert songpal_device.state == STATE_ON
@@ -130,12 +125,10 @@ async def test_methods(hass):
     """Test method calls."""
     mocked_device = _create_mocked_device()
 
-    with _patch_media_player_device(mocked_device):
-        songpal_device = SongpalDevice(FRIENDLY_NAME, ENDPOINT)
-        await songpal_device.initialize()
-        songpal_device.hass = hass
-        await songpal_device.async_update()
-        await hass.async_block_till_done()
+    songpal_device = SongpalDevice(FRIENDLY_NAME, mocked_device)
+    songpal_device.hass = hass
+    await songpal_device.async_update()
+    await hass.async_block_till_done()
 
     await songpal_device.async_select_source("none")
     mocked_device.input1.activate.assert_not_called()
@@ -191,14 +184,12 @@ async def test_websocket_events(hass):
     """Test websocket events."""
     mocked_device = _create_mocked_device()
 
-    with _patch_media_player_device(mocked_device):
-        songpal_device = SongpalDevice(FRIENDLY_NAME, ENDPOINT)
-        await songpal_device.initialize()
-        songpal_device.hass = hass
-        songpal_device.async_write_ha_state = MagicMock()
-        songpal_device.async_update_ha_state = AsyncMock()
-        await songpal_device.async_update()
-        await hass.async_block_till_done()
+    songpal_device = SongpalDevice(FRIENDLY_NAME, mocked_device)
+    songpal_device.hass = hass
+    songpal_device.async_write_ha_state = MagicMock()
+    songpal_device.async_update_ha_state = AsyncMock()
+    await songpal_device.async_update()
+    await hass.async_block_till_done()
 
     mocked_device.listen_notifications.assert_called_once()
     assert mocked_device.on_notification.call_count == 4

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -242,13 +242,6 @@ async def test_websocket_events(hass):
     await notification_callbacks[PowerChange](power_change)
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
-    connect_change = MagicMock()
-    connect_change.exception = "disconnected"
-    with patch("asyncio.sleep", side_effect=AsyncMock()) as sleep:
-        await notification_callbacks[ConnectChange](connect_change)
-    sleep.assert_called_once()
-    mocked_device.clear_notification_callbacks.assert_called_once()
-
 
 async def test_disconnected(hass):
     """Test disconnected behavior."""

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -1,0 +1,246 @@
+"""Test songpal media_player."""
+import pytest
+from songpal import (
+    ConnectChange,
+    ContentChange,
+    PowerChange,
+    SongpalException,
+    VolumeChange,
+)
+
+from homeassistant.components import songpal
+from homeassistant.components.songpal.const import SET_SOUND_SETTING
+from homeassistant.components.songpal.media_player import (
+    STATE_OFF,
+    STATE_ON,
+    SUPPORT_SONGPAL,
+    SongpalDevice,
+    async_setup_entry,
+)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from . import (
+    CONF_DATA,
+    CONF_ENDPOINT,
+    CONF_NAME,
+    ENDPOINT,
+    FRIENDLY_NAME,
+    MAC,
+    MODEL,
+    SW_VERSION,
+    _create_mocked_device,
+    _patch_media_player_device,
+)
+
+from tests.async_mock import AsyncMock, MagicMock, call, patch
+from tests.common import MockConfigEntry
+
+
+async def test_setup_platform(hass):
+    """Test the legacy setup platform."""
+    mocked_device = _create_mocked_device(throw_exception=True)
+    with _patch_media_player_device(mocked_device):
+        await async_setup_component(
+            hass,
+            "media_player",
+            {
+                "media_player": [
+                    {
+                        "platform": songpal.DOMAIN,
+                        CONF_NAME: FRIENDLY_NAME,
+                        CONF_ENDPOINT: ENDPOINT,
+                    }
+                ],
+            },
+        )
+        await hass.async_block_till_done()
+
+    # No device is set up
+    mocked_device.assert_not_called()
+
+
+async def test_setup_failed(hass):
+    """Test failed to set up the entity."""
+    mocked_device = _create_mocked_device(throw_exception=True)
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    mocked_add_entity = MagicMock()
+
+    with _patch_media_player_device(mocked_device), pytest.raises(PlatformNotReady):
+        await async_setup_entry(hass, entry, mocked_add_entity)
+    mocked_add_entity.assert_not_called()
+
+
+async def test_properties(hass):
+    """Test property values."""
+    mocked_device = _create_mocked_device()
+
+    with _patch_media_player_device(mocked_device):
+        songpal_device = SongpalDevice(FRIENDLY_NAME, ENDPOINT)
+        await songpal_device.initialize()
+
+    assert songpal_device.should_poll is False
+    assert songpal_device.name == FRIENDLY_NAME
+    assert songpal_device.unique_id == MAC
+    assert songpal_device.device_info == {
+        "connections": {(dr.CONNECTION_NETWORK_MAC, MAC)},
+        "identifiers": {(songpal.DOMAIN, MAC)},
+        "manufacturer": "Sony Corporation",
+        "name": FRIENDLY_NAME,
+        "sw_version": SW_VERSION,
+        "model": MODEL,
+    }
+    assert songpal_device.available is False
+
+    songpal_device.hass = hass
+    await songpal_device.async_update()
+    await hass.async_block_till_done()
+
+    assert songpal_device.available is True
+    assert songpal_device.source_list == ["title1", "title2"]
+    assert songpal_device.state == STATE_ON
+    assert songpal_device.source == "title2"
+    assert songpal_device.volume_level == 0.5
+    assert songpal_device.is_volume_muted is False
+    assert songpal_device.supported_features == SUPPORT_SONGPAL
+
+    # no volume
+    type(mocked_device).get_volume_information = AsyncMock(return_value=[])
+    await songpal_device.async_update()
+    assert songpal_device.available is False
+
+    # multiple volumes
+    volume1 = mocked_device.volume1
+    volume2 = MagicMock()
+    type(mocked_device).get_volume_information = AsyncMock(
+        return_value=[volume1, volume2]
+    )
+    await songpal_device.async_update()
+    assert songpal_device.available is True
+    assert songpal_device._volume_control == volume1  # pylint: disable=protected-access
+
+    # exception
+    type(mocked_device).get_power = AsyncMock(side_effect=SongpalException("exception"))
+    await songpal_device.async_update()
+    assert songpal_device.available is False
+
+
+async def test_methods(hass):
+    """Test method calls."""
+    mocked_device = _create_mocked_device()
+
+    with _patch_media_player_device(mocked_device):
+        songpal_device = SongpalDevice(FRIENDLY_NAME, ENDPOINT)
+        await songpal_device.initialize()
+        songpal_device.hass = hass
+        await songpal_device.async_update()
+        await hass.async_block_till_done()
+
+    await songpal_device.async_select_source("none")
+    mocked_device.input1.activate.assert_not_called()
+    await songpal_device.async_select_source("title1")
+    mocked_device.input1.activate.assert_called_once()
+
+    await songpal_device.async_set_volume_level(0.6)
+    await songpal_device.async_volume_up()
+    await songpal_device.async_volume_down()
+    assert mocked_device.volume1.set_volume.call_count == 3
+    mocked_device.volume1.set_volume.assert_has_calls(
+        [call(60), call("+1"), call("-1")]
+    )
+
+    await songpal_device.async_turn_on()
+    await songpal_device.async_turn_off()
+    assert mocked_device.set_power.call_count == 2
+    mocked_device.set_power.assert_has_calls([call(True), call(False)])
+
+    await songpal_device.async_mute_volume(True)
+    mocked_device.volume1.set_mute.assert_called_once_with(True)
+
+
+async def test_services(hass):
+    """Test custom services."""
+    MockConfigEntry(
+        domain=songpal.DOMAIN, data={CONF_NAME: "d1", CONF_ENDPOINT: ENDPOINT}
+    ).add_to_hass(hass)
+    mocked_device = _create_mocked_device()
+
+    with _patch_media_player_device(mocked_device):
+        await async_setup_component(hass, songpal.DOMAIN, {})
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        songpal.DOMAIN,
+        SET_SOUND_SETTING,
+        {"entity_id": "media_player.d1", "name": "name", "value": "value"},
+        blocking=True,
+    )
+    mocked_device.set_sound_settings.assert_called_once_with("name", "value")
+    mocked_device.set_sound_settings.reset_mock()
+    await hass.services.async_call(
+        songpal.DOMAIN,
+        SET_SOUND_SETTING,
+        {"entity_id": "all", "name": "name", "value": "value"},
+        blocking=True,
+    )
+    mocked_device.set_sound_settings.assert_called_once_with("name", "value")
+
+
+async def test_websocket_events(hass):
+    """Test websocket events."""
+    mocked_device = _create_mocked_device()
+
+    with _patch_media_player_device(mocked_device):
+        songpal_device = SongpalDevice(FRIENDLY_NAME, ENDPOINT)
+        await songpal_device.initialize()
+        songpal_device.hass = hass
+        songpal_device.async_write_ha_state = MagicMock()
+        songpal_device.async_update_ha_state = AsyncMock()
+        await songpal_device.async_update()
+        await hass.async_block_till_done()
+
+    mocked_device.listen_notifications.assert_called_once()
+    assert mocked_device.on_notification.call_count == 4
+
+    notification_callbacks = mocked_device.notification_callbacks
+
+    volume_change = MagicMock()
+    volume_change.mute = True
+    volume_change.volume = 20
+    await notification_callbacks[VolumeChange](volume_change)
+    assert songpal_device.is_volume_muted is True
+    assert songpal_device.volume_level == 0.2
+    songpal_device.async_write_ha_state.assert_called_once()
+    songpal_device.async_write_ha_state.reset_mock()
+
+    content_change = MagicMock()
+    content_change.is_input = False
+    content_change.uri = "uri1"
+    await notification_callbacks[ContentChange](content_change)
+    assert songpal_device.source == "title2"
+    songpal_device.async_write_ha_state.assert_not_called()
+    content_change.is_input = True
+    await notification_callbacks[ContentChange](content_change)
+    assert songpal_device.source == "title1"
+    songpal_device.async_write_ha_state.assert_called_once()
+    songpal_device.async_write_ha_state.reset_mock()
+
+    power_change = MagicMock()
+    power_change.status = False
+    await notification_callbacks[PowerChange](power_change)
+    assert songpal_device.state == STATE_OFF
+    songpal_device.async_write_ha_state.assert_called_once()
+    songpal_device.async_write_ha_state.reset_mock()
+
+    connect_change = MagicMock()
+    connect_change.exception = "disconnected"
+
+    async def _mocked_sleep(delay):
+        songpal_device._available = True  # pylint: disable=protected-access
+
+    with patch("asyncio.sleep", side_effect=_mocked_sleep) as sleep:
+        await notification_callbacks[ConnectChange](connect_change)
+    sleep.assert_called_once()
+    mocked_device.clear_notification_callbacks.assert_called_once()
+    songpal_device.async_update_ha_state.assert_called_once_with(force_refresh=True)

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -12,11 +12,8 @@ from songpal import (
 
 from homeassistant.components import media_player, songpal
 from homeassistant.components.songpal.const import SET_SOUND_SETTING
-from homeassistant.components.songpal.media_player import (
-    STATE_OFF,
-    STATE_ON,
-    SUPPORT_SONGPAL,
-)
+from homeassistant.components.songpal.media_player import SUPPORT_SONGPAL
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -251,10 +248,14 @@ async def test_disconnected(hass, caplog):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
+    async def _assert_state():
+        state = hass.states.get(ENTITY_ID)
+        assert state.state == STATE_UNAVAILABLE
+
     connect_change = MagicMock()
     connect_change.exception = "disconnected"
     type(mocked_device).get_supported_methods = AsyncMock(
-        side_effect=[SongpalException(""), SongpalException(""), None]
+        side_effect=[SongpalException(""), SongpalException(""), _assert_state]
     )
     notification_callbacks = mocked_device.notification_callbacks
     with patch("homeassistant.components.songpal.media_player.INITIAL_RETRY_DELAY", 0):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
To call `songpal/set_sound_setting` on all songpal devices, the `entity_id` now need to be set to `all` instead of left unset.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following reviews by @MartinHjelmare in #34714, here are some code improvements including the test import and service registration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
