### PR TITLE
Use show_advanced_options in devolo home control

### DIFF
--- a/homeassistant/components/devolo_home_control/config_flow.py
+++ b/homeassistant/components/devolo_home_control/config_flow.py
@@ -30,12 +30,17 @@ class DevoloHomeControlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.data_schema = {
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str,
-            vol.Required(CONF_MYDEVOLO, default=DEFAULT_MYDEVOLO): str,
-            vol.Required(CONF_HOMECONTROL, default=DEFAULT_MPRM): str,
         }
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
+        if self.show_advanced_options:
+            self.data_schema = {
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+                vol.Required(CONF_MYDEVOLO): str,
+                vol.Required(CONF_HOMECONTROL): str,
+            }
         if user_input is None:
             return self._show_form(user_input)
         user = user_input[CONF_USERNAME]
@@ -46,8 +51,12 @@ class DevoloHomeControlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             mydevolo = Mydevolo()
         mydevolo.user = user
         mydevolo.password = password
-        mydevolo.url = user_input[CONF_MYDEVOLO]
-        mydevolo.mprm = user_input[CONF_HOMECONTROL]
+        if self.show_advanced_options:
+            mydevolo.url = user_input[CONF_MYDEVOLO]
+            mydevolo.mprm = user_input[CONF_HOMECONTROL]
+        else:
+            mydevolo.url = DEFAULT_MYDEVOLO
+            mydevolo.mprm = DEFAULT_MPRM
         credentials_valid = await self.hass.async_add_executor_job(
             mydevolo.credentials_valid
         )

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -30,12 +30,7 @@ async def test_form(hass):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-                "home_control_url": "https://homecontrol.mydevolo.com",
-                "mydevolo_url": "https://www.mydevolo.com",
-            },
+            {"username": "test-username", "password": "test-password"},
         )
 
     assert result2["type"] == "create_entry"
@@ -67,12 +62,7 @@ async def test_form_invalid_credentials(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-                "home_control_url": "https://homecontrol.mydevolo.com",
-                "mydevolo_url": "https://www.mydevolo.com",
-            },
+            {"username": "test-username", "password": "test-password"},
         )
 
         assert result["errors"] == {"base": "invalid_credentials"}
@@ -91,12 +81,51 @@ async def test_form_already_configured(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
-            data={
-                "username": "test-username",
-                "password": "test-password",
-                "home_control_url": "https://homecontrol.mydevolo.com",
-                "mydevolo_url": "https://www.mydevolo.com",
-            },
+            data={"username": "test-username", "password": "test-password"},
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
+
+
+async def test_form_advanced_options(hass):
+    """Test if we get the advanced options if user has enabled it."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user", "show_advanced_options": True}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.devolo_home_control.async_setup", return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.devolo_home_control.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.devolo_home_control.config_flow.Mydevolo.credentials_valid",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.devolo_home_control.config_flow.Mydevolo.get_gateway_ids",
+        return_value=["123456"],
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "test-username",
+                "password": "test-password",
+                "home_control_url": "https://test_url.test",
+                "mydevolo_url": "https://test_mydevolo_url.test",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "devolo Home Control"
+    assert result2["data"] == {
+        "username": "test-username",
+        "password": "test-password",
+        "home_control_url": "https://test_url.test",
+        "mydevolo_url": "https://test_mydevolo_url.test",
+    }
+
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
With this pull request a user has the option to change the used URLs if they are not on the production stage of mydevolo. Test for this form has been added

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
