### PR TITLE
DRAFT Universal Powerline Bus - firing event.

### DIFF
--- a/homeassistant/components/upb/__init__.py
+++ b/homeassistant/components/upb/__init__.py
@@ -34,6 +34,15 @@ async def async_setup_entry(hass, config_entry):
             hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
 
+    def _scene_event(changeset):
+        self.hass.bus.fire(event, changeset)
+
+    async_dispatcher_connect(
+        self.hass,
+        f"{DOMAIN}.scene_event",
+        _scene_event,
+    )
+
     return True
 
 

--- a/homeassistant/components/upb/scene.py
+++ b/homeassistant/components/upb/scene.py
@@ -42,6 +42,23 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class UpbLink(UpbEntity, Scene):
     """Representation of an UPB Link."""
 
+    def _element_changed(self, element, changeset):
+        """Callback from UPB lib when event on link occurred."""
+
+        change = changeset.get("last_change")
+        if change is None:
+            return
+        if change.get("command") is None:
+            return
+        if change["command"] not in TRIGGER_TYPES:
+            return
+
+        event = f"{DOMAIN}.scene_{change['command']}"
+        data = {ATTR_ENTITY_ID: self.entity_id}
+        data[ATTR_BRIGHTNESS_PCT] = change.get("level", -1)
+        data[ATTR_RATE] = change.get("rate", -1)
+        async_dispatcher_send(hass, f"{}.scene_event", data)
+
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the task."""
         self._element.activate()


### PR DESCRIPTION
Here is a proposed solution to entities not firing events. This
is not tested code and is submitted to align on approach.

The requirement for automation is to know:
- What kind of event occurred (activate, deactivate, etc)
- The entity that activated, deactivated, etc.
- Some data associated with the activate, deactivate, etc. The data
  is unlikely relevant to this discussion.

A UPB link is modeled in hass as UpbLink derived from Scene.

Example types of events are when a link is activated, deactivated,
or when a fade is started or stopped.

In case someone has not seen the previous PR, the event was fired
in the _element_changed method (below). This PR moves the firing of
the event to the integration's setup function. The prior PR also used
device_trigger, which is believed to be no longer relevant. Previous
PR here: https://github.com/home-assistant/core/pull/35470

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
