### PR TITLE
Fix bsblan get key CONF_PASSKEY

### DIFF
--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -36,7 +36,7 @@ class BSBLanFlowHandler(ConfigFlow, domain=DOMAIN):
             info = await self._get_bsblan_info(
                 host=user_input[CONF_HOST],
                 port=user_input[CONF_PORT],
-                passkey=user_input.get(CONF_PASSKEY, None),
+                passkey=user_input.get(CONF_PASSKEY),
             )
         except BSBLanError:
             return self._show_setup_form({"base": "connection_error"})
@@ -50,7 +50,7 @@ class BSBLanFlowHandler(ConfigFlow, domain=DOMAIN):
             data={
                 CONF_HOST: user_input[CONF_HOST],
                 CONF_PORT: user_input[CONF_PORT],
-                CONF_PASSKEY: user_input.get(CONF_PASSKEY, None),
+                CONF_PASSKEY: user_input.get(CONF_PASSKEY),
                 CONF_DEVICE_IDENT: info.device_identification,
             },
         )

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -36,7 +36,7 @@ class BSBLanFlowHandler(ConfigFlow, domain=DOMAIN):
             info = await self._get_bsblan_info(
                 host=user_input[CONF_HOST],
                 port=user_input[CONF_PORT],
-                passkey=user_input[CONF_PASSKEY],
+                passkey=user_input.get(CONF_PASSKEY, None),
             )
         except BSBLanError:
             return self._show_setup_form({"base": "connection_error"})
@@ -50,7 +50,7 @@ class BSBLanFlowHandler(ConfigFlow, domain=DOMAIN):
             data={
                 CONF_HOST: user_input[CONF_HOST],
                 CONF_PORT: user_input[CONF_PORT],
-                CONF_PASSKEY: user_input[CONF_PASSKEY],
+                CONF_PASSKEY: user_input.get(CONF_PASSKEY, None),
                 CONF_DEVICE_IDENT: info.device_identification,
             },
         )
@@ -63,7 +63,7 @@ class BSBLanFlowHandler(ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_HOST): str,
                     vol.Optional(CONF_PORT, default=80): int,
-                    vol.Optional(CONF_PASSKEY, default=""): str,
+                    vol.Optional(CONF_PASSKEY): str,
                 }
             ),
             errors=errors or {},


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

  The code didn't work without passkey. Changed the 
`user_input[passkey]` instead `user_input.get(CONF_PASSKEY, None)`



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
