### PR TITLE
Migrate ISY994 to PyISY v2

### DIFF
--- a/homeassistant/components/isy994/binary_sensor.py
+++ b/homeassistant/components/isy994/binary_sensor.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 from typing import Callable
 
+from pyisy.constants import ISY_VALUE_UNKNOWN
+
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR,
     BinarySensorEntity,
@@ -86,11 +88,6 @@ def _detect_device_type(node) -> str:
     return None
 
 
-def _is_val_unknown(val):
-    """Determine if a number value represents UNKNOWN from PyISY."""
-    return val == -1 * float("inf")
-
-
 class ISYBinarySensorEntity(ISYNodeEntity, BinarySensorEntity):
     """Representation of an ISY994 binary sensor device.
 
@@ -106,21 +103,21 @@ class ISYBinarySensorEntity(ISYNodeEntity, BinarySensorEntity):
         self._negative_node = None
         self._heartbeat_device = None
         self._device_class_from_type = _detect_device_type(self._node)
-        if _is_val_unknown(self._node.status._val):
+        if self._node.status == ISY_VALUE_UNKNOWN:
             self._computed_state = None
             self._status_was_unknown = True
         else:
-            self._computed_state = bool(self._node.status._val)
+            self._computed_state = bool(self._node.status)
             self._status_was_unknown = False
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node and subnode event emitters."""
         await super().async_added_to_hass()
 
-        self._node.controlEvents.subscribe(self._positive_node_control_handler)
+        self._node.control_events.subscribe(self._positive_node_control_handler)
 
         if self._negative_node is not None:
-            self._negative_node.controlEvents.subscribe(
+            self._negative_node.control_events.subscribe(
                 self._negative_node_control_handler
             )
 
@@ -146,20 +143,19 @@ class ISYBinarySensorEntity(ISYNodeEntity, BinarySensorEntity):
         """
         self._negative_node = child
 
-        # pylint: disable=protected-access
-        if not _is_val_unknown(self._negative_node.status._val):
+        if self._negative_node.status != ISY_VALUE_UNKNOWN:
             # If the negative node has a value, it means the negative node is
             # in use for this device. Next we need to check to see if the
             # negative and positive nodes disagree on the state (both ON or
             # both OFF).
-            if self._negative_node.status._val == self._node.status._val:
+            if self._negative_node.status == self._node.status:
                 # The states disagree, therefore we cannot determine the state
                 # of the sensor until we receive our first ON event.
                 self._computed_state = None
 
     def _negative_node_control_handler(self, event: object) -> None:
         """Handle an "On" control event from the "negative" node."""
-        if event == "DON":
+        if event.control == "DON":
             _LOGGER.debug(
                 "Sensor %s turning Off via the Negative node sending a DON command",
                 self.name,
@@ -175,7 +171,7 @@ class ISYBinarySensorEntity(ISYNodeEntity, BinarySensorEntity):
         will come to this node, with the negative node representing Off
         events
         """
-        if event == "DON":
+        if event.control == "DON":
             _LOGGER.debug(
                 "Sensor %s turning On via the Primary node sending a DON command",
                 self.name,
@@ -183,7 +179,7 @@ class ISYBinarySensorEntity(ISYNodeEntity, BinarySensorEntity):
             self._computed_state = True
             self.schedule_update_ha_state()
             self._heartbeat()
-        if event == "DOF":
+        if event.control == "DOF":
             _LOGGER.debug(
                 "Sensor %s turning Off via the Primary node sending a DOF command",
                 self.name,
@@ -263,14 +259,14 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity):
         """Subscribe to the node and subnode event emitters."""
         await super().async_added_to_hass()
 
-        self._node.controlEvents.subscribe(self._heartbeat_node_control_handler)
+        self._node.control_events.subscribe(self._heartbeat_node_control_handler)
 
         # Start the timer on bootup, so we can change from UNKNOWN to ON
         self._restart_timer()
 
     def _heartbeat_node_control_handler(self, event: object) -> None:
         """Update the heartbeat timestamp when an On event is sent."""
-        if event == "DON":
+        if event.control == "DON":
             self.heartbeat()
 
     def heartbeat(self):

--- a/homeassistant/components/isy994/binary_sensor.py
+++ b/homeassistant/components/isy994/binary_sensor.py
@@ -24,14 +24,14 @@ def setup_platform(
 ):
     """Set up the ISY994 binary sensor platform."""
     devices = []
-    devices_by_nid = {}
+    devices_by_address = {}
     child_nodes = []
 
     for node in hass.data[ISY994_NODES][BINARY_SENSOR]:
         if node.parent_node is None:
             device = ISYBinarySensorEntity(node)
             devices.append(device)
-            devices_by_nid[node.nid] = device
+            devices_by_address[node.address] = device
         else:
             # We'll process the child nodes last, to ensure all parent nodes
             # have been processed
@@ -39,17 +39,17 @@ def setup_platform(
 
     for node in child_nodes:
         try:
-            parent_device = devices_by_nid[node.parent_node.nid]
+            parent_device = devices_by_address[node.parent_node.address]
         except KeyError:
             _LOGGER.error(
                 "Node %s has a parent node %s, but no device "
                 "was created for the parent. Skipping.",
-                node.nid,
-                node.parent_nid,
+                node.address,
+                node.primary_node,
             )
         else:
             device_type = _detect_device_type(node)
-            subnode_id = int(node.nid[-1], 16)
+            subnode_id = int(node.address[-1], 16)
             if device_type in ("opening", "moisture"):
                 # These sensors use an optional "negative" subnode 2 to snag
                 # all state changes

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -81,7 +81,6 @@ MANUFACTURER = "Universal Devices, Inc"
 
 CONF_IGNORE_STRING = "ignore_string"
 CONF_SENSOR_STRING = "sensor_string"
-CONF_ENABLE_CLIMATE = "enable_climate"
 CONF_TLS_VER = "tls"
 
 DEFAULT_IGNORE_STRING = "{IGNORE ME}"
@@ -89,8 +88,6 @@ DEFAULT_SENSOR_STRING = "sensor"
 DEFAULT_TLS_VERSION = 1.1
 
 KEY_ACTIONS = "actions"
-KEY_FOLDER = "folder"
-KEY_MY_PROGRAMS = "My Programs"
 KEY_STATUS = "status"
 
 SUPPORTED_PLATFORMS = [BINARY_SENSOR, SENSOR, LOCK, FAN, COVER, LIGHT, SWITCH]
@@ -104,7 +101,6 @@ ISY_GROUP_PLATFORM = SWITCH
 
 ISY994_ISY = "isy"
 ISY994_NODES = "isy994_nodes"
-ISY994_WEATHER = "isy994_weather"
 ISY994_PROGRAMS = "isy994_programs"
 
 # Do not use the Home Assistant consts for the states here - we're matching exact API
@@ -474,6 +470,3 @@ ISY_BIN_SENS_DEVICE_TYPES = {
     "motion": ["16.1.", "16.4.", "16.5.", "16.3.", "16.22."],
     "climate": ["5.11.", "5.10."],
 }
-
-# TEMPORARY CONSTANTS -- REMOVE AFTER PyISYv2 IS AVAILABLE
-ISY_VALUE_UNKNOWN = -1 * float("inf")

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -37,6 +37,7 @@ from homeassistant.const import (
     LENGTH_INCHES,
     LENGTH_KILOMETERS,
     LENGTH_METERS,
+    LENGTH_MILES,
     MASS_KILOGRAMS,
     MASS_POUNDS,
     POWER_WATT,
@@ -284,12 +285,26 @@ UOM_FRIENDLY_NAME = {
     "90": FREQUENCY_HERTZ,
     "91": DEGREE,
     "92": f"{DEGREE} South",
+    "100": "",  # Range 0-255, no unit.
     "101": f"{DEGREE} (x2)",
     "102": "kWs",
     "103": "$",
     "104": "¢",
     "105": LENGTH_INCHES,
-    "106": "mm/day",
+    "106": f"mm/{TIME_DAYS}",
+    "107": "",  # raw 1-byte unsigned value
+    "108": "",  # raw 2-byte unsigned value
+    "109": "",  # raw 3-byte unsigned value
+    "110": "",  # raw 4-byte unsigned value
+    "111": "",  # raw 1-byte signed value
+    "112": "",  # raw 2-byte signed value
+    "113": "",  # raw 3-byte signed value
+    "114": "",  # raw 4-byte signed value
+    "116": LENGTH_MILES,
+    "117": "mb",
+    "118": "hPa",
+    "119": f"{POWER_WATT}{TIME_HOURS}",
+    "120": f"{LENGTH_INCHES}/{TIME_DAYS}",
 }
 
 UOM_TO_STATES = {
@@ -462,6 +477,21 @@ UOM_TO_STATES = {
         7: HVAC_MODE_AUTO,  # Program Cool-Set @ Local Device Only
     },
     "99": {7: FAN_ON, 8: FAN_AUTO},  # Insteon Thermostat Fan Mode
+    "115": {  # Most recent On style action taken for lamp control
+        0: "on",
+        1: "off",
+        2: "fade up",
+        3: "fade down",
+        4: "fade stop",
+        5: "fast on",
+        6: "fast off",
+        7: "triple press on",
+        8: "triple press off",
+        9: "4x press on",
+        10: "4x press off",
+        11: "5x press on",
+        12: "5x press off",
+    },
 }
 
 ISY_BIN_SENS_DEVICE_TYPES = {

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -1,5 +1,13 @@
 """Representation of ISYEntity Types."""
 
+from pyisy.constants import (
+    COMMAND_FRIENDLY_NAME,
+    EVENT_PROPS_IGNORED,
+    ISY_VALUE_UNKNOWN,
+)
+from pyisy.helpers import NodeProperty
+
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import Dict
 
@@ -7,39 +15,48 @@ from homeassistant.helpers.typing import Dict
 class ISYEntity(Entity):
     """Representation of an ISY994 device."""
 
-    _attrs = {}
     _name: str = None
 
     def __init__(self, node) -> None:
         """Initialize the insteon device."""
         self._node = node
+        self._attrs = {}
         self._change_handler = None
         self._control_handler = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node change events."""
-        self._change_handler = self._node.status.subscribe("changed", self.on_update)
+        self._change_handler = self._node.status_events.subscribe(self.on_update)
 
-        if hasattr(self._node, "controlEvents"):
-            self._control_handler = self._node.controlEvents.subscribe(self.on_control)
+        if hasattr(self._node, "control_events"):
+            self._control_handler = self._node.control_events.subscribe(self.on_control)
 
     def on_update(self, event: object) -> None:
         """Handle the update event from the ISY994 Node."""
         self.schedule_update_ha_state()
 
-    def on_control(self, event: object) -> None:
+    def on_control(self, event: NodeProperty) -> None:
         """Handle a control event from the ISY994 Node."""
-        self.hass.bus.fire(
-            "isy994_control", {"entity_id": self.entity_id, "control": event}
-        )
+        event_data = {
+            "entity_id": self.entity_id,
+            "control": event.control,
+            "value": event.value,
+            "formatted": event.formatted,
+            "uom": event.uom,
+            "precision": event.prec,
+        }
+
+        if event.value is None or event.control not in EVENT_PROPS_IGNORED:
+            # New state attributes may be available, update the state.
+            self.schedule_update_ha_state()
+
+        self.hass.bus.fire("isy994_control", event_data)
 
     @property
     def unique_id(self) -> str:
         """Get the unique identifier of the device."""
-        # pylint: disable=protected-access
-        if hasattr(self._node, "_id"):
-            return self._node._id
-
+        if hasattr(self._node, "address"):
+            return self._node.address
         return None
 
     @property
@@ -56,20 +73,13 @@ class ISYEntity(Entity):
     def value(self) -> int:
         """Get the current value of the device."""
         # pylint: disable=protected-access
-        return self._node.status._val
-
-    def is_unknown(self) -> bool:
-        """Get whether or not the value of this Entity's node is unknown.
-
-        PyISY reports unknown values as -inf
-        """
-        return self.value == -1 * float("inf")
+        return self._node.status
 
     @property
     def state(self):
         """Return the state of the ISY device."""
-        if self.is_unknown():
-            return None
+        if self.value == ISY_VALUE_UNKNOWN:
+            return STATE_UNKNOWN
         return super().state
 
 
@@ -78,12 +88,26 @@ class ISYNodeEntity(ISYEntity):
 
     @property
     def device_state_attributes(self) -> Dict:
-        """Get the state attributes for the device."""
+        """Get the state attributes for the device.
+
+        The 'aux_properties' in the pyisy Node class are combined with the
+        other attributes which have been picked up from the event stream and
+        the combined result are returned as the device state attributes.
+        """
         attr = {}
         if hasattr(self._node, "aux_properties"):
-            for name, val in self._node.aux_properties.items():
-                attr[name] = f"{val.get('value')} {val.get('uom')}"
-        return attr
+            # Cast as list due to RuntimeError if a new property is added while running.
+            for name, value in list(self._node.aux_properties.items()):
+                attr_name = COMMAND_FRIENDLY_NAME.get(name, name)
+                attr[attr_name] = str(value.formatted).lower()
+
+        # If a Group/Scene, set a property if the entire scene is on/off
+        if hasattr(self._node, "group_all_on"):
+            # pylint: disable=protected-access
+            attr["group_all_on"] = "on" if self._node.group_all_on else "off"
+
+        self._attrs.update(attr)
+        return self._attrs
 
 
 class ISYProgramEntity(ISYEntity):
@@ -94,3 +118,22 @@ class ISYProgramEntity(ISYEntity):
         super().__init__(status)
         self._name = name
         self._actions = actions
+
+    @property
+    def device_state_attributes(self) -> Dict:
+        """Get the state attributes for the device."""
+        attr = {}
+        if self._actions:
+            attr["actions_enabled"] = self._actions.enabled
+            attr["actions_last_finished"] = self._actions.last_finished
+            attr["actions_last_run"] = self._actions.last_run
+            attr["actions_last_update"] = self._actions.last_update
+            attr["ran_else"] = self._actions.ran_else
+            attr["ran_then"] = self._actions.ran_then
+            attr["run_at_startup"] = self._actions.run_at_startup
+            attr["running"] = self._actions.running
+        attr["status_enabled"] = self._node.enabled
+        attr["status_last_finished"] = self._node.last_finished
+        attr["status_last_run"] = self._node.last_run
+        attr["status_last_update"] = self._node.last_update
+        return attr

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -73,7 +73,6 @@ class ISYEntity(Entity):
     @property
     def value(self) -> int:
         """Get the current value of the device."""
-        # pylint: disable=protected-access
         return self._node.status
 
     @property
@@ -104,7 +103,6 @@ class ISYNodeEntity(ISYEntity):
 
         # If a Group/Scene, set a property if the entire scene is on/off
         if hasattr(self._node, "group_all_on"):
-            # pylint: disable=protected-access
             attr["group_all_on"] = STATE_ON if self._node.group_all_on else STATE_OFF
 
         self._attrs.update(attr)

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -2,12 +2,13 @@
 
 from pyisy.constants import (
     COMMAND_FRIENDLY_NAME,
+    EMPTY_TIME,
     EVENT_PROPS_IGNORED,
     ISY_VALUE_UNKNOWN,
 )
 from pyisy.helpers import NodeProperty
 
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import Dict
 
@@ -104,7 +105,7 @@ class ISYNodeEntity(ISYEntity):
         # If a Group/Scene, set a property if the entire scene is on/off
         if hasattr(self._node, "group_all_on"):
             # pylint: disable=protected-access
-            attr["group_all_on"] = "on" if self._node.group_all_on else "off"
+            attr["group_all_on"] = STATE_ON if self._node.group_all_on else STATE_OFF
 
         self._attrs.update(attr)
         return self._attrs
@@ -125,15 +126,21 @@ class ISYProgramEntity(ISYEntity):
         attr = {}
         if self._actions:
             attr["actions_enabled"] = self._actions.enabled
-            attr["actions_last_finished"] = self._actions.last_finished
-            attr["actions_last_run"] = self._actions.last_run
-            attr["actions_last_update"] = self._actions.last_update
+            if attr["actions_last_finished"] != EMPTY_TIME:
+                attr["actions_last_finished"] = self._actions.last_finished
+            if attr["actions_last_run"] != EMPTY_TIME:
+                attr["actions_last_run"] = self._actions.last_run
+            if attr["actions_last_update"] != EMPTY_TIME:
+                attr["actions_last_update"] = self._actions.last_update
             attr["ran_else"] = self._actions.ran_else
             attr["ran_then"] = self._actions.ran_then
             attr["run_at_startup"] = self._actions.run_at_startup
             attr["running"] = self._actions.running
         attr["status_enabled"] = self._node.enabled
-        attr["status_last_finished"] = self._node.last_finished
-        attr["status_last_run"] = self._node.last_run
-        attr["status_last_update"] = self._node.last_update
+        if attr["status_last_finished"] != EMPTY_TIME:
+            attr["status_last_finished"] = self._node.last_finished
+        if attr["status_last_run"] != EMPTY_TIME:
+            attr["status_last_run"] = self._node.last_run
+        if attr["status_last_update"] != EMPTY_TIME:
+            attr["status_last_update"] = self._node.last_update
         return attr

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -124,21 +124,21 @@ class ISYProgramEntity(ISYEntity):
         attr = {}
         if self._actions:
             attr["actions_enabled"] = self._actions.enabled
-            if attr["actions_last_finished"] != EMPTY_TIME:
+            if self._actions.last_finished != EMPTY_TIME:
                 attr["actions_last_finished"] = self._actions.last_finished
-            if attr["actions_last_run"] != EMPTY_TIME:
+            if self._actions.last_run != EMPTY_TIME:
                 attr["actions_last_run"] = self._actions.last_run
-            if attr["actions_last_update"] != EMPTY_TIME:
+            if self._actions.last_update != EMPTY_TIME:
                 attr["actions_last_update"] = self._actions.last_update
             attr["ran_else"] = self._actions.ran_else
             attr["ran_then"] = self._actions.ran_then
             attr["run_at_startup"] = self._actions.run_at_startup
             attr["running"] = self._actions.running
         attr["status_enabled"] = self._node.enabled
-        if attr["status_last_finished"] != EMPTY_TIME:
+        if self._node.last_finished != EMPTY_TIME:
             attr["status_last_finished"] = self._node.last_finished
-        if attr["status_last_run"] != EMPTY_TIME:
+        if self._node.last_run != EMPTY_TIME:
             attr["status_last_run"] = self._node.last_run
-        if attr["status_last_update"] != EMPTY_TIME:
+        if self._node.last_update != EMPTY_TIME:
             attr["status_last_update"] = self._node.last_update
         return attr

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -60,7 +60,7 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
 
     def set_speed(self, speed: str) -> None:
         """Send the set speed command to the ISY994 fan device."""
-        self._node.on(val=STATE_TO_VALUE.get(speed, 255))
+        self._node.turn_on(val=STATE_TO_VALUE.get(speed, 255))
 
     def turn_on(self, speed: str = None, **kwargs) -> None:
         """Send the turn on command to the ISY994 fan device."""
@@ -68,7 +68,7 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 fan device."""
-        self._node.off()
+        self._node.turn_off()
 
     @property
     def speed_list(self) -> list:
@@ -87,21 +87,19 @@ class ISYFanProgramEntity(ISYProgramEntity, FanEntity):
     @property
     def speed(self) -> str:
         """Return the current speed."""
-        # TEMPORARY: Cast value to int until PyISYv2.
-        return VALUE_TO_STATE.get(int(self.value))
+        return VALUE_TO_STATE.get(self.value)
 
     @property
     def is_on(self) -> bool:
         """Get if the fan is on."""
-        # TEMPORARY: Cast value to int until PyISYv2.
-        return int(self.value) != 0
+        return self.value != 0
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn on command to ISY994 fan program."""
-        if not self._actions.runThen():
+        if not self._actions.run_then():
             _LOGGER.error("Unable to turn off the fan")
 
     def turn_on(self, speed: str = None, **kwargs) -> None:
         """Send the turn off command to ISY994 fan program."""
-        if not self._actions.runElse():
+        if not self._actions.run_else():
             _LOGGER.error("Unable to turn on the fan")

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -76,7 +76,7 @@ def _check_for_insteon_type(
             # Hacky special-case just for FanLinc, which has a light module
             # as one of its nodes. Note that this special-case is not necessary
             # on ISY 5.x firmware as it uses the superior NodeDefs method
-            if platform == FAN and int(node.nid[-1]) == 1:
+            if platform == FAN and int(node.address[-1]) == 1:
                 hass.data[ISY994_NODES][LIGHT].append(node)
                 return True
 

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -1,7 +1,9 @@
 """Sorting helpers for ISY994 device classifications."""
-from collections import namedtuple
+from typing import Union
 
-from PyISY.Nodes import Group
+from pyisy.constants import PROTO_GROUP, PROTO_INSTEON, PROTO_PROGRAM, TAG_FOLDER
+from pyisy.nodes import Group, Node, Nodes
+from pyisy.programs import Programs
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.fan import DOMAIN as FAN
@@ -13,22 +15,17 @@ from .const import (
     _LOGGER,
     ISY994_NODES,
     ISY994_PROGRAMS,
-    ISY994_WEATHER,
     ISY_GROUP_PLATFORM,
     KEY_ACTIONS,
-    KEY_FOLDER,
-    KEY_MY_PROGRAMS,
     KEY_STATUS,
     NODE_FILTERS,
     SUPPORTED_PLATFORMS,
     SUPPORTED_PROGRAM_PLATFORMS,
 )
 
-WeatherNode = namedtuple("WeatherNode", ("status", "name", "uom"))
-
 
 def _check_for_node_def(
-    hass: HomeAssistantType, node, single_platform: str = None
+    hass: HomeAssistantType, node: Union[Group, Node], single_platform: str = None
 ) -> bool:
     """Check if the node matches the node_def_id for any platforms.
 
@@ -52,7 +49,7 @@ def _check_for_node_def(
 
 
 def _check_for_insteon_type(
-    hass: HomeAssistantType, node, single_platform: str = None
+    hass: HomeAssistantType, node: Union[Group, Node], single_platform: str = None
 ) -> bool:
     """Check if the node matches the Insteon type for any platforms.
 
@@ -60,6 +57,8 @@ def _check_for_insteon_type(
     works for Insteon device. "Node Server" (v5+) and Z-Wave and others will
     not have a type.
     """
+    if not hasattr(node, "protocol") or node.protocol != PROTO_INSTEON:
+        return False
     if not hasattr(node, "type") or node.type is None:
         # Node doesn't have a type (non-Insteon device most likely)
         return False
@@ -88,7 +87,10 @@ def _check_for_insteon_type(
 
 
 def _check_for_uom_id(
-    hass: HomeAssistantType, node, single_platform: str = None, uom_list: list = None
+    hass: HomeAssistantType,
+    node: Union[Group, Node],
+    single_platform: str = None,
+    uom_list: list = None,
 ) -> bool:
     """Check if a node's uom matches any of the platforms uom filter.
 
@@ -116,7 +118,10 @@ def _check_for_uom_id(
 
 
 def _check_for_states_in_uom(
-    hass: HomeAssistantType, node, single_platform: str = None, states_list: list = None
+    hass: HomeAssistantType,
+    node: Union[Group, Node],
+    single_platform: str = None,
+    states_list: list = None,
 ) -> bool:
     """Check if a list of uoms matches two possible filters.
 
@@ -168,7 +173,10 @@ def _is_sensor_a_binary_sensor(hass: HomeAssistantType, node) -> bool:
 
 
 def _categorize_nodes(
-    hass: HomeAssistantType, nodes, ignore_identifier: str, sensor_identifier: str
+    hass: HomeAssistantType,
+    nodes: Nodes,
+    ignore_identifier: str,
+    sensor_identifier: str,
 ) -> None:
     """Sort the nodes to their proper platforms."""
     for (path, node) in nodes:
@@ -177,7 +185,7 @@ def _categorize_nodes(
             # Don't import this node as a device at all
             continue
 
-        if isinstance(node, Group):
+        if hasattr(node, "protocol") and node.protocol == PROTO_GROUP:
             hass.data[ISY994_NODES][ISY_GROUP_PLATFORM].append(node)
             continue
 
@@ -203,47 +211,37 @@ def _categorize_nodes(
             continue
 
 
-def _categorize_programs(hass: HomeAssistantType, programs: dict) -> None:
+def _categorize_programs(hass: HomeAssistantType, programs: Programs) -> None:
     """Categorize the ISY994 programs."""
     for platform in SUPPORTED_PROGRAM_PLATFORMS:
-        try:
-            folder = programs[KEY_MY_PROGRAMS][f"HA.{platform}"]
-        except KeyError:
+        folder = programs.get_by_name(f"HA.{platform}")
+        if not folder:
             continue
+
         for dtype, _, node_id in folder.children:
-            if dtype != KEY_FOLDER:
+            if dtype != TAG_FOLDER:
                 continue
             entity_folder = folder[node_id]
-            try:
-                status = entity_folder[KEY_STATUS]
-                assert status.dtype == "program", "Not a program"
-                if platform != BINARY_SENSOR:
-                    actions = entity_folder[KEY_ACTIONS]
-                    assert actions.dtype == "program", "Not a program"
-                else:
-                    actions = None
-            except (AttributeError, KeyError, AssertionError):
+
+            actions = None
+            status = entity_folder.get_by_name(KEY_STATUS)
+            if not status or not status.protocol == PROTO_PROGRAM:
                 _LOGGER.warning(
-                    "Program entity '%s' not loaded due "
-                    "to invalid folder structure.",
+                    "Program %s entity '%s' not loaded, invalid/missing status program.",
+                    platform,
                     entity_folder.name,
                 )
                 continue
 
+            if platform != BINARY_SENSOR:
+                actions = entity_folder.get_by_name(KEY_ACTIONS)
+                if not actions or not actions.protocol == PROTO_PROGRAM:
+                    _LOGGER.warning(
+                        "Program %s entity '%s' not loaded, invalid/missing actions program.",
+                        platform,
+                        entity_folder.name,
+                    )
+                    continue
+
             entity = (entity_folder.name, status, actions)
             hass.data[ISY994_PROGRAMS][platform].append(entity)
-
-
-def _categorize_weather(hass: HomeAssistantType, climate) -> None:
-    """Categorize the ISY994 weather data."""
-    climate_attrs = dir(climate)
-    weather_nodes = [
-        WeatherNode(
-            getattr(climate, attr),
-            attr.replace("_", " "),
-            getattr(climate, f"{attr}_units"),
-        )
-        for attr in climate_attrs
-        if f"{attr}_units" in climate_attrs
-    ]
-    hass.data[ISY994_WEATHER].extend(weather_nodes)

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -2,6 +2,6 @@
   "domain": "isy994",
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==2.0.1"],
+  "requirements": ["pyisy==2.0.2"],
   "codeowners": ["@bdraco", "@shbatm"]
 }

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -2,6 +2,6 @@
   "domain": "isy994",
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["PyISY==1.1.2"],
+  "requirements": ["pyisy==2.0.1"],
   "codeowners": ["@bdraco", "@shbatm"]
 }

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -1,13 +1,15 @@
 """Support for ISY994 sensors."""
 from typing import Callable
 
+from pyisy.constants import ISY_VALUE_UNKNOWN
+
 from homeassistant.components.sensor import DOMAIN as SENSOR
-from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers.typing import ConfigType
 
-from . import ISY994_NODES, ISY994_WEATHER
+from . import ISY994_NODES
 from .const import _LOGGER, UOM_FRIENDLY_NAME, UOM_TO_STATES
-from .entity import ISYEntity, ISYNodeEntity
+from .entity import ISYNodeEntity
 
 
 def setup_platform(
@@ -20,9 +22,6 @@ def setup_platform(
         _LOGGER.debug("Loading %s", node.name)
         devices.append(ISYSensorEntity(node))
 
-    for node in hass.data[ISY994_WEATHER]:
-        devices.append(ISYWeatherDevice(node))
-
     add_entities(devices)
 
 
@@ -32,81 +31,45 @@ class ISYSensorEntity(ISYNodeEntity):
     @property
     def raw_unit_of_measurement(self) -> str:
         """Get the raw unit of measurement for the ISY994 sensor device."""
-        if len(self._node.uom) == 1:
-            if self._node.uom[0] in UOM_FRIENDLY_NAME:
-                friendly_name = UOM_FRIENDLY_NAME.get(self._node.uom[0])
-                if friendly_name in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
-                    friendly_name = self.hass.config.units.temperature_unit
-                return friendly_name
-            return self._node.uom[0]
-        return None
+        uom = self._node.uom
+
+        # Backwards compatibility for ISYv4 Firmware:
+        if isinstance(uom, list):
+            return UOM_FRIENDLY_NAME.get(uom[0], uom[0])
+        return UOM_FRIENDLY_NAME.get(uom)
 
     @property
     def state(self) -> str:
         """Get the state of the ISY994 sensor device."""
-        if self.is_unknown():
-            return None
+        if self.value == ISY_VALUE_UNKNOWN:
+            return STATE_UNKNOWN
 
-        if len(self._node.uom) == 1:
-            if self._node.uom[0] in UOM_TO_STATES:
-                states = UOM_TO_STATES.get(self._node.uom[0])
-                # TEMPORARY: Cast value to int until PyISYv2.
-                if int(self.value) in states:
-                    return states.get(int(self.value))
-            elif self._node.prec and self._node.prec != [0]:
-                str_val = str(self.value)
-                int_prec = int(self._node.prec)
-                decimal_part = str_val[-int_prec:]
-                whole_part = str_val[: len(str_val) - int_prec]
-                val = float(f"{whole_part}.{decimal_part}")
-                raw_units = self.raw_unit_of_measurement
-                if raw_units in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
-                    val = self.hass.config.units.temperature(val, raw_units)
+        uom = self._node.uom
+        # Backwards compatibility for ISYv4 Firmware:
+        if isinstance(uom, list):
+            uom = uom[0]
+        if not uom:
+            return STATE_UNKNOWN
 
-                return str(val)
-            else:
-                return self.value
-
-        return None
+        states = UOM_TO_STATES.get(uom)
+        if states and states.get(self.value):
+            return states.get(self.value)
+        if self._node.prec and int(self._node.prec) != 0:
+            str_val = str(self.value)
+            int_prec = int(self._node.prec)
+            decimal_part = str_val[-int_prec:]
+            whole_part = str_val[: len(str_val) - int_prec]
+            val = float(f"{whole_part}.{decimal_part}")
+            raw_units = self.raw_unit_of_measurement
+            if raw_units in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
+                val = self.hass.config.units.temperature(val, raw_units)
+            return val
+        return self.value
 
     @property
     def unit_of_measurement(self) -> str:
         """Get the unit of measurement for the ISY994 sensor device."""
         raw_units = self.raw_unit_of_measurement
         if raw_units in (TEMP_FAHRENHEIT, TEMP_CELSIUS):
-            return self.hass.config.units.temperature_unit
-        return raw_units
-
-
-# Depreciated, not renaming. Will be removed in next PR.
-class ISYWeatherDevice(ISYEntity):
-    """Representation of an ISY994 weather device."""
-
-    @property
-    def raw_units(self) -> str:
-        """Return the raw unit of measurement."""
-        if self._node.uom == "F":
-            return TEMP_FAHRENHEIT
-        if self._node.uom == "C":
-            return TEMP_CELSIUS
-        return self._node.uom
-
-    @property
-    def state(self) -> object:
-        """Return the value of the node."""
-        # pylint: disable=protected-access
-        val = self._node.status._val
-        raw_units = self._node.uom
-
-        if raw_units in [TEMP_CELSIUS, TEMP_FAHRENHEIT]:
-            return self.hass.config.units.temperature(val, raw_units)
-        return val
-
-    @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement for the node."""
-        raw_units = self.raw_units
-
-        if raw_units in [TEMP_CELSIUS, TEMP_FAHRENHEIT]:
             return self.hass.config.units.temperature_unit
         return raw_units

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -1,7 +1,10 @@
 """Support for ISY994 switches."""
 from typing import Callable
 
+from pyisy.constants import ISY_VALUE_UNKNOWN, PROTO_GROUP
+
 from homeassistant.components.switch import DOMAIN as SWITCH, SwitchEntity
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.typing import ConfigType
 
 from . import ISY994_NODES, ISY994_PROGRAMS
@@ -30,17 +33,26 @@ class ISYSwitchEntity(ISYNodeEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 device is in the on state."""
+        if self.value == ISY_VALUE_UNKNOWN:
+            return STATE_UNKNOWN
         return bool(self.value)
 
     def turn_off(self, **kwargs) -> None:
-        """Send the turn on command to the ISY994 switch."""
-        if not self._node.off():
-            _LOGGER.debug("Unable to turn on switch.")
+        """Send the turn off command to the ISY994 switch."""
+        if not self._node.turn_off():
+            _LOGGER.debug("Unable to turn off switch.")
 
     def turn_on(self, **kwargs) -> None:
-        """Send the turn off command to the ISY994 switch."""
-        if not self._node.on():
+        """Send the turn oon command to the ISY994 switch."""
+        if not self._node.turn_on():
             _LOGGER.debug("Unable to turn on switch.")
+
+    @property
+    def icon(self) -> str:
+        """Get the icon for groups."""
+        if hasattr(self._node, "protocol") and self._node.protocol == PROTO_GROUP:
+            return "mdi:google-circles-communities"  # Matches isy scene icon
+        return super().icon
 
 
 class ISYSwitchProgramEntity(ISYProgramEntity, SwitchEntity):
@@ -53,12 +65,12 @@ class ISYSwitchProgramEntity(ISYProgramEntity, SwitchEntity):
 
     def turn_on(self, **kwargs) -> None:
         """Send the turn on command to the ISY994 switch program."""
-        if not self._actions.runThen():
+        if not self._actions.run_then():
             _LOGGER.error("Unable to turn on switch")
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 switch program."""
-        if not self._actions.runElse():
+        if not self._actions.run_else():
             _LOGGER.error("Unable to turn off switch")
 
     @property

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -43,7 +43,7 @@ class ISYSwitchEntity(ISYNodeEntity, SwitchEntity):
             _LOGGER.debug("Unable to turn off switch.")
 
     def turn_on(self, **kwargs) -> None:
-        """Send the turn oon command to the ISY994 switch."""
+        """Send the turn on command to the ISY994 switch."""
         if not self._node.turn_on():
             _LOGGER.debug("Unable to turn on switch.")
 

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -18,8 +18,7 @@ def setup_platform(
     """Set up the ISY994 switch platform."""
     devices = []
     for node in hass.data[ISY994_NODES][SWITCH]:
-        if not node.dimmable:
-            devices.append(ISYSwitchEntity(node))
+        devices.append(ISYSwitchEntity(node))
 
     for name, status, actions in hass.data[ISY994_PROGRAMS][SWITCH]:
         devices.append(ISYSwitchProgramEntity(name, status, actions))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,9 +49,6 @@ PyEssent==0.13
 # homeassistant.components.github
 PyGithub==1.43.8
 
-# homeassistant.components.isy994
-PyISY==1.1.2
-
 # homeassistant.components.mvglive
 PyMVGLive==1.1.4
 
@@ -1379,6 +1376,9 @@ pyirishrail==0.0.2
 
 # homeassistant.components.iss
 pyiss==1.0.1
+
+# homeassistant.components.isy994
+pyisy==2.0.1
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1378,7 +1378,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==2.0.1
+pyisy==2.0.2
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
PyISY Version 2 is a significant update to the original module used to communicate with the ISY. As part of the update and many bug fixes, some breaking changes were introduced:

- Remove ISY Climate Module support: the ISY Climate Module was retired by UDI on 3/30/2020: [UDI Announcement](https://www.universal-devices.com/byebyeclimatemodule/), support has been removed from the module, so any entities based on Climate module nodes will no longer import into Home Assistant. The `enable_climate` configuration option will need be removed from your `configuration.yaml` file.
- Device State Attributes have changed: some attributes' names and types will have changed as part of the changes to PyISY. If a user relied on a device state attribute for a given entity, they should check that it is still there and formatted the same. In general, *more* state attributes that were previously unavailable, should appear.
- `isy994_control` events now return with additional information about the event. If a user relies on the `control` event property in Automations, these will need to be updated since the format has changed to include the additional detail.  
- Nodes that are "grouped" together in the ISY Admin Console will now be correctly identified and sorted, this will cause additional entities to be added to Home Assistant. If you were using this "group" feature to ignore some sub-devices in Home Assistant, you will now need to use the "ignore_string" in the name instead.
- Turning on a light without providing a brightness value will use the ISY Device's `On Level` property instead of turning on to full brightness (if Home Assistant doesn't have a stored value for the last brightness).

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
PyISY version 2 has been released which supports significant back-end updates but is not backwards-compatible with the current v1.1.2.

This is the third PR in a series (9 total) to include migration to PyISYv2 and "modernization" of the isy994 integration based on testing done over the past year in the HACS custom component. 

Full migration plan is captured in PR #35212

This specific PR includes the necessary changed to add basic support and compatibility for the update module:

- Bare minimum changes to support PyISYv2.
- Renaming imports and functions to new names.
- Use available constants from the module.
- Remove ISY Climate Module support.
- Device State Attribute fixes (using NodeProperty)
- isy994_control changes (using NodeProperty)
- Turn On command uses device on-level instead of full brightness (part of PyISYv2).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

# The following line will need to be removed:
enable_climate: true  
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #35212
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13336

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

Tag: @bdraco @OverloadUT 