### PR TITLE
Add config flow and 2FA support for Blink

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -80,6 +80,21 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up Blink via config entry."""
+    if DOMAIN not in hass.data:
+        username = entry.data[CONF_USERNAME]
+        password = entry.data[CONF_PASSWORD]
+        scan_interval = entry.data[CONF_SCAN_INTERVAL]
+        hass.data[DOMAIN] = blinkpy.Blink(
+            username=username,
+            password=password,
+            motion_interval=DEFAULT_OFFSET,
+            legacy_subdomain=False,
+            no_prompt=True,
+            device_id="Home Assistant",
+        )
+        hass.data[DOMAIN].refresh_rate = scan_interval
+        await hass.async_add_executor_job(hass.data[DOMAIN].start)
+
     for component in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
+    BLINK_CONFIG,
     DEFAULT_OFFSET,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -66,6 +67,7 @@ async def async_setup(hass, config):
         device_id="Home Assistant",
     )
     hass.data[DOMAIN].refresh_rate = scan_interval
+    hass.data[BLINK_CONFIG] = conf
     await hass.async_add_executor_job(hass.data[DOMAIN].start)
 
     if not hass.config_entries.async_entries(DOMAIN) and hass.data[DOMAIN]:

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -50,6 +50,9 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up a config entry."""
+    if DOMAIN not in config:
+        return True
+
     hass.data[DOMAIN] = config.get(DOMAIN, {})
 
     if not hass.config_entries.async_entries(DOMAIN) and hass.data[DOMAIN]:

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -98,7 +98,7 @@ async def async_setup_entry(hass, entry):
     )
 
     if not hass.data[DOMAIN][entry.entry_id].available:
-        _LOGGER.error("Blink unavailable for setup.")
+        _LOGGER.error("Blink unavailable for setup")
         return False
 
     for component in PLATFORMS:

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -1,78 +1,33 @@
 """Support for Blink Home Camera System."""
-from datetime import timedelta
+import asyncio
 import logging
 
 from blinkpy import blinkpy
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
-    CONF_BINARY_SENSORS,
     CONF_FILENAME,
-    CONF_MODE,
-    CONF_MONITORED_CONDITIONS,
     CONF_NAME,
-    CONF_OFFSET,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
-    CONF_SENSORS,
     CONF_USERNAME,
-    TEMP_FAHRENHEIT,
 )
-from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers import config_validation as cv
+
+from .const import (
+    DEFAULT_OFFSET,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    PLATFORMS,
+    SERVICE_REFRESH,
+    SERVICE_SAVE_VIDEO,
+    SERVICE_TRIGGER,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "blink"
-BLINK_DATA = "blink"
-
-CONF_CAMERA = "camera"
-CONF_ALARM_CONTROL_PANEL = "alarm_control_panel"
-
-DEFAULT_BRAND = "Blink"
-DEFAULT_ATTRIBUTION = "Data provided by immedia-semi.com"
-SIGNAL_UPDATE_BLINK = "blink_update"
-
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=300)
-
-TYPE_CAMERA_ARMED = "motion_enabled"
-TYPE_MOTION_DETECTED = "motion_detected"
-TYPE_TEMPERATURE = "temperature"
-TYPE_BATTERY = "battery"
-TYPE_WIFI_STRENGTH = "wifi_strength"
-
-SERVICE_REFRESH = "blink_update"
-SERVICE_TRIGGER = "trigger_camera"
-SERVICE_SAVE_VIDEO = "save_video"
-
-BINARY_SENSORS = {
-    TYPE_CAMERA_ARMED: ["Camera Armed", "mdi:verified"],
-    TYPE_MOTION_DETECTED: ["Motion Detected", "mdi:run-fast"],
-}
-
-SENSORS = {
-    TYPE_TEMPERATURE: ["Temperature", TEMP_FAHRENHEIT, "mdi:thermometer"],
-    TYPE_BATTERY: ["Battery", "", "mdi:battery-80"],
-    TYPE_WIFI_STRENGTH: ["Wifi Signal", "dBm", "mdi:wifi-strength-2"],
-}
-
-BINARY_SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(BINARY_SENSORS)): vol.All(
-            cv.ensure_list, [vol.In(BINARY_SENSORS)]
-        )
-    }
-)
-
-SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)): vol.All(
-            cv.ensure_list, [vol.In(SENSORS)]
-        )
-    }
-)
-
 SERVICE_TRIGGER_SCHEMA = vol.Schema({vol.Required(CONF_NAME): cv.string})
-
 SERVICE_SAVE_VIDEO_SCHEMA = vol.Schema(
     {vol.Required(CONF_NAME): cv.string, vol.Required(CONF_FILENAME): cv.string}
 )
@@ -86,10 +41,6 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): cv.time_period,
-                vol.Optional(CONF_BINARY_SENSORS, default={}): BINARY_SENSOR_SCHEMA,
-                vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
-                vol.Optional(CONF_OFFSET, default=1): int,
-                vol.Optional(CONF_MODE, default=""): cv.string,
             }
         )
     },
@@ -97,58 +48,83 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass, config):
-    """Set up Blink System."""
+async def async_setup(hass, config):
+    """Set up a config entry."""
+    hass.data[DOMAIN] = config.get(DOMAIN, {})
 
-    conf = config[BLINK_DATA]
-    username = conf[CONF_USERNAME]
-    password = conf[CONF_PASSWORD]
-    scan_interval = conf[CONF_SCAN_INTERVAL]
-    is_legacy = bool(conf[CONF_MODE] == "legacy")
-    motion_interval = conf[CONF_OFFSET]
-    hass.data[BLINK_DATA] = blinkpy.Blink(
+    if not hass.config_entries.async_entries(DOMAIN) and hass.data[DOMAIN]:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up Blink via config entry."""
+    username = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+    scan_interval = entry.data[CONF_SCAN_INTERVAL]
+    hass.data[DOMAIN] = blinkpy.Blink(
         username=username,
         password=password,
-        motion_interval=motion_interval,
-        legacy_subdomain=is_legacy,
+        motion_interval=DEFAULT_OFFSET,
+        legacy_subdomain=False,
+        no_prompt=True,
+        device_id="Home Assistant",
     )
-    hass.data[BLINK_DATA].refresh_rate = scan_interval.total_seconds()
-    hass.data[BLINK_DATA].start()
+    hass.data[DOMAIN].refresh_rate = scan_interval.total_seconds()
+    await hass.async_add_executor_job(hass.data[DOMAIN].start())
 
-    platforms = [
-        ("alarm_control_panel", {}),
-        ("binary_sensor", conf[CONF_BINARY_SENSORS]),
-        ("camera", {}),
-        ("sensor", conf[CONF_SENSORS]),
-    ]
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
 
-    for component, schema in platforms:
-        discovery.load_platform(hass, component, DOMAIN, schema, config)
-
-    def trigger_camera(call):
+    async def async_trigger_camera(call):
         """Trigger a camera."""
-        cameras = hass.data[BLINK_DATA].cameras
+        cameras = hass.data[DOMAIN].cameras
         name = call.data[CONF_NAME]
         if name in cameras:
-            cameras[name].snap_picture()
-        hass.data[BLINK_DATA].refresh(force_cache=True)
+            await hass.sync_add_executor_job(cameras[name].snap_picture())
+        await hass.async_add_executor_job(hass.data[DOMAIN].refresh(force_cache=True))
 
-    def blink_refresh(event_time):
+    async def async_blink_refresh(event_time):
         """Call blink to refresh info."""
-        hass.data[BLINK_DATA].refresh(force_cache=True)
+        await hass.async_add_executor_job(hass.data[DOMAIN].refresh(force_cache=True))
 
     async def async_save_video(call):
         """Call save video service handler."""
         await async_handle_save_video_service(hass, call)
 
-    hass.services.register(DOMAIN, SERVICE_REFRESH, blink_refresh)
-    hass.services.register(
-        DOMAIN, SERVICE_TRIGGER, trigger_camera, schema=SERVICE_TRIGGER_SCHEMA
+    hass.services.async_register(DOMAIN, SERVICE_REFRESH, async_blink_refresh)
+    hass.services.async_register(
+        DOMAIN, SERVICE_TRIGGER, async_trigger_camera, schema=SERVICE_TRIGGER_SCHEMA
     )
-    hass.services.register(
+    hass.services.async_register(
         DOMAIN, SERVICE_SAVE_VIDEO, async_save_video, schema=SERVICE_SAVE_VIDEO_SCHEMA
     )
     return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload Blink entry."""
+    hass.data.pop(DOMAIN)
+
+    tasks = []
+
+    for platform in PLATFORMS:
+        tasks.append(
+            hass.config_entries.async_forward_entry_unload(config_entry, platform)
+        )
+
+    hass.services.async_remove(DOMAIN, SERVICE_REFRESH)
+    hass.services.async_remove(DOMAIN, SERVICE_TRIGGER)
+    hass.services.async_remove(DOMAIN, SERVICE_SAVE_VIDEO_SCHEMA)
+
+    return all(await asyncio.gather(*tasks))
 
 
 async def async_handle_save_video_service(hass, call):
@@ -161,7 +137,7 @@ async def async_handle_save_video_service(hass, call):
 
     def _write_video(camera_name, video_path):
         """Call video write."""
-        all_cameras = hass.data[BLINK_DATA].cameras
+        all_cameras = hass.data[DOMAIN].cameras
         if camera_name in all_cameras:
             all_cameras[camera_name].video_to_file(video_path)
 

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -55,22 +55,9 @@ async def async_setup(hass, config):
         return True
 
     conf = config.get(DOMAIN, {})
-    username = conf[CONF_USERNAME]
-    password = conf[CONF_PASSWORD]
-    scan_interval = conf[CONF_SCAN_INTERVAL]
-    hass.data[DOMAIN] = blinkpy.Blink(
-        username=username,
-        password=password,
-        motion_interval=DEFAULT_OFFSET,
-        legacy_subdomain=False,
-        no_prompt=True,
-        device_id="Home Assistant",
-    )
-    hass.data[DOMAIN].refresh_rate = scan_interval
     hass.data[BLINK_CONFIG] = conf
-    await hass.async_add_executor_job(hass.data[DOMAIN].start)
 
-    if not hass.config_entries.async_entries(DOMAIN) and hass.data[DOMAIN]:
+    if not hass.config_entries.async_entries(DOMAIN) and hass.data[BLINK_CONFIG]:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_IMPORT}

--- a/homeassistant/components/blink/alarm_control_panel.py
+++ b/homeassistant/components/blink/alarm_control_panel.py
@@ -18,7 +18,7 @@ ICON = "mdi:security"
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Set up the Blink Alarm Control Panels."""
-    data = hass.data[DOMAIN]
+    data = hass.data[DOMAIN][config.unique_id]
 
     sync_modules = []
     for sync_name, sync_module in data.sync.items():

--- a/homeassistant/components/blink/alarm_control_panel.py
+++ b/homeassistant/components/blink/alarm_control_panel.py
@@ -9,23 +9,21 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
 )
 
-from . import BLINK_DATA, DEFAULT_ATTRIBUTION
+from .const import DEFAULT_ATTRIBUTION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 ICON = "mdi:security"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Arlo Alarm Control Panels."""
-    if discovery_info is None:
-        return
-    data = hass.data[BLINK_DATA]
+async def async_setup_entry(hass, config, async_add_entities):
+    """Set up the Blink Alarm Control Panels."""
+    data = hass.data[DOMAIN]
 
     sync_modules = []
     for sync_name, sync_module in data.sync.items():
         sync_modules.append(BlinkSyncModule(data, sync_name, sync_module))
-    add_entities(sync_modules, True)
+    async_add_entities(sync_modules)
 
 
 class BlinkSyncModule(AlarmControlPanelEntity):
@@ -61,7 +59,7 @@ class BlinkSyncModule(AlarmControlPanelEntity):
     @property
     def name(self):
         """Return the name of the panel."""
-        return f"{BLINK_DATA} {self._name}"
+        return f"{DOMAIN} {self._name}"
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/blink/alarm_control_panel.py
+++ b/homeassistant/components/blink/alarm_control_panel.py
@@ -18,7 +18,7 @@ ICON = "mdi:security"
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Set up the Blink Alarm Control Panels."""
-    data = hass.data[DOMAIN][config.unique_id]
+    data = hass.data[DOMAIN][config.entry_id]
 
     sync_modules = []
     for sync_name, sync_module in data.sync.items():

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -11,7 +11,7 @@ BINARY_SENSORS = {
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Set up the blink binary sensors."""
-    data = hass.data[DOMAIN]
+    data = hass.data[DOMAIN][config.unique_id]
 
     devs = []
     for camera in data.cameras:

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -11,7 +11,7 @@ BINARY_SENSORS = {
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Set up the blink binary sensors."""
-    data = hass.data[DOMAIN][config.unique_id]
+    data = hass.data[DOMAIN][config.entry_id]
 
     devs = []
     for camera in data.cameras:

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -13,11 +13,11 @@ async def async_setup_entry(hass, config, async_add_entities):
     """Set up the blink binary sensors."""
     data = hass.data[DOMAIN][config.entry_id]
 
-    devs = []
+    entities = []
     for camera in data.cameras:
         for sensor_type in BINARY_SENSORS:
-            devs.append(BlinkBinarySensor(data, camera, sensor_type))
-    async_add_entities(devs)
+            entities.append(BlinkBinarySensor(data, camera, sensor_type))
+    async_add_entities(entities)
 
 
 class BlinkBinarySensor(BinarySensorEntity):

--- a/homeassistant/components/blink/binary_sensor.py
+++ b/homeassistant/components/blink/binary_sensor.py
@@ -1,21 +1,23 @@
 """Support for Blink system camera control."""
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import CONF_MONITORED_CONDITIONS
 
-from . import BINARY_SENSORS, BLINK_DATA
+from .const import DOMAIN, TYPE_CAMERA_ARMED, TYPE_MOTION_DETECTED
+
+BINARY_SENSORS = {
+    TYPE_CAMERA_ARMED: ["Camera Armed", "mdi:verified"],
+    TYPE_MOTION_DETECTED: ["Motion Detected", "mdi:run-fast"],
+}
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_entry(hass, config, async_add_entities):
     """Set up the blink binary sensors."""
-    if discovery_info is None:
-        return
-    data = hass.data[BLINK_DATA]
+    data = hass.data[DOMAIN]
 
     devs = []
     for camera in data.cameras:
-        for sensor_type in discovery_info[CONF_MONITORED_CONDITIONS]:
+        for sensor_type in BINARY_SENSORS:
             devs.append(BlinkBinarySensor(data, camera, sensor_type))
-    add_entities(devs, True)
+    async_add_entities(devs)
 
 
 class BlinkBinarySensor(BinarySensorEntity):
@@ -26,7 +28,7 @@ class BlinkBinarySensor(BinarySensorEntity):
         self.data = data
         self._type = sensor_type
         name, icon = BINARY_SENSORS[sensor_type]
-        self._name = f"{BLINK_DATA} {camera} {name}"
+        self._name = f"{DOMAIN} {camera} {name}"
         self._icon = icon
         self._camera = data.cameras[camera]
         self._state = None

--- a/homeassistant/components/blink/camera.py
+++ b/homeassistant/components/blink/camera.py
@@ -11,7 +11,7 @@ ATTR_VIDEO_CLIP = "video"
 ATTR_IMAGE = "image"
 
 
-async def asaync_setup_entry(hass, config, async_add_entities):
+async def async_setup_entry(hass, config, async_add_entities):
     """Set up a Blink Camera."""
     data = hass.data[DOMAIN]
     devs = []

--- a/homeassistant/components/blink/camera.py
+++ b/homeassistant/components/blink/camera.py
@@ -14,11 +14,11 @@ ATTR_IMAGE = "image"
 async def async_setup_entry(hass, config, async_add_entities):
     """Set up a Blink Camera."""
     data = hass.data[DOMAIN][config.entry_id]
-    devs = []
+    entities = []
     for name, camera in data.cameras.items():
-        devs.append(BlinkCamera(data, name, camera))
+        entities.append(BlinkCamera(data, name, camera))
 
-    async_add_entities(devs)
+    async_add_entities(entities)
 
 
 class BlinkCamera(Camera):

--- a/homeassistant/components/blink/camera.py
+++ b/homeassistant/components/blink/camera.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.camera import Camera
 
-from . import BLINK_DATA, DEFAULT_BRAND
+from .const import DEFAULT_BRAND, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,16 +11,14 @@ ATTR_VIDEO_CLIP = "video"
 ATTR_IMAGE = "image"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def asaync_setup_entry(hass, config, async_add_entities):
     """Set up a Blink Camera."""
-    if discovery_info is None:
-        return
-    data = hass.data[BLINK_DATA]
+    data = hass.data[DOMAIN]
     devs = []
     for name, camera in data.cameras.items():
         devs.append(BlinkCamera(data, name, camera))
 
-    add_entities(devs)
+    async_add_entities(devs)
 
 
 class BlinkCamera(Camera):
@@ -30,7 +28,7 @@ class BlinkCamera(Camera):
         """Initialize a camera."""
         super().__init__()
         self.data = data
-        self._name = f"{BLINK_DATA} {name}"
+        self._name = f"{DOMAIN} {name}"
         self._camera = camera
         self._unique_id = f"{camera.serial}-camera"
         self.response = None

--- a/homeassistant/components/blink/camera.py
+++ b/homeassistant/components/blink/camera.py
@@ -13,7 +13,7 @@ ATTR_IMAGE = "image"
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Set up a Blink Camera."""
-    data = hass.data[DOMAIN][config.unique_id]
+    data = hass.data[DOMAIN][config.entry_id]
     devs = []
     for name, camera in data.cameras.items():
         devs.append(BlinkCamera(data, name, camera))

--- a/homeassistant/components/blink/camera.py
+++ b/homeassistant/components/blink/camera.py
@@ -13,7 +13,7 @@ ATTR_IMAGE = "image"
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Set up a Blink Camera."""
-    data = hass.data[DOMAIN]
+    data = hass.data[DOMAIN][config.unique_id]
     devs = []
     for name, camera in data.cameras.items():
         devs.append(BlinkCamera(data, name, camera))

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -1,10 +1,10 @@
 """Config flow to configure Blink."""
 import logging
 
-from blinkpy import blinkpy
+from blinkpy.blinkpy import Blink
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant import config_entries, core, exceptions
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PIN,
@@ -12,9 +12,20 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 
-from .const import DEFAULT_OFFSET, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DEFAULT_OFFSET, DEFAULT_SCAN_INTERVAL, DEVICE_ID, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def validate_input(hass: core.HomeAssistant, blink, data):
+    """Validate the user input allows us to connect."""
+    response = await hass.async_add_executor_job(blink.get_auth_token)
+    if not response:
+        raise InvalidAuth
+    if blink.key_required:
+        raise Require2FA
+
+    return blink.login_response
 
 
 class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -30,10 +41,12 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_USERNAME: "",
             CONF_PASSWORD: "",
             CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+            "login_response": None,
         }
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
+        errors = {}
         if user_input is not None:
             self.data[CONF_USERNAME] = user_input["username"]
             self.data[CONF_PASSWORD] = user_input["password"]
@@ -43,25 +56,26 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if CONF_SCAN_INTERVAL in user_input:
                 self.data[CONF_SCAN_INTERVAL] = user_input["scan_interval"]
 
-            try:
-                self.blink = self.hass.data[DOMAIN]
-            except KeyError:
-                self.blink = blinkpy.Blink(
-                    username=self.data[CONF_USERNAME],
-                    password=self.data[CONF_PASSWORD],
-                    motion_interval=DEFAULT_OFFSET,
-                    legacy_subdomain=False,
-                    no_prompt=True,
-                    device_id="Home Assistant",
-                )
-                self.blink.refresh_rate = self.data[CONF_SCAN_INTERVAL]
-                await self.hass.async_add_executor_job(self.blink.start)
+            self.blink = Blink(
+                username=self.data[CONF_USERNAME],
+                password=self.data[CONF_PASSWORD],
+                motion_interval=DEFAULT_OFFSET,
+                legacy_subdomain=False,
+                no_prompt=True,
+                device_id=DEVICE_ID,
+            )
 
-            if not self.blink.key_required:
-                # No key required, we're good
-                self.hass.data[DOMAIN] = {self.unique_id: self.blink}
+            try:
+                response = await validate_input(self.hass, self.blink, self.data)
+                self.data["login_response"] = response
                 return self.async_create_entry(title=DOMAIN, data=self.data,)
-            return await self.async_step_2fa()
+            except Require2FA:
+                return await self.async_step_2fa()
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
 
         data_schema = {
             vol.Required("username"): str,
@@ -74,7 +88,7 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ] = int
 
         return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(data_schema), errors={},
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors,
         )
 
     async def async_step_2fa(self, user_input=None):
@@ -86,9 +100,7 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if await self.hass.async_add_executor_job(
                 self.blink.login_handler.send_auth_key, self.blink, pin
             ):
-                await self.hass.async_add_executor_job(self.blink.setup_post_verify)
-                self.hass.data[DOMAIN] = {self.unique_id: self.blink}
-                return self.async_create_entry(title=DOMAIN, data=self.data,)
+                return await self.async_step_user(user_input=self.data)
 
         return self.async_show_form(
             step_id="2fa", data_schema=vol.Schema({vol.Required("pin"): str}),
@@ -97,3 +109,11 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_data):
         """Import blink config from configuration.yaml."""
         return await self.async_step_user(import_data)
+
+
+class Require2FA(exceptions.HomeAssistantError):
+    """Error to indicate we require 2FA."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -30,7 +30,7 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
         if self._async_current_entries():
-            return self.async_abort(reason="one_instance_only")
+            return self.async_abort(reason="already_configured")
 
         stored_username = ""
         stored_password = ""

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -82,11 +82,6 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("password"): str,
         }
 
-        if self.show_advanced_options:
-            data_schema[
-                vol.Required("scan_interval", default=DEFAULT_SCAN_INTERVAL)
-            ] = int
-
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(data_schema), errors=errors,
         )

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -97,8 +97,7 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=DOMAIN, data=config_data,)
 
         return self.async_show_form(
-            step_id="2fa",
-            data_schema=vol.Schema({vol.Required("pin", default="None"): str}),
+            step_id="2fa", data_schema=vol.Schema({vol.Required("pin"): str}),
         )
 
     async def async_step_import(self, import_data):

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -29,9 +29,6 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
-        if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
-
         stored_username = ""
         stored_password = ""
         stored_interval = DEFAULT_SCAN_INTERVAL
@@ -90,7 +87,9 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             pin = user_input[CONF_PIN]
             if not pin or pin.lower() == "none":
                 pin = None
-            if self.blink.login_handler.send_auth_key(self.blink, pin):
+            if await self.hass.async_add_executor_job(
+                self.blink.login_handler.send_auth_key, self.blink, pin
+            ):
                 await self.hass.async_add_executor_job(self.blink.setup_post_verify)
                 self.hass.data[DOMAIN] = self.blink
                 config_data = {

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -93,17 +93,18 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_2fa(self, user_input=None):
         """Handle 2FA step."""
-        if user_input:
-            pin = user_input[CONF_PIN]
-            if not pin or pin.lower() == "none":
-                pin = None
+        if user_input is not None:
+            pin = user_input.get(CONF_PIN)
             if await self.hass.async_add_executor_job(
                 self.blink.login_handler.send_auth_key, self.blink, pin
             ):
                 return await self.async_step_user(user_input=self.data)
 
         return self.async_show_form(
-            step_id="2fa", data_schema=vol.Schema({vol.Required("pin"): str}),
+            step_id="2fa",
+            data_schema=vol.Schema(
+                {vol.Optional("pin"): vol.All(str, vol.Length(min=1))}
+            ),
         )
 
     async def async_step_import(self, import_data):

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -1,0 +1,93 @@
+"""Config flow to configure Blink."""
+import logging
+
+from blinkpy import blinkpy
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_PIN,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.helpers import config_validation as cv
+
+from .const import DEFAULT_OFFSET, DEFAULT_SCAN_INTERVAL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Blink config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize the blink flow."""
+        self.blink = None
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason="one_instance_only")
+
+        stored_username = ""
+        stored_password = ""
+        stored_interval = DEFAULT_SCAN_INTERVAL
+
+        if DOMAIN in self.hass.data:
+            stored_username = self.hass.data[DOMAIN].get(CONF_USERNAME)
+            stored_password = self.hass.data[DOMAIN].get(CONF_PASSWORD)
+            stored_interval = self.hass.data[DOMAIN].get(CONF_SCAN_INTERVAL)
+
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_USERNAME])
+            self.blink = blinkpy.Blink(
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
+                motion_interval=DEFAULT_OFFSET,
+                legacy_subdomain=False,
+                no_prompt=True,
+                device_id="Home Assistant",
+            )
+            self.blink.refresh_rate = user_input[CONF_SCAN_INTERVAL].total_seconds()
+
+            await self.hass.async_add_executor_job(self._blink.start())
+
+            if not self.blink.key_required:
+                # No key required, we're good
+                return await self.async_create_entry(
+                    title=DOMAIN,
+                    data={CONF_USERNAME: self.blink.login_handler.data["username"]},
+                )
+            else:
+                return await self.async_step_2fa()
+
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_USERNAME, default=stored_username): cv.string,
+                        vol.Required(CONF_PASSWORD, default=stored_password): cv.string,
+                        vol.Optional(
+                            CONF_SCAN_INTERVAL, default=stored_interval
+                        ): cv.time_period,
+                    }
+                ),
+                errors={},
+            )
+
+    async def async_step_2fa(self, user_input=None):
+        """Handle 2FA step."""
+        if user_input:
+            await self.blink.setup_post_verify()
+            return await self.async_create_entry(
+                title=DOMAIN,
+                data={CONF_USERNAME: self.blink.login_handler.data["username"]},
+            )
+
+        return self.async_show_form(
+            step_id="2FA", data_schema=vol.Schema({CONF_PIN: str})
+        )

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -17,7 +17,7 @@ from .const import DEFAULT_OFFSET, DEFAULT_SCAN_INTERVAL, DEVICE_ID, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-async def validate_input(hass: core.HomeAssistant, blink, data):
+async def validate_input(hass: core.HomeAssistant, blink):
     """Validate the user input allows us to connect."""
     response = await hass.async_add_executor_job(blink.get_auth_token)
     if not response:
@@ -66,7 +66,7 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
             try:
-                response = await validate_input(self.hass, self.blink, self.data)
+                response = await validate_input(self.hass, self.blink)
                 self.data["login_response"] = response
                 return self.async_create_entry(title=DOMAIN, data=self.data,)
             except Require2FA:

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -62,27 +62,27 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     title=DOMAIN,
                     data={CONF_USERNAME: self.blink.login_handler.data["username"]},
                 )
-            else:
-                return await self.async_step_2fa()
 
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(
-                    {
-                        vol.Required(CONF_USERNAME, default=stored_username): cv.string,
-                        vol.Required(CONF_PASSWORD, default=stored_password): cv.string,
-                        vol.Optional(
-                            CONF_SCAN_INTERVAL, default=stored_interval
-                        ): cv.time_period,
-                    }
-                ),
-                errors={},
-            )
+            return await self.async_step_2fa()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME, default=stored_username): cv.string,
+                    vol.Required(CONF_PASSWORD, default=stored_password): cv.string,
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=stored_interval
+                    ): cv.time_period,
+                }
+            ),
+            errors={},
+        )
 
     async def async_step_2fa(self, user_input=None):
         """Handle 2FA step."""
         if user_input:
-            await self.blink.setup_post_verify()
+            await self.hass.async_add_executor_job(self.blink.setup_post_verify())
             return await self.async_create_entry(
                 title=DOMAIN,
                 data={CONF_USERNAME: self.blink.login_handler.data["username"]},
@@ -91,3 +91,7 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="2FA", data_schema=vol.Schema({CONF_PIN: str})
         )
+
+    async def async_step_import(self, import_data):
+        """Import blink config from configuration.yaml."""
+        return await self.async_step_user(import_data)

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -63,7 +63,6 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not self.blink.key_required:
                 # No key required, we're good
-                await self.hass.async_add_executor_job(self.blink.setup_post_verify)
                 self.hass.data[DOMAIN] = self.blink
                 config_data = {
                     CONF_USERNAME: user_input[CONF_USERNAME],

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -1,0 +1,26 @@
+"""Constants for Blink."""
+from datetime import timedelta
+
+DOMAIN = "blink"
+BLINK_CONFIG = "blink"
+
+CONF_CAMERA = "camera"
+CONF_ALARM_CONTROL_PANEL = "alarm_control_panel"
+
+DEFAULT_BRAND = "Blink"
+DEFAULT_ATTRIBUTION = "Data provided by immedia-semi.com"
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=300)
+DEFAULT_OFFSET = 1
+SIGNAL_UPDATE_BLINK = "blink_update"
+
+TYPE_CAMERA_ARMED = "motion_enabled"
+TYPE_MOTION_DETECTED = "motion_detected"
+TYPE_TEMPERATURE = "temperature"
+TYPE_BATTERY = "battery"
+TYPE_WIFI_STRENGTH = "wifi_strength"
+
+SERVICE_REFRESH = "blink_update"
+SERVICE_TRIGGER = "trigger_camera"
+SERVICE_SAVE_VIDEO = "save_video"
+
+PLATFORMS = ("alarm_control_panel", "binary_sensor", "camera", "sensor")

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -20,5 +20,6 @@ TYPE_WIFI_STRENGTH = "wifi_strength"
 SERVICE_REFRESH = "blink_update"
 SERVICE_TRIGGER = "trigger_camera"
 SERVICE_SAVE_VIDEO = "save_video"
+SERVICE_SEND_PIN = "send_pin"
 
 PLATFORMS = ("alarm_control_panel", "binary_sensor", "camera", "sensor")

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -1,6 +1,4 @@
 """Constants for Blink."""
-from datetime import timedelta
-
 DOMAIN = "blink"
 BLINK_CONFIG = "blink"
 
@@ -9,7 +7,7 @@ CONF_ALARM_CONTROL_PANEL = "alarm_control_panel"
 
 DEFAULT_BRAND = "Blink"
 DEFAULT_ATTRIBUTION = "Data provided by immedia-semi.com"
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=300)
+DEFAULT_SCAN_INTERVAL = 300
 DEFAULT_OFFSET = 1
 SIGNAL_UPDATE_BLINK = "blink_update"
 

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -1,6 +1,6 @@
 """Constants for Blink."""
 DOMAIN = "blink"
-BLINK_CONFIG = "blink_config"
+DEVICE_ID = "Home Assistant"
 
 CONF_CAMERA = "camera"
 CONF_ALARM_CONTROL_PANEL = "alarm_control_panel"

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -1,6 +1,6 @@
 """Constants for Blink."""
 DOMAIN = "blink"
-BLINK_CONFIG = "blink"
+BLINK_CONFIG = "blink_config"
 
 CONF_CAMERA = "camera"
 CONF_ALARM_CONTROL_PANEL = "alarm_control_panel"

--- a/homeassistant/components/blink/manifest.json
+++ b/homeassistant/components/blink/manifest.json
@@ -2,6 +2,6 @@
   "domain": "blink",
   "name": "Blink",
   "documentation": "https://www.home-assistant.io/integrations/blink",
-  "requirements": ["blinkpy==0.14.3"],
+  "requirements": ["blinkpy==0.15.0-rc1"],
   "codeowners": ["@fronzbot"]
 }

--- a/homeassistant/components/blink/manifest.json
+++ b/homeassistant/components/blink/manifest.json
@@ -3,5 +3,6 @@
   "name": "Blink",
   "documentation": "https://www.home-assistant.io/integrations/blink",
   "requirements": ["blinkpy==0.15.0-rc1"],
-  "codeowners": ["@fronzbot"]
+  "codeowners": ["@fronzbot"],
+  "config_flow": true
 }

--- a/homeassistant/components/blink/manifest.json
+++ b/homeassistant/components/blink/manifest.json
@@ -2,7 +2,7 @@
   "domain": "blink",
   "name": "Blink",
   "documentation": "https://www.home-assistant.io/integrations/blink",
-  "requirements": ["blinkpy==0.15.0-rc1"],
+  "requirements": ["blinkpy==0.15.0"],
   "codeowners": ["@fronzbot"],
   "config_flow": true
 }

--- a/homeassistant/components/blink/sensor.py
+++ b/homeassistant/components/blink/sensor.py
@@ -17,7 +17,7 @@ SENSORS = {
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Initialize a Blink sensor."""
-    data = hass.data[DOMAIN]
+    data = hass.data[DOMAIN][config.unique_id]
     devs = []
     for camera in data.cameras:
         for sensor_type in SENSORS:

--- a/homeassistant/components/blink/sensor.py
+++ b/homeassistant/components/blink/sensor.py
@@ -17,7 +17,7 @@ SENSORS = {
 
 async def async_setup_entry(hass, config, async_add_entities):
     """Initialize a Blink sensor."""
-    data = hass.data[DOMAIN][config.unique_id]
+    data = hass.data[DOMAIN][config.entry_id]
     devs = []
     for camera in data.cameras:
         for sensor_type in SENSORS:

--- a/homeassistant/components/blink/sensor.py
+++ b/homeassistant/components/blink/sensor.py
@@ -1,25 +1,29 @@
 """Support for Blink system camera sensors."""
 import logging
 
-from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.const import TEMP_FAHRENHEIT
 from homeassistant.helpers.entity import Entity
 
-from . import BLINK_DATA, SENSORS
+from .const import DOMAIN, TYPE_BATTERY, TYPE_TEMPERATURE, TYPE_WIFI_STRENGTH
 
 _LOGGER = logging.getLogger(__name__)
 
+SENSORS = {
+    TYPE_TEMPERATURE: ["Temperature", TEMP_FAHRENHEIT, "mdi:thermometer"],
+    TYPE_BATTERY: ["Battery", "", "mdi:battery-80"],
+    TYPE_WIFI_STRENGTH: ["Wifi Signal", "dBm", "mdi:wifi-strength-2"],
+}
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up a Blink sensor."""
-    if discovery_info is None:
-        return
-    data = hass.data[BLINK_DATA]
+
+async def async_setup_entry(hass, config, async_add_entities):
+    """Initialize a Blink sensor."""
+    data = hass.data[DOMAIN]
     devs = []
     for camera in data.cameras:
-        for sensor_type in discovery_info[CONF_MONITORED_CONDITIONS]:
+        for sensor_type in SENSORS:
             devs.append(BlinkSensor(data, camera, sensor_type))
 
-    add_entities(devs, True)
+    async_add_entities(devs)
 
 
 class BlinkSensor(Entity):
@@ -28,7 +32,7 @@ class BlinkSensor(Entity):
     def __init__(self, data, camera, sensor_type):
         """Initialize sensors from Blink camera."""
         name, units, icon = SENSORS[sensor_type]
-        self._name = f"{BLINK_DATA} {camera} {name}"
+        self._name = f"{DOMAIN} {camera} {name}"
         self._camera_name = name
         self._type = sensor_type
         self.data = data

--- a/homeassistant/components/blink/sensor.py
+++ b/homeassistant/components/blink/sensor.py
@@ -18,12 +18,12 @@ SENSORS = {
 async def async_setup_entry(hass, config, async_add_entities):
     """Initialize a Blink sensor."""
     data = hass.data[DOMAIN][config.entry_id]
-    devs = []
+    entities = []
     for camera in data.cameras:
         for sensor_type in SENSORS:
-            devs.append(BlinkSensor(data, camera, sensor_type))
+            entities.append(BlinkSensor(data, camera, sensor_type))
 
-    async_add_entities(devs)
+    async_add_entities(entities)
 
 
 class BlinkSensor(Entity):

--- a/homeassistant/components/blink/services.yaml
+++ b/homeassistant/components/blink/services.yaml
@@ -19,3 +19,10 @@ save_video:
     filename:
       description: Filename to writable path (directory may need to be included in whitelist_dirs in config)
       example: "/tmp/video.mp4"
+
+send_pin:
+  description: Send a new pin to blink for 2FA.
+  fields:
+    pin:
+      description: Pin received from blink. Leave empty if you only received a verification email.
+      example: "abc123"

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Sign-in with Blink account",
+        "data": { "username": "Username", "password": "Password"}
+      },
+      "2fa": {
+        "title": "Two-factor authentication",
+        "data": { "2fa": "Two-factor code" },
+        "description": "Enter the pin sent to your email. If the email does not contain a pin, enter 'None'"
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": { "already_configured": "Device is already configured" }
+  }
+}

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -17,6 +17,9 @@
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+        "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -3,7 +3,10 @@
     "step": {
       "user": {
         "title": "Sign-in with Blink account",
-        "data": { "username": "Username", "password": "Password"}
+        "data": {
+            "username": "[%key:common::config_flow::data::username%]",
+            "password": "[%key:common::config_flow::data::password%]"
+        }
       },
       "2fa": {
         "title": "Two-factor authentication",
@@ -12,9 +15,8 @@
       }
     },
     "error": {
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
-    },
-    "abort": { "already_configured": "Device is already configured" }
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    }
   }
 }

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -11,7 +11,7 @@
       "2fa": {
         "title": "Two-factor authentication",
         "data": { "2fa": "Two-factor code" },
-        "description": "Enter the pin sent to your email. If the email does not contain a pin, enter 'None'"
+        "description": "Enter the pin sent to your email. If the email does not contain a pin, leave blank"
       }
     },
     "error": {

--- a/homeassistant/components/blink/translations/en.json
+++ b/homeassistant/components/blink/translations/en.json
@@ -13,7 +13,7 @@
                     "2fa": "Two-factor code"
                 },
                 "title": "Two-factor authentication",
-                "description": "Enter the pin sent to your email. If the email does not contain a pin, enter 'None'"
+                "description": "Enter the pin sent to your email. If the email does not contain a pin, leave blank"
             },
             "user": {
                 "data": {

--- a/homeassistant/components/blink/translations/en.json
+++ b/homeassistant/components/blink/translations/en.json
@@ -1,0 +1,28 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "2fa": {
+                "data": {
+                    "2fa": "Two-factor code"
+                },
+                "title": "Two-factor authentication",
+                "description": "Enter the pin sent to your email. If the email does not contain a pin, enter 'None'"
+            },
+            "user": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username",
+                    "scan_interval": "Scan Interval"
+                },
+                "title": "Sign-in with Blink account"
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -17,6 +17,7 @@ FLOWS = [
     "august",
     "axis",
     "blebox",
+    "blink",
     "braviatv",
     "brother",
     "cast",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -336,7 +336,7 @@ bizkaibus==0.1.1
 blebox_uniapi==1.3.2
 
 # homeassistant.components.blink
-blinkpy==0.15.0-rc1
+blinkpy==0.15.0
 
 # homeassistant.components.blinksticklight
 blinkstick==1.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -336,7 +336,7 @@ bizkaibus==0.1.1
 blebox_uniapi==1.3.2
 
 # homeassistant.components.blink
-blinkpy==0.14.3
+blinkpy==0.15.0-rc1
 
 # homeassistant.components.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
As of May 11, 2020 Blink has removed the old username/password authentication method which means all current Blink integrations will be broken.  In order to support this change, a 2FA key must be entered before setup can continue.  Some users may not have 2FA enabled on their account yet, but you will still receive an email at login asking you to allow the device to continue setting up.  Your current YAML config will be converted to a GUI-based config flow but the only supported entries are `username`, `password`, and `scan_interval`.  All other entries must be removed otherwise the integration will not be configured.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #35214 
More information on fronzbot/blinkpy#210

Moving forward, Blink is migrating to 2FA.  What this means is that I'll need to remove YAML config at some point, but for now we can migrate users since another endpoint exists that just requires you to click "Allow Device" in your email (no time limit as far as I can tell...which is clearly excellent security 😏).  So here is a summary of changes (many changes not mentioned here were made to the core library: [fronzbot/blinkpy](https://github.com/fronzbot/blinkpy))

- Added config flow to the integration
  - I've tested this and it works.  I've also test yaml configuration and it works.
  - Currently using the `show_advanced_options` for `scan_interval` in `config_flow.py` doesn't seem to work, so I could use some help here.  Not sure why it's broken.  Given that users can still use yaml config, I figured I can save this as a "to-do" since we've got a bit of a time crunch before this integration breaks for all users.
- Made many things async (as much as possible, and where I understood it to be useful/necessary)
- I've double checked log entries to ensure there's no I/O in event loop issues, since a lot of things have been changed to async

I'm not sure my implementation of the config flow is correct.  I know it works, but "works" and "correct" are rarely the same thing 😄.  So I appreciate any and all feedback.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
blink:
  username: EMAIL ADDRESS
  password: PASSWORD
  scan_interval: 300
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35214 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13360

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
