### PR TITLE
Correctly handle failed Atag update in coordinator

### DIFF
--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -163,10 +163,10 @@ class AtagDataUpdateCoordinator(DataUpdateCoordinator):
         with async_timeout.timeout(20):
             try:
                 await self.atag.async_update()
+                if not self.atag.sensordata:
+                    raise UpdateFailed()
             except (AtagException) as error:
                 raise UpdateFailed(error)
-        if not self.atag.sensordata:
-            return False
         return self.atag.sensordata
 
 

--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -165,7 +165,8 @@ class AtagDataUpdateCoordinator(DataUpdateCoordinator):
                 await self.atag.async_update()
             except (AtagException) as error:
                 raise UpdateFailed(error)
-
+        if not self.atag.sensordata:
+            return False
         return self.atag.sensordata
 
 

--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -164,7 +164,7 @@ class AtagDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 await self.atag.async_update()
                 if not self.atag.sensordata:
-                    raise UpdateFailed()
+                    raise UpdateFailed("No data")
             except (AtagException) as error:
                 raise UpdateFailed(error)
         return self.atag.sensordata


### PR DESCRIPTION
## Proposed change
This is a small fix to prevent errors when setting up the integration, if the communication with the Atag One did not return the necessary data. This additional check on sensordata availability prevents the config entry from loading until the first update has been succesful.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #35190

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
