### PR TITLE
Add config options to Daikin and add support for Daikin zeroconf discovery

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -28,11 +28,18 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 COMPONENT_TYPES = ["climate", "sensor", "switch"]
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {vol.Optional(CONF_HOSTS, default=[]): vol.All(cv.ensure_list, [cv.string])}
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN, invalidation_version="0.112.0"),
+        {
+            DOMAIN: vol.Schema(
+                {
+                    vol.Optional(CONF_HOSTS, default=[]): vol.All(
+                        cv.ensure_list, [cv.string]
+                    )
+                }
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -63,6 +63,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     conf = entry.data
     daikin_api = await daikin_api_setup(
         hass,
+        entry,
         conf[CONF_HOST],
         conf.get(CONF_KEY),
         conf.get(CONF_UUID),
@@ -92,7 +93,7 @@ async def async_unload_entry(hass, config_entry):
     return True
 
 
-async def daikin_api_setup(hass, host, key, uuid, password):
+async def daikin_api_setup(hass, entry, host, key, uuid, password):
     """Create a Daikin instance only once."""
 
     session = hass.helpers.aiohttp_client.async_get_clientsession()
@@ -111,7 +112,7 @@ async def daikin_api_setup(hass, host, key, uuid, password):
         _LOGGER.error("Unexpected error creating device %s", host)
         return None
 
-    api = DaikinApi(device)
+    api = DaikinApi(device, entry)
 
     return api
 
@@ -119,9 +120,10 @@ async def daikin_api_setup(hass, host, key, uuid, password):
 class DaikinApi:
     """Keep the Daikin instance in one place and centralize the update."""
 
-    def __init__(self, device: Appliance):
+    def __init__(self, device: Appliance, entry: ConfigEntry):
         """Initialize the Daikin Handle."""
         self.device = device
+        self.entry = entry
         self.name = device.values.get("name", "Daikin AC")
         self.ip_address = device.device_ip
         self._available = True

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -32,6 +32,7 @@ from .const import (
     ATTR_STATE_OFF,
     ATTR_STATE_ON,
     ATTR_TARGET_TEMPERATURE,
+    CONF_TEMPERATURE_STEPS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -130,7 +131,9 @@ class DaikinClimate(ClimateEntity):
             # temperature
             elif attr == ATTR_TEMPERATURE:
                 try:
-                    values[HA_ATTR_TO_DAIKIN[ATTR_TARGET_TEMPERATURE]] = str(int(value))
+                    values[HA_ATTR_TO_DAIKIN[ATTR_TARGET_TEMPERATURE]] = str(
+                        float(value)
+                    )
                 except ValueError:
                     _LOGGER.error("Invalid temperature %s", value)
 
@@ -170,6 +173,8 @@ class DaikinClimate(ClimateEntity):
     @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
+        if self._api.entry.options.get(CONF_TEMPERATURE_STEPS):
+            return 0.5
         return 1
 
     async def async_set_temperature(self, **kwargs):

--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -62,6 +62,7 @@ SENSOR_TYPES = {
 CONF_KEY = "key"
 CONF_UUID = "uuid"
 
+CONF_TEMPERATURE_STEPS = "temperature_steps"
 KEY_MAC = "mac"
 KEY_IP = "ip"
 

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -3,7 +3,7 @@
   "name": "Daikin AC",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
-  "requirements": ["pydaikin==2.0.1"],
+  "requirements": ["pydaikin==2.0.2"],
   "codeowners": ["@fredrike"],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/daikin",
   "requirements": ["pydaikin==2.0.2"],
   "codeowners": ["@fredrike"],
+  "zeroconf": ["_dkapi._tcp.local."],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/daikin/strings.json
+++ b/homeassistant/components/daikin/strings.json
@@ -1,4 +1,14 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure options for Daikin",
+        "data": {
+          "temperature_steps": "Use 0.5 steps for target temperature (default is 1.0)."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/homeassistant/components/daikin/strings.json
+++ b/homeassistant/components/daikin/strings.json
@@ -13,7 +13,7 @@
     "step": {
       "user": {
         "title": "Configure Daikin AC",
-        "description": "Enter IP address of your Daikin AC.",
+        "description": "Enter IP address of your Daikin AC.\n\nNote that [%key:common::config_flow::data::api_key%] and [%key:common::config_flow::data::password%] are used by BRP072Cxx and SKYFi devices respectively.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "key": "[%key:common::config_flow::data::api_key%]",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -12,6 +12,7 @@ ZEROCONF = {
     ],
     "_daap._tcp.local.": [
         "forked_daapd"
+    ],
     "_dkapi._tcp.local.": [
         "daikin"
     ],

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -12,6 +12,8 @@ ZEROCONF = {
     ],
     "_daap._tcp.local.": [
         "forked_daapd"
+    "_dkapi._tcp.local.": [
+        "daikin"
     ],
     "_elg._tcp.local.": [
         "elgato"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1263,7 +1263,7 @@ pycsspeechtts==1.0.3
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-pydaikin==2.0.1
+pydaikin==2.0.2
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -539,7 +539,7 @@ pychromecast==5.2.0
 pycoolmasternet==0.0.4
 
 # homeassistant.components.daikin
-pydaikin==2.0.1
+pydaikin==2.0.2
 
 # homeassistant.components.deconz
 pydeconz==70

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -6,8 +6,13 @@ from aiohttp import ClientError
 from aiohttp.web_exceptions import HTTPForbidden
 import pytest
 
-from homeassistant.components.daikin import config_flow
 from homeassistant.components.daikin.const import KEY_IP, KEY_MAC
+from homeassistant.config_entries import (
+    SOURCE_DISCOVERY,
+    SOURCE_IMPORT,
+    SOURCE_USER,
+    SOURCE_ZEROCONF,
+)
 from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -20,13 +25,6 @@ from tests.common import MockConfigEntry
 
 MAC = "AABBCCDDEEFF"
 HOST = "127.0.0.1"
-
-
-def init_config_flow(hass):
-    """Init a configuration flow."""
-    flow = config_flow.FlowHandler()
-    flow.hass = hass
-    return flow
 
 
 @pytest.fixture
@@ -45,13 +43,16 @@ def mock_daikin():
 
 async def test_user(hass, mock_daikin):
     """Test user config."""
-    flow = init_config_flow(hass)
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_USER},
+    )
 
-    result = await flow.async_step_user()
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    result = await flow.async_step_user({CONF_HOST: HOST})
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_USER}, data={CONF_HOST: HOST},
+    )
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
@@ -60,23 +61,26 @@ async def test_user(hass, mock_daikin):
 
 async def test_abort_if_already_setup(hass, mock_daikin):
     """Test we abort if Daikin is already setup."""
-    flow = init_config_flow(hass)
-    MockConfigEntry(domain="daikin", data={KEY_MAC: MAC}).add_to_hass(hass)
+    MockConfigEntry(domain="daikin", unique_id=MAC).add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_USER}, data={CONF_HOST: HOST, KEY_MAC: MAC},
+    )
 
-    result = await flow.async_step_user({CONF_HOST: HOST})
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
 
 
 async def test_import(hass, mock_daikin):
     """Test import step."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_import({})
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_IMPORT}, data={},
+    )
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    result = await flow.async_step_import({CONF_HOST: HOST})
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_IMPORT}, data={CONF_HOST: HOST},
+    )
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
@@ -85,9 +89,11 @@ async def test_import(hass, mock_daikin):
 
 async def test_discovery(hass, mock_daikin):
     """Test discovery step."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_discovery({KEY_IP: HOST, KEY_MAC: MAC})
+    result = await hass.config_entries.flow.async_init(
+        "daikin",
+        context={"source": SOURCE_DISCOVERY},
+        data={KEY_IP: HOST, KEY_MAC: MAC},
+    )
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
@@ -105,10 +111,28 @@ async def test_discovery(hass, mock_daikin):
 )
 async def test_device_abort(hass, mock_daikin, s_effect, reason):
     """Test device abort."""
-    flow = init_config_flow(hass)
     mock_daikin.factory.side_effect = s_effect
 
-    result = await flow.async_step_user({CONF_HOST: HOST})
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_USER}, data={CONF_HOST: HOST, KEY_MAC: MAC},
+    )
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {"base": reason}
     assert result["step_id"] == "user"
+
+
+async def test_zeroconf(hass, mock_daikin):
+    """Test zeroconf step."""
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_ZEROCONF}, data={},
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_init(
+        "daikin", context={"source": SOURCE_ZEROCONF}, data={CONF_HOST: HOST},
+    )
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == HOST
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][KEY_MAC] == MAC


### PR DESCRIPTION
## Description:
Multiple fixes in one PR.

- Some (but not all) Daikin units supports Target Temp in 0.5 steps, this adds an option for setting that.
- Deprecated yaml support (just warning).
- Add support for zeroconf of some Daikin units.

**Related issue (if applicable):** fixes #35414, #34551, #35715

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#13199

## Example entry for `configuration.yaml` (if applicable):

--yaml is deprecated 😄 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
    - I don't think that is applicable anymore.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
    - I'm not sure if we need to test options..

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
