### PR TITLE
Use common strings for ipp config flow

### DIFF
--- a/homeassistant/components/ipp/strings.json
+++ b/homeassistant/components/ipp/strings.json
@@ -14,7 +14,7 @@
         }
       },
       "zeroconf_confirm": {
-        "description": "[%key:common::config_flow::description::confirm_setup%]",
+        "description": "Do you want to add the printer named `{name}` to Home Assistant?",
         "title": "Discovered printer"
       }
     },

--- a/homeassistant/components/ipp/strings.json
+++ b/homeassistant/components/ipp/strings.json
@@ -14,7 +14,7 @@
         }
       },
       "zeroconf_confirm": {
-        "description": "Do you want to add the printer named `{name}` to Home Assistant?",
+        "description": "Do you want to set up {name}?",
         "title": "Discovered printer"
       }
     },

--- a/homeassistant/components/ipp/strings.json
+++ b/homeassistant/components/ipp/strings.json
@@ -6,8 +6,8 @@
         "title": "Link your printer",
         "description": "Set up your printer via Internet Printing Protocol (IPP) to integrate with Home Assistant.",
         "data": {
-          "host": "Host or IP address",
-          "port": "Port",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
           "base_path": "Relative path to the printer",
           "ssl": "Printer supports communication over SSL/TLS",
           "verify_ssl": "Printer uses a proper SSL certificate"
@@ -19,12 +19,12 @@
       }
     },
     "error": {
-      "connection_error": "Failed to connect to printer.",
+      "connection_error": "[%key:common::config_flow::error::cannot_connect%]",
       "connection_upgrade": "Failed to connect to printer. Please try again with SSL/TLS option checked."
     },
     "abort": {
-      "already_configured": "This printer is already configured.",
-      "connection_error": "Failed to connect to printer.",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "connection_error": "[%key:common::config_flow::error::cannot_connect%]",
       "connection_upgrade": "Failed to connect to printer due to connection upgrade being required.",
       "ipp_error": "Encountered IPP error.",
       "ipp_version_error": "IPP version not supported by printer.",

--- a/homeassistant/components/ipp/strings.json
+++ b/homeassistant/components/ipp/strings.json
@@ -14,7 +14,7 @@
         }
       },
       "zeroconf_confirm": {
-        "description": "Do you want to add the printer named `{name}` to Home Assistant?",
+        "description": "[%key:common::config_flow::description::confirm_setup%]",
         "title": "Discovered printer"
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
