### PR TITLE
Provide yeelight unique_id using ssdp discovery

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -236,7 +236,7 @@ class YeelightDevice:
         """Return configured device model.
 
         Model method returns declared model, and if not, it tries to get it from
-        capabilities call. This way even if model is not defined, we can get real model
+        cached capabilities. This way even if model is not defined, we can get real model
         here. Useful for correct color temp range etc.
         """
         return self._bulb_device.model

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import Optional
 
 import voluptuous as vol
 from yeelight import Bulb, BulbException
@@ -291,6 +292,15 @@ class YeelightDevice:
 
         return self._device_type
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID.
+
+        Uses data returned from get_capabilities call ( https://yeelight.readthedocs.io/en/latest/yeelight.html#yeelight.Bulb.get_capabilities )
+        """
+
+        return self.bulb.capabilities.get("id")
+
     def turn_on(self, duration=DEFAULT_TRANSITION, light_type=None, power_mode=None):
         """Turn on device."""
         try:
@@ -341,9 +351,7 @@ class YeelightDevice:
             )
 
     def _initialize_device(self):
-        if self._available:
-            self._get_capabilities()
-
+        self._get_capabilities()
         self._initialized = True
         dispatcher_send(self._hass, DEVICE_INITIALIZED, self.ipaddr)
 
@@ -354,8 +362,4 @@ class YeelightDevice:
 
     def setup(self):
         """Fetch initial device properties."""
-        initial_update = self._update_properties()
-
-        # We can build correct class anyway.
-        if not initial_update and self.model:
-            self._initialize_device()
+        self._update_properties()

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -292,10 +292,7 @@ class YeelightDevice:
 
     @property
     def unique_id(self) -> Optional[str]:
-        """Return a unique ID.
-
-        Uses data returned from get_capabilities call ( https://yeelight.readthedocs.io/en/latest/yeelight.html#yeelight.Bulb.get_capabilities )
-        """
+        """Return a unique ID."""
 
         return self.bulb.capabilities.get("id")
 

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -237,8 +237,6 @@ class YeelightDevice:
         """Return configured device model.
 
         Model method returns declared model, and if not, it tries to get it from
-        cached capabilities. This way even if model is not defined, we can get real model
-        here. Useful for correct color temp range etc.
         """
         return self._bulb_device.model
 

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -293,7 +293,6 @@ class YeelightDevice:
     @property
     def unique_id(self) -> Optional[str]:
         """Return a unique ID."""
-
         return self.bulb.capabilities.get("id")
 
     def turn_on(self, duration=DEFAULT_TRANSITION, light_type=None, power_mode=None):

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -201,8 +201,7 @@ class YeelightDevice:
         self._config = config
         self._ipaddr = ipaddr
         self._name = config.get(CONF_NAME)
-        self._model = config.get(CONF_MODEL)
-        self._bulb_device = Bulb(self.ipaddr, model=self._model)
+        self._bulb_device = Bulb(self.ipaddr, model=config.get(CONF_MODEL))
         self._device_type = None
         self._available = False
         self._initialized = False
@@ -234,8 +233,13 @@ class YeelightDevice:
 
     @property
     def model(self):
-        """Return configured device model."""
-        return self._model
+        """Return configured device model.
+
+        Model method returns declared model, and if not, it tries to get it from
+        capabilities call. This way even if model is not defined, we can get real model
+        here. Useful for correct color temp range etc.
+        """
+        return self._bulb_device.model
 
     @property
     def is_nightlight_supported(self) -> bool:
@@ -313,8 +317,6 @@ class YeelightDevice:
         try:
             self.bulb.get_properties(UPDATE_REQUEST_PROPERTIES)
             self._available = True
-            if not self._initialized:
-                self._initialize_device()
         except BulbException as ex:
             if self._available:  # just inform once
                 _LOGGER.error(
@@ -323,6 +325,22 @@ class YeelightDevice:
             self._available = False
 
         return self._available
+
+    def _get_capabilities(self):
+        """Read new properties from the device."""
+        if not self.bulb:
+            return
+
+        try:
+            self.bulb.get_capabilities()
+        except BulbException as ex:
+            if self._available:  # just inform once
+                _LOGGER.error(
+                    "Unable to get device capabilities %s, %s: %s",
+                    self.ipaddr,
+                    self.name,
+                    ex,
+                )
 
     def _initialize_device(self):
         self._initialized = True
@@ -337,6 +355,11 @@ class YeelightDevice:
         """Fetch initial device properties."""
         initial_update = self._update_properties()
 
-        # We can build correct class anyway.
-        if not initial_update and self.model:
+        if initial_update:
+            # Try to get capabilities for reported model / fw version
+            self._get_capabilities()
             self._initialize_device()
+        else:
+            # We can build correct class anyway.
+            if self.model:
+                self._initialize_device()

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -337,7 +337,7 @@ class YeelightDevice:
         return self._available
 
     def _get_capabilities(self):
-        """Read new capabilities from the device."""
+        """Request device capabilities."""
         try:
             self.bulb.get_capabilities()
         except BulbException as ex:

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -234,10 +234,7 @@ class YeelightDevice:
 
     @property
     def model(self):
-        """Return configured device model.
-
-        Model method returns declared model, and if not, it tries to get it from
-        """
+        """Return configured/autodetected device model."""
         return self._bulb_device.model
 
     @property

--- a/homeassistant/components/yeelight/binary_sensor.py
+++ b/homeassistant/components/yeelight/binary_sensor.py
@@ -1,5 +1,6 @@
 """Sensor platform support for yeelight."""
 import logging
+from typing import Optional
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -37,6 +38,14 @@ class YeelightNightlightModeSensor(BinarySensorEntity):
                 self.async_write_ha_state,
             )
         )
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID."""
+        unique = self._device.unique_id
+
+        if unique:
+            return unique + "-nightlight_sensor"
 
     @property
     def should_poll(self):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -1,5 +1,6 @@
 """Light platform support for yeelight."""
 import logging
+from typing import Optional
 
 import voluptuous as vol
 import yeelight
@@ -471,6 +472,15 @@ class YeelightGenericLight(LightEntity):
         return False
 
     @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID.
+
+        Uses data returned from get_capabilities call ( https://yeelight.readthedocs.io/en/latest/yeelight.html#yeelight.Bulb.get_capabilities )
+
+        """
+        return self._bulb.capabilities["id"]
+
+    @property
     def available(self) -> bool:
         """Return if bulb is available."""
         return self.device.available
@@ -903,6 +913,11 @@ class YeelightNightLightMode(YeelightGenericLight):
     """Representation of a Yeelight when in nightlight mode."""
 
     @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID."""
+        return super().unique_id + "-nightlight"
+
+    @property
     def name(self) -> str:
         """Return the name of the device if any."""
         return f"{self.device.name} nightlight"
@@ -984,6 +999,11 @@ class YeelightAmbientLight(YeelightColorLightWithoutNightlightSwitch):
         self._max_mireds = kelvin_to_mired(1700)
 
         self._light_type = LightType.Ambient
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID."""
+        return super().unique_id + "-ambilight"
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -478,7 +478,8 @@ class YeelightGenericLight(LightEntity):
         Uses data returned from get_capabilities call ( https://yeelight.readthedocs.io/en/latest/yeelight.html#yeelight.Bulb.get_capabilities )
 
         """
-        return self._bulb.capabilities["id"]
+
+        return self._bulb.capabilities.get("id")
 
     @property
     def available(self) -> bool:
@@ -915,7 +916,10 @@ class YeelightNightLightMode(YeelightGenericLight):
     @property
     def unique_id(self) -> Optional[str]:
         """Return a unique ID."""
-        return super().unique_id + "-nightlight"
+        unique = super().unique_id
+
+        if unique:
+            return unique + "-nightlight"
 
     @property
     def name(self) -> str:
@@ -1003,7 +1007,10 @@ class YeelightAmbientLight(YeelightColorLightWithoutNightlightSwitch):
     @property
     def unique_id(self) -> Optional[str]:
         """Return a unique ID."""
-        return super().unique_id + "-ambilight"
+        unique = super().unique_id
+
+        if unique:
+            return unique + "-ambilight"
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -473,13 +473,9 @@ class YeelightGenericLight(LightEntity):
 
     @property
     def unique_id(self) -> Optional[str]:
-        """Return a unique ID.
+        """Return a unique ID."""
 
-        Uses data returned from get_capabilities call ( https://yeelight.readthedocs.io/en/latest/yeelight.html#yeelight.Bulb.get_capabilities )
-
-        """
-
-        return self._bulb.capabilities.get("id")
+        return self.device.unique_id
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.5.1"],
+  "requirements": ["yeelight==0.5.2"],
   "after_dependencies": ["discovery"],
   "codeowners": ["@rytilahti", "@zewelor"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2203,7 +2203,7 @@ ya_ma==0.3.8
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.yeelight
-yeelight==0.5.1
+yeelight==0.5.2
 
 # homeassistant.components.yeelightsunflower
 yeelightsunflower==0.0.10


### PR DESCRIPTION
## Proposed change
Add unique_id to yeelight component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Get unique_id from the device itself, using SSDP query to invidual device. Its implemented via new method from python-yeelight ( https://yeelight.readthedocs.io/en/latest/yeelight.html#yeelight.Bulb.get_capabilities ).
Query device once ( during initialization ) and then use cached capabilities.

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/34304
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
