### PR TITLE
Refactor ZHA config flow

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -1,8 +1,14 @@
 """All constants related to the ZHA component."""
 import enum
 import logging
+from typing import List
 
+import bellows.zigbee.application
 from zigpy.config import CONF_DEVICE_PATH  # noqa: F401 # pylint: disable=unused-import
+import zigpy_cc.zigbee.application
+import zigpy_deconz.zigbee.application
+import zigpy_xbee.zigbee.application
+import zigpy_zigate.zigbee.application
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.cover import DOMAIN as COVER
@@ -12,6 +18,8 @@ from homeassistant.components.light import DOMAIN as LIGHT
 from homeassistant.components.lock import DOMAIN as LOCK
 from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
+
+from .typing import CALLABLE_T
 
 ATTR_ARGS = "args"
 ATTR_ATTRIBUTE = "attribute"
@@ -98,7 +106,6 @@ CONF_FLOWCONTROL = "flow_control"
 CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
 CONF_ZIGPY = "zigpy_config"
-CONTROLLER = "controller"
 
 DATA_DEVICE_CONFIG = "zha_device_config"
 DATA_ZHA = "zha"
@@ -149,16 +156,51 @@ POWER_BATTERY_OR_UNKNOWN = "Battery or Unknown"
 class RadioType(enum.Enum):
     """Possible options for radio type."""
 
-    ezsp = "ezsp"
-    deconz = "deconz"
-    ti_cc = "ti_cc"
-    zigate = "zigate"
-    xbee = "xbee"
+    ezsp = (
+        "ESZP: Radio based on Silabs chip using EmberZNet protocol",
+        bellows.zigbee.application.ControllerApplication,
+    )
+    deconz = (
+        "Conbee, Conbee II, RaspBee radios from dresden elektronik",
+        zigpy_deconz.zigbee.application.ControllerApplication,
+    )
+    ti_cc = (
+        "TI_CC: Radios based on Texas Instruments chips using ZNP protocol",
+        zigpy_cc.zigbee.application.ControllerApplication,
+    )
+    zigate = "ZiGate Radio", zigpy_zigate.zigbee.application.ControllerApplication
+    xbee = (
+        "Digi XBee S2C, XBee 3 radios",
+        zigpy_xbee.zigbee.application.ControllerApplication,
+    )
 
     @classmethod
-    def list(cls):
+    def list(cls) -> List[str]:
         """Return list of enum's values."""
-        return [e.value for e in RadioType]
+        return [e.description for e in RadioType]
+
+    @classmethod
+    def get_by_description(cls, description: str) -> str:
+        """Get radio by description."""
+        for radio in cls:
+            if radio.description == description:
+                return radio.name
+        raise ValueError
+
+    def __init__(self, description: str, controller_cls: CALLABLE_T):
+        """Init instance."""
+        self._desc = description
+        self._ctrl_cls = controller_cls
+
+    @property
+    def controller(self) -> CALLABLE_T:
+        """Return controller class."""
+        return self._ctrl_cls
+
+    @property
+    def description(self) -> str:
+        """Return radio type description."""
+        return self._desc
 
 
 REPORT_CONFIG_MAX_INT = 900
@@ -262,7 +304,6 @@ ZHA_GW_MSG_GROUP_REMOVED = "group_removed"
 ZHA_GW_MSG_LOG_ENTRY = "log_entry"
 ZHA_GW_MSG_LOG_OUTPUT = "log_output"
 ZHA_GW_MSG_RAW_INIT = "raw_device_initialized"
-ZHA_GW_RADIO_DESCRIPTION = "radio_description"
 
 EFFECT_BLINK = 0x00
 EFFECT_BREATHE = 0x01

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -165,7 +165,7 @@ class RadioType(enum.Enum):
         zigpy_deconz.zigbee.application.ControllerApplication,
     )
     ti_cc = (
-        "TI_CC: Radios based on Texas Instruments chips using ZNP protocol",
+        "TI_CC: CC2531, CC2530, CC2652R, CC1352 etc, Texas Instruments ZNP protocol",
         zigpy_cc.zigbee.application.ControllerApplication,
     )
     zigate = "ZiGate Radio", zigpy_zigate.zigbee.application.ControllerApplication

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -176,7 +176,7 @@ class RadioType(enum.Enum):
 
     @classmethod
     def list(cls) -> List[str]:
-        """Return list of enum's values."""
+        """Return a list of descriptions."""
         return [e.description for e in RadioType]
 
     @classmethod

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -157,7 +157,7 @@ class RadioType(enum.Enum):
     """Possible options for radio type."""
 
     ezsp = (
-        "ESZP: Radio based on Silabs chip using EmberZNet protocol",
+        "ESZP: HUSBZB-1, Elelabs, Telegesis, Silabs EmberZNet protocol",
         bellows.zigbee.application.ControllerApplication,
     )
     deconz = (

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -37,7 +37,6 @@ from .const import (
     CONF_DATABASE,
     CONF_RADIO_TYPE,
     CONF_ZIGPY,
-    CONTROLLER,
     DATA_ZHA,
     DATA_ZHA_BRIDGE_ID,
     DATA_ZHA_GATEWAY,
@@ -73,12 +72,12 @@ from .const import (
     ZHA_GW_MSG_LOG_ENTRY,
     ZHA_GW_MSG_LOG_OUTPUT,
     ZHA_GW_MSG_RAW_INIT,
-    ZHA_GW_RADIO_DESCRIPTION,
+    RadioType,
 )
 from .device import DeviceStatus, ZHADevice
 from .group import GroupMember, ZHAGroup
 from .patches import apply_application_controller_patch
-from .registries import GROUP_ENTITY_DOMAINS, RADIO_TYPES
+from .registries import GROUP_ENTITY_DOMAINS
 from .store import async_get_registry
 from .typing import ZhaGroupType, ZigpyEndpointType, ZigpyGroupType
 
@@ -125,8 +124,8 @@ class ZHAGateway:
 
         radio_type = self._config_entry.data[CONF_RADIO_TYPE]
 
-        app_controller_cls = RADIO_TYPES[radio_type][CONTROLLER]
-        self.radio_description = RADIO_TYPES[radio_type][ZHA_GW_RADIO_DESCRIPTION]
+        app_controller_cls = RadioType[radio_type].controller
+        self.radio_description = RadioType[radio_type].description
 
         app_config = self._config.get(CONF_ZIGPY, {})
         database = self._config.get(

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -3,14 +3,9 @@ import collections
 from typing import Callable, Dict, List, Set, Tuple, Union
 
 import attr
-import bellows.zigbee.application
 import zigpy.profiles.zha
 import zigpy.profiles.zll
 import zigpy.zcl as zcl
-import zigpy_cc.zigbee.application
-import zigpy_deconz.zigbee.application
-import zigpy_xbee.zigbee.application
-import zigpy_zigate.zigbee.application
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.cover import DOMAIN as COVER
@@ -23,7 +18,6 @@ from homeassistant.components.switch import DOMAIN as SWITCH
 
 # importing channels updates registries
 from . import channels as zha_channels  # noqa: F401 pylint: disable=unused-import
-from .const import CONTROLLER, ZHA_GW_RADIO_DESCRIPTION, RadioType
 from .decorators import CALLABLE_T, DictRegistry, SetRegistry
 from .typing import ChannelType
 
@@ -123,29 +117,6 @@ DEVICE_TRACKER_CLUSTERS = SetRegistry()
 LIGHT_CLUSTERS = SetRegistry()
 OUTPUT_CHANNEL_ONLY_CLUSTERS = SetRegistry()
 CLIENT_CHANNELS_REGISTRY = DictRegistry()
-
-RADIO_TYPES = {
-    RadioType.deconz.name: {
-        CONTROLLER: zigpy_deconz.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "Deconz",
-    },
-    RadioType.ezsp.name: {
-        CONTROLLER: bellows.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "EZSP",
-    },
-    RadioType.ti_cc.name: {
-        CONTROLLER: zigpy_cc.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "TI CC",
-    },
-    RadioType.xbee.name: {
-        CONTROLLER: zigpy_xbee.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "XBee",
-    },
-    RadioType.zigate.name: {
-        CONTROLLER: zigpy_zigate.zigbee.application.ControllerApplication,
-        ZHA_GW_RADIO_DESCRIPTION: "ZiGate",
-    },
-}
 
 COMPONENT_CLUSTERS = {
     BINARY_SENSOR: BINARY_SENSOR_CLUSTERS,

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -1,5 +1,4 @@
 """Test configuration for the ZHA component."""
-from unittest import mock
 
 import pytest
 import zigpy
@@ -10,12 +9,11 @@ import zigpy.types
 
 import homeassistant.components.zha.core.const as zha_const
 import homeassistant.components.zha.core.device as zha_core_device
-import homeassistant.components.zha.core.registries as zha_regs
 from homeassistant.setup import async_setup_component
 
 from .common import FakeDevice, FakeEndpoint, get_zha_gateway
 
-import tests.async_mock
+from tests.async_mock import AsyncMock, MagicMock, PropertyMock, patch
 from tests.common import MockConfigEntry
 
 FIXTURE_GRP_ID = 0x1001
@@ -25,25 +23,17 @@ FIXTURE_GRP_NAME = "fixture group"
 @pytest.fixture
 def zigpy_app_controller():
     """Zigpy ApplicationController fixture."""
-    app = mock.MagicMock(spec_set=ControllerApplication)
-    app.startup = tests.async_mock.AsyncMock()
-    app.shutdown = tests.async_mock.AsyncMock()
+    app = MagicMock(spec_set=ControllerApplication)
+    app.startup = AsyncMock()
+    app.shutdown = AsyncMock()
     groups = zigpy.group.Groups(app)
     groups.add_group(FIXTURE_GRP_ID, FIXTURE_GRP_NAME, suppress_event=True)
     app.configure_mock(groups=groups)
-    type(app).ieee = mock.PropertyMock()
+    type(app).ieee = PropertyMock()
     app.ieee.return_value = zigpy.types.EUI64.convert("00:15:8d:00:02:32:4f:32")
-    type(app).nwk = mock.PropertyMock(return_value=zigpy.types.NWK(0x0000))
-    type(app).devices = mock.PropertyMock(return_value={})
+    type(app).nwk = PropertyMock(return_value=zigpy.types.NWK(0x0000))
+    type(app).devices = PropertyMock(return_value={})
     return app
-
-
-@pytest.fixture
-def zigpy_radio():
-    """Zigpy radio mock."""
-    radio = mock.MagicMock()
-    radio.connect = tests.async_mock.AsyncMock()
-    return radio
 
 
 @pytest.fixture(name="config_entry")
@@ -54,7 +44,7 @@ async def config_entry_fixture(hass):
         domain=zha_const.DOMAIN,
         data={
             zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: "/dev/ttyUSB0"},
-            zha_const.CONF_RADIO_TYPE: "MockRadio",
+            zha_const.CONF_RADIO_TYPE: "ezsp",
         },
     )
     entry.add_to_hass(hass)
@@ -62,22 +52,18 @@ async def config_entry_fixture(hass):
 
 
 @pytest.fixture
-def setup_zha(hass, config_entry, zigpy_app_controller, zigpy_radio):
+def setup_zha(hass, config_entry, zigpy_app_controller):
     """Set up ZHA component."""
     zha_config = {zha_const.CONF_ENABLE_QUIRKS: False}
-    app_ctrl = mock.MagicMock()
-    app_ctrl.new = tests.async_mock.AsyncMock(return_value=zigpy_app_controller)
-    app_ctrl.SCHEMA = zigpy.config.CONFIG_SCHEMA
-    app_ctrl.SCHEMA_DEVICE = zigpy.config.SCHEMA_DEVICE
 
-    radio_details = {
-        zha_const.CONTROLLER: app_ctrl,
-        zha_const.ZHA_GW_RADIO_DESCRIPTION: "mock radio",
-    }
+    p1 = patch(
+        "bellows.zigbee.application.ControllerApplication.new",
+        return_value=zigpy_app_controller,
+    )
 
     async def _setup(config=None):
         config = config or {}
-        with mock.patch.dict(zha_regs.RADIO_TYPES, {"MockRadio": radio_details}):
+        with p1:
             status = await async_setup_component(
                 hass, zha_const.DOMAIN, {zha_const.DOMAIN: {**zha_config, **config}}
             )
@@ -92,12 +78,12 @@ def channel():
     """Channel mock factory fixture."""
 
     def channel(name: str, cluster_id: int, endpoint_id: int = 1):
-        ch = mock.MagicMock()
+        ch = MagicMock()
         ch.name = name
         ch.generic_id = f"channel_0x{cluster_id:04x}"
         ch.id = f"{endpoint_id}:0x{cluster_id:04x}"
-        ch.async_configure = tests.async_mock.AsyncMock()
-        ch.async_initialize = tests.async_mock.AsyncMock()
+        ch.async_configure = AsyncMock()
+        ch.async_initialize = AsyncMock()
         return ch
 
     return channel
@@ -201,7 +187,7 @@ def zha_device_mock(hass, zigpy_device_mock):
         zigpy_device = zigpy_device_mock(
             endpoints, ieee, manufacturer, model, node_desc
         )
-        zha_device = zha_core_device.ZHADevice(hass, zigpy_device, mock.MagicMock())
+        zha_device = zha_core_device.ZHADevice(hass, zigpy_device, MagicMock())
         return zha_device
 
     return _zha_device


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If user gets to pick a "radio type" to be used for ZHA, then present a more descriptive Radio Type names for user to select from:
![image](https://user-images.githubusercontent.com/5826160/81454340-f662ac00-9159-11ea-8650-d6e6b5d89740.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
