### PR TITLE
Add options flow to Blink

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
@@ -60,7 +61,9 @@ def _blink_startup_wrapper(entry):
         no_prompt=True,
         device_id=DEVICE_ID,
     )
-    blink.refresh_rate = entry.data[CONF_SCAN_INTERVAL]
+    blink.refresh_rate = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+
+    _LOGGER.warning("Blink refresh rate is %s", blink.refresh_rate)
 
     try:
         blink.login_response = entry.data["login_response"]
@@ -93,6 +96,8 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up Blink via config entry."""
+    _async_import_options_from_data_if_missing(hass, entry)
+
     hass.data[DOMAIN][entry.entry_id] = await hass.async_add_executor_job(
         _blink_startup_wrapper, entry
     )
@@ -141,6 +146,16 @@ async def async_setup_entry(hass, entry):
     )
 
     return True
+
+
+@callback
+def _async_import_options_from_data_if_missing(hass, entry):
+    options = dict(entry.options)
+    if CONF_SCAN_INTERVAL not in entry.options:
+        options[CONF_SCAN_INTERVAL] = entry.data.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+        hass.config_entries.async_update_entry(entry, options=options)
 
 
 async def async_unload_entry(hass, entry):

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -63,8 +63,6 @@ def _blink_startup_wrapper(entry):
     )
     blink.refresh_rate = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
-    _LOGGER.warning("Blink refresh rate is %s", blink.refresh_rate)
-
     try:
         blink.login_response = entry.data["login_response"]
         blink.setup_params(entry.data["login_response"])

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -134,7 +134,7 @@ class BlinkOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             self.options.update(user_input)
             self.blink.refresh_rate = user_input[CONF_SCAN_INTERVAL]
-            return await self.async_create_entry(title="", data=self.options)
+            return self.async_create_entry(title="", data=self.options)
 
         options = self.config_entry.options
         scan_interval = options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
+from homeassistant.core import callback
 
 from .const import DEFAULT_OFFSET, DEFAULT_SCAN_INTERVAL, DEVICE_ID, DOMAIN
 
@@ -40,9 +41,14 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.data = {
             CONF_USERNAME: "",
             CONF_PASSWORD: "",
-            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
             "login_response": None,
         }
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get options flow for this handler."""
+        return BlinkOptionsFlowHandler(config_entry)
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
@@ -50,11 +56,14 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.data[CONF_USERNAME] = user_input["username"]
             self.data[CONF_PASSWORD] = user_input["password"]
+            try:
+                # Import scan_interval if it was in the yaml config
+                # otherwise, setting this is handled with options flow
+                self.data[CONF_SCAN_INTERVAL] = user_input[CONF_SCAN_INTERVAL]
+            except KeyError:
+                pass
 
             await self.async_set_unique_id(self.data[CONF_USERNAME])
-
-            if CONF_SCAN_INTERVAL in user_input:
-                self.data[CONF_SCAN_INTERVAL] = user_input["scan_interval"]
 
             self.blink = Blink(
                 username=self.data[CONF_USERNAME],
@@ -105,6 +114,44 @@ class BlinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_data):
         """Import blink config from configuration.yaml."""
         return await self.async_step_user(import_data)
+
+
+class BlinkOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Blink options."""
+
+    def __init__(self, config_entry):
+        """Initialize Blink options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+        self.blink = None
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Blink options."""
+        self.blink = self.hass.data[DOMAIN][self.config_entry.entry_id]
+        self.options[CONF_SCAN_INTERVAL] = self.blink.refresh_rate
+
+        return await self.async_step_simple_options()
+
+    async def async_step_simple_options(self, user_input=None):
+        """For simple options."""
+        if user_input is not None:
+            self.options.update(user_input)
+            self.blink.refresh_rate = user_input[CONF_SCAN_INTERVAL]
+            return await self._update_options()
+
+        options = self.config_entry.options
+        scan_interval = options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+
+        return self.async_show_form(
+            step_id="simple_options",
+            data_schema=vol.Schema(
+                {vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval,): int}
+            ),
+        )
+
+    async def _update_options(self):
+        """Update config entry options."""
+        return self.async_create_entry(title="", data=self.options)
 
 
 class Require2FA(exceptions.HomeAssistantError):

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -21,5 +21,16 @@
     "abort": {
         "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
-  }
+  },
+  "options": {
+    "step": {
+      "simple_options": {
+        "data": {
+          "scan_interval": "Scan Interval (seconds)"
+        },
+        "title": "Blink options",
+        "description": "Configure Blink integration"
+      }
+    }
+  }     
 }

--- a/homeassistant/components/blink/translations/en.json
+++ b/homeassistant/components/blink/translations/en.json
@@ -23,5 +23,16 @@
                 "title": "Sign-in with Blink account"
             }
         }
+    },
+    "options": {
+        "step": {
+            "simple_options": {
+                "data": {
+                    "scan_interval": "Scan Interval (seconds)"
+                },
+                "title": "Blink options",
+                "description": "Configure Blink integration"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-up to [PR #35396](https://github.com/home-assistant/core/pull/35396#issuecomment-627540589).  This allows for the `scan_interval` parameter to be configurable in the GUI via the options flow.  It's currently `yaml` configurable, it was just missing after the switch to the GUI based flow and tabled (until now).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
