### PR TITLE
Listen for group member state changes when using `expand` in templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -44,8 +44,8 @@ _ENVIRONMENT = "template.environment"
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
-    r"(?:(?:states\.|(is_state|is_state_attr|state_attr|states|expand)"
-    r"\((?:[\ \'\"]?))([\w]+\.[\w]+)|([\w]+))",
+    r"(?:(?:states\.|(?P<func>is_state|is_state_attr|state_attr|states|expand)"
+    r"\((?:[\ \'\"]?))(?P<entity_id>[\w]+\.[\w]+)|(?P<variable>[\w]+))",
     re.I | re.M,
 )
 _RE_JINJA_DELIMITERS = re.compile(r"\{%|\{\{")
@@ -87,31 +87,30 @@ def extract_entities(
     if _RE_NONE_ENTITIES.search(template):
         return MATCH_ALL
 
-    extraction = _RE_GET_ENTITIES.findall(template)
     extraction_final = []
 
-    for result in extraction:
+    for result in _RE_GET_ENTITIES.finditer(template):
         if (
-            result[1] == "trigger.entity_id"
+            result.group("entity_id") == "trigger.entity_id"
             and variables
             and "trigger" in variables
             and "entity_id" in variables["trigger"]
         ):
             extraction_final.append(variables["trigger"]["entity_id"])
-        elif result[1]:
-            if result[0] == "expand":
-                for entity in expand(hass, result[1]):
+        elif result.group("entity_id"):
+            if result.group("func") == "expand":
+                for entity in expand(hass, result.group("entity_id")):
                     extraction_final.append(entity.entity_id)
 
-            extraction_final.append(result[1])
+            extraction_final.append(result.group("entity_id"))
 
         if (
             variables
-            and result[2] in variables
-            and isinstance(variables[result[2]], str)
-            and valid_entity_id(variables[result[2]])
+            and result.group("variable") in variables
+            and isinstance(variables[result.group("variable")], str)
+            and valid_entity_id(variables[result.group("variable")])
         ):
-            extraction_final.append(variables[result[2]])
+            extraction_final.append(variables[result.group("variable")])
 
     if extraction_final:
         return list(set(extraction_final))

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1552,19 +1552,19 @@ def test_closest_function_no_location_states(hass):
 
 def test_extract_entities_none_exclude_stuff(hass):
     """Test extract entities function with none or exclude stuff."""
-    assert template.extract_entities(None) == []
+    assert template.extract_entities(hass, None) == []
 
-    assert template.extract_entities("mdi:water") == []
+    assert template.extract_entities(hass, "mdi:water") == []
 
     assert (
         template.extract_entities(
-            "{{ closest(states.zone.far_away, states.test_domain).entity_id }}"
+            hass, "{{ closest(states.zone.far_away, states.test_domain).entity_id }}"
         )
         == MATCH_ALL
     )
 
     assert (
-        template.extract_entities('{{ distance("123", states.test_object_2) }}')
+        template.extract_entities(hass, '{{ distance("123", states.test_object_2) }}')
         == MATCH_ALL
     )
 
@@ -1572,7 +1572,9 @@ def test_extract_entities_none_exclude_stuff(hass):
 def test_extract_entities_no_match_entities(hass):
     """Test extract entities function with none entities stuff."""
     assert (
-        template.extract_entities("{{ value_json.tst | timestamp_custom('%Y' True) }}")
+        template.extract_entities(
+            hass, "{{ value_json.tst | timestamp_custom('%Y' True) }}"
+        )
         == MATCH_ALL
     )
 
@@ -1671,35 +1673,38 @@ def test_generate_select(hass):
     )
 
 
-def test_extract_entities_match_entities(hass):
+async def test_extract_entities_match_entities(hass):
     """Test extract entities function with entities stuff."""
     assert (
         template.extract_entities(
+            hass,
             """
 {% if is_state('device_tracker.phone_1', 'home') %}
 Ha, Hercules is home!
 {% else %}
 Hercules is at {{ states('device_tracker.phone_1') }}.
 {% endif %}
-        """
+        """,
         )
         == ["device_tracker.phone_1"]
     )
 
     assert (
         template.extract_entities(
+            hass,
             """
 {{ as_timestamp(states.binary_sensor.garage_door.last_changed) }}
-        """
+        """,
         )
         == ["binary_sensor.garage_door"]
     )
 
     assert (
         template.extract_entities(
+            hass,
             """
 {{ states("binary_sensor.garage_door") }}
-        """
+        """,
         )
         == ["binary_sensor.garage_door"]
     )
@@ -1708,33 +1713,36 @@ Hercules is at {{ states('device_tracker.phone_1') }}.
 
     assert (
         template.extract_entities(
+            hass,
             """
 {{ is_state_attr('device_tracker.phone_2', 'battery', 40) }}
-        """
+        """,
         )
         == ["device_tracker.phone_2"]
     )
 
     assert sorted(["device_tracker.phone_1", "device_tracker.phone_2"]) == sorted(
         template.extract_entities(
+            hass,
             """
 {% if is_state('device_tracker.phone_1', 'home') %}
 Ha, Hercules is home!
 {% elif states.device_tracker.phone_2.attributes.battery < 40 %}
 Hercules you power goes done!.
 {% endif %}
-        """
+        """,
         )
     )
 
     assert sorted(["sensor.pick_humidity", "sensor.pick_temperature"]) == sorted(
         template.extract_entities(
+            hass,
             """
 {{
 states.sensor.pick_temperature.state ~ „°C (“ ~
 states.sensor.pick_humidity.state ~ „ %“
 }}
-        """
+        """,
         )
     )
 
@@ -1742,9 +1750,25 @@ states.sensor.pick_humidity.state ~ „ %“
         ["sensor.luftfeuchtigkeit_mean", "input_number.luftfeuchtigkeit"]
     ) == sorted(
         template.extract_entities(
+            hass,
             "{% if (states('sensor.luftfeuchtigkeit_mean') | int)"
             " > (states('input_number.luftfeuchtigkeit') | int +1.5)"
-            " %}true{% endif %}"
+            " %}true{% endif %}",
+        )
+    )
+
+    await group.Group.async_create_group(hass, "empty group", [])
+
+    assert ["group.empty_group"] == template.extract_entities(
+        hass, "{{ expand('group.empty_group') | list | length }}"
+    )
+
+    hass.states.async_set("test_domain.object", "exists")
+    await group.Group.async_create_group(hass, "expand group", ["test_domain.object"])
+
+    assert sorted(["group.expand_group", "test_domain.object"]) == sorted(
+        template.extract_entities(
+            hass, "{{ expand('group.expand_group') | list | length }}"
         )
     )
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1772,29 +1772,33 @@ states.sensor.pick_humidity.state ~ „ %“
         )
     )
 
+    assert ["test_domain.entity"] == template.Template(
+        '{{ is_state("test_domain.entity", "on") }}', hass
+    ).extract_entities()
+
 
 def test_extract_entities_with_variables(hass):
     """Test extract entities function with variables and entities stuff."""
     hass.states.async_set("input_boolean.switch", "on")
-    assert {"input_boolean.switch"} == extract_entities(
+    assert ["input_boolean.switch"] == template.extract_entities(
         hass, "{{ is_state('input_boolean.switch', 'off') }}", {}
     )
 
-    assert {"input_boolean.switch"} == extract_entities(
+    assert ["input_boolean.switch"] == template.extract_entities(
         hass,
         "{{ is_state(trigger.entity_id, 'off') }}",
         {"trigger": {"entity_id": "input_boolean.switch"}},
     )
 
-    assert {"no_state"} == extract_entities(
+    assert MATCH_ALL == template.extract_entities(
         hass, "{{ is_state(data, 'off') }}", {"data": "no_state"}
     )
 
-    assert {"input_boolean.switch"} == extract_entities(
+    assert ["input_boolean.switch"] == template.extract_entities(
         hass, "{{ is_state(data, 'off') }}", {"data": "input_boolean.switch"}
     )
 
-    assert {"input_boolean.switch"} == extract_entities(
+    assert ["input_boolean.switch"] == template.extract_entities(
         hass,
         "{{ is_state(trigger.entity_id, 'off') }}",
         {"trigger": {"entity_id": "input_boolean.switch"}},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This PR amends the logic that determines what state changes should be listened for when using a template (sensor). Up until now, groups were not handled as expected.

Consider the minimal configuration example below.

_Expected behavior_: The sensor should always display the sum of enabled switches, i.e. if I enable the first switch, the sensor value changes from 0 to 1. If I then enable the second switch, the sensor changes from 1 to 2.

_Actual behavior_: The sensor value doesn't change at all when I toggle any of the switches.

This is due to the extraction of entities from templates that determines what state changes should be listened for. Up until now, the `expand` template function was not handled in that logic. This PR fixes this by expanding groups and returning the contained entities. To make this a non-breaking change, and because one might also listen for changes on the group (if there are any?), the group's entity ID will also be returned.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

input_boolean:
  switch_1:
    name: "Switch 1"
  switch_2:
    name: "Switch 2"

group:
  input_booleans:
    name: "All boolean inputs"
    entities:
      - input_boolean.switch_1
      - input_boolean.switch_2


sensor:
  - platform: template
    sensors:
      length_sensor:
        value_template: "{{ expand('group.input_booleans') | selectattr('state', 'eq', 'on') | list | length }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
