### PR TITLE
UniFi - Sites don't declare role on UniFiOS 1.7.0 beta

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -134,8 +134,6 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
 
                 for site in self.sites.values():
                     if desc == site["desc"]:
-                        if "role" not in site:
-                            raise NoLocalUser
                         self.config[CONF_SITE_ID] = site["name"]
                         break
 

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -32,12 +32,7 @@ from .const import (
     LOGGER,
 )
 from .controller import get_controller
-from .errors import (
-    AlreadyConfigured,
-    AuthenticationRequired,
-    CannotConnect,
-    NoLocalUser,
-)
+from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
 
 DEFAULT_PORT = 8443
 DEFAULT_SITE_ID = "default"
@@ -151,9 +146,6 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
 
             except AlreadyConfigured:
                 return self.async_abort(reason="already_configured")
-
-            except NoLocalUser:
-                return self.async_abort(reason="no_local_user")
 
         if len(self.sites) == 1:
             self.desc = next(iter(self.sites.values()))["desc"]

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -290,8 +290,10 @@ class UniFiController:
             for site in sites.values():
                 if self.site == site["name"]:
                     self._site_name = site["desc"]
-                    self._site_role = site["role"]
                     break
+
+            description = await self.api.site_description()
+            self._site_role = description[0]["site_role"]
 
         except CannotConnect:
             raise ConfigEntryNotReady

--- a/homeassistant/components/unifi/errors.py
+++ b/homeassistant/components/unifi/errors.py
@@ -22,9 +22,5 @@ class LoginRequired(UnifiException):
     """Component got logged out."""
 
 
-class NoLocalUser(UnifiException):
-    """No local user."""
-
-
 class UserLevel(UnifiException):
     """User level too low."""

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ubiquiti UniFi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": ["aiounifi==21"],
+  "requirements": ["aiounifi==22"],
   "codeowners": ["@Kane610"],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -19,8 +19,7 @@
       "unknown_client_mac": "No client available on that MAC address"
     },
     "abort": {
-      "already_configured": "Controller site is already configured",
-      "no_local_user": "No local user found, configure a local account on controller and try again"
+      "already_configured": "Controller site is already configured"
     }
   },
   "options": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -221,7 +221,7 @@ aiopylgtv==0.3.3
 aioswitcher==1.1.0
 
 # homeassistant.components.unifi
-aiounifi==21
+aiounifi==22
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -107,7 +107,7 @@ aiopylgtv==0.3.3
 aioswitcher==1.1.0
 
 # homeassistant.components.unifi
-aiounifi==21
+aiounifi==22
 
 # homeassistant.components.wwlln
 aiowwlln==2.0.2

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -222,52 +222,6 @@ async def test_flow_fails_site_already_configured(hass, aioclient_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_flow_fails_site_has_no_local_user(hass, aioclient_mock):
-    """Test config flow."""
-    entry = MockConfigEntry(
-        domain=UNIFI_DOMAIN, data={"controller": {"host": "1.2.3.4", "site": "site_id"}}
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        UNIFI_DOMAIN, context={"source": "user"}
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    aioclient_mock.get("https://1.2.3.4:1234", status=302)
-
-    aioclient_mock.post(
-        "https://1.2.3.4:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": "application/json"},
-    )
-
-    aioclient_mock.get(
-        "https://1.2.3.4:1234/api/self/sites",
-        json={
-            "data": [{"desc": "Site name", "name": "site_id"}],
-            "meta": {"rc": "ok"},
-        },
-        headers={"content-type": "application/json"},
-    )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_HOST: "1.2.3.4",
-            CONF_USERNAME: "username",
-            CONF_PASSWORD: "password",
-            CONF_PORT: 1234,
-            CONF_VERIFY_SSL: True,
-        },
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "no_local_user"
-
-
 async def test_flow_fails_user_credentials_faulty(hass, aioclient_mock):
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -66,6 +66,7 @@ ENTRY_OPTIONS = {}
 CONFIGURATION = []
 
 SITES = {"Site name": {"desc": "Site name", "name": "site_id", "role": "admin"}}
+DESCRIPTION = [{"name": "username", "site_name": "site_id", "site_role": "admin"}]
 
 
 async def setup_unifi_integration(
@@ -73,6 +74,7 @@ async def setup_unifi_integration(
     config=ENTRY_CONFIG,
     options=ENTRY_OPTIONS,
     sites=SITES,
+    site_description=DESCRIPTION,
     clients_response=None,
     devices_response=None,
     clients_all_response=None,
@@ -130,6 +132,8 @@ async def setup_unifi_integration(
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(
         "aiounifi.Controller.login", return_value=True,
     ), patch("aiounifi.Controller.sites", return_value=sites), patch(
+        "aiounifi.Controller.site_description", return_value=site_description
+    ), patch(
         "aiounifi.Controller.request", new=mock_request
     ), patch.object(
         aiounifi.websocket.WSClient, "start", return_value=True

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -19,8 +19,8 @@ from homeassistant.setup import async_setup_component
 
 from .test_controller import (
     CONTROLLER_HOST,
+    DESCRIPTION,
     ENTRY_CONFIG,
-    SITES,
     setup_unifi_integration,
 )
 
@@ -289,12 +289,12 @@ async def test_controller_not_client(hass):
 
 async def test_not_admin(hass):
     """Test that switch platform only work on an admin account."""
-    sites = deepcopy(SITES)
-    sites["Site name"]["role"] = "not admin"
+    description = deepcopy(DESCRIPTION)
+    description[0]["site_role"] = "not admin"
     controller = await setup_unifi_integration(
         hass,
         options={CONF_TRACK_CLIENTS: False, CONF_TRACK_DEVICES: False},
-        sites=sites,
+        site_description=description,
         clients_response=[CLIENT_1],
         devices_response=[DEVICE_1],
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Site call no longer declare user role from UniFiOS 1.7.0 beta
Site description gives all the proper data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35508
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
