### PR TITLE
Increase coverage and cleanup BleBox cover

### DIFF
--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -77,7 +77,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 def create_blebox_entities(product, async_add, entity_klass, entity_type):
     """Create entities from a BleBox product's features."""
 
-    entities = [entity_klass(feature) for feature in product.features[entity_type]]
+    entities = []
+    if entity_type in product.features:
+        for feature in product.features[entity_type]:
+            entities.append(entity_klass(feature))
+
     async_add(entities, True)
 
 

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -70,8 +70,8 @@ def config_fixture():
     return {DOMAIN: {CONF_HOST: "172.100.123.4", CONF_PORT: 80}}
 
 
-@pytest.fixture
-def wrapper(request):
+@pytest.fixture(name="feature")
+def feature(request):
     """Return an entity wrapper from given fixture name."""
     return request.getfixturevalue(request.param)
 

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -50,7 +50,7 @@ def flow_feature_mock():
     )
 
 
-async def test_flow_works(hass, flow_feature_mock):
+async def test_flow_works(hass, valid_feature_mock, flow_feature_mock):
     """Test that config flow works."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -1,8 +1,11 @@
 """BleBox cover entities tests."""
 
+import logging
+
 import blebox_uniapi
 import pytest
 
+from homeassistant.components.blebox.cover import BleBoxCoverEntity
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
@@ -30,7 +33,7 @@ from homeassistant.const import (
 
 from .conftest import async_setup_entity, mock_feature
 
-from tests.async_mock import ANY, AsyncMock, PropertyMock, call, patch
+from tests.async_mock import AsyncMock, PropertyMock
 
 ALL_COVER_FIXTURES = ["gatecontroller", "shutterbox", "gatebox"]
 FIXTURES_SUPPORTING_STOP = ["gatecontroller", "shutterbox"]
@@ -188,11 +191,11 @@ async def test_init_gatebox(gatebox, hass, config):
     assert device.sw_version == "1.23"
 
 
-@pytest.mark.parametrize("wrapper", ALL_COVER_FIXTURES, indirect=["wrapper"])
-async def test_open(wrapper, hass, config):
+@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
+async def test_open(feature, hass, config):
     """Test cover opening."""
 
-    feature_mock, entity_id = wrapper
+    feature_mock, entity_id = feature
 
     def initial_update():
         feature_mock.state = 3  # manually stopped
@@ -213,11 +216,11 @@ async def test_open(wrapper, hass, config):
     assert hass.states.get(entity_id).state == STATE_OPENING
 
 
-@pytest.mark.parametrize("wrapper", ALL_COVER_FIXTURES, indirect=["wrapper"])
-async def test_close(wrapper, hass, config):
+@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
+async def test_close(feature, hass, config):
     """Test cover closing."""
 
-    feature_mock, entity_id = wrapper
+    feature_mock, entity_id = feature
 
     def initial_update():
         feature_mock.state = 4  # open
@@ -251,11 +254,11 @@ def opening_to_stop_feature_mock(feature_mock):
     feature_mock.async_stop = AsyncMock(side_effect=stop)
 
 
-@pytest.mark.parametrize("wrapper", FIXTURES_SUPPORTING_STOP, indirect=["wrapper"])
-async def test_stop(wrapper, hass, config):
+@pytest.mark.parametrize("feature", FIXTURES_SUPPORTING_STOP, indirect=["feature"])
+async def test_stop(feature, hass, config):
     """Test cover stopping."""
 
-    feature_mock, entity_id = wrapper
+    feature_mock, entity_id = feature
     opening_to_stop_feature_mock(feature_mock)
 
     await async_setup_entity(hass, config, entity_id)
@@ -268,11 +271,11 @@ async def test_stop(wrapper, hass, config):
     assert hass.states.get(entity_id).state == STATE_OPEN
 
 
-@pytest.mark.parametrize("wrapper", ALL_COVER_FIXTURES, indirect=["wrapper"])
-async def test_update(wrapper, hass, config):
+@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
+async def test_update(feature, hass, config):
     """Test cover updating."""
 
-    feature_mock, entity_id = wrapper
+    feature_mock, entity_id = feature
 
     def initial_update():
         feature_mock.current = 29  # inverted
@@ -288,12 +291,12 @@ async def test_update(wrapper, hass, config):
 
 
 @pytest.mark.parametrize(
-    "wrapper", ["gatecontroller", "shutterbox"], indirect=["wrapper"]
+    "feature", ["gatecontroller", "shutterbox"], indirect=["feature"]
 )
-async def test_set_position(wrapper, hass, config):
+async def test_set_position(feature, hass, config):
     """Test cover position setting."""
 
-    feature_mock, entity_id = wrapper
+    feature_mock, entity_id = feature
 
     def initial_update():
         feature_mock.state = 3  # closed
@@ -365,17 +368,33 @@ async def test_with_no_stop(gatebox, hass, config):
     assert not supported_features & SUPPORT_STOP
 
 
-@pytest.mark.parametrize("wrapper", ALL_COVER_FIXTURES, indirect=["wrapper"])
-async def test_update_failure(wrapper, hass, config):
+@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
+async def test_update_failure(feature, hass, config, caplog):
     """Test that update failures are logged."""
 
-    feature_mock, entity_id = wrapper
+    caplog.set_level(logging.ERROR)
 
+    feature_mock, entity_id = feature
     feature_mock.async_update = AsyncMock(side_effect=blebox_uniapi.error.ClientError)
-    name = feature_mock.full_name
+    await async_setup_entity(hass, config, entity_id)
 
-    with patch("homeassistant.components.blebox._LOGGER.error") as error:
-        await async_setup_entity(hass, config, entity_id)
+    assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
 
-        error.assert_has_calls([call("Updating '%s' failed: %s", name, ANY)])
-        assert isinstance(error.call_args[0][2], blebox_uniapi.error.ClientError)
+
+@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
+async def test_entity_properties(feature, hass, config):
+    """Test that entity properties work."""
+
+    feature_mock, entity_id = feature
+
+    # NOTE: I don't know how to test these other than directly through an entity
+    entity = BleBoxCoverEntity(feature_mock)
+
+    feature_mock.state = 1
+    assert entity.is_opening is True
+
+    feature_mock.state = 0
+    assert entity.is_closing is True
+
+    feature_mock.state = 3
+    assert entity.is_closed is True

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -391,10 +391,10 @@ async def test_entity_properties(feature, hass, config):
     entity = BleBoxCoverEntity(feature_mock)
 
     feature_mock.state = 1
-    assert entity.is_opening is True
+    assert entity.state == STATE_OPENING
 
     feature_mock.state = 0
-    assert entity.is_closing is True
+    assert entity.state == STATE_CLOSING
 
     feature_mock.state = 3
-    assert entity.is_closed is True
+    assert entity.state == STATE_CLOSED

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -5,7 +5,6 @@ import logging
 import blebox_uniapi
 import pytest
 
-from homeassistant.components.blebox.cover import BleBoxCoverEntity
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
@@ -382,19 +381,42 @@ async def test_update_failure(feature, hass, config, caplog):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_entity_properties(feature, hass, config):
+async def test_opening_state(feature, hass, config):
     """Test that entity properties work."""
 
     feature_mock, entity_id = feature
 
-    # NOTE: I don't know how to test these other than directly through an entity
-    entity = BleBoxCoverEntity(feature_mock)
+    def initial_update():
+        feature_mock.state = 1  # opening
 
-    feature_mock.state = 1
-    assert entity.state == STATE_OPENING
+    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    await async_setup_entity(hass, config, entity_id)
+    assert hass.states.get(entity_id).state == STATE_OPENING
 
-    feature_mock.state = 0
-    assert entity.state == STATE_CLOSING
 
-    feature_mock.state = 3
-    assert entity.state == STATE_CLOSED
+@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
+async def test_closing_state(feature, hass, config):
+    """Test that entity properties work."""
+
+    feature_mock, entity_id = feature
+
+    def initial_update():
+        feature_mock.state = 0  # closing
+
+    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    await async_setup_entity(hass, config, entity_id)
+    assert hass.states.get(entity_id).state == STATE_CLOSING
+
+
+@pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
+async def test_closed_state(feature, hass, config):
+    """Test that entity properties work."""
+
+    feature_mock, entity_id = feature
+
+    def initial_update():
+        feature_mock.state = 3  # closed
+
+    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    await async_setup_entity(hass, config, entity_id)
+    assert hass.states.get(entity_id).state == STATE_CLOSED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- future-proof entity-creating (mostly for upcoming PRs)
- test: increase BleBox cover coverage to 100%
- tests: rename "wrapper" fixture to "feature" (which is a tuple of a BleBox "feature" and entity id)
- tests: use caplog for error testing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
