### PR TITLE
Code conformance and sensor value clean-up on ISY994

### DIFF
--- a/homeassistant/components/isy994/binary_sensor.py
+++ b/homeassistant/components/isy994/binary_sensor.py
@@ -24,7 +24,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.typing import HomeAssistantType
@@ -136,7 +135,7 @@ async def async_setup_entry(
             # the initial state is forced "OFF"/"NORMAL" if the
             # parent device has a valid state. This is corrected
             # upon connection to the ISY event stream if subnode has a valid state.
-            initial_state = None if parent_device.state == STATE_UNKNOWN else False
+            initial_state = None if parent_device.state is None else False
             if subnode_id == SUBNODE_DUSK_DAWN:
                 # Subnode 2 is the Dusk/Dawn sensor
                 device = ISYInsteonBinarySensorEntity(node, DEVICE_CLASS_LIGHT)
@@ -216,18 +215,10 @@ class ISYBinarySensorEntity(ISYNodeEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        """Get whether the ISY994 binary sensor device is on.
-
-        Note: This method will return false if the current state is UNKNOWN
-        """
-        return bool(self.value)
-
-    @property
-    def state(self):
-        """Return the state of the binary sensor."""
-        if self.value == ISY_VALUE_UNKNOWN:
-            return STATE_UNKNOWN
-        return STATE_ON if self.is_on else STATE_OFF
+        """Get whether the ISY994 binary sensor device is on."""
+        if self._node.status == ISY_VALUE_UNKNOWN:
+            return None
+        return bool(self._node.status)
 
     @property
     def device_class(self) -> str:
@@ -354,8 +345,8 @@ class ISYInsteonBinarySensorEntity(ISYBinarySensorEntity):
             self._heartbeat()
 
     @property
-    def value(self) -> object:
-        """Get the current value of the device.
+    def is_on(self) -> bool:
+        """Get whether the ISY994 binary sensor device is on.
 
         Insteon leak sensors set their primary node to On when the state is
         DRY, not WET, so we invert the binary state if the user indicates
@@ -369,13 +360,6 @@ class ISYInsteonBinarySensorEntity(ISYBinarySensorEntity):
             return not self._computed_state
 
         return self._computed_state
-
-    @property
-    def state(self):
-        """Return the state of the binary sensor."""
-        if self._computed_state is None:
-            return STATE_UNKNOWN
-        return STATE_ON if self.is_on else STATE_OFF
 
 
 class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity):
@@ -394,7 +378,7 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity):
         self._parent_device = parent_device
         self._heartbeat_timer = None
         self._computed_state = None
-        if self.state != STATE_UNKNOWN:
+        if self.state is None:
             self._computed_state = False
 
     async def async_added_to_hass(self) -> None:
@@ -460,24 +444,14 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity):
         """
 
     @property
-    def value(self) -> object:
-        """Get the current value of this sensor."""
-        return self._computed_state
-
-    @property
     def is_on(self) -> bool:
         """Get whether the ISY994 binary sensor device is on.
 
         Note: This method will return false if the current state is UNKNOWN
+        which occurs after a restart until the first heartbeat or control
+        parent control event is received.
         """
-        return bool(self.value)
-
-    @property
-    def state(self):
-        """Return the state of the binary sensor."""
-        if self._computed_state is None:
-            return None
-        return STATE_ON if self.is_on else STATE_OFF
+        return bool(self._computed_state)
 
     @property
     def device_class(self) -> str:
@@ -502,4 +476,4 @@ class ISYBinarySensorProgramEntity(ISYProgramEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 binary sensor device is on."""
-        return bool(self.value)
+        return bool(self._node.status)

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -301,6 +301,8 @@ UOM_HVAC_ACTIONS = "66"
 UOM_HVAC_MODE_GENERIC = "67"
 UOM_HVAC_MODE_INSTEON = "98"
 UOM_FAN_MODES = "99"
+UOM_INDEX = "25"
+UOM_ON_OFF = "2"
 
 UOM_FRIENDLY_NAME = {
     "1": "A",
@@ -324,7 +326,7 @@ UOM_FRIENDLY_NAME = {
     "22": "%RH",
     "23": PRESSURE_INHG,
     "24": f"{LENGTH_INCHES}/{TIME_HOURS}",
-    "25": "index",
+    UOM_INDEX: "",  # Index type. Use "node.formatted" for value
     "26": TEMP_KELVIN,
     "27": "keyword",
     "28": MASS_KILOGRAMS,
@@ -383,7 +385,7 @@ UOM_FRIENDLY_NAME = {
     "91": DEGREE,
     "92": f"{DEGREE} South",
     "100": "",  # Range 0-255, no unit.
-    "101": f"{DEGREE} (x2)",
+    UOM_DOUBLE_TEMP: f"{DEGREE} (x2)",
     "102": "kWs",
     "103": "$",
     "104": "¢",
@@ -398,7 +400,7 @@ UOM_FRIENDLY_NAME = {
     "113": "",  # raw 3-byte signed value
     "114": "",  # raw 4-byte signed value
     "116": LENGTH_MILES,
-    "117": "mb",
+    "117": "mbar",
     "118": "hPa",
     "119": f"{POWER_WATT}{TIME_HOURS}",
     "120": f"{LENGTH_INCHES}/{TIME_DAYS}",

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -326,7 +326,7 @@ UOM_FRIENDLY_NAME = {
     "22": "%RH",
     "23": PRESSURE_INHG,
     "24": f"{LENGTH_INCHES}/{TIME_HOURS}",
-    UOM_INDEX: "",  # Index type. Use "node.formatted" for value
+    UOM_INDEX: "index",  # Index type. Use "node.formatted" for value
     "26": TEMP_KELVIN,
     "27": "keyword",
     "28": MASS_KILOGRAMS,
@@ -385,7 +385,7 @@ UOM_FRIENDLY_NAME = {
     "91": DEGREE,
     "92": f"{DEGREE} South",
     "100": "",  # Range 0-255, no unit.
-    UOM_DOUBLE_TEMP: f"{DEGREE} (x2)",
+    UOM_DOUBLE_TEMP: UOM_DOUBLE_TEMP,
     "102": "kWs",
     "103": "$",
     "104": "¢",

--- a/homeassistant/components/isy994/cover.py
+++ b/homeassistant/components/isy994/cover.py
@@ -5,16 +5,9 @@ from pyisy.constants import ISY_VALUE_UNKNOWN
 
 from homeassistant.components.cover import DOMAIN as COVER, CoverEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNKNOWN
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import (
-    _LOGGER,
-    DOMAIN as ISY994_DOMAIN,
-    ISY994_NODES,
-    ISY994_PROGRAMS,
-    UOM_TO_STATES,
-)
+from .const import _LOGGER, DOMAIN as ISY994_DOMAIN, ISY994_NODES, ISY994_PROGRAMS
 from .entity import ISYNodeEntity, ISYProgramEntity
 from .helpers import migrate_old_unique_ids
 from .services import async_setup_device_services
@@ -45,21 +38,16 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
     @property
     def current_cover_position(self) -> int:
         """Return the current cover position."""
-        if self.value in [None, ISY_VALUE_UNKNOWN]:
-            return STATE_UNKNOWN
-        return sorted((0, self.value, 100))[1]
+        if self._node.status == ISY_VALUE_UNKNOWN:
+            return None
+        return sorted((0, self._node.status, 100))[1]
 
     @property
     def is_closed(self) -> bool:
         """Get whether the ISY994 cover device is closed."""
-        return self.state == STATE_CLOSED
-
-    @property
-    def state(self) -> str:
-        """Get the state of the ISY994 cover device."""
-        if self.value == ISY_VALUE_UNKNOWN:
-            return STATE_UNKNOWN
-        return UOM_TO_STATES["97"].get(self.value, STATE_OPEN)
+        if self._node.status == ISY_VALUE_UNKNOWN:
+            return None
+        return self._node.status == 0
 
     def open_cover(self, **kwargs) -> None:
         """Send the open cover command to the ISY994 cover device."""
@@ -76,9 +64,9 @@ class ISYCoverProgramEntity(ISYProgramEntity, CoverEntity):
     """Representation of an ISY994 cover program."""
 
     @property
-    def state(self) -> str:
-        """Get the state of the ISY994 cover program."""
-        return STATE_CLOSED if bool(self.value) else STATE_OPEN
+    def is_closed(self) -> bool:
+        """Get whether the ISY994 cover program is closed."""
+        return bool(self._node.status)
 
     def open_cover(self, **kwargs) -> None:
         """Send the open cover command to the ISY994 cover program."""

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -4,13 +4,12 @@ from pyisy.constants import (
     COMMAND_FRIENDLY_NAME,
     EMPTY_TIME,
     EVENT_PROPS_IGNORED,
-    ISY_VALUE_UNKNOWN,
     PROTO_GROUP,
     PROTO_ZWAVE,
 )
 from pyisy.helpers import NodeProperty
 
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import Dict
 
@@ -51,7 +50,7 @@ class ISYEntity(Entity):
             "precision": event.prec,
         }
 
-        if event.value is None or event.control not in EVENT_PROPS_IGNORED:
+        if event.control not in EVENT_PROPS_IGNORED:
             # New state attributes may be available, update the state.
             self.schedule_update_ha_state()
 
@@ -127,18 +126,6 @@ class ISYEntity(Entity):
     def should_poll(self) -> bool:
         """No polling required since we're using the subscription."""
         return False
-
-    @property
-    def value(self) -> int:
-        """Get the current value of the device."""
-        return self._node.status
-
-    @property
-    def state(self):
-        """Return the state of the ISY device."""
-        if self.value == ISY_VALUE_UNKNOWN:
-            return STATE_UNKNOWN
-        return super().state
 
 
 class ISYNodeEntity(ISYEntity):

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -1,6 +1,8 @@
 """Support for ISY994 fans."""
 from typing import Callable
 
+from pyisy.constants import ISY_VALUE_UNKNOWN
+
 from homeassistant.components.fan import (
     DOMAIN as FAN,
     SPEED_HIGH,
@@ -58,12 +60,14 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
     @property
     def speed(self) -> str:
         """Return the current speed."""
-        return VALUE_TO_STATE.get(self.value)
+        return VALUE_TO_STATE.get(self._node.status)
 
     @property
     def is_on(self) -> bool:
         """Get if the fan is on."""
-        return self.value != 0
+        if self._node.status == ISY_VALUE_UNKNOWN:
+            return None
+        return self._node.status != 0
 
     def set_speed(self, speed: str) -> None:
         """Send the set speed command to the ISY994 fan device."""
@@ -94,12 +98,12 @@ class ISYFanProgramEntity(ISYProgramEntity, FanEntity):
     @property
     def speed(self) -> str:
         """Return the current speed."""
-        return VALUE_TO_STATE.get(self.value)
+        return VALUE_TO_STATE.get(self._node.status)
 
     @property
     def is_on(self) -> bool:
         """Get if the fan is on."""
-        return self.value != 0
+        return self._node.status != 0
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn on command to ISY994 fan program."""

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -9,7 +9,6 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -58,14 +57,16 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 light is on."""
-        if self.value == ISY_VALUE_UNKNOWN:
+        if self._node.status == ISY_VALUE_UNKNOWN:
             return False
-        return int(self.value) != 0
+        return int(self._node.status) != 0
 
     @property
     def brightness(self) -> float:
         """Get the brightness of the ISY994 light."""
-        return STATE_UNKNOWN if self.value == ISY_VALUE_UNKNOWN else int(self.value)
+        if self._node.status == ISY_VALUE_UNKNOWN:
+            return None
+        return int(self._node.status)
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""
@@ -75,8 +76,8 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
 
     def on_update(self, event: object) -> None:
         """Save brightness in the update event from the ISY994 Node."""
-        if self.value not in (0, ISY_VALUE_UNKNOWN):
-            self._last_brightness = self.value
+        if self._node.status not in (0, ISY_VALUE_UNKNOWN):
+            self._last_brightness = self._node.status
         super().on_update(event)
 
     # pylint: disable=arguments-differ

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -47,7 +47,7 @@ class ISYSensorEntity(ISYNodeEntity):
     """Representation of an ISY994 sensor device."""
 
     @property
-    def get_raw_unit_of_measurement(self) -> Union[dict, str]:
+    def raw_unit_of_measurement(self) -> Union[dict, str]:
         """Get the raw unit of measurement for the ISY994 sensor device."""
         uom = self._node.uom
 
@@ -70,7 +70,7 @@ class ISYSensorEntity(ISYNodeEntity):
             return None
 
         # Get the translated ISY Unit of Measurement
-        uom = self.get_raw_unit_of_measurement
+        uom = self.raw_unit_of_measurement
 
         # Check if this is a known index pair UOM
         if isinstance(uom, dict):
@@ -88,7 +88,7 @@ class ISYSensorEntity(ISYNodeEntity):
     @property
     def unit_of_measurement(self) -> str:
         """Get the Home Assistant unit of measurement for the device."""
-        raw_units = self.get_raw_unit_of_measurement
+        raw_units = self.raw_unit_of_measurement
         # Check if this is a known index pair UOM
         if isinstance(raw_units, dict):
             return None

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -46,9 +46,8 @@ async def async_setup_entry(
 class ISYSensorEntity(ISYNodeEntity):
     """Representation of an ISY994 sensor device."""
 
-    def get_raw_unit_of_measurement(
-        self, allow_special: bool = False
-    ) -> Union[dict, str]:
+    @property
+    def get_raw_unit_of_measurement(self) -> Union[dict, str]:
         """Get the raw unit of measurement for the ISY994 sensor device."""
         uom = self._node.uom
 
@@ -59,7 +58,7 @@ class ISYSensorEntity(ISYNodeEntity):
         # Special cases for ISY UOM index units:
         isy_states = UOM_TO_STATES.get(uom)
         if isy_states:
-            return isy_states if allow_special else None
+            return isy_states
 
         return UOM_FRIENDLY_NAME.get(uom)
 
@@ -71,7 +70,7 @@ class ISYSensorEntity(ISYNodeEntity):
             return None
 
         # Get the translated ISY Unit of Measurement
-        uom = self.get_raw_unit_of_measurement(allow_special=True)
+        uom = self.get_raw_unit_of_measurement
 
         # Check if this is a known index pair UOM
         if isinstance(uom, dict):
@@ -89,7 +88,10 @@ class ISYSensorEntity(ISYNodeEntity):
     @property
     def unit_of_measurement(self) -> str:
         """Get the Home Assistant unit of measurement for the device."""
-        raw_units = self.get_raw_unit_of_measurement()
+        raw_units = self.get_raw_unit_of_measurement
+        # Check if this is a known index pair UOM
+        if isinstance(raw_units, dict):
+            return None
         if raw_units in (TEMP_FAHRENHEIT, TEMP_CELSIUS, UOM_DOUBLE_TEMP):
             return self.hass.config.units.temperature_unit
         return raw_units

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -5,7 +5,6 @@ from pyisy.constants import ISY_VALUE_UNKNOWN, PROTO_GROUP
 
 from homeassistant.components.switch import DOMAIN as SWITCH, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import _LOGGER, DOMAIN as ISY994_DOMAIN, ISY994_NODES, ISY994_PROGRAMS
@@ -39,9 +38,9 @@ class ISYSwitchEntity(ISYNodeEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 device is in the on state."""
-        if self.value == ISY_VALUE_UNKNOWN:
-            return STATE_UNKNOWN
-        return bool(self.value)
+        if self._node.status == ISY_VALUE_UNKNOWN:
+            return None
+        return bool(self._node.status)
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 switch."""
@@ -67,7 +66,7 @@ class ISYSwitchProgramEntity(ISYProgramEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 switch program is on."""
-        return bool(self.value)
+        return bool(self._node.status)
 
     def turn_on(self, **kwargs) -> None:
         """Send the turn on command to the ISY994 switch program."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is the final planned PR in a series to include migration to PyISYv2 and "modernization" of the isy994 integration based on testing done over the past year in the HACS custom component.

Full migration plan is captured in PR #35212

This PR is focused on Home Assistant code conformance cleanups, as well as simplification of `sensor` value and unit of measurement handling.

#### Code Clean-up

- Move common ISY value conversion function to `helpers.py` for `climate` and `sensor` platforms to share; also standardize the method for converting to float from the ISY's `integer * 10^-precision` value.
- Update all platforms to not overload the default `state` method for the Component. Instead overload the preferred method (e.g. `is_on`, `is_locked`, `is_closed`).
- Remove legacy `value` type-conversion method in base classes, since PyISY now makes sure `node.status` is an integer type.
- Remove outdated and now-useless call to `self._node.update(0.5)`, since the connection uses the ISY's Event Stream, this function doesn't do anything anymore.
- Use `None` for unknown status on all platforms.

#### Sensors' UOMs and States:

- Fix temperature not being converted if value was an integer (unreported issue) and conversion of Insteon's double-temp-halves-precision unit.
- Consolidate UOM dictionary look-ups into one function and minimize number of calls.
- Convert ISY's key:state pairs to states better.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #35212
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] N/A this change

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

Tag: @bdraco @OverloadUT 