### PR TITLE
Allow zeroconf instance sharing

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 from homeassistant.generated.zeroconf import HOMEKIT, ZEROCONF
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.helpers.singleton import singleton
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,12 +55,40 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
+@singleton(DOMAIN)
+async def async_get_instance(hass):
+    """Zeroconf instance to be shared with other integrations that use it."""
+    return await hass.async_add_executor_job(_get_instance, hass)
+
+
+def _get_instance(hass, default_interface=False):
+    """Create an instance."""
+    args = [InterfaceChoice.Default] if default_interface else []
+    zeroconf = HaZeroconf(*args)
+
+    def stop_zeroconf(_):
+        """Stop Zeroconf."""
+        zeroconf.ha_close()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_zeroconf)
+
+    return zeroconf
+
+
+class HaZeroconf(Zeroconf):
+    """Zeroconf that cannot be closed."""
+
+    def close(self):
+        """Fake method to avoid integrations closing it."""
+
+    ha_close = Zeroconf.close
+
+
 def setup(hass, config):
     """Set up Zeroconf and make Home Assistant discoverable."""
-    if DOMAIN in config and config[DOMAIN].get(CONF_DEFAULT_INTERFACE):
-        zeroconf = Zeroconf(interfaces=InterfaceChoice.Default)
-    else:
-        zeroconf = Zeroconf()
+    zeroconf = hass.data[DOMAIN] = _get_instance(
+        hass, config.get(DOMAIN, {}).get(CONF_DEFAULT_INTERFACE)
+    )
     zeroconf_name = f"{hass.config.location_name}.{ZEROCONF_TYPE}"
 
     params = {
@@ -141,12 +170,6 @@ def setup(hass, config):
 
     if HOMEKIT_TYPE not in ZEROCONF:
         ServiceBrowser(zeroconf, HOMEKIT_TYPE, handlers=[service_update])
-
-    def stop_zeroconf(_):
-        """Stop Zeroconf."""
-        zeroconf.close()
-
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_zeroconf)
 
     return True
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Zeroconf instances are expensive. @bdraco noticed that each Homekit instance has their own instance, and on big networks it's eating CPU. 

This new approach allows the zeroconf instance to be shared.

For integrations to use it, `zeroconf` needs to be in either `dependencies` or `after_dependencies` so that a user can configure the used interface.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
