### PR TITLE
Fix light.toggle service arguments

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -167,12 +167,19 @@ def preprocess_turn_on_alternatives(params):
     if rgb_color is not None:
         params[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
 
+    return params
+
+
+def filter_turn_off_params(params):
+    """Filter out params not used in turn off."""
+    return {k: v for k, v in params.items() if k in (ATTR_TRANSITION, ATTR_FLASH)}
+
 
 def preprocess_turn_off(params):
     """Process data for turning light off if brightness is 0."""
     if ATTR_BRIGHTNESS in params and params[ATTR_BRIGHTNESS] == 0:
         # Zero brightness: Light will be turned off
-        params = {k: v for k, v in params.items() if k in (ATTR_TRANSITION, ATTR_FLASH)}
+        params = filter_turn_off_params(params)
         return (True, params)  # Light should be turned off
 
     return (False, None)  # Light should be turned on
@@ -198,13 +205,7 @@ async def async_setup(hass, config):
             if entity_field in data
         }
 
-        preprocess_turn_on_alternatives(data)
-        turn_lights_off, off_params = preprocess_turn_off(data)
-
-        base["params"] = data
-        base["turn_lights_off"] = turn_lights_off
-        base["off_params"] = off_params
-
+        base["params"] = preprocess_turn_on_alternatives(data)
         return base
 
     async def async_handle_light_on_service(light, call):
@@ -213,8 +214,6 @@ async def async_setup(hass, config):
         If brightness is set to 0, this service will turn the light off.
         """
         params = call.data["params"]
-        turn_light_off = call.data["turn_lights_off"]
-        off_params = call.data["off_params"]
 
         if not params:
             default_profile = Profiles.get_default(light.entity_id)
@@ -222,7 +221,6 @@ async def async_setup(hass, config):
             if default_profile is not None:
                 params = {ATTR_PROFILE: default_profile}
                 preprocess_turn_on_alternatives(params)
-                turn_light_off, off_params = preprocess_turn_off(params)
 
         elif ATTR_BRIGHTNESS_STEP in params or ATTR_BRIGHTNESS_STEP_PCT in params:
             brightness = light.brightness if light.is_on else 0
@@ -236,12 +234,23 @@ async def async_setup(hass, config):
                 brightness += round(params.pop(ATTR_BRIGHTNESS_STEP_PCT) / 100 * 255)
 
             params[ATTR_BRIGHTNESS] = max(0, min(255, brightness))
-            turn_light_off, off_params = preprocess_turn_off(params)
 
+        turn_light_off, off_params = preprocess_turn_off(params)
         if turn_light_off:
             await light.async_turn_off(**off_params)
         else:
             await light.async_turn_on(**params)
+
+    async def async_handle_toggle_service(light, call):
+        """Handle toggling a light.
+
+        If brightness is set to 0, this service will turn the light off.
+        """
+        if light.is_on:
+            off_params = filter_turn_off_params(call.data["params"])
+            await light.async_turn_off(**off_params)
+        else:
+            await async_handle_light_on_service(light, call)
 
     # Listen for light on and light off service calls.
 
@@ -258,7 +267,9 @@ async def async_setup(hass, config):
     )
 
     component.async_register_entity_service(
-        SERVICE_TOGGLE, LIGHT_TURN_ON_SCHEMA, "async_toggle"
+        SERVICE_TOGGLE,
+        vol.All(cv.make_entity_service_schema(LIGHT_TURN_ON_SCHEMA), preprocess_data),
+        async_handle_toggle_service,
     )
 
     return True

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -128,16 +128,80 @@ async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL, transition=None):
 
 
 @bind_hass
-def toggle(hass, entity_id=ENTITY_MATCH_ALL, transition=None):
+def toggle(
+    hass,
+    entity_id=ENTITY_MATCH_ALL,
+    transition=None,
+    brightness=None,
+    brightness_pct=None,
+    rgb_color=None,
+    xy_color=None,
+    hs_color=None,
+    color_temp=None,
+    kelvin=None,
+    white_value=None,
+    profile=None,
+    flash=None,
+    effect=None,
+    color_name=None,
+):
     """Toggle all or specified light."""
-    hass.add_job(async_toggle, hass, entity_id, transition)
+    hass.add_job(
+        async_toggle,
+        hass,
+        entity_id,
+        transition,
+        brightness,
+        brightness_pct,
+        rgb_color,
+        xy_color,
+        hs_color,
+        color_temp,
+        kelvin,
+        white_value,
+        profile,
+        flash,
+        effect,
+        color_name,
+    )
 
 
-async def async_toggle(hass, entity_id=ENTITY_MATCH_ALL, transition=None):
-    """Toggle all or specified light."""
+async def async_toggle(
+    hass,
+    entity_id=ENTITY_MATCH_ALL,
+    transition=None,
+    brightness=None,
+    brightness_pct=None,
+    rgb_color=None,
+    xy_color=None,
+    hs_color=None,
+    color_temp=None,
+    kelvin=None,
+    white_value=None,
+    profile=None,
+    flash=None,
+    effect=None,
+    color_name=None,
+):
+    """Turn all or specified light on."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_TRANSITION, transition)]
+        for key, value in [
+            (ATTR_ENTITY_ID, entity_id),
+            (ATTR_PROFILE, profile),
+            (ATTR_TRANSITION, transition),
+            (ATTR_BRIGHTNESS, brightness),
+            (ATTR_BRIGHTNESS_PCT, brightness_pct),
+            (ATTR_RGB_COLOR, rgb_color),
+            (ATTR_XY_COLOR, xy_color),
+            (ATTR_HS_COLOR, hs_color),
+            (ATTR_COLOR_TEMP, color_temp),
+            (ATTR_KELVIN, kelvin),
+            (ATTR_WHITE_VALUE, white_value),
+            (ATTR_FLASH, flash),
+            (ATTR_EFFECT, effect),
+            (ATTR_COLOR_NAME, color_name),
+        ]
         if value is not None
     }
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -263,6 +263,15 @@ class TestLight(unittest.TestCase):
             light.ATTR_HS_COLOR: (prof_h, prof_s),
         } == data
 
+        # Test toggle with parameters
+        common.toggle(self.hass, ent3.entity_id, profile=prof_name, brightness_pct=100)
+        self.hass.block_till_done()
+        _, data = ent3.last_call("turn_on")
+        assert {
+            light.ATTR_BRIGHTNESS: 255,
+            light.ATTR_HS_COLOR: (prof_h, prof_s),
+        } == data
+
         # Test bad data
         common.turn_on(self.hass)
         common.turn_on(self.hass, ent1.entity_id, profile="nonexisting")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The [documentation](https://www.home-assistant.io/integrations/light/#service-lighttoggle) promises that the `light.toggle` service takes the same arguments as `turn_on` service. However, preprocessing is only applied to `turn_on`, which causes some attribute  like `profile` and `brightness_pct` not working on `toggle` service. This PR is a fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35197, fixes #30809, fixes #30861, 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
