### PR TITLE
Fix handling of additional data in core config storage

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1480,11 +1480,13 @@ class Config:
                     external_url=network.normalize_url(str(base_url))
                 )
 
-        # Try to migrate base_url to internal_url/external_url
-        if data and "external_url" not in data:
-            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, migrate_base_url)
-
         if data:
+            # Try to migrate base_url to internal_url/external_url
+            if "external_url" not in data:
+                self.hass.bus.async_listen_once(
+                    EVENT_HOMEASSISTANT_START, migrate_base_url
+                )
+
             self._update(
                 source=SOURCE_STORAGE,
                 latitude=data.get("latitude"),

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1454,10 +1454,6 @@ class Config:
         )
         data = await store.async_load()
 
-        if data and "external_url" in data:
-            self._update(source=SOURCE_STORAGE, **data)
-            return
-
         async def migrate_base_url(_: Event) -> None:
             """Migrate base_url to internal_url/external_url."""
             if self.hass.config.api is None:
@@ -1485,10 +1481,21 @@ class Config:
                 )
 
         # Try to migrate base_url to internal_url/external_url
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, migrate_base_url)
+        if data and "external_url" not in data:
+            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, migrate_base_url)
 
         if data:
-            self._update(source=SOURCE_STORAGE, **data)
+            self._update(
+                source=SOURCE_STORAGE,
+                latitude=data.get("latitude"),
+                longitude=data.get("longitude"),
+                elevation=data.get("elevation"),
+                unit_system=data.get("unit_system"),
+                location_name=data.get("location_name"),
+                time_zone=data.get("time_zone"),
+                external_url=data.get("external_url", _UNDEF),
+                internal_url=data.get("internal_url", _UNDEF),
+            )
 
     async def async_store(self) -> None:
         """Store [homeassistant] core config."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1294,17 +1294,17 @@ async def test_migration_base_url(hass, hass_storage):
     with patch.object(hass.bus, "async_listen_once") as mock_listen:
         # Empty config
         await config.async_load()
-        assert len(mock_listen.mock_calls) == 1
+        assert len(mock_listen.mock_calls) == 0
 
         # With just a name
         stored["data"] = {"location_name": "Test Name"}
         await config.async_load()
-        assert len(mock_listen.mock_calls) == 2
+        assert len(mock_listen.mock_calls) == 1
 
         # With external url
         stored["data"]["external_url"] = "https://example.com"
         await config.async_load()
-        assert len(mock_listen.mock_calls) == 2
+        assert len(mock_listen.mock_calls) == 1
 
     # Test that the event listener works
     assert mock_listen.mock_calls[0][1][0] == EVENT_HOMEASSISTANT_START
@@ -1319,3 +1319,14 @@ async def test_migration_base_url(hass, hass_storage):
         hass.config.api = Mock(deprecated_base_url=internal)
         await mock_listen.mock_calls[0][1][1](None)
         assert config.internal_url == internal
+
+
+async def test_additional_data_in_core_config(hass, hass_storage):
+    """Test that we can handle additional data in core configuration."""
+    config = ha.Config(hass)
+    hass_storage[ha.CORE_STORAGE_KEY] = {
+        "version": 1,
+        "data": {"location_name": "Test Name", "additional_valid_key": "value"},
+    }
+    await config.async_load()
+    assert config.location_name == "Test Name"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

0.110 introduces new core configs, however, when reverting back to a previous version of Home Assistant, the core configuration won't load because of the additional keys in the stored configuration.

This PR addresses this issue. While we cannot fix the done releases, we can prevent it from crashing a user's instance when downgrading in future versions.

Based on: <https://community.home-assistant.io/t/reverting-back-to-latest-docker-build-back-from-dev-ha-container-has-errors-and-wont-start-now/195644/2>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
