### PR TITLE
Add timers to xiaomi_miio vacuum

### DIFF
--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Miio",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.9.45", "python-miio==0.5.0.1", "croniter==0.3.31"],
+  "requirements": ["construct==2.9.45", "python-miio==0.5.1"],
   "codeowners": ["@rytilahti", "@syssi"],
   "zeroconf": ["_miio._udp.local."]
 }

--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Miio",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.9.45", "python-miio==0.5.0.1"],
+  "requirements": ["construct==2.9.45", "python-miio==0.5.0.1", "croniter==0.3.31"],
   "codeowners": ["@rytilahti", "@syssi"],
   "zeroconf": ["_miio._udp.local."]
 }

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -72,6 +72,7 @@ ATTR_RC_VELOCITY = "velocity"
 ATTR_STATUS = "status"
 ATTR_ZONE_ARRAY = "zone"
 ATTR_ZONE_REPEATER = "repeats"
+ATTR_TIMEZONE = "timezone"
 ATTR_TIMERS = "timers"
 
 SUPPORT_XIAOMI = (
@@ -217,6 +218,7 @@ class MiroboVacuum(StateVacuumEntity):
         self._fan_speeds = None
         self._fan_speeds_reverse = None
 
+        self.timezone = None
         self._timers = None
 
     @property
@@ -315,6 +317,9 @@ class MiroboVacuum(StateVacuumEntity):
 
             if self.vacuum_state.got_error:
                 attrs[ATTR_ERROR] = self.vacuum_state.error
+
+            if self.timezone:
+                attrs[ATTR_TIMEZONE] = self.timezone
 
             if self.timers:
                 attrs[ATTR_TIMERS] = self.timers
@@ -453,6 +458,7 @@ class MiroboVacuum(StateVacuumEntity):
             self.last_clean = self._vacuum.last_clean_details()
             self.dnd_state = self._vacuum.dnd_status()
 
+            self.timezone = self._vacuum.timezone()
             self._timers = self._vacuum.timer()
 
             self._available = True

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -72,6 +72,7 @@ ATTR_RC_VELOCITY = "velocity"
 ATTR_STATUS = "status"
 ATTR_ZONE_ARRAY = "zone"
 ATTR_ZONE_REPEATER = "repeats"
+ATTR_TIMERS = "timers"
 
 SUPPORT_XIAOMI = (
     SUPPORT_STATE
@@ -216,6 +217,8 @@ class MiroboVacuum(StateVacuumEntity):
         self._fan_speeds = None
         self._fan_speeds_reverse = None
 
+        self._timers = None
+
     @property
     def name(self):
         """Return the name of the device."""
@@ -263,6 +266,11 @@ class MiroboVacuum(StateVacuumEntity):
         return list(self._fan_speeds) if self._fan_speeds else []
 
     @property
+    def timers(self):
+        """Get the list of added timers of the vacuum cleaner."""
+        return [{"enabled": timer.enabled, "time": timer.ts} for timer in self._timers]
+
+    @property
     def device_state_attributes(self):
         """Return the specific state attributes of this vacuum cleaner."""
         attrs = {}
@@ -307,6 +315,9 @@ class MiroboVacuum(StateVacuumEntity):
 
             if self.vacuum_state.got_error:
                 attrs[ATTR_ERROR] = self.vacuum_state.error
+
+            if self.timers:
+                attrs[ATTR_TIMERS] = self.timers
         return attrs
 
     @property
@@ -441,6 +452,8 @@ class MiroboVacuum(StateVacuumEntity):
             self.clean_history = self._vacuum.clean_history()
             self.last_clean = self._vacuum.last_clean_details()
             self.dnd_state = self._vacuum.dnd_status()
+
+            self._timers = self._vacuum.timer()
 
             self._available = True
         except OSError as exc:

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -3,7 +3,6 @@ from functools import partial
 import logging
 
 from miio import DeviceException, Vacuum  # pylint: disable=import-error
-from pytz import utc
 import voluptuous as vol
 
 from homeassistant.components.vacuum import (
@@ -29,6 +28,7 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.util.dt import as_utc
 
 from .const import (
     SERVICE_CLEAN_ZONE,
@@ -273,7 +273,7 @@ class MiroboVacuum(StateVacuumEntity):
             {
                 "enabled": timer.enabled,
                 "cron": timer.cron,
-                "next_schedule": timer.next_schedule.astimezone(utc),
+                "next_schedule": as_utc(timer.next_schedule),
             }
             for timer in self._timers
         ]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -450,6 +450,9 @@ coronavirus==1.1.1
 # homeassistant.components.crimereports
 crimereports==1.0.1
 
+# homeassistant.components.xiaomi_miio
+croniter==0.3.31
+
 # homeassistant.components.datadog
 datadog==0.15.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -450,9 +450,6 @@ coronavirus==1.1.1
 # homeassistant.components.crimereports
 crimereports==1.0.1
 
-# homeassistant.components.xiaomi_miio
-croniter==0.3.31
-
 # homeassistant.components.datadog
 datadog==0.15.0
 
@@ -1705,7 +1702,7 @@ python-juicenet==1.0.1
 # python-lirc==1.2.3
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.0.1
+python-miio==0.5.1
 
 # homeassistant.components.mpd
 python-mpd2==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -199,6 +199,9 @@ coronavirus==1.1.1
 # homeassistant.scripts.credstash
 # credstash==1.15.0
 
+# homeassistant.components.xiaomi_miio
+croniter==0.3.31
+
 # homeassistant.components.datadog
 datadog==0.15.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -199,9 +199,6 @@ coronavirus==1.1.1
 # homeassistant.scripts.credstash
 # credstash==1.15.0
 
-# homeassistant.components.xiaomi_miio
-croniter==0.3.31
-
 # homeassistant.components.datadog
 datadog==0.15.0
 
@@ -720,7 +717,7 @@ python-izone==1.1.2
 python-juicenet==1.0.1
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.0.1
+python-miio==0.5.1
 
 # homeassistant.components.nest
 python-nest==4.1.0

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -33,6 +33,7 @@ from homeassistant.components.xiaomi_miio.vacuum import (
     ATTR_FILTER_LEFT,
     ATTR_MAIN_BRUSH_LEFT,
     ATTR_SIDE_BRUSH_LEFT,
+    ATTR_TIMERS,
     CONF_HOST,
     CONF_NAME,
     CONF_TOKEN,
@@ -60,6 +61,7 @@ STATUS_CALLS = [
     mock.call.consumable_status(),
     mock.call.clean_history(),
     mock.call.dnd_status(),
+    mock.call.timer(),
 ]
 
 
@@ -93,6 +95,16 @@ def mirobo_is_got_error_fixture():
     mock_vacuum.dnd_status().enabled = True
     mock_vacuum.dnd_status().start = time(hour=22, minute=0)
     mock_vacuum.dnd_status().end = time(hour=6, minute=0)
+
+    mock_timer_1 = mock.MagicMock()
+    mock_timer_1.enabled = True
+    mock_timer_1.ts = time(hour=9, minute=0)
+
+    mock_timer_2 = mock.MagicMock()
+    mock_timer_2.enabled = False
+    mock_timer_2.ts = time(hour=11, minute=0)
+
+    mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
@@ -159,6 +171,16 @@ def mirobo_is_on_fixture():
     mock_vacuum.status().state = "Test Xiaomi Cleaning"
     mock_vacuum.status().state_code = 5
     mock_vacuum.dnd_status().enabled = False
+
+    mock_timer_1 = mock.MagicMock()
+    mock_timer_1.enabled = True
+    mock_timer_1.ts = time(hour=9, minute=0)
+
+    mock_timer_2 = mock.MagicMock()
+    mock_timer_2.enabled = False
+    mock_timer_2.ts = time(hour=11, minute=0)
+
+    mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
@@ -241,6 +263,10 @@ async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     assert state.attributes.get(ATTR_CLEANING_COUNT) == 35
     assert state.attributes.get(ATTR_CLEANED_TOTAL_AREA) == 123
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 695
+    assert state.attributes.get(ATTR_TIMERS) == [
+        {"enabled": True, "time": time(hour=9, minute=0)},
+        {"enabled": False, "time": time(hour=11, minute=0)},
+    ]
 
     # Call services
     await hass.services.async_call(
@@ -341,6 +367,10 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     assert state.attributes.get(ATTR_CLEANING_COUNT) == 41
     assert state.attributes.get(ATTR_CLEANED_TOTAL_AREA) == 323
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 675
+    assert state.attributes.get(ATTR_TIMERS) == [
+        {"enabled": True, "time": time(hour=9, minute=0)},
+        {"enabled": False, "time": time(hour=11, minute=0)},
+    ]
 
     # Xiaomi vacuum specific services:
     await hass.services.async_call(

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -34,6 +34,7 @@ from homeassistant.components.xiaomi_miio.vacuum import (
     ATTR_MAIN_BRUSH_LEFT,
     ATTR_SIDE_BRUSH_LEFT,
     ATTR_TIMERS,
+    ATTR_TIMEZONE,
     CONF_HOST,
     CONF_NAME,
     CONF_TOKEN,
@@ -105,6 +106,8 @@ def mirobo_is_got_error_fixture():
     mock_timer_2.ts = time(hour=11, minute=0)
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
+
+    mock_vacuum.timezone.return_value = "Europe/Berlin"
 
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
@@ -181,6 +184,8 @@ def mirobo_is_on_fixture():
     mock_timer_2.ts = time(hour=11, minute=0)
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
+
+    mock_vacuum.timezone.return_value = "Europe/Berlin"
 
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
@@ -267,6 +272,7 @@ async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
         {"enabled": True, "time": time(hour=9, minute=0)},
         {"enabled": False, "time": time(hour=11, minute=0)},
     ]
+    assert state.attributes.get(ATTR_TIMEZONE) == "Europe/Berlin"
 
     # Call services
     await hass.services.async_call(
@@ -371,6 +377,7 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
         {"enabled": True, "time": time(hour=9, minute=0)},
         {"enabled": False, "time": time(hour=11, minute=0)},
     ]
+    assert state.attributes.get(ATTR_TIMEZONE) == "Europe/Berlin"
 
     # Xiaomi vacuum specific services:
     await hass.services.async_call(

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -1,8 +1,9 @@
 """The tests for the Xiaomi vacuum platform."""
-from datetime import time, timedelta
+from datetime import datetime, time, timedelta
 from unittest import mock
 
 import pytest
+from pytz import utc
 
 from homeassistant.components.vacuum import (
     ATTR_BATTERY_ICON,
@@ -62,6 +63,7 @@ STATUS_CALLS = [
     mock.call.consumable_status(),
     mock.call.clean_history(),
     mock.call.dnd_status(),
+    mock.call.timezone(),
     mock.call.timer(),
 ]
 
@@ -97,22 +99,25 @@ def mirobo_is_got_error_fixture():
     mock_vacuum.dnd_status().start = time(hour=22, minute=0)
     mock_vacuum.dnd_status().end = time(hour=6, minute=0)
 
+    mock_vacuum.timezone.return_value = "Europe/Berlin"
+
     mock_timer_1 = mock.MagicMock()
     mock_timer_1.enabled = True
-    mock_timer_1.ts = time(hour=9, minute=0)
+    mock_timer_1.cron = "5 5 1 8 1"
 
     mock_timer_2 = mock.MagicMock()
     mock_timer_2.enabled = False
-    mock_timer_2.ts = time(hour=11, minute=0)
+    mock_timer_2.cron = "5 5 1 8 2"
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
-    mock_vacuum.timezone.return_value = "Europe/Berlin"
-
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls:
+    ) as mock_vaccum_cls, mock.patch(
+        "homeassistant.components.xiaomi_miio.vacuum.croniter.get_next"
+    ) as mock_next_schedule:
         mock_vaccum_cls.return_value = mock_vacuum
+        mock_next_schedule.return_value = datetime(2020, 5, 23, 15, 21, 10)
         yield mock_vacuum
 
 
@@ -175,22 +180,25 @@ def mirobo_is_on_fixture():
     mock_vacuum.status().state_code = 5
     mock_vacuum.dnd_status().enabled = False
 
+    mock_vacuum.timezone.return_value = "Europe/Berlin"
+
     mock_timer_1 = mock.MagicMock()
     mock_timer_1.enabled = True
-    mock_timer_1.ts = time(hour=9, minute=0)
+    mock_timer_1.cron = "5 5 1 8 1"
 
     mock_timer_2 = mock.MagicMock()
     mock_timer_2.enabled = False
-    mock_timer_2.ts = time(hour=11, minute=0)
+    mock_timer_2.cron = "5 5 1 8 2"
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
-    mock_vacuum.timezone.return_value = "Europe/Berlin"
-
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls:
+    ) as mock_vaccum_cls, mock.patch(
+        "homeassistant.components.xiaomi_miio.vacuum.croniter.get_next"
+    ) as mock_next_schedule:
         mock_vaccum_cls.return_value = mock_vacuum
+        mock_next_schedule.return_value = datetime(2020, 5, 23, 15, 21, 10)
         yield mock_vacuum
 
 
@@ -268,11 +276,19 @@ async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     assert state.attributes.get(ATTR_CLEANING_COUNT) == 35
     assert state.attributes.get(ATTR_CLEANED_TOTAL_AREA) == 123
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 695
-    assert state.attributes.get(ATTR_TIMERS) == [
-        {"enabled": True, "time": time(hour=9, minute=0)},
-        {"enabled": False, "time": time(hour=11, minute=0)},
-    ]
     assert state.attributes.get(ATTR_TIMEZONE) == "Europe/Berlin"
+    assert state.attributes.get(ATTR_TIMERS) == [
+        {
+            "enabled": True,
+            "cron": "5 5 1 8 1",
+            "next_schedule": datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc),
+        },
+        {
+            "enabled": False,
+            "cron": "5 5 1 8 2",
+            "next_schedule": datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc),
+        },
+    ]
 
     # Call services
     await hass.services.async_call(
@@ -373,11 +389,19 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     assert state.attributes.get(ATTR_CLEANING_COUNT) == 41
     assert state.attributes.get(ATTR_CLEANED_TOTAL_AREA) == 323
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 675
-    assert state.attributes.get(ATTR_TIMERS) == [
-        {"enabled": True, "time": time(hour=9, minute=0)},
-        {"enabled": False, "time": time(hour=11, minute=0)},
-    ]
     assert state.attributes.get(ATTR_TIMEZONE) == "Europe/Berlin"
+    assert state.attributes.get(ATTR_TIMERS) == [
+        {
+            "enabled": True,
+            "cron": "5 5 1 8 1",
+            "next_schedule": datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc),
+        },
+        {
+            "enabled": False,
+            "cron": "5 5 1 8 2",
+            "next_schedule": datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc),
+        },
+    ]
 
     # Xiaomi vacuum specific services:
     await hass.services.async_call(

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -35,7 +35,6 @@ from homeassistant.components.xiaomi_miio.vacuum import (
     ATTR_MAIN_BRUSH_LEFT,
     ATTR_SIDE_BRUSH_LEFT,
     ATTR_TIMERS,
-    ATTR_TIMEZONE,
     CONF_HOST,
     CONF_NAME,
     CONF_TOKEN,
@@ -63,7 +62,6 @@ STATUS_CALLS = [
     mock.call.consumable_status(),
     mock.call.clean_history(),
     mock.call.dnd_status(),
-    mock.call.timezone(),
     mock.call.timer(),
 ]
 
@@ -99,25 +97,22 @@ def mirobo_is_got_error_fixture():
     mock_vacuum.dnd_status().start = time(hour=22, minute=0)
     mock_vacuum.dnd_status().end = time(hour=6, minute=0)
 
-    mock_vacuum.timezone.return_value = "Europe/Berlin"
-
     mock_timer_1 = mock.MagicMock()
     mock_timer_1.enabled = True
     mock_timer_1.cron = "5 5 1 8 1"
+    mock_timer_1.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
     mock_timer_2 = mock.MagicMock()
     mock_timer_2.enabled = False
     mock_timer_2.cron = "5 5 1 8 2"
+    mock_timer_2.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls, mock.patch(
-        "homeassistant.components.xiaomi_miio.vacuum.croniter.get_next"
-    ) as mock_next_schedule:
+    ) as mock_vaccum_cls:
         mock_vaccum_cls.return_value = mock_vacuum
-        mock_next_schedule.return_value = datetime(2020, 5, 23, 15, 21, 10)
         yield mock_vacuum
 
 
@@ -180,25 +175,22 @@ def mirobo_is_on_fixture():
     mock_vacuum.status().state_code = 5
     mock_vacuum.dnd_status().enabled = False
 
-    mock_vacuum.timezone.return_value = "Europe/Berlin"
-
     mock_timer_1 = mock.MagicMock()
     mock_timer_1.enabled = True
     mock_timer_1.cron = "5 5 1 8 1"
+    mock_timer_1.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
     mock_timer_2 = mock.MagicMock()
     mock_timer_2.enabled = False
     mock_timer_2.cron = "5 5 1 8 2"
+    mock_timer_2.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
     with mock.patch(
         "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls, mock.patch(
-        "homeassistant.components.xiaomi_miio.vacuum.croniter.get_next"
-    ) as mock_next_schedule:
+    ) as mock_vaccum_cls:
         mock_vaccum_cls.return_value = mock_vacuum
-        mock_next_schedule.return_value = datetime(2020, 5, 23, 15, 21, 10)
         yield mock_vacuum
 
 
@@ -276,7 +268,6 @@ async def test_xiaomi_vacuum_services(hass, caplog, mock_mirobo_is_got_error):
     assert state.attributes.get(ATTR_CLEANING_COUNT) == 35
     assert state.attributes.get(ATTR_CLEANED_TOTAL_AREA) == 123
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 695
-    assert state.attributes.get(ATTR_TIMEZONE) == "Europe/Berlin"
     assert state.attributes.get(ATTR_TIMERS) == [
         {
             "enabled": True,
@@ -389,7 +380,6 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     assert state.attributes.get(ATTR_CLEANING_COUNT) == 41
     assert state.attributes.get(ATTR_CLEANED_TOTAL_AREA) == 323
     assert state.attributes.get(ATTR_CLEANING_TOTAL_TIME) == 675
-    assert state.attributes.get(ATTR_TIMEZONE) == "Europe/Berlin"
     assert state.attributes.get(ATTR_TIMERS) == [
         {
             "enabled": True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
I like to add the list of configured timers as an attribute for a vacuum.
So that users can display them in the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to called API from python-miio: 
https://python-miio.readthedocs.io/en/latest/miio.html#miio.vacuum.Vacuum.timer

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
