### PR TITLE
Fix zwave_mqtt discovery of switch entities

### DIFF
--- a/homeassistant/components/zwave_mqtt/discovery.py
+++ b/homeassistant/components/zwave_mqtt/discovery.py
@@ -65,20 +65,6 @@ DISCOVERY_SCHEMAS = (
     },
     {  # Switch platform
         const.DISC_COMPONENT: "switch",
-        const.DISC_GENERIC_DEVICE_CLASS: (
-            const_ozw.GENERIC_TYPE_METER,
-            const_ozw.GENERIC_TYPE_SENSOR_ALARM,
-            const_ozw.GENERIC_TYPE_SENSOR_BINARY,
-            const_ozw.GENERIC_TYPE_SWITCH_BINARY,
-            const_ozw.GENERIC_TYPE_ENTRY_CONTROL,
-            const_ozw.GENERIC_TYPE_SENSOR_MULTILEVEL,
-            const_ozw.GENERIC_TYPE_SWITCH_MULTILEVEL,
-            const_ozw.GENERIC_TYPE_GENERIC_CONTROLLER,
-            const_ozw.GENERIC_TYPE_SWITCH_REMOTE,
-            const_ozw.GENERIC_TYPE_REPEATER_SLAVE,
-            const_ozw.GENERIC_TYPE_THERMOSTAT,
-            const_ozw.GENERIC_TYPE_WALL_CONTROLLER,
-        ),
         const.DISC_VALUES: {
             const.DISC_PRIMARY: {
                 const.DISC_COMMAND_CLASS: (CommandClass.SWITCH_BINARY,),


### PR DESCRIPTION
## Proposed change
Limit of device_class is redundant as we're already scoping to the Binary Switch CommandClass as primary value. The device class can be completely left out. Makes code easier to read and prevents us from updating the code everytime a new Z-Wave devicetype is invented.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
Fixes issues like these: 
https://github.com/cgarwood/homeassistant-zwave_mqtt/issues/127

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [  ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
