### PR TITLE
Ensure homekit_controller recieves zeroconf c# updates

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -178,8 +178,14 @@ def setup(hass, config):
         _LOGGER.debug("Discovered new device %s %s", name, info)
 
         # If we can handle it as a HomeKit discovery, we do that here.
-        if service_type == HOMEKIT_TYPE and handle_homekit(hass, info):
-            return
+        if service_type == HOMEKIT_TYPE:
+            handle_homekit(hass, info)
+            # Continue on here as homekit_controller
+            # still needs to get updates on devices
+            # so it can see when the 'c#' field is updated.
+            #
+            # If the device already has homekit pairings
+            # homekit_controller will ignore it.
 
         for domain in ZEROCONF[service_type]:
             hass.add_job(

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -228,7 +228,7 @@ def handle_homekit(hass, info) -> bool:
     props = info.get(HOMEKIT_PROPERTIES, {})
 
     for key in props:
-        if key.lower() in HOMEKIT_MODEL:
+        if key.lower() == HOMEKIT_MODEL:
             model = props[key]
             break
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -191,15 +191,10 @@ def setup(hass, config):
             # We only send updates to homekit_controller
             # if the device is already paired in order to avoid
             # offering a second discovery for the same device
-            _LOGGER.debug("info: %s", info)
             if (
                 HOMEKIT_PROPERTIES in info
                 and HOMEKIT_PAIRED_STATUS_FLAG in info[HOMEKIT_PROPERTIES]
             ):
-                _LOGGER.debug(
-                    "status_flag: %s",
-                    info[HOMEKIT_PROPERTIES][HOMEKIT_PAIRED_STATUS_FLAG],
-                )
                 try:
                     if not int(info[HOMEKIT_PROPERTIES][HOMEKIT_PAIRED_STATUS_FLAG]):
                         return

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -123,7 +123,8 @@ async def test_homekit_match_partial_space(hass, mock_zeroconf):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    assert len(mock_config_flow.mock_calls) == 1
+    # One call to `lifx`, one call to `homekit_controller`
+    assert len(mock_config_flow.mock_calls) == 2
     assert mock_config_flow.mock_calls[0][1][0] == "lifx"
 
 
@@ -142,7 +143,8 @@ async def test_homekit_match_partial_dash(hass, mock_zeroconf):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    assert len(mock_config_flow.mock_calls) == 1
+    # One call to `rachio`, one call to `homekit_controller`
+    assert len(mock_config_flow.mock_calls) == 2
     assert mock_config_flow.mock_calls[0][1][0] == "rachio"
 
 
@@ -159,7 +161,8 @@ async def test_homekit_match_full(hass, mock_zeroconf):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    assert len(mock_config_flow.mock_calls) == 1
+    # One call to `hue`, one call to `homekit_controller`
+    assert len(mock_config_flow.mock_calls) == 2
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
 
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -18,6 +18,9 @@ PROPERTIES = {
     NON_ASCII_KEY: None,
 }
 
+HOMEKIT_STATUS_UNPAIRED = b"0"
+HOMEKIT_STATUS_PAIRED = b"1"
+
 
 @pytest.fixture
 def mock_zeroconf():
@@ -45,8 +48,8 @@ def get_service_info_mock(service_type, name):
     )
 
 
-def get_homekit_info_mock(model):
-    """Return homekit info for get_service_info."""
+def get_homekit_info_mock(model, pairing_status):
+    """Return homekit info for get_service_info for an homekit device."""
 
     def mock_homekit_info(service_type, name):
         return ServiceInfo(
@@ -57,7 +60,7 @@ def get_homekit_info_mock(model):
             weight=0,
             priority=0,
             server="name.local.",
-            properties={b"md": model.encode()},
+            properties={b"md": model.encode(), b"sf": pairing_status},
         )
 
     return mock_homekit_info
@@ -119,12 +122,13 @@ async def test_homekit_match_partial_space(hass, mock_zeroconf):
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock("LIFX bulb")
+        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
+            "LIFX bulb", HOMEKIT_STATUS_UNPAIRED
+        )
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    # One call to `lifx`, one call to `homekit_controller`
-    assert len(mock_config_flow.mock_calls) == 2
+    assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "lifx"
 
 
@@ -138,13 +142,12 @@ async def test_homekit_match_partial_dash(hass, mock_zeroconf):
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ) as mock_service_browser:
         mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
-            "Rachio-fa46ba"
+            "Rachio-fa46ba", HOMEKIT_STATUS_UNPAIRED
         )
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    # One call to `rachio`, one call to `homekit_controller`
-    assert len(mock_config_flow.mock_calls) == 2
+    assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "rachio"
 
 
@@ -157,13 +160,58 @@ async def test_homekit_match_full(hass, mock_zeroconf):
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock("BSB002")
+        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
+            "BSB002", HOMEKIT_STATUS_UNPAIRED
+        )
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+
+    homekit_mock = get_homekit_info_mock("BSB002", HOMEKIT_STATUS_UNPAIRED)
+    info = homekit_mock("_hap._tcp.local.", "BSB002._hap._tcp.local.")
+    import pprint
+
+    pprint.pprint(["homekit", info])
+    assert len(mock_service_browser.mock_calls) == 1
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "hue"
+
+
+async def test_homekit_already_paired(hass, mock_zeroconf):
+    """Test that an already paired device is sent to homekit_controller."""
+    with patch.dict(
+        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ) as mock_service_browser:
+        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
+            "tado", HOMEKIT_STATUS_PAIRED
+        )
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(mock_service_browser.mock_calls) == 1
-    # One call to `hue`, one call to `homekit_controller`
     assert len(mock_config_flow.mock_calls) == 2
-    assert mock_config_flow.mock_calls[0][1][0] == "hue"
+    assert mock_config_flow.mock_calls[0][1][0] == "tado"
+    assert mock_config_flow.mock_calls[1][1][0] == "homekit_controller"
+
+
+async def test_homekit_invalid_paring_status(hass, mock_zeroconf):
+    """Test that missing paring data is not sent to homekit_controller."""
+    with patch.dict(
+        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ) as mock_service_browser:
+        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
+            "tado", b"invalid"
+        )
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+
+    assert len(mock_service_browser.mock_calls) == 1
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "tado"
 
 
 async def test_info_from_service_non_utf8(hass):


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
    
If an integration has a homekit config flow step
homekit_controller would not see updates for
devices that were paired with it and would not
rescan for changes.

Revision: We only send updates to homekit_controller if the
device is already paired.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35532
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
