### PR TITLE
Add Zerproc integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -862,6 +862,8 @@ omit =
     homeassistant/components/zamg/weather.py
     homeassistant/components/zengge/light.py
     homeassistant/components/zeroconf/*
+    homeassistant/components/zerproc/__init__.py
+    homeassistant/components/zerproc/const.py
     homeassistant/components/zestimate/sensor.py
     homeassistant/components/zha/api.py
     homeassistant/components/zha/core/channels/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -462,6 +462,7 @@ homeassistant/components/yessssms/* @flowolf
 homeassistant/components/yi/* @bachya
 homeassistant/components/yr/* @danielhiversen
 homeassistant/components/zeroconf/* @robbiet480 @Kane610
+homeassistant/components/zerproc/* @emlove
 homeassistant/components/zha/* @dmulcahey @adminiuga
 homeassistant/components/zone/* @home-assistant/core
 homeassistant/components/zoneminder/* @rohankapoorcom

--- a/homeassistant/components/zerproc/__init__.py
+++ b/homeassistant/components/zerproc/__init__.py
@@ -1,0 +1,40 @@
+"""Zerproc lights integration."""
+import asyncio
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+PLATFORMS = ["light"]
+
+
+async def async_setup(hass, config):
+    """Set up the Zerproc platform."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_IMPORT})
+    )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Zerproc from a config entry."""
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    return all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )

--- a/homeassistant/components/zerproc/config_flow.py
+++ b/homeassistant/components/zerproc/config_flow.py
@@ -1,0 +1,26 @@
+"""Config flow for Zerproc."""
+import logging
+
+import pyzerproc
+
+from homeassistant import config_entries
+from homeassistant.helpers import config_entry_flow
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_has_devices(hass) -> bool:
+    """Return if there are devices that can be discovered."""
+    try:
+        devices = await hass.async_add_executor_job(pyzerproc.discover)
+        return len(devices) > 0
+    except pyzerproc.ZerprocException:
+        _LOGGER.error("Unable to discover nearby Zerproc devices", exc_info=True)
+        return False
+
+
+config_entry_flow.register_discovery_flow(
+    DOMAIN, "Zerproc", _async_has_devices, config_entries.CONN_CLASS_LOCAL_POLL
+)

--- a/homeassistant/components/zerproc/const.py
+++ b/homeassistant/components/zerproc/const.py
@@ -1,0 +1,2 @@
+"""Constants for the Zerproc integration."""
+DOMAIN = "zerproc"

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -59,9 +59,9 @@ def discover_entities(hass: HomeAssistant) -> List[Entity]:
     for light in connect_lights(new_lights):
         # Double-check the light hasn't been added in another thread
         if light.address not in hass.data[DOMAIN]["light_entities"]:
-            entity = ZerprocLight(hass, light)
+            entity = ZerprocLight(light)
             hass.data[DOMAIN]["light_entities"][light.address] = entity
-            entities.append(ZerprocLight(hass, light))
+            entities.append(ZerprocLight(light))
 
     return entities
 
@@ -101,7 +101,7 @@ async def async_setup_entry(
 class ZerprocLight(Light):
     """Representation of an Zerproc Light."""
 
-    def __init__(self, hass, light):
+    def __init__(self, light):
         """Initialize a Zerproc light."""
         self._light = light
         self._name = None
@@ -113,7 +113,9 @@ class ZerprocLight(Light):
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         self.async_on_remove(
-            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_hass_shutdown)
+            self.hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP, self.on_hass_shutdown
+            )
         )
 
     def on_hass_shutdown(self, event):

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -117,7 +117,7 @@ class ZerprocLight(Light):
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        await self.hass.async_add_executor_job(self._light.disconnect())
+        await self.hass.async_add_executor_job(self._light.disconnect)
 
     def on_hass_shutdown(self, event):
         """Execute when Home Assistant is shutting down."""

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -112,7 +112,9 @@ class ZerprocLight(Light):
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_hass_shutdown)
+        self.async_on_remove(
+            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_hass_shutdown)
+        )
 
     def on_hass_shutdown(self, event):
         """Execute when Home Assistant is shutting down."""

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -1,0 +1,194 @@
+"""Zerproc light platform."""
+import asyncio
+from datetime import timedelta
+import logging
+from typing import Callable, List, Optional
+
+import pyzerproc
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_HS_COLOR,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR,
+    Light,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import HomeAssistantType
+import homeassistant.util.color as color_util
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_ZERPROC = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
+
+DISCOVERY_INTERVAL = timedelta(seconds=60)
+
+
+def connect_light(light: pyzerproc.Light) -> Optional[pyzerproc.Light]:
+    """Attempt to connect to the light, and return the entity."""
+    try:
+        light.connect(auto_reconnect=True)
+    except pyzerproc.ZerprocException:
+        _LOGGER.debug("Unable to connect to '%s'", light.address, exc_info=True)
+        return None
+
+    return light
+
+
+async def discover_entities(
+    hass: HomeAssistant, async_add_entities: Callable[[List[Entity], bool], None]
+) -> List[Entity]:
+    """Attempt to discover new lights."""
+    lights = await hass.async_add_executor_job(pyzerproc.discover)
+
+    # Filter out already discovered lights
+    new_lights = [
+        light
+        for light in lights
+        if light.address not in hass.data[DOMAIN]["light_entities"]
+    ]
+
+    entities = []
+    for light in await asyncio.gather(
+        *[hass.async_add_executor_job(connect_light, light) for light in new_lights]
+    ):
+        if light is not None:
+            entity = ZerprocLight(hass, light)
+            hass.data[DOMAIN]["light_entities"][light.address] = entity
+            entities.append(ZerprocLight(hass, light))
+
+    async_add_entities(entities, update_before_add=True)
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType,
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up Abode light devices."""
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    if "light_entities" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["light_entities"] = {}
+
+    warned = False
+
+    async def discover(*args):
+        """Wrap discovery to include params."""
+        nonlocal warned
+        try:
+            await discover_entities(hass, async_add_entities)
+            warned = False
+        except pyzerproc.ZerprocException:
+            if warned is False:
+                _LOGGER.warning("Error discovering Zerproc lights", exc_info=True)
+                warned = True
+
+    # Initial discovery
+    hass.async_add_job(discover)
+
+    # Perform recurring discovery of new devices
+    async_track_time_interval(hass, discover, DISCOVERY_INTERVAL)
+
+
+class ZerprocLight(Light):
+    """Representation of an Zerproc Light."""
+
+    def __init__(self, hass, light):
+        """Initialize a Zerproc light."""
+        self._light = light
+        self._name = None
+        self._is_on = None
+        self._hs_color = None
+        self._brightness = None
+        self._available = True
+
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_hass_shutdown)
+
+    def on_hass_shutdown(self, event):
+        """Execute when Home Assistant is shutting down."""
+        self._light.disconnect()
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._light.name
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return self._light.address
+
+    @property
+    def device_info(self):
+        """Device info for this light."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+        }
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_ZERPROC
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        return self._brightness
+
+    @property
+    def hs_color(self):
+        """Return the hs color."""
+        return self._hs_color
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._is_on
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on."""
+        if ATTR_BRIGHTNESS in kwargs or ATTR_HS_COLOR in kwargs:
+            default_hs = (0, 0) if self._hs_color is None else self._hs_color
+            hue_sat = kwargs.get(ATTR_HS_COLOR, default_hs)
+
+            default_brightness = 255 if self._brightness is None else self._brightness
+            brightness = kwargs.get(ATTR_BRIGHTNESS, default_brightness)
+
+            rgb = color_util.color_hsv_to_RGB(*hue_sat, brightness / 255 * 100)
+            self._light.set_color(*rgb)
+        else:
+            self._light.turn_on()
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._light.turn_off()
+
+    def update(self):
+        """Fetch new state data for this light."""
+        try:
+            state = self._light.get_state()
+        except pyzerproc.ZerprocException:
+            if self._available:
+                _LOGGER.warning("Unable to connect to %s", self.entity_id)
+            self._available = False
+            return
+        if self._available is False:
+            _LOGGER.info("Reconnected to %s", self.entity_id)
+            self._available = True
+        self._is_on = state.is_on
+        hsv = color_util.color_RGB_to_hsv(*state.color)
+        self._hs_color = hsv[:2]
+        self._brightness = int(round((hsv[2] / 100) * 255))

--- a/homeassistant/components/zerproc/manifest.json
+++ b/homeassistant/components/zerproc/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "zerproc",
+  "name": "Zerproc",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/zerproc",
+  "requirements": [
+    "pyzerproc==0.2.4"
+  ],
+  "codeowners": [
+    "@emlove"
+  ]
+}

--- a/homeassistant/components/zerproc/strings.json
+++ b/homeassistant/components/zerproc/strings.json
@@ -3,12 +3,12 @@
   "config": {
     "step": {
       "confirm": {
-        "description": "Do you want to set up Zerproc lights?"
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
       }
     },
     "abort": {
-      "single_instance_allowed": "Only a single configuration of Zerproc lights is necessary.",
-      "no_devices_found": "No Zerproc lights found nearby."
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     }
   }
 }

--- a/homeassistant/components/zerproc/strings.json
+++ b/homeassistant/components/zerproc/strings.json
@@ -1,0 +1,14 @@
+{
+  "title": "Zerproc",
+  "config": {
+    "step": {
+      "confirm": {
+        "description": "Do you want to set up Zerproc lights?"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of Zerproc lights is necessary.",
+      "no_devices_found": "No Zerproc lights found nearby."
+    }
+  }
+}

--- a/homeassistant/components/zerproc/translations/en.json
+++ b/homeassistant/components/zerproc/translations/en.json
@@ -1,0 +1,14 @@
+{
+    "config": {
+        "abort": {
+            "no_devices_found": "No Zerproc lights found nearby.",
+            "single_instance_allowed": "Only a single configuration of Zerproc lights is necessary."
+        },
+        "step": {
+            "confirm": {
+                "description": "Do you want to set up Zerproc lights?"
+            }
+        }
+    },
+    "title": "Zerproc"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -150,6 +150,7 @@ FLOWS = [
     "wled",
     "wwlln",
     "xiaomi_miio",
+    "zerproc",
     "zha",
     "zwave",
     "zwave_mqtt"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1798,6 +1798,9 @@ pyzabbix==0.7.4
 # homeassistant.components.qrcode
 pyzbar==0.1.7
 
+# homeassistant.components.zerproc
+pyzerproc==0.2.4
+
 # homeassistant.components.qnap
 qnapstats==0.3.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -716,6 +716,9 @@ pyvizio==0.1.47
 # homeassistant.components.html5
 pywebpush==1.9.2
 
+# homeassistant.components.zerproc
+pyzerproc==0.2.4
+
 # homeassistant.components.rachio
 rachiopy==0.1.3
 

--- a/tests/components/zerproc/__init__.py
+++ b/tests/components/zerproc/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the zerproc integration."""

--- a/tests/components/zerproc/test_config_flow.py
+++ b/tests/components/zerproc/test_config_flow.py
@@ -1,0 +1,30 @@
+"""Test the zerproc config flow."""
+from asynctest import patch
+
+from homeassistant.components.zerproc.config_flow import _async_has_devices
+
+
+class MockException(Exception):
+    """Mock exception class."""
+
+
+async def test_has_devices(hass):
+    """Test we get the form."""
+    with patch(
+        "homeassistant.components.zerproc.config_flow.pyzerproc.discover",
+        return_value=[],
+    ):
+        assert await _async_has_devices(hass) is False
+    with patch(
+        "homeassistant.components.zerproc.config_flow.pyzerproc.discover",
+        return_value=["Light1", "Light2"],
+    ):
+        assert await _async_has_devices(hass) is True
+    with patch(
+        "homeassistant.components.zerproc.config_flow.pyzerproc.discover",
+        side_effect=MockException("TEST"),
+    ), patch(
+        "homeassistant.components.zerproc.config_flow.pyzerproc.ZerprocException",
+        new=MockException,
+    ):
+        assert await _async_has_devices(hass) is False

--- a/tests/components/zerproc/test_config_flow.py
+++ b/tests/components/zerproc/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the zerproc config flow."""
 from asynctest import patch
+import pyzerproc
 
 from homeassistant import config_entries, setup
 from homeassistant.components.zerproc.config_flow import DOMAIN
@@ -22,14 +23,7 @@ async def test_flow_success(hass):
     ) as mock_setup, patch(
         "homeassistant.components.zerproc.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {},)
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Zerproc"
@@ -57,14 +51,33 @@ async def test_flow_no_devices_found(hass):
     ) as mock_setup, patch(
         "homeassistant.components.zerproc.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {},)
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "no_devices_found"
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 0
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+async def test_flow_exceptions_caught(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.zerproc.config_flow.pyzerproc.discover",
+        side_effect=pyzerproc.ZerprocException("TEST"),
+    ), patch(
+        "homeassistant.components.zerproc.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.zerproc.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {},)
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "no_devices_found"

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -1,0 +1,232 @@
+"""Test the zerproc lights."""
+from asynctest import patch
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_HS_COLOR,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR,
+)
+from homeassistant.components.zerproc.light import (
+    DOMAIN,
+    ZerprocLight,
+    async_setup_entry,
+)
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+from tests.async_mock import MagicMock
+
+
+class MockException(Exception):
+    """Mock exception class."""
+
+
+class MockLight(MagicMock):
+    """Mock pyzerproc light class."""
+
+    def __init__(self, address, name=None):
+        """Initialize the mock class."""
+        super().__init__()
+        self.address = address
+        self.name = name
+
+    def _get_child_mock(self, **kwargs):
+        return MagicMock(**kwargs)
+
+
+async def test_init(hass):
+    """Test platform setup."""
+    hass.async_add_job = MagicMock()
+    discover = None
+
+    def async_track_time_interval(hass, action, interval):
+        nonlocal discover
+        discover = action
+
+    entities_added = []
+
+    def async_add_entities(entities, update_before_add=False):
+        nonlocal entities_added
+        entities_added += entities
+
+    with patch(
+        "homeassistant.components.zerproc.light.async_track_time_interval",
+        new=async_track_time_interval,
+    ):
+        await async_setup_entry(hass, None, async_add_entities)
+
+    assert discover is not None
+
+    mock_light_1 = MockLight("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
+    mock_light_2 = MockLight("11:22:33:44:55:66", "LEDBlue-33445566")
+
+    with patch(
+        "homeassistant.components.zerproc.light.pyzerproc.Light", MockLight
+    ), patch(
+        "homeassistant.components.zerproc.light.pyzerproc.discover",
+        return_value=[mock_light_1, mock_light_2],
+    ):
+        await discover(None)
+        # Calling twice should not create duplicate entities
+        await discover(None)
+
+    assert len(entities_added) == 2
+    assert entities_added[0].name == "LEDBlue-CCDDEEFF"
+    assert entities_added[0].unique_id == "AA:BB:CC:DD:EE:FF"
+    assert entities_added[1].name == "LEDBlue-33445566"
+    assert entities_added[1].unique_id == "11:22:33:44:55:66"
+
+    entities_added.clear()
+    hass.data[DOMAIN]["light_entities"] = {}
+
+    # Test an exception connecting to one of the lights
+    mock_light_1.connect.side_effect = MockException("FOO")
+    with patch(
+        "homeassistant.components.zerproc.light.pyzerproc.Light", MockLight
+    ), patch(
+        "homeassistant.components.zerproc.light.pyzerproc.discover",
+        return_value=[mock_light_1, mock_light_2],
+    ), patch(
+        "homeassistant.components.zerproc.light.pyzerproc.ZerprocException",
+        new=MockException,
+    ):
+        await discover(None)
+
+    # The second light should still have been added correctly
+    assert len(entities_added) == 1
+    assert entities_added[0].name == "LEDBlue-33445566"
+    assert entities_added[0].unique_id == "11:22:33:44:55:66"
+
+    entities_added.clear()
+    hass.data[DOMAIN]["light_entities"] = {}
+
+    # Test an exception during discovery
+    with patch(
+        "homeassistant.components.zerproc.light.pyzerproc.discover",
+        side_effect=MockException("TEST"),
+    ), patch(
+        "homeassistant.components.zerproc.light.pyzerproc.ZerprocException",
+        new=MockException,
+    ):
+        await discover(None)
+
+    # Should not add entities and the exception should be captured
+    assert len(entities_added) == 0
+
+
+def test_light_properties(hass):
+    """Test ZerprocLight class properties."""
+    hass.bus.async_listen_once = MagicMock()
+
+    light = MockLight("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
+    entity = ZerprocLight(hass, light)
+
+    hass.bus.async_listen_once.assert_called_with(
+        EVENT_HOMEASSISTANT_STOP, entity.on_hass_shutdown
+    )
+
+    assert entity.name == "LEDBlue-CCDDEEFF"
+    assert entity.unique_id == "AA:BB:CC:DD:EE:FF"
+    assert entity.device_info == {
+        "identifiers": {(DOMAIN, entity.unique_id)},
+        "name": entity.name,
+    }
+    assert entity.supported_features == SUPPORT_BRIGHTNESS | SUPPORT_COLOR
+
+
+def test_light_turn_on(hass):
+    """Test ZerprocLight turn_on."""
+    light = MockLight("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
+    entity = ZerprocLight(hass, light)
+
+    entity.turn_on()
+    light.turn_on.assert_called()
+
+    light.reset_mock()
+
+    entity.turn_on(**{ATTR_BRIGHTNESS: 25})
+
+    light.turn_on.assert_not_called()
+    light.set_color.assert_called_with(25, 25, 25)
+
+    light.reset_mock()
+    entity._hs_color = (50, 50)
+
+    entity.turn_on(**{ATTR_BRIGHTNESS: 25})
+
+    light.turn_on.assert_not_called()
+    light.set_color.assert_called_with(25, 22, 12)
+
+    light.reset_mock()
+
+    entity.turn_on(**{ATTR_HS_COLOR: (50, 50)})
+
+    light.turn_on.assert_not_called()
+    light.set_color.assert_called_with(255, 233, 127)
+
+    light.reset_mock()
+    entity._brightness = 75
+
+    entity.turn_on(**{ATTR_HS_COLOR: (50, 50)})
+
+    light.turn_on.assert_not_called()
+    light.set_color.assert_called_with(75, 68, 37)
+
+    light.reset_mock()
+
+    entity.turn_on(**{ATTR_BRIGHTNESS: 200, ATTR_HS_COLOR: (75, 75)})
+
+    light.turn_on.assert_not_called()
+    light.set_color.assert_called_with(162, 200, 50)
+
+
+def test_light_turn_off(hass):
+    """Test ZerprocLight turn_off."""
+    light = MockLight("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
+    entity = ZerprocLight(hass, light)
+
+    entity.turn_off()
+    light.turn_off.assert_called()
+
+
+def test_light_update(hass):
+    """Test ZerprocLight update."""
+    light = MockLight("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
+    entity = ZerprocLight(hass, light)
+
+    assert entity.available is True
+
+    # Test an exception during discovery
+    with patch(
+        "homeassistant.components.zerproc.light.pyzerproc.ZerprocException",
+        new=MockException,
+    ):
+        light.get_state.side_effect = MockException("TEST")
+        entity.update()
+
+    assert entity.available is False
+
+    state = MagicMock()
+    state.is_on = False
+    state.color = (200, 128, 100)
+    light.get_state.side_effect = None
+    light.get_state.return_value = state
+
+    entity.update()
+
+    assert entity.available is True
+    assert entity.brightness == 200
+    assert entity.is_on is False
+    assert entity.hs_color == (16.8, 50.0)
+
+    state.is_on = True
+    state.color = (175, 150, 220)
+    light.get_state.side_effect = None
+    light.get_state.return_value = state
+
+    entity.update()
+
+    assert entity.available is True
+    assert entity.brightness == 220
+    assert entity.is_on is True
+    assert entity.hs_color == (261.429, 31.818)


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a new integration for Zerproc bluetooth LED string lights.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
zerproc:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13388

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/13388

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
