### PR TITLE
0.109.6

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -66,7 +66,6 @@ SERVICE_HANDLERS = {
     SERVICE_OCTOPRINT: ("octoprint", None),
     SERVICE_FREEBOX: ("freebox", None),
     SERVICE_YEELIGHT: ("yeelight", None),
-    "panasonic_viera": ("media_player", "panasonic_viera"),
     "yamaha": ("media_player", "yamaha"),
     "logitech_mediaserver": ("media_player", "squeezebox"),
     "denonavr": ("media_player", "denonavr"),

--- a/homeassistant/components/islamic_prayer_times/__init__.py
+++ b/homeassistant/components/islamic_prayer_times/__init__.py
@@ -125,11 +125,11 @@ class IslamicPrayerClient:
         """
         _LOGGER.debug("Scheduling next update for Islamic prayer times")
 
-        now = dt_util.as_local(dt_util.now())
+        now = dt_util.utcnow()
 
         midnight_dt = self.prayer_times_info["Midnight"]
 
-        if now > dt_util.as_local(midnight_dt):
+        if now > dt_util.as_utc(midnight_dt):
             next_update_at = midnight_dt + timedelta(days=1, minutes=1)
             _LOGGER.debug(
                 "Midnight is after day the changes so schedule update for after Midnight the next day"

--- a/homeassistant/components/islamic_prayer_times/sensor.py
+++ b/homeassistant/components/islamic_prayer_times/sensor.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.const import DEVICE_CLASS_TIMESTAMP
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
 
 from .const import DATA_UPDATED, DOMAIN, PRAYER_TIMES_ICON, SENSOR_TYPES
 
@@ -48,7 +49,11 @@ class IslamicPrayerTimeSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self.client.prayer_times_info.get(self.sensor_type).isoformat()
+        return (
+            self.client.prayer_times_info.get(self.sensor_type)
+            .astimezone(dt_util.UTC)
+            .isoformat()
+        )
 
     @property
     def should_poll(self):

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["pymyq==2.0.1"],
+  "requirements": ["pymyq==2.0.2"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -95,7 +95,6 @@ async def async_setup_entry(hass, config_entry):
         continuous=config_entry.options[CONF_CONTINUOUS],
         delay=config_entry.options[CONF_DELAY],
     )
-    roomba.exclude = "wifistat"  # ignore wifistat to avoid unnecessary updates
 
     try:
         if not await async_connect_or_timeout(hass, roomba):

--- a/homeassistant/components/roomba/binary_sensor.py
+++ b/homeassistant/components/roomba/binary_sensor.py
@@ -45,3 +45,7 @@ class RoombaBinStatus(IRobotEntity, BinarySensorDevice):
     def state(self):
         """Return the state of the sensor."""
         return roomba_reported_state(self.vacuum).get("bin", {}).get("full", False)
+
+    def new_state_filter(self, new_state):
+        """Filter the new state."""
+        return "bin" in new_state

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -102,9 +102,15 @@ class IRobotEntity(Entity):
         """Register callback function."""
         self.vacuum.register_on_message_callback(self.on_message)
 
+    def new_state_filter(self, new_state):
+        """Filter the new state."""
+        raise NotImplementedError
+
     def on_message(self, json_data):
         """Update state on message change."""
-        self.schedule_update_ha_state()
+        state = json_data.get("state", {}).get("reported", {})
+        if self.new_state_filter(state):
+            self.schedule_update_ha_state()
 
 
 class IRobotVacuum(IRobotEntity, StateVacuumDevice):
@@ -212,6 +218,11 @@ class IRobotVacuum(IRobotEntity, StateVacuumDevice):
 
     def on_message(self, json_data):
         """Update state on message change."""
+        new_state = json_data.get("state", {}).get("reported", {})
+        if (
+            len(new_state) == 1 and "signal" in new_state
+        ):  # filter out wifi stat messages
+            return
         _LOGGER.debug("Got new state from the vacuum: %s", json_data)
         self.vacuum_state = roomba_reported_state(self.vacuum)
         self.schedule_update_ha_state()

--- a/homeassistant/components/roomba/sensor.py
+++ b/homeassistant/components/roomba/sensor.py
@@ -46,3 +46,7 @@ class RoombaBattery(IRobotEntity):
     def state(self):
         """Return the state of the sensor."""
         return roomba_reported_state(self.vacuum).get("batPct")
+
+    def new_state_filter(self, new_state):
+        """Filter the new state."""
+        return "batPct" in new_state

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -164,10 +164,14 @@ class SynologyDSMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             discovery_info[ssdp.ATTR_UPNP_FRIENDLY_NAME].split("(", 1)[0].strip()
         )
 
+        mac = discovery_info[ssdp.ATTR_UPNP_SERIAL].upper()
         # Synology NAS can broadcast on multiple IP addresses, since they can be connected to multiple ethernets.
         # The serial of the NAS is actually its MAC address.
-        if self._mac_already_configured(discovery_info[ssdp.ATTR_UPNP_SERIAL].upper()):
+        if self._mac_already_configured(mac):
             return self.async_abort(reason="already_configured")
+
+        await self.async_set_unique_id(mac)
+        self._abort_if_unique_id_configured()
 
         self.discovered_conf = {
             CONF_NAME: friendly_name,

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 109
-PATCH_VERSION = "5"
+PATCH_VERSION = "6"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1429,7 +1429,7 @@ pymsteams==0.1.12
 pymusiccast==0.1.6
 
 # homeassistant.components.myq
-pymyq==2.0.1
+pymyq==2.0.2
 
 # homeassistant.components.mysensors
 pymysensors==0.18.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -579,7 +579,7 @@ pymodbus==2.3.0
 pymonoprice==0.3
 
 # homeassistant.components.myq
-pymyq==2.0.1
+pymyq==2.0.2
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/tests/components/islamic_prayer_times/__init__.py
+++ b/tests/components/islamic_prayer_times/__init__.py
@@ -42,4 +42,4 @@ NEW_PRAYER_TIMES_TIMESTAMPS = {
     "Midnight": datetime(2020, 1, 1, 00, 43, 0),
 }
 
-NOW = datetime(2020, 1, 1, 00, 00, 0)
+NOW = datetime(2020, 1, 1, 00, 00, 0).astimezone()

--- a/tests/components/islamic_prayer_times/test_sensor.py
+++ b/tests/components/islamic_prayer_times/test_sensor.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant.components import islamic_prayer_times
+import homeassistant.util.dt as dt_util
 
 from . import NOW, PRAYER_TIMES, PRAYER_TIMES_TIMESTAMPS
 
@@ -26,5 +27,5 @@ async def test_islamic_prayer_times_sensors(hass):
                 hass.states.get(
                     f"sensor.{prayer}_{islamic_prayer_times.const.SENSOR_TYPES[prayer]}"
                 ).state
-                == PRAYER_TIMES_TIMESTAMPS[prayer].isoformat()
+                == PRAYER_TIMES_TIMESTAMPS[prayer].astimezone(dt_util.UTC).isoformat()
             )

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -383,6 +383,7 @@ async def test_form_ssdp(hass: HomeAssistantType, service: MagicMock):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == SERIAL
     assert result["title"] == "192.168.1.5"
     assert result["data"][CONF_HOST] == "192.168.1.5"
     assert result["data"][CONF_PORT] == 5001


### PR DESCRIPTION
- Fix roomba 980 position report ([@shenxn] - [#35316]) ([roomba docs])
- Update pymyq to 2.0.2 ([@bdraco] - [#35330]) ([myq docs])
- Fix Synology DSM discovery can't be ignored ([@Quentame] - [#35331]) ([synology_dsm docs])
- Remove panasonic_viera from legacy discovery (@joogps - #34909)
- Fix Islamic prayer sensor timestamp format (@engrbm87 - #35243)

[#35316]: https://github.com/home-assistant/core/pull/35316
[#35330]: https://github.com/home-assistant/core/pull/35330
[#35331]: https://github.com/home-assistant/core/pull/35331
[@Quentame]: https://github.com/Quentame
[@bdraco]: https://github.com/bdraco
[@shenxn]: https://github.com/shenxn
[myq docs]: https://www.home-assistant.io/integrations/myq/
[roomba docs]: https://www.home-assistant.io/integrations/roomba/
[synology_dsm docs]: https://www.home-assistant.io/integrations/synology_dsm/