### PR TITLE
Improve Vacuum Entity

### DIFF
--- a/homeassistant/components/demo/vacuum.py
+++ b/homeassistant/components/demo/vacuum.py
@@ -134,15 +134,11 @@ class DemoVacuum(VacuumEntity):
     @property
     def fan_speed(self):
         """Return the status of the vacuum."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
-            return
-
         return self._fan_speed
 
     @property
     def fan_speed_list(self):
         """Return the status of the vacuum."""
-        assert self.supported_features & SUPPORT_FAN_SPEED != 0
         return FAN_SPEEDS
 
     @property
@@ -297,16 +293,11 @@ class StateDemoVacuum(StateVacuumEntity):
     @property
     def fan_speed(self):
         """Return the current fan speed of the vacuum."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
-            return
-
         return self._fan_speed
 
     @property
     def fan_speed_list(self):
         """Return the list of supported fan speeds."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
-            return
         return FAN_SPEEDS
 
     @property

--- a/homeassistant/components/demo/vacuum.py
+++ b/homeassistant/components/demo/vacuum.py
@@ -279,9 +279,6 @@ class StateDemoVacuum(StateVacuumEntity):
     @property
     def battery_level(self):
         """Return the current battery level of the vacuum."""
-        if self.supported_features & SUPPORT_BATTERY == 0:
-            return
-
         return max(0, min(100, self._battery_level))
 
     @property

--- a/homeassistant/components/demo/vacuum.py
+++ b/homeassistant/components/demo/vacuum.py
@@ -126,9 +126,6 @@ class DemoVacuum(VacuumEntity):
     @property
     def status(self):
         """Return the status of the vacuum."""
-        if self.supported_features & SUPPORT_STATUS == 0:
-            return
-
         return self._status
 
     @property
@@ -144,9 +141,6 @@ class DemoVacuum(VacuumEntity):
     @property
     def battery_level(self):
         """Return the status of the vacuum."""
-        if self.supported_features & SUPPORT_BATTERY == 0:
-            return
-
         return max(0, min(100, self._battery_level))
 
     @property

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -395,33 +395,21 @@ class MqttVacuum(
     @property
     def status(self):
         """Return a status string for the vacuum."""
-        if self.supported_features & SUPPORT_STATUS == 0:
-            return None
-
         return self._status
 
     @property
     def fan_speed(self):
         """Return the status of the vacuum."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
-            return None
-
         return self._fan_speed
 
     @property
     def fan_speed_list(self):
-        """Return the status of the vacuum.
-
-        No need to check SUPPORT_FAN_SPEED, this won't be called if fan_speed is None.
-        """
+        """Return the status of the vacuum."""
         return self._fan_speed_list
 
     @property
     def battery_level(self):
         """Return the status of the vacuum."""
-        if self.supported_features & SUPPORT_BATTERY == 0:
-            return None
-
         return max(0, min(100, self._battery_level))
 
     @property

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -275,24 +275,16 @@ class MqttStateVacuum(
     @property
     def fan_speed(self):
         """Return fan speed of the vacuum."""
-        if self.supported_features & SUPPORT_FAN_SPEED == 0:
-            return None
-
         return self._state_attrs.get(FAN_SPEED, 0)
 
     @property
     def fan_speed_list(self):
-        """Return fan speed list of the vacuum.
-
-        No need to check SUPPORT_FAN_SPEED, this won't be called if fan_speed is None.
-        """
+        """Return fan speed list of the vacuum."""
         return self._fan_speed_list
 
     @property
     def battery_level(self):
         """Return battery level of the vacuum."""
-        if self.supported_features & SUPPORT_BATTERY == 0:
-            return None
         return max(0, min(100, self._state_attrs.get(BATTERY, 0)))
 
     @property

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -128,16 +128,6 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         return SUPPORT_IROBOT
 
     @property
-    def fan_speed(self):
-        """Return the fan speed of the vacuum cleaner."""
-        return None
-
-    @property
-    def fan_speed_list(self):
-        """Get the list of available fan speed steps of the vacuum cleaner."""
-        return []
-
-    @property
     def battery_level(self):
         """Return the battery level of the vacuum cleaner."""
         return self.vacuum_state.get("batPct")

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -163,6 +163,20 @@ class _BaseVacuum(Entity):
         if self.supported_features & SUPPORT_FAN_SPEED:
             return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
 
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the vacuum cleaner."""
+        data = {}
+
+        if self.battery_level is not None:
+            data[ATTR_BATTERY_LEVEL] = self.battery_level
+            data[ATTR_BATTERY_ICON] = self.battery_icon
+
+        if self.supported_features & SUPPORT_FAN_SPEED:
+            data[ATTR_FAN_SPEED] = self.fan_speed
+
+        return data
+
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
         raise NotImplementedError()
@@ -255,17 +269,10 @@ class VacuumEntity(_BaseVacuum, ToggleEntity):
     @property
     def state_attributes(self):
         """Return the state attributes of the vacuum cleaner."""
-        data = {}
+        data = super().state_attributes
 
         if self.status is not None:
             data[ATTR_STATUS] = self.status
-
-        if self.battery_level is not None:
-            data[ATTR_BATTERY_LEVEL] = self.battery_level
-            data[ATTR_BATTERY_ICON] = self.battery_icon
-
-        if self.fan_speed is not None:
-            data[ATTR_FAN_SPEED] = self.fan_speed
 
         return data
 
@@ -336,20 +343,6 @@ class StateVacuumEntity(_BaseVacuum):
         return icon_for_battery_level(
             battery_level=self.battery_level, charging=charging
         )
-
-    @property
-    def state_attributes(self):
-        """Return the state attributes of the vacuum cleaner."""
-        data = {}
-
-        if self.battery_level is not None:
-            data[ATTR_BATTERY_LEVEL] = self.battery_level
-            data[ATTR_BATTERY_ICON] = self.battery_icon
-
-        if self.fan_speed is not None:
-            data[ATTR_FAN_SPEED] = self.fan_speed
-
-        return data
 
     def start(self):
         """Start or resume the cleaning task."""

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -168,7 +168,7 @@ class _BaseVacuum(Entity):
         """Return the state attributes of the vacuum cleaner."""
         data = {}
 
-        if self.battery_level is not None:
+        if self.supported_features & SUPPORT_BATTERY:
             data[ATTR_BATTERY_LEVEL] = self.battery_level
             data[ATTR_BATTERY_ICON] = self.battery_icon
 
@@ -271,7 +271,7 @@ class VacuumEntity(_BaseVacuum, ToggleEntity):
         """Return the state attributes of the vacuum cleaner."""
         data = super().state_attributes
 
-        if self.status is not None:
+        if self.supported_features & SUPPORT_STATUS:
             data[ATTR_STATUS] = self.status
 
         return data

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -148,6 +148,11 @@ class _BaseVacuum(Entity):
         return None
 
     @property
+    def battery_icon(self):
+        """Return the battery icon for the vacuum cleaner."""
+        raise NotImplementedError()
+
+    @property
     def fan_speed(self):
         """Return the fan speed of the vacuum cleaner."""
         return None

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -348,7 +348,6 @@ class StateVacuumEntity(_BaseVacuum):
 
         if self.fan_speed is not None:
             data[ATTR_FAN_SPEED] = self.fan_speed
-            data[ATTR_FAN_SPEED_LIST] = self.fan_speed_list
 
         return data
 

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -157,6 +157,12 @@ class _BaseVacuum(Entity):
         """Get the list of available fan speed steps of the vacuum cleaner."""
         raise NotImplementedError()
 
+    @property
+    def capability_attributes(self):
+        """Return capability attributes."""
+        if self.supported_features & SUPPORT_FAN_SPEED:
+            return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
+
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
         raise NotImplementedError()
@@ -247,12 +253,6 @@ class VacuumEntity(_BaseVacuum, ToggleEntity):
         )
 
     @property
-    def capability_attributes(self):
-        """Return capability attributes."""
-        if self.supported_features & SUPPORT_FAN_SPEED:
-            return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
-
-    @property
     def state_attributes(self):
         """Return the state attributes of the vacuum cleaner."""
         data = {}
@@ -336,12 +336,6 @@ class StateVacuumEntity(_BaseVacuum):
         return icon_for_battery_level(
             battery_level=self.battery_level, charging=charging
         )
-
-    @property
-    def capability_attributes(self):
-        """Return capability attributes."""
-        if self.supported_features & SUPPORT_FAN_SPEED:
-            return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
 
     @property
     def state_attributes(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a followup to #35347.
- `state_attributes` and `capability_attributes` are moved to `_BaseVacuum`.
- `support_features` is now checked in `state_attributes` so integrations no longer need those checks in properties.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
