### PR TITLE
Fix zwave_mqtt creating the device name

### DIFF
--- a/homeassistant/components/zwave_mqtt/entity.py
+++ b/homeassistant/components/zwave_mqtt/entity.py
@@ -265,15 +265,20 @@ class ZWaveDeviceEntity(Entity):
 
 def create_device_name(node: OZWNode):
     """Generate sensible (short) default device name from a OZWNode."""
-    if node.meta_data["Name"]:
-        dev_name = node.meta_data["Name"]
-    elif node.node_product_name:
-        dev_name = node.node_product_name
-    elif node.node_device_type_string:
-        dev_name = node.node_device_type_string
-    else:
-        dev_name = node.specific_string
-    return dev_name
+    # Prefer custom name set by OZWAdmin if present
+    if node.node_name:
+        return node.node_name
+    # Prefer short devicename from metedata if present
+    if node.meta_data and node.meta_data.get("Name"):
+        return node.meta_data["Name"]
+    # Fallback to productname or devicetype
+    if node.node_product_name:
+        return node.node_product_name
+    if node.node_device_type_string:
+        return node.node_device_type_string
+    if node.node_specific_string:
+        return node.node_specific_string
+    return f"Node {node.id}"
 
 
 def create_device_id(node: OZWNode, node_instance: int = 1):

--- a/homeassistant/components/zwave_mqtt/entity.py
+++ b/homeassistant/components/zwave_mqtt/entity.py
@@ -268,16 +268,17 @@ def create_device_name(node: OZWNode):
     # Prefer custom name set by OZWAdmin if present
     if node.node_name:
         return node.node_name
-    # Prefer short devicename from metedata if present
+    # Prefer short devicename from metadata if present
     if node.meta_data and node.meta_data.get("Name"):
         return node.meta_data["Name"]
-    # Fallback to productname or devicetype
+    # Fallback to productname or devicetype strings
     if node.node_product_name:
         return node.node_product_name
     if node.node_device_type_string:
         return node.node_device_type_string
     if node.node_specific_string:
         return node.node_specific_string
+    # Last resort: use Node id (should never happen, but just in case)
     return f"Node {node.id}"
 
 


### PR DESCRIPTION
## Proposed change
Creating the devicename included a typo and was missing the custom (preferred) name set by the OZW Admin tool. This will prevent an exception when a new node is added.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests



## Additional information
- This PR fixes or closes issue: fixes #35601 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
