### PR TITLE
Add config flow, use async loading, and restore brightness option to ISY994

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -1,31 +1,34 @@
 """Support the ISY-994 controllers."""
+import asyncio
+from functools import partial
+from typing import Optional
 from urllib.parse import urlparse
 
 from pyisy import ISY
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP,
-)
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     _LOGGER,
     CONF_IGNORE_STRING,
+    CONF_RESTORE_LIGHT_STATE,
     CONF_SENSOR_STRING,
     CONF_TLS_VER,
     DEFAULT_IGNORE_STRING,
+    DEFAULT_RESTORE_LIGHT_STATE,
     DEFAULT_SENSOR_STRING,
     DOMAIN,
+    ISY994_ISY,
     ISY994_NODES,
     ISY994_PROGRAMS,
     SUPPORTED_PLATFORMS,
     SUPPORTED_PROGRAM_PLATFORMS,
+    UNDO_UPDATE_LISTENER,
 )
 from .helpers import _categorize_nodes, _categorize_programs
 
@@ -43,6 +46,9 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(
                     CONF_SENSOR_STRING, default=DEFAULT_SENSOR_STRING
                 ): cv.string,
+                vol.Required(
+                    CONF_RESTORE_LIGHT_STATE, default=DEFAULT_RESTORE_LIGHT_STATE
+                ): bool,
             }
         )
     },
@@ -50,24 +56,71 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the ISY 994 platform."""
-    hass.data[ISY994_NODES] = {}
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the isy994 integration from YAML."""
+    isy_config: Optional[ConfigType] = config.get(DOMAIN)
+    hass.data.setdefault(DOMAIN, {})
+
+    if not isy_config:
+        return True
+
+    # Only import if we haven't before.
+    config_entry = _async_find_matching_config_entry(hass)
+    if not config_entry:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_IMPORT},
+                data=dict(isy_config),
+            )
+        )
+        return True
+
+    # Update the entry based on the YAML configuration, in case it changed.
+    hass.config_entries.async_update_entry(config_entry, data=dict(isy_config))
+    return True
+
+
+@callback
+def _async_find_matching_config_entry(hass):
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.source == config_entries.SOURCE_IMPORT:
+            return entry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: config_entries.ConfigEntry
+) -> bool:
+    """Set up the ISY 994 integration."""
+    # As there currently is no way to import options from yaml
+    # when setting up a config entry, we fallback to adding
+    # the options to the config entry and pull them out here if
+    # they are missing from the options
+    _async_import_options_from_data_if_missing(hass, entry)
+
+    hass.data[DOMAIN][entry.entry_id] = {}
+    hass_isy_data = hass.data[DOMAIN][entry.entry_id]
+
+    hass_isy_data[ISY994_NODES] = {}
     for platform in SUPPORTED_PLATFORMS:
-        hass.data[ISY994_NODES][platform] = []
+        hass_isy_data[ISY994_NODES][platform] = []
 
-    hass.data[ISY994_PROGRAMS] = {}
+    hass_isy_data[ISY994_PROGRAMS] = {}
     for platform in SUPPORTED_PROGRAM_PLATFORMS:
-        hass.data[ISY994_PROGRAMS][platform] = []
+        hass_isy_data[ISY994_PROGRAMS][platform] = []
 
-    isy_config = config.get(DOMAIN)
+    isy_config = entry.data
+    isy_options = entry.options
 
-    user = isy_config.get(CONF_USERNAME)
-    password = isy_config.get(CONF_PASSWORD)
+    # Required
+    user = isy_config[CONF_USERNAME]
+    password = isy_config[CONF_PASSWORD]
+    host = urlparse(isy_config[CONF_HOST])
+
+    # Optional
     tls_version = isy_config.get(CONF_TLS_VER)
-    host = urlparse(isy_config.get(CONF_HOST))
-    ignore_identifier = isy_config.get(CONF_IGNORE_STRING)
-    sensor_identifier = isy_config.get(CONF_SENSOR_STRING)
+    ignore_identifier = isy_options.get(CONF_IGNORE_STRING, DEFAULT_IGNORE_STRING)
+    sensor_identifier = isy_options.get(CONF_SENSOR_STRING, DEFAULT_SENSOR_STRING)
 
     if host.scheme == "http":
         https = False
@@ -80,31 +133,103 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return False
 
     # Connect to ISY controller.
-    isy = ISY(
-        host.hostname,
-        port,
-        username=user,
-        password=password,
-        use_https=https,
-        tls_ver=tls_version,
-        log=_LOGGER,
+    isy = await hass.async_add_executor_job(
+        partial(
+            ISY,
+            host.hostname,
+            port,
+            username=user,
+            password=password,
+            use_https=https,
+            tls_ver=tls_version,
+            log=_LOGGER,
+            webroot=host.path,
+        )
     )
     if not isy.connected:
         return False
 
-    _categorize_nodes(hass, isy.nodes, ignore_identifier, sensor_identifier)
-    _categorize_programs(hass, isy.programs)
+    _categorize_nodes(hass_isy_data, isy.nodes, ignore_identifier, sensor_identifier)
+    _categorize_programs(hass_isy_data, isy.programs)
 
-    def stop(event: object) -> None:
-        """Stop ISY auto updates."""
-        isy.auto_update = False
+    # Dump ISY Clock Information. Future: Add ISY as sensor to Hass with attrs
+    _LOGGER.info(repr(isy.clock))
 
-    # Listen for HA stop to disconnect.
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop)
+    hass_isy_data[ISY994_ISY] = isy
 
     # Load platforms for the devices in the ISY controller that we support.
     for platform in SUPPORTED_PLATFORMS:
-        discovery.load_platform(hass, platform, DOMAIN, {}, config)
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
 
-    isy.auto_update = True
+    def _start_auto_update() -> None:
+        """Start isy auto update."""
+        _LOGGER.debug("ISY Starting Event Stream and automatic updates.")
+        isy.auto_update = True
+
+    await hass.async_add_executor_job(_start_auto_update)
+
+    undo_listener = entry.add_update_listener(_async_update_listener)
+
+    hass_isy_data[UNDO_UPDATE_LISTENER] = undo_listener
+
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: config_entries.ConfigEntry
+):
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+@callback
+def _async_import_options_from_data_if_missing(
+    hass: HomeAssistant, entry: config_entries.ConfigEntry
+):
+    options = dict(entry.options)
+    modified = False
+    for importable_option in [
+        CONF_IGNORE_STRING,
+        CONF_SENSOR_STRING,
+        CONF_RESTORE_LIGHT_STATE,
+    ]:
+        if importable_option not in entry.options and importable_option in entry.data:
+            options[importable_option] = entry.data[importable_option]
+            modified = True
+
+    if modified:
+        hass.config_entries.async_update_entry(entry, options=options)
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: config_entries.ConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in SUPPORTED_PLATFORMS
+            ]
+        )
+    )
+
+    hass_isy_data = hass.data[DOMAIN][entry.entry_id]
+
+    isy = hass_isy_data[ISY994_ISY]
+
+    def _stop_auto_update() -> None:
+        """Start isy auto update."""
+        _LOGGER.debug("ISY Stopping Event Stream and automatic updates.")
+        isy.auto_update = False
+
+    await hass.async_add_executor_job(_stop_auto_update)
+
+    hass_isy_data[UNDO_UPDATE_LISTENER]()
+
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -1,0 +1,180 @@
+"""Config flow for Universal Devices ISY994 integration."""
+import logging
+from urllib.parse import urlparse
+
+from pyisy.configuration import Configuration
+from pyisy.connection import Connection
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
+
+from .const import (
+    CONF_IGNORE_STRING,
+    CONF_RESTORE_LIGHT_STATE,
+    CONF_SENSOR_STRING,
+    CONF_TLS_VER,
+    DEFAULT_IGNORE_STRING,
+    DEFAULT_RESTORE_LIGHT_STATE,
+    DEFAULT_SENSOR_STRING,
+    DEFAULT_TLS_VERSION,
+)
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_TLS_VER, default=DEFAULT_TLS_VERSION): vol.In([1.1, 1.2]),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    user = data[CONF_USERNAME]
+    password = data[CONF_PASSWORD]
+    host = urlparse(data[CONF_HOST])
+    tls_version = data.get(CONF_TLS_VER)
+
+    if host.scheme == "http":
+        https = False
+        port = host.port or 80
+    elif host.scheme == "https":
+        https = True
+        port = host.port or 443
+    else:
+        _LOGGER.error("isy994 host value in configuration is invalid")
+        raise InvalidHost
+
+    # Connect to ISY controller.
+    isy_conf = await hass.async_add_executor_job(
+        _fetch_isy_configuration,
+        host.hostname,
+        port,
+        user,
+        password,
+        https,
+        tls_version,
+        host.path,
+    )
+
+    # Return info that you want to store in the config entry.
+    return {"title": f"{isy_conf['name']} ({host.hostname})", "uuid": isy_conf["uuid"]}
+
+
+def _fetch_isy_configuration(
+    address, port, username, password, use_https, tls_ver, webroot
+):
+    """Validate and fetch the configuration from the ISY."""
+    try:
+        isy_conn = Connection(
+            address,
+            port,
+            username,
+            password,
+            use_https,
+            tls_ver,
+            log=_LOGGER,
+            webroot=webroot,
+        )
+    except ValueError as err:
+        raise InvalidAuth(err.args[0])
+
+    return Configuration(log=_LOGGER, xml=isy_conn.get_config())
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Universal Devices ISY994."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        info = None
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidHost:
+                errors["base"] = "invalid_host"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+            if "base" not in errors:
+                await self.async_set_unique_id(info["uuid"])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, user_input):
+        """Handle import."""
+        return await self.async_step_user(user_input)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for isy994."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Handle options flow."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = self.config_entry.options
+        restore_light_state = options.get(
+            CONF_RESTORE_LIGHT_STATE, DEFAULT_RESTORE_LIGHT_STATE
+        )
+        ignore_string = options.get(CONF_IGNORE_STRING, DEFAULT_IGNORE_STRING)
+        sensor_string = options.get(CONF_SENSOR_STRING, DEFAULT_SENSOR_STRING)
+
+        options_schema = vol.Schema(
+            {
+                vol.Optional(CONF_IGNORE_STRING, default=ignore_string): str,
+                vol.Optional(CONF_SENSOR_STRING, default=sensor_string): str,
+                vol.Required(
+                    CONF_RESTORE_LIGHT_STATE, default=restore_light_state
+                ): bool,
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=options_schema)
+
+
+class InvalidHost(exceptions.HomeAssistantError):
+    """Error to indicate the host value is invalid."""
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -98,9 +98,12 @@ MANUFACTURER = "Universal Devices, Inc"
 CONF_IGNORE_STRING = "ignore_string"
 CONF_SENSOR_STRING = "sensor_string"
 CONF_TLS_VER = "tls"
+CONF_RESTORE_LIGHT_STATE = "restore_light_state"
 
 DEFAULT_IGNORE_STRING = "{IGNORE ME}"
 DEFAULT_SENSOR_STRING = "sensor"
+DEFAULT_VAR_SENSOR_STRING = "HA."
+DEFAULT_RESTORE_LIGHT_STATE = False
 DEFAULT_TLS_VERSION = 1.1
 DEFAULT_PROGRAM_STRING = "HA."
 
@@ -140,8 +143,12 @@ TYPE_CATEOGRY_LOCK = "15."
 TYPE_CATEGORY_SAFETY = "16."
 TYPE_CATEGORY_X10 = "113."
 
+UNDO_UPDATE_LISTENER = "undo_update_listener"
+
 # Do not use the Home Assistant consts for the states here - we're matching exact API
 # responses, not using them for Home Assistant states
+# Z-Wave Categories: https://www.universal-devices.com/developers/
+#                      wsdk/5.0.4/4_fam.xml
 NODE_FILTERS = {
     BINARY_SENSOR: {
         FILTER_UOM: [],

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -102,7 +102,6 @@ CONF_RESTORE_LIGHT_STATE = "restore_light_state"
 
 DEFAULT_IGNORE_STRING = "{IGNORE ME}"
 DEFAULT_SENSOR_STRING = "sensor"
-DEFAULT_VAR_SENSOR_STRING = "HA."
 DEFAULT_RESTORE_LIGHT_STATE = False
 DEFAULT_TLS_VERSION = 1.1
 DEFAULT_PROGRAM_STRING = "HA."
@@ -139,7 +138,7 @@ TYPE_CATEGORY_POOL_CTL = "6."
 TYPE_CATEGORY_SENSOR_ACTUATORS = "7."
 TYPE_CATEGORY_ENERGY_MGMT = "9."
 TYPE_CATEGORY_COVER = "14."
-TYPE_CATEOGRY_LOCK = "15."
+TYPE_CATEGORY_LOCK = "15."
 TYPE_CATEGORY_SAFETY = "16."
 TYPE_CATEGORY_X10 = "113."
 
@@ -147,8 +146,8 @@ UNDO_UPDATE_LISTENER = "undo_update_listener"
 
 # Do not use the Home Assistant consts for the states here - we're matching exact API
 # responses, not using them for Home Assistant states
-# Z-Wave Categories: https://www.universal-devices.com/developers/
-#                      wsdk/5.0.4/4_fam.xml
+# Insteon Types: https://www.universal-devices.com/developers/wsdk/5.0.4/1_fam.xml
+# Z-Wave Categories: https://www.universal-devices.com/developers/wsdk/5.0.4/4_fam.xml
 NODE_FILTERS = {
     BINARY_SENSOR: {
         FILTER_UOM: [],
@@ -198,7 +197,7 @@ NODE_FILTERS = {
         FILTER_UOM: ["11"],
         FILTER_STATES: ["locked", "unlocked"],
         FILTER_NODE_DEF_ID: ["DoorLock"],
-        FILTER_INSTEON_TYPE: [TYPE_CATEOGRY_LOCK, "4.64."],
+        FILTER_INSTEON_TYPE: [TYPE_CATEGORY_LOCK, "4.64."],
         FILTER_ZWAVE_CAT: ["111"],
     },
     FAN: {

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -57,6 +57,13 @@ class ISYEntity(Entity):
     def unique_id(self) -> str:
         """Get the unique identifier of the device."""
         if hasattr(self._node, "address"):
+            return f"{self._node.isy.configuration['uuid']}_{self._node.address}"
+        return None
+
+    @property
+    def old_unique_id(self) -> str:
+        """Get the old unique identifier of the device."""
+        if hasattr(self._node, "address"):
             return self._node.address
         return None
 

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -10,11 +10,12 @@ from homeassistant.components.fan import (
     SUPPORT_SET_SPEED,
     FanEntity,
 )
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
 
-from . import ISY994_NODES, ISY994_PROGRAMS
-from .const import _LOGGER
+from .const import _LOGGER, DOMAIN as ISY994_DOMAIN, ISY994_NODES, ISY994_PROGRAMS
 from .entity import ISYNodeEntity, ISYProgramEntity
+from .helpers import migrate_old_unique_ids
 
 VALUE_TO_STATE = {
     0: SPEED_OFF,
@@ -30,22 +31,26 @@ for key in VALUE_TO_STATE:
     STATE_TO_VALUE[VALUE_TO_STATE[key]] = key
 
 
-def setup_platform(
-    hass, config: ConfigType, add_entities: Callable[[list], None], discovery_info=None
-):
+async def async_setup_entry(
+    hass: HomeAssistantType,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list], None],
+) -> bool:
     """Set up the ISY994 fan platform."""
+    hass_isy_data = hass.data[ISY994_DOMAIN][entry.entry_id]
     devices = []
 
-    for node in hass.data[ISY994_NODES][FAN]:
-        devices.append(ISYFanEntity(node))
+    for node in hass_isy_data[ISY994_NODES][FAN]:
+        devices.append(ISYFanDevice(node))
 
-    for name, status, actions in hass.data[ISY994_PROGRAMS][FAN]:
+    for name, status, actions in hass_isy_data[ISY994_PROGRAMS][FAN]:
         devices.append(ISYFanProgramEntity(name, status, actions))
 
-    add_entities(devices)
+    await migrate_old_unique_ids(hass, FAN, devices)
+    async_add_entities(devices)
 
 
-class ISYFanEntity(ISYNodeEntity, FanEntity):
+class ISYFanDevice(ISYNodeEntity, FanEntity):
     """Representation of an ISY994 fan device."""
 
     @property

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
     devices = []
 
     for node in hass_isy_data[ISY994_NODES][FAN]:
-        devices.append(ISYFanDevice(node))
+        devices.append(ISYFanEntity(node))
 
     for name, status, actions in hass_isy_data[ISY994_PROGRAMS][FAN]:
         devices.append(ISYFanProgramEntity(name, status, actions))
@@ -50,7 +50,7 @@ async def async_setup_entry(
     async_add_entities(devices)
 
 
-class ISYFanDevice(ISYNodeEntity, FanEntity):
+class ISYFanEntity(ISYNodeEntity, FanEntity):
     """Representation of an ISY994 fan device."""
 
     @property

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -8,35 +8,49 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS,
     LightEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import HomeAssistantType
 
-from . import ISY994_NODES
-from .const import _LOGGER
+from .const import (
+    _LOGGER,
+    CONF_RESTORE_LIGHT_STATE,
+    DOMAIN as ISY994_DOMAIN,
+    ISY994_NODES,
+)
 from .entity import ISYNodeEntity
+from .helpers import migrate_old_unique_ids
 
 ATTR_LAST_BRIGHTNESS = "last_brightness"
 
 
-def setup_platform(
-    hass, config: ConfigType, add_entities: Callable[[list], None], discovery_info=None
-):
+async def async_setup_entry(
+    hass: HomeAssistantType,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list], None],
+) -> bool:
     """Set up the ISY994 light platform."""
-    devices = []
-    for node in hass.data[ISY994_NODES][LIGHT]:
-        devices.append(ISYLightEntity(node))
+    hass_isy_data = hass.data[ISY994_DOMAIN][entry.entry_id]
+    isy_options = entry.options
+    restore_light_state = isy_options.get(CONF_RESTORE_LIGHT_STATE, False)
 
-    add_entities(devices)
+    devices = []
+    for node in hass_isy_data[ISY994_NODES][LIGHT]:
+        devices.append(ISYLightEntity(node, restore_light_state))
+
+    await migrate_old_unique_ids(hass, LIGHT, devices)
+    async_add_entities(devices)
 
 
 class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     """Representation of an ISY994 light device."""
 
-    def __init__(self, node) -> None:
+    def __init__(self, node, restore_light_state) -> None:
         """Initialize the ISY994 light device."""
         super().__init__(node)
         self._last_brightness = None
+        self._restore_light_state = restore_light_state
 
     @property
     def is_on(self) -> bool:
@@ -49,6 +63,13 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     def brightness(self) -> float:
         """Get the brightness of the ISY994 light."""
         return STATE_UNKNOWN if self.value == ISY_VALUE_UNKNOWN else int(self.value)
+
+    @property
+    def device_state_attributes(self) -> Dict:
+        """Return the light attributes."""
+        attribs = super().device_state_attributes
+        attribs[ATTR_LAST_BRIGHTNESS] = self._last_brightness
+        return attribs
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""
@@ -65,7 +86,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     # pylint: disable=arguments-differ
     def turn_on(self, brightness=None, **kwargs) -> None:
         """Send the turn on command to the ISY994 light device."""
-        if brightness is None and self._last_brightness:
+        if self._restore_light_state and brightness is None and self._last_brightness:
             brightness = self._last_brightness
         if not self._node.turn_on(val=brightness):
             _LOGGER.debug("Unable to turn on light")
@@ -74,13 +95,6 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS
-
-    @property
-    def device_state_attributes(self) -> Dict:
-        """Return the light attributes."""
-        attribs = super().device_state_attributes
-        attribs[ATTR_LAST_BRIGHTNESS] = self._last_brightness
-        return attribs
 
     async def async_added_to_hass(self) -> None:
         """Restore last_brightness on restart."""

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -64,13 +64,6 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
         """Get the brightness of the ISY994 light."""
         return STATE_UNKNOWN if self.value == ISY_VALUE_UNKNOWN else int(self.value)
 
-    @property
-    def device_state_attributes(self) -> Dict:
-        """Return the light attributes."""
-        attribs = super().device_state_attributes
-        attribs[ATTR_LAST_BRIGHTNESS] = self._last_brightness
-        return attribs
-
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""
         self._last_brightness = self.brightness
@@ -90,6 +83,13 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
             brightness = self._last_brightness
         if not self._node.turn_on(val=brightness):
             _LOGGER.debug("Unable to turn on light")
+
+    @property
+    def device_state_attributes(self) -> Dict:
+        """Return the light attributes."""
+        attribs = super().device_state_attributes
+        attribs[ATTR_LAST_BRIGHTNESS] = self._last_brightness
+        return attribs
 
     @property
     def supported_features(self):

--- a/homeassistant/components/isy994/lock.py
+++ b/homeassistant/components/isy994/lock.py
@@ -4,28 +4,33 @@ from typing import Callable
 from pyisy.constants import ISY_VALUE_UNKNOWN
 
 from homeassistant.components.lock import DOMAIN as LOCK, LockEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_LOCKED, STATE_UNKNOWN, STATE_UNLOCKED
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import HomeAssistantType
 
-from . import ISY994_NODES, ISY994_PROGRAMS
-from .const import _LOGGER
+from .const import _LOGGER, DOMAIN as ISY994_DOMAIN, ISY994_NODES, ISY994_PROGRAMS
 from .entity import ISYNodeEntity, ISYProgramEntity
+from .helpers import migrate_old_unique_ids
 
 VALUE_TO_STATE = {0: STATE_UNLOCKED, 100: STATE_LOCKED}
 
 
-def setup_platform(
-    hass, config: ConfigType, add_entities: Callable[[list], None], discovery_info=None
-):
+async def async_setup_entry(
+    hass: HomeAssistantType,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list], None],
+) -> bool:
     """Set up the ISY994 lock platform."""
+    hass_isy_data = hass.data[ISY994_DOMAIN][entry.entry_id]
     devices = []
-    for node in hass.data[ISY994_NODES][LOCK]:
+    for node in hass_isy_data[ISY994_NODES][LOCK]:
         devices.append(ISYLockEntity(node))
 
-    for name, status, actions in hass.data[ISY994_PROGRAMS][LOCK]:
+    for name, status, actions in hass_isy_data[ISY994_PROGRAMS][LOCK]:
         devices.append(ISYLockProgramEntity(name, status, actions))
 
-    add_entities(devices)
+    await migrate_old_unique_ids(hass, LOCK, devices)
+    async_add_entities(devices)
 
 
 class ISYLockEntity(ISYNodeEntity, LockEntity):

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,5 +3,6 @@
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
   "requirements": ["pyisy==2.0.2"],
-  "codeowners": ["@bdraco", "@shbatm"]
+  "codeowners": ["@bdraco", "@shbatm"],
+  "config_flow": true
 }

--- a/homeassistant/components/isy994/strings.json
+++ b/homeassistant/components/isy994/strings.json
@@ -1,0 +1,39 @@
+{
+  "title": "Universal Devices ISY994",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "Username",
+          "host": "URL",
+          "password": "Password",
+          "tls": "The TLS version of the ISY controller."
+        },
+        "description": "The host entry must be in full URL format, e.g., http://192.168.10.100:80",
+        "title": "Connect to your ISY994"
+      }
+    },
+    "error": {
+      "unknown": "Unexpected error",
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "invalid_host": "The host entry was not in full URL format, e.g., http://192.168.10.100:80"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "ISY994 Options",
+        "description": "Set the options for the ISY Integration: \n • Node Sensor String: Any device or folder that contains 'Node Sensor String' in the name will be treated as a sensor or binary sensor. \n • Ignore String: Any device with 'Ignore String' in the name will be ignored.  \n • Restore Light Brightness: If enabled, the previous brightness will be restored when turning on a light instead of the device's built-in On-Level.",
+        "data": {
+          "sensor_string": "Node Sensor String",
+          "ignore_string": "Ignore String",
+          "restore_light_state": "Restore Light Brightness"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/isy994/strings.json
+++ b/homeassistant/components/isy994/strings.json
@@ -16,7 +16,7 @@
     "error": {
       "unknown": "Unexpected error",
       "cannot_connect": "Failed to connect, please try again",
-      "invalid_auth": "Invalid authentication",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_host": "The host entry was not in full URL format, e.g., http://192.168.10.100:80"
     },
     "abort": {

--- a/homeassistant/components/isy994/strings.json
+++ b/homeassistant/components/isy994/strings.json
@@ -4,9 +4,9 @@
     "step": {
       "user": {
         "data": {
-          "username": "Username",
+          "username": "[%key:common::config_flow::data::username%]",
           "host": "URL",
-          "password": "Password",
+          "password": "[%key:common::config_flow::data::password%]",
           "tls": "The TLS version of the ISY controller."
         },
         "description": "The host entry must be in full URL format, e.g., http://192.168.10.100:80",
@@ -14,13 +14,13 @@
       }
     },
     "error": {
-      "unknown": "Unexpected error",
-      "cannot_connect": "Failed to connect, please try again",
+      "unknown": "[%key:common::config_flow::error::unknown%",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_host": "The host entry was not in full URL format, e.g., http://192.168.10.100:80"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%"
     }
   },
   "options": {

--- a/homeassistant/components/isy994/translations/en.json
+++ b/homeassistant/components/isy994/translations/en.json
@@ -1,0 +1,39 @@
+{
+  "title": "Universal Devices ISY994",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "Username",
+          "host": "URL",
+          "password": "Password",
+          "tls": "The TLS version of the ISY controller."
+        },
+        "description": "The host entry must be in full URL format, e.g., http://192.168.10.100:80",
+        "title": "Connect to your ISY994"
+      }
+    },
+    "error": {
+      "unknown": "Unexpected error",
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "invalid_host": "The host entry was not in full URL format, e.g., http://192.168.10.100:80"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "ISY994 Options",
+        "description": "Set the options for the ISY Integration: \n • Node Sensor String: Any device or folder that contains 'Node Sensor String' in the name will be treated as a sensor or binary sensor. \n • Ignore String: Any device with 'Ignore String' in the name will be ignored.  \n • Restore Light Brightness: If enabled, the previous brightness will be restored when turning on a light instead of the device's built-in On-Level.",
+        "data": {
+          "sensor_string": "Node Sensor String",
+          "ignore_string": "Ignore String",
+          "restore_light_state": "Restore Light Brightness"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -68,6 +68,7 @@ FLOWS = [
     "ipp",
     "iqvia",
     "islamic_prayer_times",
+    "isy994",
     "izone",
     "juicenet",
     "konnected",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -572,6 +572,9 @@ pyipp==0.10.1
 # homeassistant.components.iqvia
 pyiqvia==0.2.1
 
+# homeassistant.components.isy994
+pyisy==2.0.2
+
 # homeassistant.components.kira
 pykira==0.1.1
 

--- a/tests/components/isy994/__init__.py
+++ b/tests/components/isy994/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Universal Devices ISY994 integration."""

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -78,8 +78,6 @@ async def test_form(hass: HomeAssistantType):
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
     await hass.async_block_till_done()
-    # assert len(mock_connection_class.mock_calls) == 3
-    # assert len(mock_config_class.mock_calls) == 1
 
 
 async def test_form_invalid_host(hass: HomeAssistantType):

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -1,0 +1,196 @@
+"""Test the Universal Devices ISY994 config flow."""
+
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.isy994.config_flow import CannotConnect
+from homeassistant.components.isy994.const import (
+    CONF_IGNORE_STRING,
+    CONF_RESTORE_LIGHT_STATE,
+    CONF_SENSOR_STRING,
+    CONF_TLS_VER,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.typing import HomeAssistantType
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+MOCK_HOSTNAME = "1.1.1.1"
+MOCK_USERNAME = "test-username"
+MOCK_PASSWORD = "test-password"
+
+# Don't use the integration defaults here to make sure they're being set correctly.
+MOCK_TLS_VERSION = 1.2
+MOCK_IGNORE_STRING = "{IGNOREME}"
+MOCK_RESTORE_LIGHT_STATE = True
+MOCK_SENSOR_STRING = "IMASENSOR"
+
+MOCK_USER_INPUT = {
+    "host": f"http://{MOCK_HOSTNAME}",
+    "username": MOCK_USERNAME,
+    "password": MOCK_PASSWORD,
+    "tls": MOCK_TLS_VERSION,
+}
+MOCK_IMPORT_BASIC_CONFIG = {
+    CONF_HOST: f"http://{MOCK_HOSTNAME}",
+    CONF_USERNAME: MOCK_USERNAME,
+    CONF_PASSWORD: MOCK_PASSWORD,
+}
+MOCK_IMPORT_FULL_CONFIG = {
+    CONF_HOST: f"http://{MOCK_HOSTNAME}",
+    CONF_USERNAME: MOCK_USERNAME,
+    CONF_PASSWORD: MOCK_PASSWORD,
+    CONF_IGNORE_STRING: MOCK_IGNORE_STRING,
+    CONF_RESTORE_LIGHT_STATE: MOCK_RESTORE_LIGHT_STATE,
+    CONF_SENSOR_STRING: MOCK_SENSOR_STRING,
+    CONF_TLS_VER: MOCK_TLS_VERSION,
+}
+
+MOCK_DEVICE_NAME = "Name of the device"
+MOCK_UUID = "CE:FB:72:31:B7:B9"
+MOCK_VALIDATED_RESPONSE = {"name": MOCK_DEVICE_NAME, "uuid": MOCK_UUID}
+
+PATCH_CONFIGURATION = "homeassistant.components.isy994.config_flow.Configuration"
+PATCH_CONNECTION = "homeassistant.components.isy994.config_flow.Connection"
+
+
+async def test_form(hass: HomeAssistantType):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {}
+
+    with patch(PATCH_CONFIGURATION) as mock_config_class, patch(
+        PATCH_CONNECTION
+    ) as mock_connection_class:
+        isy_conn = mock_connection_class.return_value
+        isy_conn.get_config.return_value = "<xml></xml>"
+        mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT,
+        )
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
+    assert result2["result"].unique_id == MOCK_UUID
+    assert result2["data"] == MOCK_USER_INPUT
+    await hass.async_block_till_done()
+    # assert len(mock_connection_class.mock_calls) == 3
+    # assert len(mock_config_class.mock_calls) == 1
+
+
+async def test_form_invalid_host(hass: HomeAssistantType):
+    """Test we handle invalid host."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "host": MOCK_HOSTNAME,  # Test with missing protocol (http://)
+            "username": MOCK_USERNAME,
+            "password": MOCK_PASSWORD,
+            "tls": MOCK_TLS_VERSION,
+        },
+    )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "invalid_host"}
+
+
+async def test_form_invalid_auth(hass: HomeAssistantType):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(PATCH_CONFIGURATION), patch(
+        PATCH_CONNECTION, side_effect=ValueError("PyISY could not connect to the ISY."),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT,
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistantType):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(PATCH_CONFIGURATION), patch(
+        PATCH_CONNECTION, side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT,
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_existing_config_entry(hass: HomeAssistantType):
+    """Test if config entry already exists."""
+    MockConfigEntry(domain=DOMAIN, unique_id=MOCK_UUID).add_to_hass(hass)
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {}
+
+    with patch(PATCH_CONFIGURATION) as mock_config_class, patch(
+        PATCH_CONNECTION
+    ) as mock_connection_class:
+        isy_conn = mock_connection_class.return_value
+        isy_conn.get_config.return_value = "<xml></xml>"
+        mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT,
+        )
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+
+
+async def test_import_flow_some_fields(hass: HomeAssistantType) -> None:
+    """Test import config flow with just the basic fields."""
+    with patch(PATCH_CONFIGURATION) as mock_config_class, patch(
+        PATCH_CONNECTION
+    ) as mock_connection_class:
+        isy_conn = mock_connection_class.return_value
+        isy_conn.get_config.return_value = "<xml></xml>"
+        mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_IMPORT_BASIC_CONFIG,
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"][CONF_HOST] == f"http://{MOCK_HOSTNAME}"
+    assert result["data"][CONF_USERNAME] == MOCK_USERNAME
+    assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
+
+
+async def test_import_flow_all_fields(hass: HomeAssistantType) -> None:
+    """Test import config flow with all fields."""
+    with patch(PATCH_CONFIGURATION) as mock_config_class, patch(
+        PATCH_CONNECTION
+    ) as mock_connection_class:
+        isy_conn = mock_connection_class.return_value
+        isy_conn.get_config.return_value = "<xml></xml>"
+        mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_IMPORT_FULL_CONFIG,
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"][CONF_HOST] == f"http://{MOCK_HOSTNAME}"
+    assert result["data"][CONF_USERNAME] == MOCK_USERNAME
+    assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
+    assert result["data"][CONF_IGNORE_STRING] == MOCK_IGNORE_STRING
+    assert result["data"][CONF_RESTORE_LIGHT_STATE] == MOCK_RESTORE_LIGHT_STATE
+    assert result["data"][CONF_SENSOR_STRING] == MOCK_SENSOR_STRING
+    assert result["data"][CONF_TLS_VER] == MOCK_TLS_VERSION

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -53,6 +53,8 @@ MOCK_VALIDATED_RESPONSE = {"name": MOCK_DEVICE_NAME, "uuid": MOCK_UUID}
 
 PATCH_CONFIGURATION = "homeassistant.components.isy994.config_flow.Configuration"
 PATCH_CONNECTION = "homeassistant.components.isy994.config_flow.Connection"
+PATCH_ASYNC_SETUP = "homeassistant.components.isy994.async_setup"
+PATCH_ASYNC_SETUP_ENTRY = "homeassistant.components.isy994.async_setup_entry"
 
 
 async def test_form(hass: HomeAssistantType):
@@ -66,7 +68,11 @@ async def test_form(hass: HomeAssistantType):
 
     with patch(PATCH_CONFIGURATION) as mock_config_class, patch(
         PATCH_CONNECTION
-    ) as mock_connection_class:
+    ) as mock_connection_class, patch(
+        PATCH_ASYNC_SETUP, return_value=True
+    ) as mock_setup, patch(
+        PATCH_ASYNC_SETUP_ENTRY, return_value=True,
+    ) as mock_setup_entry:
         isy_conn = mock_connection_class.return_value
         isy_conn.get_config.return_value = "<xml></xml>"
         mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
@@ -78,6 +84,8 @@ async def test_form(hass: HomeAssistantType):
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
     await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_form_invalid_host(hass: HomeAssistantType):
@@ -158,7 +166,9 @@ async def test_import_flow_some_fields(hass: HomeAssistantType) -> None:
     """Test import config flow with just the basic fields."""
     with patch(PATCH_CONFIGURATION) as mock_config_class, patch(
         PATCH_CONNECTION
-    ) as mock_connection_class:
+    ) as mock_connection_class, patch(PATCH_ASYNC_SETUP, return_value=True), patch(
+        PATCH_ASYNC_SETUP_ENTRY, return_value=True,
+    ):
         isy_conn = mock_connection_class.return_value
         isy_conn.get_config.return_value = "<xml></xml>"
         mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
@@ -176,7 +186,9 @@ async def test_import_flow_all_fields(hass: HomeAssistantType) -> None:
     """Test import config flow with all fields."""
     with patch(PATCH_CONFIGURATION) as mock_config_class, patch(
         PATCH_CONNECTION
-    ) as mock_connection_class:
+    ) as mock_connection_class, patch(PATCH_ASYNC_SETUP, return_value=True), patch(
+        PATCH_ASYNC_SETUP_ENTRY, return_value=True,
+    ):
         isy_conn = mock_connection_class.return_value
         isy_conn.get_config.return_value = "<xml></xml>"
         mock_config_class.return_value = MOCK_VALIDATED_RESPONSE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The ISY994 integration now includes a `restore_light_state` option. In 0.109.0, a change was made to restore a light's brightness to the previous state when turned on with no `brightness` parameter. This was, in part, to fix an issue where the light to turn on to full brightness when no parameters were given, regardless of the physical device's `On Level` brightness setting. Using the `On Level` is now supported and is the default behavior. To keep the current behavior and use Home Assistant's last brightness, set the `restore_light_state` is set to `True` or enable the option in the new config flow options.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is the fifth PR in a series (~10 total) to include migration to PyISYv2 and "modernization" of the isy994 integration based on testing done over the past year in the HACS custom component. 

Full migration plan is captured in PR #35212

This specific PR includes add a config and options flow for the ISY994 integration and adds support for the `restore_light_state` option.

As part of the config flow changes, `unique_ids` will be migrated to a new format which includes the `uuid` of the ISY they are associated with. The config flow supports adding multiple ISYs; however, Z-Wave and NodeServer Nodes can share addresses across ISYs, so an additional identifier is required. This should be a seamless update and is not labelled as a breaking change. Entity IDs should not change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# New Optional Setting in configuration.yaml
restore_light_state = false
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #34972, https://github.com/shbatm/hacs-isy994/pull/46
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13369

## Local Tests Performed

- [x] Import from `configuration.yaml`
- [x] Unload and disconnect on removal from UI.
- [x] Re-add local connection from Config Flow and reconnect.
- [x] Add connection to ISY Portal with webroot in URL

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

Tag: @bdraco, @OverloadUT 