### PR TITLE
Update ZHA config flow Zigbee radio description

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -157,7 +157,7 @@ class RadioType(enum.Enum):
     """Possible options for radio type."""
 
     ezsp = (
-        "EZSP = Silicon Labs EmberZNet protocol (ex; Elelabs, HUSBZB-1, Telegesis)",
+        "EZSP = Silicon Labs EmberZNet protocol: Elelabs, HUSBZB-1, Telegesis",
         bellows.zigbee.application.ControllerApplication,
     )
     deconz = (
@@ -165,15 +165,15 @@ class RadioType(enum.Enum):
         zigpy_deconz.zigbee.application.ControllerApplication,
     )
     ti_cc = (
-        "TI_CC = Texas Instruments Z-Stack ZNP protocol (ex: CC253x, CC26x2, CC13x2)",
+        "TI_CC = Texas Instruments Z-Stack ZNP protocol: CC253x, CC26x2, CC13x2",
         zigpy_cc.zigbee.application.ControllerApplication,
     )
     zigate = (
-        "ZiGate = ZiGate Serial protocol: PiZiGate, ZiGate USB-TTL, ZiGate WiFi",
+        "ZiGate = ZiGate Zigbee radios: PiZiGate, ZiGate USB-TTL, ZiGate WiFi",
         zigpy_zigate.zigbee.application.ControllerApplication,
     )
     xbee = (
-        "XBee = Digi XBee ZB Coordinator Firmware protocol (Digi XBee Series 2, 2C, 3)",
+        "XBee = Digi XBee Zigbee radios: Digi XBee Series 2, 2C, 3",
         zigpy_xbee.zigbee.application.ControllerApplication,
     )
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -169,7 +169,7 @@ class RadioType(enum.Enum):
         zigpy_cc.zigbee.application.ControllerApplication,
     )
     zigate = (
-        "ZiGate = ZiGate Serial protocol (ZiGate WiFi, ZiGate USB-TTL, PiZiGate)",
+        "ZiGate = ZiGate Serial protocol: PiZiGate, ZiGate USB-TTL, ZiGate WiFi",
         zigpy_zigate.zigbee.application.ControllerApplication,
     )
     xbee = (

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -161,7 +161,7 @@ class RadioType(enum.Enum):
         bellows.zigbee.application.ControllerApplication,
     )
     deconz = (
-        "deCONZ = dresden elektronik deCONZ protocol (ex; ConBee I/II, RaspBee I/II)",
+        "deCONZ = dresden elektronik deCONZ protocol: ConBee I/II, RaspBee I/II",
         zigpy_deconz.zigbee.application.ControllerApplication,
     )
     ti_cc = (

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -165,7 +165,7 @@ class RadioType(enum.Enum):
         zigpy_deconz.zigbee.application.ControllerApplication,
     )
     ti_cc = (
-        "TI_CC = : Texas Instruments Z-Stack ZNP protocol (ex; CC253x, CC26x2, CC13x2)",
+        "TI_CC = Texas Instruments Z-Stack ZNP protocol (ex: CC253x, CC26x2, CC13x2)",
         zigpy_cc.zigbee.application.ControllerApplication,
     )
     zigate = (

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -157,20 +157,23 @@ class RadioType(enum.Enum):
     """Possible options for radio type."""
 
     ezsp = (
-        "ESZP: HUSBZB-1, Elelabs, Telegesis, Silabs EmberZNet protocol",
+        "ezsp = Silicon Labs Ember based radios with EmberZNet Zigbee firmware",
         bellows.zigbee.application.ControllerApplication,
     )
     deconz = (
-        "Conbee, Conbee II, RaspBee radios from dresden elektronik",
+        "deconz = dresden elektronik ConBee and RaspBee based radios with deCONZ Zigbee firmware",
         zigpy_deconz.zigbee.application.ControllerApplication,
     )
     ti_cc = (
-        "TI_CC: CC2531, CC2530, CC2652R, CC1352 etc, Texas Instruments ZNP protocol",
+        "ti_cc = : Texas Instruments CC253x/CC26x2/CC13x2 based radios with Z-Stack firmware",
         zigpy_cc.zigbee.application.ControllerApplication,
     )
-    zigate = "ZiGate Radio", zigpy_zigate.zigbee.application.ControllerApplication
+    zigate = (
+        "zigate = ZiGate USB-TTL, PiZiGate, and WiFi based Zigbee radios with ZiGate firmware",
+        zigpy_zigate.zigbee.application.ControllerApplication,
+    )
     xbee = (
-        "Digi XBee S2C, XBee 3 radios",
+        "xbee = Digi XBee Series 2 and 3 based radios with XBee Zigbee firmware",
         zigpy_xbee.zigbee.application.ControllerApplication,
     )
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -157,23 +157,23 @@ class RadioType(enum.Enum):
     """Possible options for radio type."""
 
     ezsp = (
-        "ezsp = Silicon Labs Ember based radios with EmberZNet Zigbee firmware",
+        "EZSP = Silicon Labs EmberZNet protocol (ex; Elelabs, HUSBZB-1, Telegesis)",
         bellows.zigbee.application.ControllerApplication,
     )
     deconz = (
-        "deconz = dresden elektronik ConBee and RaspBee based radios with deCONZ Zigbee firmware",
+        "deCONZ = dresden elektronik deCONZ protocol (ex; ConBee I/II, RaspBee I/II)",
         zigpy_deconz.zigbee.application.ControllerApplication,
     )
     ti_cc = (
-        "ti_cc = : Texas Instruments CC253x/CC26x2/CC13x2 based radios with Z-Stack firmware",
+        "TI_CC = : Texas Instruments Z-Stack ZNP protocol (ex; CC253x, CC26x2, CC13x2)",
         zigpy_cc.zigbee.application.ControllerApplication,
     )
     zigate = (
-        "zigate = ZiGate USB-TTL, PiZiGate, and WiFi based Zigbee radios with ZiGate firmware",
+        "ZiGate = ZiGate Serial protocol (ZiGate WiFi, ZiGate USB-TTL, PiZiGate)",
         zigpy_zigate.zigbee.application.ControllerApplication,
     )
     xbee = (
-        "xbee = Digi XBee Series 2 and 3 based radios with XBee Zigbee firmware",
+        "XBee = Digi XBee ZB Coordinator Firmware protocol (Digi XBee Series 2, 2C, 3)",
         zigpy_xbee.zigbee.application.ControllerApplication,
     )
 


### PR DESCRIPTION
## Breaking change
No

## Proposed change
Update ZHA config flow Zigbee radio descriptions for "radio type" user get to pick to be used for ZHA.

 ezsp = Silicon Labs Ember based radios with EmberZNet Zigbee firmware
 deconz = dresden elektronik ConBee and RaspBee based radios with deCONZ Zigbee firmware
 ti_cc = Texas Instruments CC253x/CC26x2/CC13x2 based radios with Z-Stack firmware
 zigate = ZiGate USB-TTL, PiZiGate, and WiFi based Zigbee radios with ZiGate firmware
 xbee = Digi XBee Series 2 and 3 based radios with XBee Zigbee firmware

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
n/a

## Additional information
n/a

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
