### PR TITLE
Add validator for battery scan option

### DIFF
--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -38,8 +38,10 @@ MIN_SEEN_NEW = 5
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_TRACK_BATTERY): cv.boolean,
-        vol.Optional(CONF_TRACK_BATTERY_INTERVAL): cv.time_period,
+        vol.Optional(CONF_TRACK_BATTERY, default=False): cv.boolean,
+        vol.Optional(
+            CONF_TRACK_BATTERY_INTERVAL, default=DEFAULT_TRACK_BATTERY_INTERVAL
+        ): cv.time_period,
     }
 )
 
@@ -60,10 +62,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop)
 
-    if config.get(CONF_TRACK_BATTERY, False):
-        battery_track_interval = config.get(
-            CONF_TRACK_BATTERY_INTERVAL, DEFAULT_TRACK_BATTERY_INTERVAL
-        )
+    if config[CONF_TRACK_BATTERY]:
+        battery_track_interval = config[CONF_TRACK_BATTERY_INTERVAL]
     else:
         battery_track_interval = timedelta(0)
 

--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -5,7 +5,9 @@ import logging
 from uuid import UUID
 
 import pygatt  # pylint: disable=import-error
+import voluptuous as vol
 
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.components.device_tracker.const import (
     CONF_SCAN_INTERVAL,
     CONF_TRACK_NEW,
@@ -17,6 +19,7 @@ from homeassistant.components.device_tracker.legacy import (
     async_load_config,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time
 import homeassistant.util.dt as dt_util
 
@@ -26,11 +29,19 @@ _LOGGER = logging.getLogger(__name__)
 # Battery characteristic: 0x2a19 (https://www.bluetooth.com/specifications/gatt/characteristics/)
 BATTERY_CHARACTERISTIC_UUID = UUID("00002a19-0000-1000-8000-00805f9b34fb")
 CONF_TRACK_BATTERY = "track_battery"
+CONF_TRACK_BATTERY_INTERVAL = "track_battery_interval"
 DEFAULT_TRACK_BATTERY_INTERVAL = timedelta(days=1)
 DATA_BLE = "BLE"
 DATA_BLE_ADAPTER = "ADAPTER"
 BLE_PREFIX = "BLE_"
 MIN_SEEN_NEW = 5
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_TRACK_BATTERY): cv.boolean,
+        vol.Optional(CONF_TRACK_BATTERY_INTERVAL): cv.time_period,
+    }
+)
 
 
 def setup_scanner(hass, config, see, discovery_info=None):
@@ -49,8 +60,10 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop)
 
-    if config.get(CONF_TRACK_BATTERY):
-        battery_track_interval = DEFAULT_TRACK_BATTERY_INTERVAL
+    if config.get(CONF_TRACK_BATTERY, False):
+        battery_track_interval = config.get(
+            CONF_TRACK_BATTERY_INTERVAL, DEFAULT_TRACK_BATTERY_INTERVAL
+        )
     else:
         battery_track_interval = timedelta(0)
 


### PR DESCRIPTION
Add a validator for the track battery option.
Also add the possibility of configuring the battery scan interval.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the configuration validator for the new "Bluetooth LE battery scan" functionality. On the initial PR, the configuration was being read without any validation; now the platform schema is being extended with the right validation.

Also used the chance to add the possibility of configuring the interval to check the battery status.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
device_tracker:
  - platform: bluetooth_le_tracker
    track_battery: true
    track_battery_interval: "01:00:00"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #33222 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13397

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
