### PR TITLE
Guard blowing up converting 0 mired/kelvin

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -296,18 +296,29 @@ class HueLight(LightEntity):
     @property
     def min_mireds(self):
         """Return the coldest color_temp that this light supports."""
-        if self.is_group or "ct" not in self.light.controlcapabilities:
+        if self.is_group:
             return super().min_mireds
 
-        return self.light.controlcapabilities["ct"]["min"]
+        min_mireds = self.light.controlcapabilities.get("ct", {}).get("min")
+
+        # We filter out '0' too, which can be incorrectly reported by 3rd party buls
+        if not min_mireds:
+            return super().min_mireds
+
+        return min_mireds
 
     @property
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
-        if self.is_group or "ct" not in self.light.controlcapabilities:
+        if self.is_group:
             return super().max_mireds
 
-        return self.light.controlcapabilities["ct"]["max"]
+        max_mireds = self.light.controlcapabilities.get("ct", {}).get("max")
+
+        if not max_mireds:
+            return super().max_mireds
+
+        return max_mireds
 
     @property
     def is_on(self):

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -507,15 +507,11 @@ def _get_blue(temperature: float) -> float:
 
 def color_temperature_mired_to_kelvin(mired_temperature: float) -> float:
     """Convert absolute mired shift to degrees kelvin."""
-    if mired_temperature == 0:
-        return 0
     return math.floor(1000000 / mired_temperature)
 
 
 def color_temperature_kelvin_to_mired(kelvin_temperature: float) -> float:
     """Convert degrees kelvin to mired shift."""
-    if kelvin_temperature == 0:
-        return 0
     return math.floor(1000000 / kelvin_temperature)
 
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -507,11 +507,15 @@ def _get_blue(temperature: float) -> float:
 
 def color_temperature_mired_to_kelvin(mired_temperature: float) -> float:
     """Convert absolute mired shift to degrees kelvin."""
+    if mired_temperature == 0:
+        return 0
     return math.floor(1000000 / mired_temperature)
 
 
 def color_temperature_kelvin_to_mired(kelvin_temperature: float) -> float:
     """Convert degrees kelvin to mired shift."""
+    if kelvin_temperature == 0:
+        return 0
     return math.floor(1000000 / kelvin_temperature)
 
 

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -292,14 +292,16 @@ def test_color_temperature_mired_to_kelvin():
     """Test color_temperature_mired_to_kelvin."""
     assert color_util.color_temperature_mired_to_kelvin(40) == 25000
     assert color_util.color_temperature_mired_to_kelvin(200) == 5000
-    assert color_util.color_temperature_mired_to_kelvin(0) == 0
+    with pytest.raises(ZeroDivisionError):
+        assert color_util.color_temperature_mired_to_kelvin(0)
 
 
 def test_color_temperature_kelvin_to_mired():
     """Test color_temperature_kelvin_to_mired."""
     assert color_util.color_temperature_kelvin_to_mired(25000) == 40
     assert color_util.color_temperature_kelvin_to_mired(5000) == 200
-    assert color_util.color_temperature_kelvin_to_mired(0) == 0
+    with pytest.raises(ZeroDivisionError):
+        assert color_util.color_temperature_kelvin_to_mired(0)
 
 
 def test_returns_same_value_for_any_two_temperatures_below_1000():

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -288,28 +288,18 @@ def test_gamut():
     assert not color_util.check_valid_gamut(GAMUT_INVALID_4)
 
 
-def test_should_return_25000_kelvin_when_input_is_40_mired():
-    """Function should return 25000K if given 40 mired."""
-    kelvin = color_util.color_temperature_mired_to_kelvin(40)
-    assert kelvin == 25000
+def test_color_temperature_mired_to_kelvin():
+    """Test color_temperature_mired_to_kelvin."""
+    assert color_util.color_temperature_mired_to_kelvin(40) == 25000
+    assert color_util.color_temperature_mired_to_kelvin(200) == 5000
+    assert color_util.color_temperature_mired_to_kelvin(0) == 0
 
 
-def test_should_return_5000_kelvin_when_input_is_200_mired():
-    """Function should return 5000K if given 200 mired."""
-    kelvin = color_util.color_temperature_mired_to_kelvin(200)
-    assert kelvin == 5000
-
-
-def test_should_return_40_mired_when_input_is_25000_kelvin():
-    """Function should return 40 mired when given 25000 Kelvin."""
-    mired = color_util.color_temperature_kelvin_to_mired(25000)
-    assert mired == 40
-
-
-def test_should_return_200_mired_when_input_is_5000_kelvin():
-    """Function should return 200 mired when given 5000 Kelvin."""
-    mired = color_util.color_temperature_kelvin_to_mired(5000)
-    assert mired == 200
+def test_color_temperature_kelvin_to_mired():
+    """Test color_temperature_kelvin_to_mired."""
+    assert color_util.color_temperature_kelvin_to_mired(25000) == 40
+    assert color_util.color_temperature_kelvin_to_mired(5000) == 200
+    assert color_util.color_temperature_kelvin_to_mired(0) == 0
 
 
 def test_returns_same_value_for_any_two_temperatures_below_1000():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
No longer raise when a user is trying to convert 0 mireds to kelvin.

```txt
2020-05-05   23:00:16   ERROR  (MainThread) [ homeassistant.components.google_assistant.smart_home ] Unexpected error
Traceback (most recent call last):
  File  "/usr/src/homeassistant/homeassistant/components/google_assistant/smart_home.py" , line  57 , in _process
    result = await handler(hass, data, inputs[ 0 ].get( "payload" ))
  File  "/usr/src/homeassistant/homeassistant/components/google_assistant/smart_home.py" , line  90 , in async_devices_sync
    for entity in async_get_entities(hass,  data.config )
  File  "/usr/src/homeassistant/homeassistant/components/google_assistant/helpers.py" , line  433 , in sync_serialize
    device[ "attributes" ].update( trt.sync_attributes ())
  File  "/usr/src/homeassistant/homeassistant/components/google_assistant/trait.py" , line  338 , in sync_attributes
    attrs.get(light.ATTR_MIN_MIREDS)
  File  "/usr/src/homeassistant/homeassistant/util/color.py" , line  510 , in color_temperature_mired_to_kelvin
    return  math.floor ( 1000000  / mired_temperature)
ZeroDivisionError: division by zero
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35880
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
