### PR TITLE
Add more verbose error messages to microsoft_face

### DIFF
--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -98,8 +98,7 @@ async def async_setup(hass, config):
             entities[g_id] = MicrosoftFaceGroupEntity(hass, face, g_id, name)
             entities[g_id].async_write_ha_state()
         except HomeAssistantError as err:
-            msg = f"Can't create group '{g_id}' with error: {err}"
-            _LOGGER.error(msg)
+            _LOGGER.error("Can't create group '%s' with error: %s", g_id, err)
             raise
 
     hass.services.async_register(
@@ -117,8 +116,7 @@ async def async_setup(hass, config):
             entity = entities.pop(g_id)
             hass.states.async_remove(entity.entity_id, service.context)
         except HomeAssistantError as err:
-            msg = f"Can't delete group '{g_id}' with error: {err}"
-            _LOGGER.error(msg)
+            _LOGGER.error("Can't delete group '%s' with error: %s", g_id, err)
             raise
 
     hass.services.async_register(
@@ -132,8 +130,7 @@ async def async_setup(hass, config):
         try:
             await face.call_api("post", f"persongroups/{g_id}/train")
         except HomeAssistantError as err:
-            msg = f"Can't train group '{g_id}' with error: {err}"
-            _LOGGER.error(msg)
+            _LOGGER.error("Can't train group '%s' with error: %s", g_id, err)
             raise
 
     hass.services.async_register(
@@ -153,8 +150,7 @@ async def async_setup(hass, config):
             face.store[g_id][name] = user_data["personId"]
             entities[g_id].async_write_ha_state()
         except HomeAssistantError as err:
-            msg = f"Can't create person '{name}' with error: {err}"
-            _LOGGER.error(msg)
+            _LOGGER.error("Can't create person '%s' with error: %s", name, err)
             raise
 
     hass.services.async_register(
@@ -173,8 +169,7 @@ async def async_setup(hass, config):
             face.store[g_id].pop(name)
             entities[g_id].async_write_ha_state()
         except HomeAssistantError as err:
-            msg = f"Can't delete person '{p_id}' with error: {err}"
-            _LOGGER.error(msg)
+            _LOGGER.error("Can't delete person '%s' with error: %s", p_id, err)
             raise
 
     hass.services.async_register(
@@ -213,10 +208,9 @@ async def async_setup(hass, config):
                 binary=True,
             )
         except HomeAssistantError as err:
-            msg = "Can't add an image of the person '{}' with error: {}".format(
-                p_name, err
+            _LOGGER.error(
+                "Can't add an image of the person '%s' with error: %s", p_name, err
             )
-            _LOGGER.error(msg)
             raise
 
     hass.services.async_register(
@@ -348,13 +342,11 @@ class MicrosoftFace:
             raise HomeAssistantError(answer["error"]["message"])
 
         except aiohttp.ClientError as err:
-            msg = f"Can't connect to microsoft face api with error: {err}"
-            _LOGGER.error(msg)
+            _LOGGER.error("Can't connect to microsoft face api with error: %s", err)
             raise
 
         except asyncio.TimeoutError:
-            msg = f"Timeout from microsoft face api with '{response.url}'"
-            _LOGGER.warning(msg)
+            _LOGGER.warning("Timeout from microsoft face api with '%s'", response.url)
             raise
 
         raise HomeAssistantError("Network error on microsoft face api.")

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -331,7 +331,7 @@ class MicrosoftFace:
 
                 if response.status == 401:
                     raise HomeAssistantError(
-                        "Authentication failed. Please check the 'azure_region' and 'api_key'"
+                        "Authentication failed. Please check the 'azure_region' and the 'api_key'"
                     )
 
                 if response.status == 202:

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -344,5 +344,3 @@ class MicrosoftFace:
         except asyncio.TimeoutError:
             _LOGGER.warning("Timeout from microsoft face api with '%s'", response.url)
             raise
-
-        raise HomeAssistantError("Network error on microsoft face api.")

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -98,7 +98,7 @@ async def async_setup(hass, config):
             entities[g_id] = MicrosoftFaceGroupEntity(hass, face, g_id, name)
             entities[g_id].async_write_ha_state()
         except HomeAssistantError as err:
-            msg = "Can't create group '{}' with error: {}".format(g_id, err)
+            msg = f"Can't create group '{g_id}' with error: {err}"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
@@ -117,7 +117,7 @@ async def async_setup(hass, config):
             entity = entities.pop(g_id)
             hass.states.async_remove(entity.entity_id, service.context)
         except HomeAssistantError as err:
-            msg = "Can't delete group '{}' with error: {}".format(g_id, err)
+            msg = f"Can't delete group '{g_id}' with error: {err}"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
@@ -132,7 +132,7 @@ async def async_setup(hass, config):
         try:
             await face.call_api("post", f"persongroups/{g_id}/train")
         except HomeAssistantError as err:
-            msg ="Can't train group '{}' with error: {}".format(g_id, err)
+            msg = f"Can't train group '{g_id}' with error: {err}"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
@@ -153,7 +153,7 @@ async def async_setup(hass, config):
             face.store[g_id][name] = user_data["personId"]
             entities[g_id].async_write_ha_state()
         except HomeAssistantError as err:
-            msg = "Can't create person '{}' with error: {}".format(name, err)
+            msg = f"Can't create person '{name}' with error: {err}"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
@@ -173,7 +173,7 @@ async def async_setup(hass, config):
             face.store[g_id].pop(name)
             entities[g_id].async_write_ha_state()
         except HomeAssistantError as err:
-            msg = "Can't delete person '{}' with error: {}".format(p_id, err)
+            msg = f"Can't delete person '{p_id}' with error: {err}"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
@@ -187,14 +187,17 @@ async def async_setup(hass, config):
         p_name = service.data[ATTR_PERSON]
 
         if g_id not in face.store:
-            msg = "Can't add an image of the person '{}' with error: Unknown group '{}'".format(p_name,g_id)
+            msg = "Can't add an image of the person '{}' with error: Unknown group '{}'".format(
+                p_name, g_id
+            )
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
-        
         p_id = face.store[g_id].get(p_name)
         if p_id is None:
-            msg = "Can't add an image of the person '{}' with error: Person unknown in group '{}'".format(p_name, g_id)
+            msg = "Can't add an image of the person '{}' with error: Person unknown in group '{}'".format(
+                p_name, g_id
+            )
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
@@ -210,10 +213,11 @@ async def async_setup(hass, config):
                 binary=True,
             )
         except HomeAssistantError as err:
-            msg = "Can't add an image of the person '{}' with error: {}".format(p_name, err)
+            msg = "Can't add an image of the person '{}' with error: {}".format(
+                p_name, err
+            )
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
-
 
     hass.services.async_register(
         DOMAIN, SERVICE_FACE_PERSON, async_face_person, schema=SCHEMA_FACE_SERVICE
@@ -304,10 +308,10 @@ class MicrosoftFace:
 
     async def call_api(self, method, function, data=None, binary=False, params=None):
         """Make an api call."""
-        
+
         headers = {"Ocp-Apim-Subscription-Key": self._api_key}
         url = self._server_url.format(function)
-        
+
         payload = None
         if binary:
             headers[CONTENT_TYPE] = "application/octet-stream"
@@ -324,15 +328,17 @@ class MicrosoftFace:
                 response = await getattr(self.websession, method)(
                     url, data=payload, headers=headers, params=params
                 )
-              
+
                 if response.status == 401:
-                    raise HomeAssistantError("Authentication failed. Please check the 'azure_region' and 'api_key'")
+                    raise HomeAssistantError(
+                        "Authentication failed. Please check the 'azure_region' and 'api_key'"
+                    )
 
                 if response.status == 202:
                     return None
 
                 answer = await response.json()
-                
+
             if response.status < 300:
                 return answer
 
@@ -341,13 +347,13 @@ class MicrosoftFace:
             )
             raise HomeAssistantError(answer["error"]["message"])
 
-        except aiohttp.ClientError as ce:
-            msg = "Can't connect to microsoft face api with error: {}".format(ce)
+        except aiohttp.ClientError as err:
+            msg = f"Can't connect to microsoft face api with error: {err}"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
         except asyncio.TimeoutError:
-            msg = "Timeout from microsoft face api with '{}'".format(response.url)
+            msg = f"Timeout from microsoft face api with '{response.url}'"
             _LOGGER.warning(msg)
             raise HomeAssistantError(msg)
 

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -182,17 +182,13 @@ async def async_setup(hass, config):
         p_name = service.data[ATTR_PERSON]
 
         if g_id not in face.store:
-            msg = "Can't add an image of the person '{}' with error: Unknown group '{}'".format(
-                p_name, g_id
-            )
+            msg = f"Can't add an image of the person '{p_name}' with error: Unknown group '{g_id}'"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 
         p_id = face.store[g_id].get(p_name)
         if p_id is None:
-            msg = "Can't add an image of the person '{}' with error: Person unknown in group '{}'".format(
-                p_name, g_id
-            )
+            msg = f"Can't add an image of the person '{p_name}' with error: Person unknown in group '{g_id}'"
             _LOGGER.error(msg)
             raise HomeAssistantError(msg)
 

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -100,7 +100,7 @@ async def async_setup(hass, config):
         except HomeAssistantError as err:
             msg = f"Can't create group '{g_id}' with error: {err}"
             _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
+            raise
 
     hass.services.async_register(
         DOMAIN, SERVICE_CREATE_GROUP, async_create_group, schema=SCHEMA_GROUP_SERVICE
@@ -119,7 +119,7 @@ async def async_setup(hass, config):
         except HomeAssistantError as err:
             msg = f"Can't delete group '{g_id}' with error: {err}"
             _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
+            raise
 
     hass.services.async_register(
         DOMAIN, SERVICE_DELETE_GROUP, async_delete_group, schema=SCHEMA_GROUP_SERVICE
@@ -134,7 +134,7 @@ async def async_setup(hass, config):
         except HomeAssistantError as err:
             msg = f"Can't train group '{g_id}' with error: {err}"
             _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
+            raise
 
     hass.services.async_register(
         DOMAIN, SERVICE_TRAIN_GROUP, async_train_group, schema=SCHEMA_TRAIN_SERVICE
@@ -155,7 +155,7 @@ async def async_setup(hass, config):
         except HomeAssistantError as err:
             msg = f"Can't create person '{name}' with error: {err}"
             _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
+            raise
 
     hass.services.async_register(
         DOMAIN, SERVICE_CREATE_PERSON, async_create_person, schema=SCHEMA_PERSON_SERVICE
@@ -175,7 +175,7 @@ async def async_setup(hass, config):
         except HomeAssistantError as err:
             msg = f"Can't delete person '{p_id}' with error: {err}"
             _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
+            raise
 
     hass.services.async_register(
         DOMAIN, SERVICE_DELETE_PERSON, async_delete_person, schema=SCHEMA_PERSON_SERVICE
@@ -217,7 +217,7 @@ async def async_setup(hass, config):
                 p_name, err
             )
             _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
+            raise
 
     hass.services.async_register(
         DOMAIN, SERVICE_FACE_PERSON, async_face_person, schema=SCHEMA_FACE_SERVICE
@@ -350,11 +350,11 @@ class MicrosoftFace:
         except aiohttp.ClientError as err:
             msg = f"Can't connect to microsoft face api with error: {err}"
             _LOGGER.error(msg)
-            raise HomeAssistantError(msg)
+            raise
 
         except asyncio.TimeoutError:
             msg = f"Timeout from microsoft face api with '{response.url}'"
             _LOGGER.warning(msg)
-            raise HomeAssistantError(msg)
+            raise
 
         raise HomeAssistantError("Network error on microsoft face api.")


### PR DESCRIPTION
Improved the output and traceability of errors and errormessages.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
I found the initial setup of this component too hard. I kept keeping errors during the setup. To resolve this i've put more validation in place and made the messages more informative.
I also found it very cumbersome to have to check in the log for the result of service calls.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
This is a simple PR with only more informative error messages and validations. 

## Checklist
- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
