### PR TITLE
async_get_url -> get_url

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -799,7 +799,7 @@ class CameraCapabilities(AlexaEntity):
             return False
 
         try:
-            network.async_get_url(
+            network.get_url(
                 self.hass,
                 allow_internal=False,
                 allow_ip=False,

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1535,7 +1535,7 @@ async def async_api_initialize_camera_stream(hass, config, directive, context):
     camera_image = hass.states.get(entity.entity_id).attributes["entity_picture"]
 
     try:
-        external_url = network.async_get_url(
+        external_url = network.get_url(
             hass,
             allow_internal=False,
             allow_ip=False,

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -151,11 +151,9 @@ async def _configure_almond_for_ha(
         if entry.data["type"] == TYPE_OAUTH2:
             # If we're connecting over OAuth2, we will only set up connection
             # with Home Assistant if we're remotely accessible.
-            hass_url = network.async_get_url(
-                hass, allow_internal=False, prefer_cloud=True
-            )
+            hass_url = network.get_url(hass, allow_internal=False, prefer_cloud=True)
         else:
-            hass_url = network.async_get_url(hass)
+            hass_url = network.get_url(hass)
     except network.NoURLAvailableError:
         # If no URL is available, we're not going to configure Almond to connect to HA.
         return

--- a/homeassistant/components/ambiclimate/config_flow.py
+++ b/homeassistant/components/ambiclimate/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 
 from .const import (
     AUTH_CALLBACK_NAME,
@@ -131,7 +131,7 @@ class AmbiclimateFlowHandler(config_entries.ConfigFlow):
         )
 
     def _cb_url(self):
-        return f"{async_get_url(self.hass)}{AUTH_CALLBACK_PATH}"
+        return f"{get_url(self.hass)}{AUTH_CALLBACK_PATH}"
 
     async def _get_authorize_url(self):
         oauth = self._generate_oauth()

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -46,7 +46,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_when_setup
 
@@ -685,7 +685,7 @@ async def async_handle_play_stream_service(camera, service_call):
     )
     data = {
         ATTR_ENTITY_ID: entity_ids,
-        ATTR_MEDIA_CONTENT_ID: f"{async_get_url(hass)}{url}",
+        ATTR_MEDIA_CONTENT_ID: f"{get_url(hass)}{url}",
         ATTR_MEDIA_CONTENT_TYPE: FORMAT_CONTENT_TYPE[fmt],
     }
 

--- a/homeassistant/components/cast/home_assistant_cast.py
+++ b/homeassistant/components/cast/home_assistant_cast.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import auth, config_entries, core
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers import config_validation as cv, dispatcher
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 
 from .const import DOMAIN, SIGNAL_HASS_CAST_SHOW_VIEW
 
@@ -41,7 +41,7 @@ async def async_setup_ha_cast(
 
     async def handle_show_view(call: core.ServiceCall):
         """Handle a Show View service call."""
-        hass_url = async_get_url(hass, require_ssl=True)
+        hass_url = get_url(hass, require_ssl=True)
 
         controller = HomeAssistantController(
             # If you are developing Home Assistant Cast, uncomment and set to your dev app id.

--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.util import dt as dt_util, slugify
 
 from .const import CONF_EVENTS, DOMAIN, DOOR_STATION, DOOR_STATION_INFO, PLATFORMS
@@ -253,7 +253,7 @@ class ConfiguredDoorBird:
     def register_events(self, hass):
         """Register events on device."""
         # Get the URL of this server
-        hass_url = async_get_url(hass)
+        hass_url = get_url(hass)
 
         # Override url if another is specified in the configuration
         if self.custom_url is not None:

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.util.json import load_json, save_json
 
 _CONFIGURING = {}
@@ -181,7 +181,7 @@ def request_app_setup(hass, config, add_entities, config_path, discovery_info=No
         else:
             setup_platform(hass, config, add_entities, discovery_info)
 
-    start_url = f"{async_get_url(hass)}{FITBIT_AUTH_CALLBACK_PATH}"
+    start_url = f"{get_url(hass)}{FITBIT_AUTH_CALLBACK_PATH}"
 
     description = f"""Please create a Fitbit developer app at
                        https://dev.fitbit.com/apps/new.
@@ -216,7 +216,7 @@ def request_oauth_completion(hass):
     def fitbit_configuration_callback(callback_data):
         """Handle configuration updates."""
 
-    start_url = f"{async_get_url(hass)}{FITBIT_AUTH_START}"
+    start_url = f"{get_url(hass)}{FITBIT_AUTH_START}"
 
     description = f"Please authorize Fitbit by visiting {start_url}"
 
@@ -308,7 +308,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             config_file.get(ATTR_CLIENT_ID), config_file.get(ATTR_CLIENT_SECRET)
         )
 
-        redirect_uri = f"{async_get_url(hass)}{FITBIT_AUTH_CALLBACK_PATH}"
+        redirect_uri = f"{get_url(hass)}{FITBIT_AUTH_CALLBACK_PATH}"
 
         fitbit_auth_start_url, _ = oauth.authorize_token_url(
             redirect_uri=redirect_uri,
@@ -353,7 +353,7 @@ class FitbitAuthCallbackView(HomeAssistantView):
 
         result = None
         if data.get("code") is not None:
-            redirect_uri = f"{async_get_url(hass)}{FITBIT_AUTH_CALLBACK_PATH}"
+            redirect_uri = f"{get_url(hass)}{FITBIT_AUTH_CALLBACK_PATH}"
 
             try:
                 result = self.oauth.fetch_access_token(data.get("code"), redirect_uri)

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, HomeAssistant, State, callback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.helpers.storage import Store
 
 from . import trait
@@ -426,7 +426,7 @@ class GoogleEntity:
                 "webhookId": self.config.local_sdk_webhook_id,
                 "httpPort": self.hass.http.server_port,
                 "httpSSL": self.hass.config.api.use_ssl,
-                "baseUrl": async_get_url(self.hass, prefer_external=True),
+                "baseUrl": get_url(self.hass, prefer_external=True),
                 "proxyDeviceId": agent_user_id,
             }
 

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -50,7 +50,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.util import color as color_util, temperature as temp_util
 
 from .const import (
@@ -248,7 +248,7 @@ class CameraStreamTrait(_Trait):
         url = await self.hass.components.camera.async_request_stream(
             self.state.entity_id, "hls"
         )
-        self.stream_info = {"cameraStreamAccessUrl": f"{async_get_url(self.hass)}{url}"}
+        self.stream_info = {"cameraStreamAccessUrl": f"{get_url(self.hass)}{url}"}
 
 
 @register_trait

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -171,7 +171,7 @@ class ApiConfig:
                 extra = ""
 
             _LOGGER.warning(
-                "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.async_get_url` method instead. Please report issue%s for %s using this method at %s, line %s: %s",
+                "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.get_url` method instead. Please report issue%s for %s using this method at %s, line %s: %s",
                 extra,
                 integration,
                 found_frame.filename[index:],

--- a/homeassistant/components/konnected/panel.py
+++ b/homeassistant/components/konnected/panel.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 
 from .const import (
     CONF_ACTIVATION,
@@ -298,7 +298,7 @@ class AlarmPanel:
         # keeping self.hass.data check for backwards compatibility
         # newly configured integrations store this in the config entry
         desired_api_host = self.options.get(CONF_API_HOST) or (
-            self.hass.data[DOMAIN].get(CONF_API_HOST) or async_get_url(self.hass)
+            self.hass.data[DOMAIN].get(CONF_API_HOST) or get_url(self.hass)
         )
         desired_api_endpoint = desired_api_host + ENDPOINT_ROOT
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -48,7 +48,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.loader import bind_hass
 
 from .const import (
@@ -821,7 +821,7 @@ async def _async_fetch_image(hass, url):
     cache_maxsize = ENTITY_IMAGE_CACHE[CACHE_MAXSIZE]
 
     if urlparse(url).hostname is None:
-        url = f"{async_get_url(hass)}{url}"
+        url = f"{get_url(hass)}{url}"
 
     if url not in cache_images:
         cache_images[url] = {CACHE_LOCK: asyncio.Lock()}

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 
 from .const import (  # pylint: disable=unused-import
     AUTH_CALLBACK_NAME,
@@ -280,9 +280,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         session = async_get_clientsession(self.hass)
         self.plexauth = PlexAuth(payload, session)
         await self.plexauth.initiate_auth()
-        forward_url = (
-            f"{async_get_url(self.hass)}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
-        )
+        forward_url = f"{get_url(self.hass)}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
         auth_url = self.plexauth.auth_url(forward_url)
         return self.async_external_step(step_id="obtain_token", url=auth_url)
 

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.network import NoURLAvailableError, async_get_url
+from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import (
@@ -113,7 +113,7 @@ def get_webhook_url(hass: HomeAssistantType) -> str:
 
 def _get_app_template(hass: HomeAssistantType):
     try:
-        endpoint = f"at {async_get_url(hass, allow_cloud=False, prefer_external=True)}"
+        endpoint = f"at {get_url(hass, allow_cloud=False, prefer_external=True)}"
     except NoURLAvailableError:
         endpoint = ""
 

--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     HTTP_BAD_REQUEST,
     HTTP_UNAUTHORIZED,
 )
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 
 from . import (
     CONF_ALLOWED_CHAT_IDS,
@@ -34,7 +34,7 @@ async def async_setup_platform(hass, config):
 
     current_status = await hass.async_add_job(bot.getWebhookInfo)
     base_url = config.get(
-        CONF_URL, async_get_url(hass, require_ssl=True, allow_internal=False)
+        CONF_URL, get_url(hass, require_ssl=True, allow_internal=False)
     )
 
     # Some logging of Bot current status:

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -162,7 +162,7 @@ async def async_setup(hass, config):
             options = service.data.get(ATTR_OPTIONS)
 
             try:
-                url = await tts.get_url(
+                url = await tts.async_get_url(
                     p_type, message, cache=cache, language=language, options=options
                 )
             except HomeAssistantError as err:
@@ -273,7 +273,9 @@ class SpeechManager:
             provider.name = engine
         self.providers[engine] = provider
 
-    async def get_url(self, engine, message, cache=None, language=None, options=None):
+    async def async_get_url(
+        self, engine, message, cache=None, language=None, options=None
+    ):
         """Get URL for play message.
 
         This method is a coroutine.
@@ -547,7 +549,7 @@ class TextToSpeechUrlView(HomeAssistantView):
         options = data.get(ATTR_OPTIONS)
 
         try:
-            url = await self.tts.get_url(
+            url = await self.tts.async_get_url(
                 p_type, message, cache=cache, language=language, options=options
             )
             resp = self.json({"url": url}, HTTP_OK)

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform, discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_prepare_setup_platform
 
@@ -115,7 +115,7 @@ async def async_setup(hass, config):
         use_cache = conf.get(CONF_CACHE, DEFAULT_CACHE)
         cache_dir = conf.get(CONF_CACHE_DIR, DEFAULT_CACHE_DIR)
         time_memory = conf.get(CONF_TIME_MEMORY, DEFAULT_TIME_MEMORY)
-        base_url = conf.get(CONF_BASE_URL) or async_get_url(hass)
+        base_url = conf.get(CONF_BASE_URL) or get_url(hass)
 
         await tts.async_init_cache(use_cache, cache_dir, time_memory, base_url)
     except (HomeAssistantError, KeyError) as err:
@@ -162,7 +162,7 @@ async def async_setup(hass, config):
             options = service.data.get(ATTR_OPTIONS)
 
             try:
-                url = await tts.async_get_url(
+                url = await tts.get_url(
                     p_type, message, cache=cache, language=language, options=options
                 )
             except HomeAssistantError as err:
@@ -273,9 +273,7 @@ class SpeechManager:
             provider.name = engine
         self.providers[engine] = provider
 
-    async def async_get_url(
-        self, engine, message, cache=None, language=None, options=None
-    ):
+    async def get_url(self, engine, message, cache=None, language=None, options=None):
         """Get URL for play message.
 
         This method is a coroutine.
@@ -549,7 +547,7 @@ class TextToSpeechUrlView(HomeAssistantView):
         options = data.get(ATTR_OPTIONS)
 
         try:
-            url = await self.tts.async_get_url(
+            url = await self.tts.get_url(
                 p_type, message, cache=cache, language=language, options=options
             )
             resp = self.json({"url": url}, HTTP_OK)

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.http.const import KEY_REAL_IP
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.const import HTTP_OK
 from homeassistant.core import callback
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ def async_generate_id():
 def async_generate_url(hass, webhook_id):
     """Generate the full URL for a webhook_id."""
     return "{}{}".format(
-        async_get_url(hass, prefer_external=True, allow_cloud=False),
+        get_url(hass, prefer_external=True, allow_cloud=False),
         async_generate_path(webhook_id),
     )
 

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import track_time_interval
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 from homeassistant.util.json import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
@@ -232,7 +232,7 @@ def _request_app_setup(hass, config):
         _configurator = hass.data[DOMAIN]["configuring"][DOMAIN]
         configurator.notify_errors(_configurator, error_msg)
 
-    start_url = f"{async_get_url(hass)}{WINK_AUTH_CALLBACK_PATH}"
+    start_url = f"{get_url(hass)}{WINK_AUTH_CALLBACK_PATH}"
 
     description = f"""Please create a Wink developer app at
                      https://developer.wink.com.
@@ -270,7 +270,7 @@ def _request_oauth_completion(hass, config):
         """Call setup again."""
         setup(hass, config)
 
-    start_url = f"{async_get_url(hass)}{WINK_AUTH_START}"
+    start_url = f"{get_url(hass)}{WINK_AUTH_START}"
 
     description = f"Please authorize Wink by visiting {start_url}"
 
@@ -350,7 +350,7 @@ def setup(hass, config):
         # Home .
         else:
 
-            redirect_uri = f"{async_get_url(hass)}{WINK_AUTH_CALLBACK_PATH}"
+            redirect_uri = f"{get_url(hass)}{WINK_AUTH_CALLBACK_PATH}"
 
             wink_auth_start_url = pywink.get_authorization_url(
                 config_file.get(ATTR_CLIENT_ID), redirect_uri

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
 )
 from homeassistant.generated.zeroconf import HOMEKIT, ZEROCONF
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.network import NoURLAvailableError, async_get_url
+from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,12 +73,12 @@ def setup(hass, config):
     }
 
     try:
-        params["external_url"] = async_get_url(hass, allow_internal=False)
+        params["external_url"] = get_url(hass, allow_internal=False)
     except NoURLAvailableError:
         pass
 
     try:
-        params["internal_url"] = async_get_url(hass, allow_external=False)
+        params["internal_url"] = get_url(hass, allow_external=False)
     except NoURLAvailableError:
         pass
 

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -21,7 +21,7 @@ from yarl import URL
 from homeassistant import config_entries
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.network import async_get_url
+from homeassistant.helpers.network import get_url
 
 from .aiohttp_client import async_get_clientsession
 
@@ -118,7 +118,7 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        return f"{async_get_url(self.hass)}{AUTH_CALLBACK_PATH}"
+        return f"{get_url(self.hass)}{AUTH_CALLBACK_PATH}"
 
     async def async_generate_authorize_url(self, flow_id: str) -> str:
         """Generate a url for the user to authorize."""

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import yarl
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import bind_hass
 from homeassistant.util.network import (
@@ -24,8 +24,7 @@ class NoURLAvailableError(HomeAssistantError):
 
 
 @bind_hass
-@callback
-def async_get_url(
+def get_url(
     hass: HomeAssistant,
     *,
     require_ssl: bool = False,
@@ -47,7 +46,7 @@ def async_get_url(
 
         if allow_internal and url_type == TYPE_URL_INTERNAL:
             try:
-                return _async_get_internal_url(
+                return _get_internal_url(
                     hass,
                     allow_ip=allow_ip,
                     require_ssl=require_ssl,
@@ -58,7 +57,7 @@ def async_get_url(
 
         if allow_external and url_type == TYPE_URL_EXTERNAL:
             try:
-                return _async_get_external_url(
+                return _get_external_url(
                     hass,
                     allow_cloud=allow_cloud,
                     allow_ip=allow_ip,
@@ -74,8 +73,7 @@ def async_get_url(
 
 
 @bind_hass
-@callback
-def _async_get_internal_url(
+def _get_internal_url(
     hass: HomeAssistant,
     *,
     allow_ip: bool = True,
@@ -94,7 +92,7 @@ def _async_get_internal_url(
 
     # Fallback to old base_url
     try:
-        return _async_get_deprecated_base_url(
+        return _get_deprecated_base_url(
             hass,
             internal=True,
             allow_ip=allow_ip,
@@ -120,8 +118,7 @@ def _async_get_internal_url(
 
 
 @bind_hass
-@callback
-def _async_get_external_url(
+def _get_external_url(
     hass: HomeAssistant,
     *,
     allow_cloud: bool = True,
@@ -133,7 +130,7 @@ def _async_get_external_url(
     """Get external URL of this instance."""
     if prefer_cloud and allow_cloud:
         try:
-            return _async_get_cloud_url(hass)
+            return _get_cloud_url(hass)
         except NoURLAvailableError:
             pass
 
@@ -153,7 +150,7 @@ def _async_get_external_url(
             return normalize_url(str(external_url))
 
     try:
-        return _async_get_deprecated_base_url(
+        return _get_deprecated_base_url(
             hass,
             allow_ip=allow_ip,
             require_ssl=require_ssl,
@@ -164,7 +161,7 @@ def _async_get_external_url(
 
     if allow_cloud:
         try:
-            return _async_get_cloud_url(hass)
+            return _get_cloud_url(hass)
         except NoURLAvailableError:
             pass
 
@@ -172,8 +169,7 @@ def _async_get_external_url(
 
 
 @bind_hass
-@callback
-def _async_get_cloud_url(hass: HomeAssistant) -> str:
+def _get_cloud_url(hass: HomeAssistant) -> str:
     """Get external Home Assistant Cloud URL of this instance."""
     if "cloud" in hass.config.components:
         try:
@@ -185,8 +181,7 @@ def _async_get_cloud_url(hass: HomeAssistant) -> str:
 
 
 @bind_hass
-@callback
-def _async_get_deprecated_base_url(
+def _get_deprecated_base_url(
     hass: HomeAssistant,
     *,
     internal: bool = False,

--- a/tests/components/almond/test_init.py
+++ b/tests/components/almond/test_init.py
@@ -42,7 +42,7 @@ async def test_set_up_oauth_remote_url(hass, aioclient_mock):
 
     hass.config.components.add("cloud")
     with patch("homeassistant.components.almond.ALMOND_SETUP_DELAY", 0), patch(
-        "homeassistant.helpers.network.async_get_url",
+        "homeassistant.helpers.network.get_url",
         return_value="https://example.nabu.casa",
     ), patch("pyalmond.WebAlmondAPI.async_create_device") as mock_create_device:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -327,7 +327,7 @@ async def test_use_of_base_url_integration(hass, caplog):
         assert hass.config.api.base_url == "http://127.0.0.1:8123"
 
     assert (
-        "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.async_get_url` method instead. Please report issue for example using this method at homeassistant/components/example/__init__.py, line 42: url = hass.config.api.base_url"
+        "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.get_url` method instead. Please report issue for example using this method at homeassistant/components/example/__init__.py, line 42: url = hass.config.api.base_url"
         in caplog.text
     )
 
@@ -351,7 +351,7 @@ async def test_use_of_base_url_integration_webhook(hass, caplog):
             Mock(
                 filename="/home/frenck/homeassistant/components/webhook/__init__.py",
                 lineno="42",
-                line="return async_get_url(hass)",
+                line="return get_url(hass)",
             ),
             Mock(
                 filename="/home/frenck/example/client.py",
@@ -363,7 +363,7 @@ async def test_use_of_base_url_integration_webhook(hass, caplog):
         assert hass.config.api.base_url == "http://127.0.0.1:8123"
 
     assert (
-        "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.async_get_url` method instead. Please report issue for example using this method at homeassistant/components/example/__init__.py, line 42: url = hass.config.api.base_url"
+        "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.get_url` method instead. Please report issue for example using this method at homeassistant/components/example/__init__.py, line 42: url = hass.config.api.base_url"
         in caplog.text
     )
 
@@ -394,6 +394,6 @@ async def test_use_of_base_url_custom_component(hass, caplog):
         assert hass.config.api.base_url == "http://127.0.0.1:8123"
 
     assert (
-        "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.async_get_url` method instead. Please report issue to the custom component author for example using this method at custom_components/example/__init__.py, line 42: url = hass.config.api.base_url"
+        "Detected use of deprecated `base_url` property, use `homeassistant.helpers.network.get_url` method instead. Please report issue to the custom component author for example using this method at custom_components/example/__init__.py, line 42: url = hass.config.api.base_url"
         in caplog.text
     )

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -6,11 +6,11 @@ from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import (
     NoURLAvailableError,
-    _async_get_cloud_url,
-    _async_get_deprecated_base_url,
-    _async_get_external_url,
-    _async_get_internal_url,
-    async_get_url,
+    _get_cloud_url,
+    _get_deprecated_base_url,
+    _get_external_url,
+    _get_internal_url,
+    get_url,
 )
 
 from tests.async_mock import Mock, patch
@@ -26,14 +26,14 @@ async def test_get_url_internal(hass: HomeAssistant):
     )
 
     assert hass.config.internal_url == "http://example.local:8123"
-    assert _async_get_internal_url(hass) == "http://example.local:8123"
-    assert _async_get_internal_url(hass, allow_ip=False) == "http://example.local:8123"
+    assert _get_internal_url(hass) == "http://example.local:8123"
+    assert _get_internal_url(hass, allow_ip=False) == "http://example.local:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_standard_port=True)
+        _get_internal_url(hass, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
     # Test with internal URL: https://example.local:8123
     await async_process_ha_core_config(
@@ -41,14 +41,12 @@ async def test_get_url_internal(hass: HomeAssistant):
     )
 
     assert hass.config.internal_url == "https://example.local:8123"
-    assert _async_get_internal_url(hass) == "https://example.local:8123"
-    assert _async_get_internal_url(hass, allow_ip=False) == "https://example.local:8123"
-    assert (
-        _async_get_internal_url(hass, require_ssl=True) == "https://example.local:8123"
-    )
+    assert _get_internal_url(hass) == "https://example.local:8123"
+    assert _get_internal_url(hass, allow_ip=False) == "https://example.local:8123"
+    assert _get_internal_url(hass, require_ssl=True) == "https://example.local:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_standard_port=True)
+        _get_internal_url(hass, require_standard_port=True)
 
     # Test with internal URL: http://example.local:80/
     await async_process_ha_core_config(
@@ -56,15 +54,12 @@ async def test_get_url_internal(hass: HomeAssistant):
     )
 
     assert hass.config.internal_url == "http://example.local:80/"
-    assert _async_get_internal_url(hass) == "http://example.local"
-    assert _async_get_internal_url(hass, allow_ip=False) == "http://example.local"
-    assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "http://example.local"
-    )
+    assert _get_internal_url(hass) == "http://example.local"
+    assert _get_internal_url(hass, allow_ip=False) == "http://example.local"
+    assert _get_internal_url(hass, require_standard_port=True) == "http://example.local"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
     # Test with internal URL: https://example.local:443
     await async_process_ha_core_config(
@@ -72,13 +67,12 @@ async def test_get_url_internal(hass: HomeAssistant):
     )
 
     assert hass.config.internal_url == "https://example.local:443"
-    assert _async_get_internal_url(hass) == "https://example.local"
-    assert _async_get_internal_url(hass, allow_ip=False) == "https://example.local"
+    assert _get_internal_url(hass) == "https://example.local"
+    assert _get_internal_url(hass, allow_ip=False) == "https://example.local"
     assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "https://example.local"
+        _get_internal_url(hass, require_standard_port=True) == "https://example.local"
     )
-    assert _async_get_internal_url(hass, require_ssl=True) == "https://example.local"
+    assert _get_internal_url(hass, require_ssl=True) == "https://example.local"
 
     # Test with internal URL: https://192.168.0.1
     await async_process_ha_core_config(
@@ -86,15 +80,12 @@ async def test_get_url_internal(hass: HomeAssistant):
     )
 
     assert hass.config.internal_url == "https://192.168.0.1"
-    assert _async_get_internal_url(hass) == "https://192.168.0.1"
-    assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "https://192.168.0.1"
-    )
-    assert _async_get_internal_url(hass, require_ssl=True) == "https://192.168.0.1"
+    assert _get_internal_url(hass) == "https://192.168.0.1"
+    assert _get_internal_url(hass, require_standard_port=True) == "https://192.168.0.1"
+    assert _get_internal_url(hass, require_ssl=True) == "https://192.168.0.1"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, allow_ip=False)
+        _get_internal_url(hass, allow_ip=False)
 
     # Test with internal URL: http://192.168.0.1:8123
     await async_process_ha_core_config(
@@ -102,16 +93,16 @@ async def test_get_url_internal(hass: HomeAssistant):
     )
 
     assert hass.config.internal_url == "http://192.168.0.1:8123"
-    assert _async_get_internal_url(hass) == "http://192.168.0.1:8123"
+    assert _get_internal_url(hass) == "http://192.168.0.1:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_standard_port=True)
+        _get_internal_url(hass, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, allow_ip=False)
+        _get_internal_url(hass, allow_ip=False)
 
 
 async def test_get_url_internal_fallback(hass: HomeAssistant):
@@ -121,60 +112,59 @@ async def test_get_url_internal_fallback(hass: HomeAssistant):
     hass.config.api = Mock(
         use_ssl=False, port=8123, deprecated_base_url=None, local_ip="192.168.123.123"
     )
-    assert _async_get_internal_url(hass) == "http://192.168.123.123:8123"
+    assert _get_internal_url(hass) == "http://192.168.123.123:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, allow_ip=False)
+        _get_internal_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_standard_port=True)
+        _get_internal_url(hass, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
     hass.config.api = Mock(
         use_ssl=False, port=80, deprecated_base_url=None, local_ip="192.168.123.123"
     )
-    assert _async_get_internal_url(hass) == "http://192.168.123.123"
+    assert _get_internal_url(hass) == "http://192.168.123.123"
     assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "http://192.168.123.123"
+        _get_internal_url(hass, require_standard_port=True) == "http://192.168.123.123"
     )
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, allow_ip=False)
+        _get_internal_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
     hass.config.api = Mock(use_ssl=True, port=443, deprecated_base_url=None)
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass)
+        _get_internal_url(hass)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_standard_port=True)
+        _get_internal_url(hass, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, allow_ip=False)
+        _get_internal_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
     # Do no accept any local loopback address as fallback
     hass.config.api = Mock(
         use_ssl=False, port=80, deprecated_base_url=None, local_ip="127.0.0.1"
     )
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass)
+        _get_internal_url(hass)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_standard_port=True)
+        _get_internal_url(hass, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, allow_ip=False)
+        _get_internal_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
 
 async def test_get_url_external(hass: HomeAssistant):
@@ -187,16 +177,16 @@ async def test_get_url_external(hass: HomeAssistant):
     )
 
     assert hass.config.external_url == "http://example.com:8123"
-    assert _async_get_external_url(hass) == "http://example.com:8123"
-    assert _async_get_external_url(hass, allow_cloud=False) == "http://example.com:8123"
-    assert _async_get_external_url(hass, allow_ip=False) == "http://example.com:8123"
-    assert _async_get_external_url(hass, prefer_cloud=True) == "http://example.com:8123"
+    assert _get_external_url(hass) == "http://example.com:8123"
+    assert _get_external_url(hass, allow_cloud=False) == "http://example.com:8123"
+    assert _get_external_url(hass, allow_ip=False) == "http://example.com:8123"
+    assert _get_external_url(hass, prefer_cloud=True) == "http://example.com:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_external_url(hass, require_standard_port=True)
+        _get_external_url(hass, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_external_url(hass, require_ssl=True)
+        _get_external_url(hass, require_ssl=True)
 
     # Test with external URL: http://example.com:80/
     await async_process_ha_core_config(
@@ -204,65 +194,56 @@ async def test_get_url_external(hass: HomeAssistant):
     )
 
     assert hass.config.external_url == "http://example.com:80/"
-    assert _async_get_external_url(hass) == "http://example.com"
-    assert _async_get_external_url(hass, allow_cloud=False) == "http://example.com"
-    assert _async_get_external_url(hass, allow_ip=False) == "http://example.com"
-    assert _async_get_external_url(hass, prefer_cloud=True) == "http://example.com"
-    assert (
-        _async_get_external_url(hass, require_standard_port=True)
-        == "http://example.com"
-    )
+    assert _get_external_url(hass) == "http://example.com"
+    assert _get_external_url(hass, allow_cloud=False) == "http://example.com"
+    assert _get_external_url(hass, allow_ip=False) == "http://example.com"
+    assert _get_external_url(hass, prefer_cloud=True) == "http://example.com"
+    assert _get_external_url(hass, require_standard_port=True) == "http://example.com"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_external_url(hass, require_ssl=True)
+        _get_external_url(hass, require_ssl=True)
 
     # Test with external url: https://example.com:443/
     await async_process_ha_core_config(
         hass, {"external_url": "https://example.com:443/"},
     )
     assert hass.config.external_url == "https://example.com:443/"
-    assert _async_get_external_url(hass) == "https://example.com"
-    assert _async_get_external_url(hass, allow_cloud=False) == "https://example.com"
-    assert _async_get_external_url(hass, allow_ip=False) == "https://example.com"
-    assert _async_get_external_url(hass, prefer_cloud=True) == "https://example.com"
-    assert _async_get_external_url(hass, require_ssl=False) == "https://example.com"
-    assert (
-        _async_get_external_url(hass, require_standard_port=True)
-        == "https://example.com"
-    )
+    assert _get_external_url(hass) == "https://example.com"
+    assert _get_external_url(hass, allow_cloud=False) == "https://example.com"
+    assert _get_external_url(hass, allow_ip=False) == "https://example.com"
+    assert _get_external_url(hass, prefer_cloud=True) == "https://example.com"
+    assert _get_external_url(hass, require_ssl=False) == "https://example.com"
+    assert _get_external_url(hass, require_standard_port=True) == "https://example.com"
 
     # Test with external URL: https://example.com:80
     await async_process_ha_core_config(
         hass, {"external_url": "https://example.com:80"},
     )
     assert hass.config.external_url == "https://example.com:80"
-    assert _async_get_external_url(hass) == "https://example.com:80"
-    assert _async_get_external_url(hass, allow_cloud=False) == "https://example.com:80"
-    assert _async_get_external_url(hass, allow_ip=False) == "https://example.com:80"
-    assert _async_get_external_url(hass, prefer_cloud=True) == "https://example.com:80"
-    assert _async_get_external_url(hass, require_ssl=True) == "https://example.com:80"
+    assert _get_external_url(hass) == "https://example.com:80"
+    assert _get_external_url(hass, allow_cloud=False) == "https://example.com:80"
+    assert _get_external_url(hass, allow_ip=False) == "https://example.com:80"
+    assert _get_external_url(hass, prefer_cloud=True) == "https://example.com:80"
+    assert _get_external_url(hass, require_ssl=True) == "https://example.com:80"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_external_url(hass, require_standard_port=True)
+        _get_external_url(hass, require_standard_port=True)
 
     # Test with external URL: https://192.168.0.1
     await async_process_ha_core_config(
         hass, {"external_url": "https://192.168.0.1"},
     )
     assert hass.config.external_url == "https://192.168.0.1"
-    assert _async_get_external_url(hass) == "https://192.168.0.1"
-    assert _async_get_external_url(hass, allow_cloud=False) == "https://192.168.0.1"
-    assert _async_get_external_url(hass, prefer_cloud=True) == "https://192.168.0.1"
-    assert (
-        _async_get_external_url(hass, require_standard_port=True)
-        == "https://192.168.0.1"
-    )
+    assert _get_external_url(hass) == "https://192.168.0.1"
+    assert _get_external_url(hass, allow_cloud=False) == "https://192.168.0.1"
+    assert _get_external_url(hass, prefer_cloud=True) == "https://192.168.0.1"
+    assert _get_external_url(hass, require_standard_port=True) == "https://192.168.0.1"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_external_url(hass, allow_ip=False)
+        _get_external_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_external_url(hass, require_ssl=True)
+        _get_external_url(hass, require_ssl=True)
 
 
 async def test_get_cloud_url(hass: HomeAssistant):
@@ -275,7 +256,7 @@ async def test_get_cloud_url(hass: HomeAssistant):
         "async_remote_ui_url",
         return_value="https://example.nabu.casa",
     ):
-        assert _async_get_cloud_url(hass) == "https://example.nabu.casa"
+        assert _get_cloud_url(hass) == "https://example.nabu.casa"
 
     with patch.object(
         hass.components.cloud,
@@ -283,7 +264,7 @@ async def test_get_cloud_url(hass: HomeAssistant):
         side_effect=cloud.CloudNotAvailable,
     ):
         with pytest.raises(NoURLAvailableError):
-            _async_get_cloud_url(hass)
+            _get_cloud_url(hass)
 
 
 async def test_get_external_url_cloud_fallback(hass: HomeAssistant):
@@ -296,7 +277,7 @@ async def test_get_external_url_cloud_fallback(hass: HomeAssistant):
     )
 
     assert hass.config.external_url == "http://1.1.1.1:8123"
-    assert _async_get_external_url(hass, prefer_cloud=True) == "http://1.1.1.1:8123"
+    assert _get_external_url(hass, prefer_cloud=True) == "http://1.1.1.1:8123"
 
     # Add Cloud to the previous test
     hass.config.components.add("cloud")
@@ -305,23 +286,13 @@ async def test_get_external_url_cloud_fallback(hass: HomeAssistant):
         "async_remote_ui_url",
         return_value="https://example.nabu.casa",
     ):
-        assert _async_get_external_url(hass, allow_cloud=False) == "http://1.1.1.1:8123"
+        assert _get_external_url(hass, allow_cloud=False) == "http://1.1.1.1:8123"
+        assert _get_external_url(hass, allow_ip=False) == "https://example.nabu.casa"
+        assert _get_external_url(hass, prefer_cloud=False) == "http://1.1.1.1:8123"
+        assert _get_external_url(hass, prefer_cloud=True) == "https://example.nabu.casa"
+        assert _get_external_url(hass, require_ssl=True) == "https://example.nabu.casa"
         assert (
-            _async_get_external_url(hass, allow_ip=False) == "https://example.nabu.casa"
-        )
-        assert (
-            _async_get_external_url(hass, prefer_cloud=False) == "http://1.1.1.1:8123"
-        )
-        assert (
-            _async_get_external_url(hass, prefer_cloud=True)
-            == "https://example.nabu.casa"
-        )
-        assert (
-            _async_get_external_url(hass, require_ssl=True)
-            == "https://example.nabu.casa"
-        )
-        assert (
-            _async_get_external_url(hass, require_standard_port=True)
+            _get_external_url(hass, require_standard_port=True)
             == "https://example.nabu.casa"
         )
 
@@ -331,7 +302,7 @@ async def test_get_external_url_cloud_fallback(hass: HomeAssistant):
     )
 
     assert hass.config.external_url == "https://example.com"
-    assert _async_get_external_url(hass, prefer_cloud=True) == "https://example.com"
+    assert _get_external_url(hass, prefer_cloud=True) == "https://example.com"
 
     # Add Cloud to the previous test
     hass.config.components.add("cloud")
@@ -340,22 +311,16 @@ async def test_get_external_url_cloud_fallback(hass: HomeAssistant):
         "async_remote_ui_url",
         return_value="https://example.nabu.casa",
     ):
-        assert _async_get_external_url(hass, allow_cloud=False) == "https://example.com"
-        assert _async_get_external_url(hass, allow_ip=False) == "https://example.com"
+        assert _get_external_url(hass, allow_cloud=False) == "https://example.com"
+        assert _get_external_url(hass, allow_ip=False) == "https://example.com"
+        assert _get_external_url(hass, prefer_cloud=False) == "https://example.com"
+        assert _get_external_url(hass, prefer_cloud=True) == "https://example.nabu.casa"
+        assert _get_external_url(hass, require_ssl=True) == "https://example.com"
         assert (
-            _async_get_external_url(hass, prefer_cloud=False) == "https://example.com"
+            _get_external_url(hass, require_standard_port=True) == "https://example.com"
         )
         assert (
-            _async_get_external_url(hass, prefer_cloud=True)
-            == "https://example.nabu.casa"
-        )
-        assert _async_get_external_url(hass, require_ssl=True) == "https://example.com"
-        assert (
-            _async_get_external_url(hass, require_standard_port=True)
-            == "https://example.com"
-        )
-        assert (
-            _async_get_external_url(hass, prefer_cloud=True, allow_cloud=False)
+            _get_external_url(hass, prefer_cloud=True, allow_cloud=False)
             == "https://example.com"
         )
 
@@ -366,16 +331,16 @@ async def test_get_url(hass: HomeAssistant):
     assert hass.config.internal_url is None
 
     with pytest.raises(NoURLAvailableError):
-        async_get_url(hass)
+        get_url(hass)
 
     hass.config.api = Mock(
         use_ssl=False, port=8123, deprecated_base_url=None, local_ip="192.168.123.123"
     )
-    assert async_get_url(hass) == "http://192.168.123.123:8123"
-    assert async_get_url(hass, prefer_external=True) == "http://192.168.123.123:8123"
+    assert get_url(hass) == "http://192.168.123.123:8123"
+    assert get_url(hass, prefer_external=True) == "http://192.168.123.123:8123"
 
     with pytest.raises(NoURLAvailableError):
-        async_get_url(hass, allow_internal=False)
+        get_url(hass, allow_internal=False)
 
     # Test only external
     hass.config.api = None
@@ -384,7 +349,7 @@ async def test_get_url(hass: HomeAssistant):
     )
     assert hass.config.external_url == "https://example.com"
     assert hass.config.internal_url is None
-    assert async_get_url(hass) == "https://example.com"
+    assert get_url(hass) == "https://example.com"
 
     # Test preference or allowance
     await async_process_ha_core_config(
@@ -393,173 +358,166 @@ async def test_get_url(hass: HomeAssistant):
     )
     assert hass.config.external_url == "https://example.com"
     assert hass.config.internal_url == "http://example.local"
-    assert async_get_url(hass) == "http://example.local"
-    assert async_get_url(hass, prefer_external=True) == "https://example.com"
-    assert async_get_url(hass, allow_internal=False) == "https://example.com"
+    assert get_url(hass) == "http://example.local"
+    assert get_url(hass, prefer_external=True) == "https://example.com"
+    assert get_url(hass, allow_internal=False) == "https://example.com"
     assert (
-        async_get_url(hass, prefer_external=True, allow_external=False)
+        get_url(hass, prefer_external=True, allow_external=False)
         == "http://example.local"
     )
 
     with pytest.raises(NoURLAvailableError):
-        async_get_url(hass, allow_external=False, require_ssl=True)
+        get_url(hass, allow_external=False, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        async_get_url(hass, allow_external=False, allow_internal=False)
+        get_url(hass, allow_external=False, allow_internal=False)
 
 
 async def test_get_deprecated_base_url_internal(hass: HomeAssistant):
     """Test getting an internal instance URL from the deprecated base_url."""
     # Test with SSL local URL
     hass.config.api = Mock(deprecated_base_url="https://example.local")
+    assert _get_deprecated_base_url(hass, internal=True) == "https://example.local"
     assert (
-        _async_get_deprecated_base_url(hass, internal=True) == "https://example.local"
-    )
-    assert (
-        _async_get_deprecated_base_url(hass, internal=True, allow_ip=False)
+        _get_deprecated_base_url(hass, internal=True, allow_ip=False)
         == "https://example.local"
     )
     assert (
-        _async_get_deprecated_base_url(hass, internal=True, require_ssl=True)
+        _get_deprecated_base_url(hass, internal=True, require_ssl=True)
         == "https://example.local"
     )
     assert (
-        _async_get_deprecated_base_url(hass, internal=True, require_standard_port=True)
+        _get_deprecated_base_url(hass, internal=True, require_standard_port=True)
         == "https://example.local"
     )
 
     # Test with no SSL, local IP URL
     hass.config.api = Mock(deprecated_base_url="http://10.10.10.10:8123")
-    assert (
-        _async_get_deprecated_base_url(hass, internal=True) == "http://10.10.10.10:8123"
-    )
+    assert _get_deprecated_base_url(hass, internal=True) == "http://10.10.10.10:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, allow_ip=False)
+        _get_deprecated_base_url(hass, internal=True, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, require_ssl=True)
+        _get_deprecated_base_url(hass, internal=True, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, require_standard_port=True)
+        _get_deprecated_base_url(hass, internal=True, require_standard_port=True)
 
     # Test with SSL, local IP URL
     hass.config.api = Mock(deprecated_base_url="https://10.10.10.10")
-    assert _async_get_deprecated_base_url(hass, internal=True) == "https://10.10.10.10"
+    assert _get_deprecated_base_url(hass, internal=True) == "https://10.10.10.10"
     assert (
-        _async_get_deprecated_base_url(hass, internal=True, require_ssl=True)
+        _get_deprecated_base_url(hass, internal=True, require_ssl=True)
         == "https://10.10.10.10"
     )
     assert (
-        _async_get_deprecated_base_url(hass, internal=True, require_standard_port=True)
+        _get_deprecated_base_url(hass, internal=True, require_standard_port=True)
         == "https://10.10.10.10"
     )
 
     # Test external URL
     hass.config.api = Mock(deprecated_base_url="https://example.com")
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True)
+        _get_deprecated_base_url(hass, internal=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, require_ssl=True)
+        _get_deprecated_base_url(hass, internal=True, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, require_standard_port=True)
+        _get_deprecated_base_url(hass, internal=True, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, allow_ip=False)
+        _get_deprecated_base_url(hass, internal=True, allow_ip=False)
 
     # Test with loopback
     hass.config.api = Mock(deprecated_base_url="https://127.0.0.42")
     with pytest.raises(NoURLAvailableError):
-        assert _async_get_deprecated_base_url(hass, internal=True)
+        assert _get_deprecated_base_url(hass, internal=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, allow_ip=False)
+        _get_deprecated_base_url(hass, internal=True, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, require_ssl=True)
+        _get_deprecated_base_url(hass, internal=True, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, internal=True, require_standard_port=True)
+        _get_deprecated_base_url(hass, internal=True, require_standard_port=True)
 
 
 async def test_get_deprecated_base_url_external(hass: HomeAssistant):
     """Test getting an external instance URL from the deprecated base_url."""
     # Test with SSL and external domain on standard port
     hass.config.api = Mock(deprecated_base_url="https://example.com:443/")
-    assert _async_get_deprecated_base_url(hass) == "https://example.com"
+    assert _get_deprecated_base_url(hass) == "https://example.com"
+    assert _get_deprecated_base_url(hass, require_ssl=True) == "https://example.com"
     assert (
-        _async_get_deprecated_base_url(hass, require_ssl=True) == "https://example.com"
-    )
-    assert (
-        _async_get_deprecated_base_url(hass, require_standard_port=True)
+        _get_deprecated_base_url(hass, require_standard_port=True)
         == "https://example.com"
     )
 
     # Test without SSL and external domain on non-standard port
     hass.config.api = Mock(deprecated_base_url="http://example.com:8123/")
-    assert _async_get_deprecated_base_url(hass) == "http://example.com:8123"
+    assert _get_deprecated_base_url(hass) == "http://example.com:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_ssl=True)
+        _get_deprecated_base_url(hass, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_standard_port=True)
+        _get_deprecated_base_url(hass, require_standard_port=True)
 
     # Test SSL on external IP
     hass.config.api = Mock(deprecated_base_url="https://1.1.1.1")
-    assert _async_get_deprecated_base_url(hass) == "https://1.1.1.1"
-    assert _async_get_deprecated_base_url(hass, require_ssl=True) == "https://1.1.1.1"
+    assert _get_deprecated_base_url(hass) == "https://1.1.1.1"
+    assert _get_deprecated_base_url(hass, require_ssl=True) == "https://1.1.1.1"
     assert (
-        _async_get_deprecated_base_url(hass, require_standard_port=True)
-        == "https://1.1.1.1"
+        _get_deprecated_base_url(hass, require_standard_port=True) == "https://1.1.1.1"
     )
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, allow_ip=False)
+        _get_deprecated_base_url(hass, allow_ip=False)
 
     # Test with private IP
     hass.config.api = Mock(deprecated_base_url="https://10.10.10.10")
     with pytest.raises(NoURLAvailableError):
-        assert _async_get_deprecated_base_url(hass)
+        assert _get_deprecated_base_url(hass)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, allow_ip=False)
+        _get_deprecated_base_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_ssl=True)
+        _get_deprecated_base_url(hass, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_standard_port=True)
+        _get_deprecated_base_url(hass, require_standard_port=True)
 
     # Test with local domain
     hass.config.api = Mock(deprecated_base_url="https://example.local")
     with pytest.raises(NoURLAvailableError):
-        assert _async_get_deprecated_base_url(hass)
+        assert _get_deprecated_base_url(hass)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, allow_ip=False)
+        _get_deprecated_base_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_ssl=True)
+        _get_deprecated_base_url(hass, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_standard_port=True)
+        _get_deprecated_base_url(hass, require_standard_port=True)
 
     # Test with loopback
     hass.config.api = Mock(deprecated_base_url="https://127.0.0.42")
     with pytest.raises(NoURLAvailableError):
-        assert _async_get_deprecated_base_url(hass)
+        assert _get_deprecated_base_url(hass)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, allow_ip=False)
+        _get_deprecated_base_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_ssl=True)
+        _get_deprecated_base_url(hass, require_ssl=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_deprecated_base_url(hass, require_standard_port=True)
+        _get_deprecated_base_url(hass, require_standard_port=True)
 
 
 async def test_get_internal_url_with_base_url_fallback(hass: HomeAssistant):
@@ -568,64 +526,60 @@ async def test_get_internal_url_with_base_url_fallback(hass: HomeAssistant):
         use_ssl=False, port=8123, deprecated_base_url=None, local_ip="192.168.123.123"
     )
     assert hass.config.internal_url is None
-    assert _async_get_internal_url(hass) == "http://192.168.123.123:8123"
+    assert _get_internal_url(hass) == "http://192.168.123.123:8123"
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, allow_ip=False)
+        _get_internal_url(hass, allow_ip=False)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_standard_port=True)
+        _get_internal_url(hass, require_standard_port=True)
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_internal_url(hass, require_ssl=True)
+        _get_internal_url(hass, require_ssl=True)
 
     # Add base_url
     hass.config.api = Mock(
         use_ssl=False, port=8123, deprecated_base_url="https://example.local"
     )
-    assert _async_get_internal_url(hass) == "https://example.local"
-    assert _async_get_internal_url(hass, allow_ip=False) == "https://example.local"
+    assert _get_internal_url(hass) == "https://example.local"
+    assert _get_internal_url(hass, allow_ip=False) == "https://example.local"
     assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "https://example.local"
+        _get_internal_url(hass, require_standard_port=True) == "https://example.local"
     )
-    assert _async_get_internal_url(hass, require_ssl=True) == "https://example.local"
+    assert _get_internal_url(hass, require_ssl=True) == "https://example.local"
 
     # Add internal URL
     await async_process_ha_core_config(
         hass, {"internal_url": "https://internal.local"},
     )
-    assert _async_get_internal_url(hass) == "https://internal.local"
-    assert _async_get_internal_url(hass, allow_ip=False) == "https://internal.local"
+    assert _get_internal_url(hass) == "https://internal.local"
+    assert _get_internal_url(hass, allow_ip=False) == "https://internal.local"
     assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "https://internal.local"
+        _get_internal_url(hass, require_standard_port=True) == "https://internal.local"
     )
-    assert _async_get_internal_url(hass, require_ssl=True) == "https://internal.local"
+    assert _get_internal_url(hass, require_ssl=True) == "https://internal.local"
 
     # Add internal URL, mixed results
     await async_process_ha_core_config(
         hass, {"internal_url": "http://internal.local:8123"},
     )
-    assert _async_get_internal_url(hass) == "http://internal.local:8123"
-    assert _async_get_internal_url(hass, allow_ip=False) == "http://internal.local:8123"
+    assert _get_internal_url(hass) == "http://internal.local:8123"
+    assert _get_internal_url(hass, allow_ip=False) == "http://internal.local:8123"
     assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "https://example.local"
+        _get_internal_url(hass, require_standard_port=True) == "https://example.local"
     )
-    assert _async_get_internal_url(hass, require_ssl=True) == "https://example.local"
+    assert _get_internal_url(hass, require_ssl=True) == "https://example.local"
 
     # Add internal URL set to an IP
     await async_process_ha_core_config(
         hass, {"internal_url": "http://10.10.10.10:8123"},
     )
-    assert _async_get_internal_url(hass) == "http://10.10.10.10:8123"
-    assert _async_get_internal_url(hass, allow_ip=False) == "https://example.local"
+    assert _get_internal_url(hass) == "http://10.10.10.10:8123"
+    assert _get_internal_url(hass, allow_ip=False) == "https://example.local"
     assert (
-        _async_get_internal_url(hass, require_standard_port=True)
-        == "https://example.local"
+        _get_internal_url(hass, require_standard_port=True) == "https://example.local"
     )
-    assert _async_get_internal_url(hass, require_ssl=True) == "https://example.local"
+    assert _get_internal_url(hass, require_ssl=True) == "https://example.local"
 
 
 async def test_get_external_url_with_base_url_fallback(hass: HomeAssistant):
@@ -634,58 +588,41 @@ async def test_get_external_url_with_base_url_fallback(hass: HomeAssistant):
     assert hass.config.internal_url is None
 
     with pytest.raises(NoURLAvailableError):
-        _async_get_external_url(hass)
+        _get_external_url(hass)
 
     # Test with SSL and external domain on standard port
     hass.config.api = Mock(deprecated_base_url="https://example.com:443/")
-    assert _async_get_external_url(hass) == "https://example.com"
-    assert _async_get_external_url(hass, allow_ip=False) == "https://example.com"
-    assert _async_get_external_url(hass, require_ssl=True) == "https://example.com"
-    assert (
-        _async_get_external_url(hass, require_standard_port=True)
-        == "https://example.com"
-    )
+    assert _get_external_url(hass) == "https://example.com"
+    assert _get_external_url(hass, allow_ip=False) == "https://example.com"
+    assert _get_external_url(hass, require_ssl=True) == "https://example.com"
+    assert _get_external_url(hass, require_standard_port=True) == "https://example.com"
 
     # Add external URL
     await async_process_ha_core_config(
         hass, {"external_url": "https://external.example.com"},
     )
-    assert _async_get_external_url(hass) == "https://external.example.com"
+    assert _get_external_url(hass) == "https://external.example.com"
+    assert _get_external_url(hass, allow_ip=False) == "https://external.example.com"
     assert (
-        _async_get_external_url(hass, allow_ip=False) == "https://external.example.com"
-    )
-    assert (
-        _async_get_external_url(hass, require_standard_port=True)
+        _get_external_url(hass, require_standard_port=True)
         == "https://external.example.com"
     )
-    assert (
-        _async_get_external_url(hass, require_ssl=True)
-        == "https://external.example.com"
-    )
+    assert _get_external_url(hass, require_ssl=True) == "https://external.example.com"
 
     # Add external URL, mixed results
     await async_process_ha_core_config(
         hass, {"external_url": "http://external.example.com:8123"},
     )
-    assert _async_get_external_url(hass) == "http://external.example.com:8123"
-    assert (
-        _async_get_external_url(hass, allow_ip=False)
-        == "http://external.example.com:8123"
-    )
-    assert (
-        _async_get_external_url(hass, require_standard_port=True)
-        == "https://example.com"
-    )
-    assert _async_get_external_url(hass, require_ssl=True) == "https://example.com"
+    assert _get_external_url(hass) == "http://external.example.com:8123"
+    assert _get_external_url(hass, allow_ip=False) == "http://external.example.com:8123"
+    assert _get_external_url(hass, require_standard_port=True) == "https://example.com"
+    assert _get_external_url(hass, require_ssl=True) == "https://example.com"
 
     # Add external URL set to an IP
     await async_process_ha_core_config(
         hass, {"external_url": "http://1.1.1.1:8123"},
     )
-    assert _async_get_external_url(hass) == "http://1.1.1.1:8123"
-    assert _async_get_external_url(hass, allow_ip=False) == "https://example.com"
-    assert (
-        _async_get_external_url(hass, require_standard_port=True)
-        == "https://example.com"
-    )
-    assert _async_get_external_url(hass, require_ssl=True) == "https://example.com"
+    assert _get_external_url(hass) == "http://1.1.1.1:8123"
+    assert _get_external_url(hass, allow_ip=False) == "https://example.com"
+    assert _get_external_url(hass, require_standard_port=True) == "https://example.com"
+    assert _get_external_url(hass, require_ssl=True) == "https://example.com"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Processes a review comment by @MartinHjelmare about the new get_url helper.

<https://github.com/home-assistant/core/pull/35224#pullrequestreview-408228566>

~~I will update the developers' documentation and development blog in a second.~~ Done.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/500

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
