### PR TITLE
Fix command line sensors removing quotes with template

### DIFF
--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -3,7 +3,6 @@ from collections.abc import Mapping
 from datetime import timedelta
 import json
 import logging
-import shlex
 import subprocess
 
 import voluptuous as vol
@@ -171,7 +170,7 @@ class CommandSensorData:
             pass
         else:
             # Template used. Construct the string used in the shell
-            command = str(" ".join([prog] + shlex.split(rendered_args)))
+            command = f"{prog} {rendered_args}"
         try:
             _LOGGER.debug("Running command: %s", command)
             return_value = subprocess.check_output(

--- a/tests/components/command_line/n_args.sh
+++ b/tests/components/command_line/n_args.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $#

--- a/tests/components/command_line/n_args.sh
+++ b/tests/components/command_line/n_args.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo $#

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -81,7 +81,7 @@ class TestCommandSensorSensor(unittest.TestCase):
             return_value=b"Works\n",
         ) as check_output:
             data = command_line.CommandSensorData(
-                self.hass, 'echo "{{{{ states.sensor.test_state.state }}}}" "3 4"', 15,
+                self.hass, 'echo "{{ states.sensor.test_state.state }}" "3 4"', 15,
             )
             data.update()
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -81,7 +81,7 @@ class TestCommandSensorSensor(unittest.TestCase):
             return_value=b"Works\n",
         ) as check_output:
             data = command_line.CommandSensorData(
-                self.hass, f'echo "{{{{ states.sensor.test_state.state }}}}" "3 4"', 15,
+                self.hass, 'echo "{{{{ states.sensor.test_state.state }}}}" "3 4"', 15,
             )
             data.update()
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Command line sensor platform."""
+import os
 import unittest
 
 from homeassistant.components.command_line import sensor as command_line
@@ -72,6 +73,19 @@ class TestCommandSensorSensor(unittest.TestCase):
         data.update()
 
         assert data.value == "Works"
+
+    def test_template_render_with_quote(self):
+        """Ensure command with templates and quotes get rendered properly."""
+        self.hass.states.set("sensor.test_state", "Works 2")
+        script_path = os.path.abspath(os.path.join(__file__, "../n_args.sh"))
+        data = command_line.CommandSensorData(
+            self.hass,
+            f'bash {script_path} "{{{{ states.sensor.test_state.state }}}}" "3 4"',
+            15,
+        )
+        data.update()
+
+        assert data.value == "2"
 
     def test_bad_command(self):
         """Test bad command."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the problem that command line sensors remove quotes in arguments when there is a template rendering.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #20483
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
