### PR TITLE
Add Device Registry support and Device Info for ISY994

### DIFF
--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -94,9 +94,9 @@ class ISYEntity(Entity):
             device_info["manufacturer"] = node.protocol
             if node.protocol == PROTO_ZWAVE:
                 # Get extra information for Z-Wave Devices
-                device_info["manufacturer"] += f" mfr_id:{node.zwave_props.mfr_id}"
+                device_info["manufacturer"] += f" MfrID:{node.zwave_props.mfr_id}"
                 device_info["model"] += (
-                    f" Type:{node.zwave_props.mfr_id} "
+                    f" Type:{node.zwave_props.devtype_gen} "
                     f"ProductTypeID:{node.zwave_props.prod_type_id} "
                     f"ProductID:{node.zwave_props.product_id}"
                 )

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -5,12 +5,16 @@ from pyisy.constants import (
     EMPTY_TIME,
     EVENT_PROPS_IGNORED,
     ISY_VALUE_UNKNOWN,
+    PROTO_GROUP,
+    PROTO_ZWAVE,
 )
 from pyisy.helpers import NodeProperty
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import Dict
+
+from .const import DOMAIN
 
 
 class ISYEntity(Entity):
@@ -52,6 +56,53 @@ class ISYEntity(Entity):
             self.schedule_update_ha_state()
 
         self.hass.bus.fire("isy994_control", event_data)
+
+    @property
+    def device_info(self):
+        """Return the device_info of the device."""
+        if hasattr(self._node, "protocol") and self._node.protocol == PROTO_GROUP:
+            # not a device
+            return None
+        uuid = self._node.isy.configuration["uuid"]
+        node = self._node
+        basename = self.name
+
+        if hasattr(self._node, "parent_node") and self._node.parent_node is not None:
+            # This is not the parent node, get the parent node.
+            node = self._node.parent_node
+            basename = node.name
+
+        device_info = {
+            "name": basename,
+            "identifiers": {},
+            "model": "Unknown",
+            "manufacturer": "Unknown",
+            "via_device": (DOMAIN, uuid),
+        }
+
+        if hasattr(node, "address"):
+            device_info["name"] += f" ({node.address})"
+        if hasattr(node, "primary_node"):
+            device_info["identifiers"] = {(DOMAIN, f"{uuid}_{node.address}")}
+        # ISYv5 Device Types
+        if hasattr(node, "node_def_id") and node.node_def_id is not None:
+            device_info["model"] = node.node_def_id
+            # Numerical Device Type
+            if hasattr(node, "type") and node.type is not None:
+                device_info["model"] += f" {node.type}"
+        if hasattr(node, "protocol"):
+            device_info["manufacturer"] = node.protocol
+            if node.protocol == PROTO_ZWAVE:
+                # Get extra information for Z-Wave Devices
+                device_info["manufacturer"] += f" mfr_id:{node.zwave_props.mfr_id}"
+                device_info["model"] += (
+                    f" Type:{node.zwave_props.mfr_id} "
+                    f"ProductTypeID:{node.zwave_props.prod_type_id} "
+                    f"ProductID:{node.zwave_props.product_id}"
+                )
+        # Note: sw_version is not exposed by the ISY for the individual devices.
+
+        return device_info
 
     @property
     def unique_id(self) -> str:

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_form(hass: HomeAssistantType):
         PATCH_ASYNC_SETUP_ENTRY, return_value=True,
     ) as mock_setup_entry:
         isy_conn = mock_connection_class.return_value
-        isy_conn.get_config.return_value = "<xml></xml>"
+        isy_conn.get_config.return_value = None
         mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], MOCK_USER_INPUT,
@@ -154,7 +154,7 @@ async def test_form_existing_config_entry(hass: HomeAssistantType):
         PATCH_CONNECTION
     ) as mock_connection_class:
         isy_conn = mock_connection_class.return_value
-        isy_conn.get_config.return_value = "<xml></xml>"
+        isy_conn.get_config.return_value = None
         mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], MOCK_USER_INPUT,
@@ -170,7 +170,7 @@ async def test_import_flow_some_fields(hass: HomeAssistantType) -> None:
         PATCH_ASYNC_SETUP_ENTRY, return_value=True,
     ):
         isy_conn = mock_connection_class.return_value
-        isy_conn.get_config.return_value = "<xml></xml>"
+        isy_conn.get_config.return_value = None
         mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_IMPORT_BASIC_CONFIG,
@@ -190,7 +190,7 @@ async def test_import_flow_all_fields(hass: HomeAssistantType) -> None:
         PATCH_ASYNC_SETUP_ENTRY, return_value=True,
     ):
         isy_conn = mock_connection_class.return_value
-        isy_conn.get_config.return_value = "<xml></xml>"
+        isy_conn.get_config.return_value = None
         mock_config_class.return_value = MOCK_VALIDATED_RESPONSE
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_IMPORT_FULL_CONFIG,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is the sixth PR in a series (~10 total) to include migration to PyISYv2 and "modernization" of the isy994 integration based on testing done over the past year in the HACS custom component.

Full migration plan is captured in PR #35212

This specific PR adds device information and Device Registry support for ISY994 entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #35212
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] N/A this change.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

Tag: @bdraco @OverloadUT 