### PR TITLE
Decouple media lookup from Plex play_media service

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -559,16 +559,11 @@ class PlexMediaPlayer(MediaPlayerEntity):
             return
 
         src = json.loads(media_id)
-        if media_type == PLEX_DOMAIN and isinstance(src, int):
-            try:
-                media = self.plex_server.fetch_item(src)
-            except plexapi.exceptions.NotFound:
-                _LOGGER.error("Media for key %s not found", src)
-                return
-            shuffle = 0
-        else:
-            shuffle = src.pop("shuffle", 0)
-            media = self.plex_server.lookup_media(media_type, **src)
+        if isinstance(src, int):
+            src = {"plex_key": src}
+
+        shuffle = src.pop("shuffle", 0)
+        media = self.plex_server.lookup_media(media_type, **src)
 
         if media is None:
             _LOGGER.error("Media could not be found: %s", media_id)

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -7,12 +7,9 @@ import requests.exceptions
 
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN, MediaPlayerEntity
 from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_EPISODE,
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
-    MEDIA_TYPE_PLAYLIST,
     MEDIA_TYPE_TVSHOW,
-    MEDIA_TYPE_VIDEO,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
@@ -561,6 +558,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             )
             return
 
+        media = None
         media_type = media_type.lower()
         src = json.loads(media_id)
         if media_type == PLEX_DOMAIN and isinstance(src, int):
@@ -571,22 +569,12 @@ class PlexMediaPlayer(MediaPlayerEntity):
                 return
             shuffle = 0
         else:
-            library = src.get("library_name")
-            shuffle = src.get("shuffle", 0)
-            media = None
-
-        try:
-            if media_type == MEDIA_TYPE_MUSIC:
-                media = self._get_music_media(library, src)
-            elif media_type == MEDIA_TYPE_EPISODE:
-                media = self._get_tv_media(library, src)
-            elif media_type == MEDIA_TYPE_PLAYLIST:
-                media = self.plex_server.playlist(src["playlist_name"])
-            elif media_type == MEDIA_TYPE_VIDEO:
-                media = self.plex_server.library.section(library).get(src["video_name"])
-        except plexapi.exceptions.NotFound:
-            _LOGGER.error("Media could not be found: %s", media_id)
-            return
+            shuffle = src.pop("shuffle", 0)
+            try:
+                media = self.plex_server.lookup_media(media_type, **src)
+            except plexapi.exceptions.NotFound:
+                _LOGGER.error("Media could not be found: %s", media_id)
+                return
 
         if media is None:
             _LOGGER.error("Media could not be found: %s", media_id)
@@ -599,79 +587,6 @@ class PlexMediaPlayer(MediaPlayerEntity):
             self.device.playMedia(playqueue)
         except requests.exceptions.ConnectTimeout:
             _LOGGER.error("Timed out playing on %s", self.name)
-
-    def _get_music_media(self, library_name, src):
-        """Find music media and return a Plex media object."""
-        artist_name = src["artist_name"]
-        album_name = src.get("album_name")
-        track_name = src.get("track_name")
-        track_number = src.get("track_number")
-
-        artist = self.plex_server.library.section(library_name).get(artist_name)
-
-        if album_name:
-            album = artist.album(album_name)
-
-            if track_name:
-                return album.track(track_name)
-
-            if track_number:
-                for track in album.tracks():
-                    if int(track.index) == int(track_number):
-                        return track
-                return None
-
-            return album
-
-        if track_name:
-            return artist.searchTracks(track_name, maxresults=1)
-        return artist
-
-    def _get_tv_media(self, library_name, src):
-        """Find TV media and return a Plex media object."""
-        show_name = src["show_name"]
-        season_number = src.get("season_number")
-        episode_number = src.get("episode_number")
-        target_season = None
-        target_episode = None
-
-        show = self.plex_server.library.section(library_name).get(show_name)
-
-        if not season_number:
-            return show
-
-        for season in show.seasons():
-            if int(season.seasonNumber) == int(season_number):
-                target_season = season
-                break
-
-        if target_season is None:
-            _LOGGER.error(
-                "Season not found: %s\\%s - S%sE%s",
-                library_name,
-                show_name,
-                str(season_number).zfill(2),
-                str(episode_number).zfill(2),
-            )
-        else:
-            if not episode_number:
-                return target_season
-
-            for episode in target_season.episodes():
-                if int(episode.index) == int(episode_number):
-                    target_episode = episode
-                    break
-
-            if target_episode is None:
-                _LOGGER.error(
-                    "Episode not found: %s\\%s - S%sE%s",
-                    library_name,
-                    show_name,
-                    str(season_number).zfill(2),
-                    str(episode_number).zfill(2),
-                )
-
-        return target_episode
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -570,11 +570,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             shuffle = 0
         else:
             shuffle = src.pop("shuffle", 0)
-            try:
-                media = self.plex_server.lookup_media(media_type, **src)
-            except plexapi.exceptions.NotFound:
-                _LOGGER.error("Media could not be found: %s", media_id)
-                return
+            media = self.plex_server.lookup_media(media_type, **src)
 
         if media is None:
             _LOGGER.error("Media could not be found: %s", media_id)

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -558,8 +558,6 @@ class PlexMediaPlayer(MediaPlayerEntity):
             )
             return
 
-        media = None
-        media_type = media_type.lower()
         src = json.loads(media_id)
         if media_type == PLEX_DOMAIN and isinstance(src, int):
             try:

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -484,7 +484,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
                 | SUPPORT_VOLUME_MUTE
             )
 
-        return 0
+        return SUPPORT_PLAY_MEDIA
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -410,7 +410,7 @@ class PlexServer:
             _LOGGER.error("Library '%s' not found", library_name)
             return None
 
-        def lookup_music(**kwargs):
+        def lookup_music():
             """Search for music and return a Plex media object."""
             album_name = kwargs.get("album_name")
             track_name = kwargs.get("track_name")
@@ -474,7 +474,7 @@ class PlexServer:
 
             return artist
 
-        def lookup_tv(**kwargs):
+        def lookup_tv():
             """Find TV media and return a Plex media object."""
             season_number = kwargs.get("season_number")
             episode_number = kwargs.get("episode_number")
@@ -515,9 +515,9 @@ class PlexServer:
                 return None
 
         if media_type == MEDIA_TYPE_MUSIC:
-            return lookup_music(**kwargs)
+            return lookup_music()
         if media_type == MEDIA_TYPE_EPISODE:
-            return lookup_tv(**kwargs)
+            return lookup_tv()
         if media_type == MEDIA_TYPE_VIDEO:
             try:
                 video_name = kwargs["video_name"]

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -376,6 +376,7 @@ class PlexServer:
 
     def lookup_media(self, media_type, **kwargs):
         """Lookup a piece of media."""
+        media_type = media_type.lower()
         if media_type == MEDIA_TYPE_PLAYLIST:
             try:
                 playlist_name = kwargs["playlist_name"]

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -467,8 +467,6 @@ class PlexServer:
             """Find TV media and return a Plex media object."""
             season_number = kwargs.get("season_number")
             episode_number = kwargs.get("episode_number")
-            season = None
-            episode = None
 
             try:
                 show_name = kwargs["show_name"]
@@ -495,7 +493,7 @@ class PlexServer:
                 return season
 
             try:
-                episode = season.episode(episode=int(episode_number))
+                return season.episode(episode=int(episode_number))
             except NotFound:
                 _LOGGER.error(
                     "Episode not found: %s - S%sE%s",
@@ -503,8 +501,7 @@ class PlexServer:
                     str(season_number).zfill(2),
                     str(episode_number).zfill(2),
                 )
-
-            return episode
+                return None
 
         if media_type == MEDIA_TYPE_MUSIC:
             return lookup_music(**kwargs)

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_USE_EPISODE_ART,
     DEBOUNCE_TIMEOUT,
     DEFAULT_VERIFY_SSL,
+    DOMAIN,
     PLEX_NEW_MP_SIGNAL,
     PLEX_UPDATE_MEDIA_PLAYER_SIGNAL,
     PLEX_UPDATE_SENSOR_SIGNAL,
@@ -377,6 +378,15 @@ class PlexServer:
     def lookup_media(self, media_type, **kwargs):
         """Lookup a piece of media."""
         media_type = media_type.lower()
+
+        if media_type == DOMAIN:
+            key = kwargs["plex_key"]
+            try:
+                return self.fetch_item(key)
+            except plexapi.exceptions.NotFound:
+                _LOGGER.error("Media for key %s not found", key)
+                return None
+
         if media_type == MEDIA_TYPE_PLAYLIST:
             try:
                 playlist_name = kwargs["playlist_name"]

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -288,6 +288,8 @@ class MockPlexLibrarySection:
 
     def get(self, query):
         """Mock the get lookup method."""
+        if self.title == "Music":
+            return MockPlexArtist(query)
         return MockPlexMediaItem(query)
 
 
@@ -320,8 +322,17 @@ class MockPlexMediaItem:
         """Mock the season lookup method."""
         return MockPlexMediaItem(season, mediatype="season")
 
-    def searchTracks(self, track_name, maxresults):
-        """Mock the searchTracks method."""
+
+class MockPlexArtist(MockPlexMediaItem):
+    """Mock a Plex Artist instance."""
+
+    def __init__(self, artist):
+        """Initialize the object."""
+        super().__init__(artist)
+        self.type = "artist"
+
+    def get(self, track):
+        """Mock the track lookup method."""
         return MockPlexMediaTrack()
 
 

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -161,6 +161,10 @@ class MockPlexServer:
         """Mock the playlist lookup method."""
         return MockPlexMediaItem(playlist, mediatype="playlist")
 
+    def fetchItem(self, item):
+        """Mock the fetchItem method."""
+        return MockPlexMediaItem("Item Name")
+
 
 class MockPlexClient:
     """Mock a PlexClient instance."""
@@ -195,7 +199,7 @@ class MockPlexClient:
     @property
     def protocolCapabilities(self):
         """Mock the protocolCapabilities attribute."""
-        return ["player"]
+        return ["playback"]
 
     @property
     def state(self):
@@ -211,6 +215,10 @@ class MockPlexClient:
     def version(self):
         """Mock the version attribute."""
         return "1.0"
+
+    def playMedia(self, item):
+        """Mock the playMedia method."""
+        pass
 
 
 class MockPlexSession:

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -152,6 +152,15 @@ class MockPlexServer:
         """Mock version of PlexServer."""
         return "1.0"
 
+    @property
+    def library(self):
+        """Mock library object of PlexServer."""
+        return MockPlexLibrary()
+
+    def playlist(self, playlist):
+        """Mock the playlist lookup method."""
+        return MockPlexMediaItem(playlist, mediatype="playlist")
+
 
 class MockPlexClient:
     """Mock a PlexClient instance."""
@@ -259,9 +268,67 @@ class MockPlexSession:
         return 2020
 
 
+class MockPlexLibrary:
+    """Mock a Plex Library instance."""
+
+    def __init__(self):
+        """Initialize the object."""
+
+    def section(self, library_name):
+        """Mock the LibrarySection lookup."""
+        return MockPlexLibrarySection(library_name)
+
+
 class MockPlexLibrarySection:
     """Mock a Plex LibrarySection instance."""
 
     def __init__(self, library="Movies"):
         """Initialize the object."""
         self.title = library
+
+    def get(self, query):
+        """Mock the get lookup method."""
+        return MockPlexMediaItem(query)
+
+
+class MockPlexMediaItem:
+    """Mock a Plex Media instance."""
+
+    def __init__(self, title, mediatype="video"):
+        """Initialize the object."""
+        self.title = str(title)
+        self.type = mediatype
+
+    def album(self, album):
+        """Mock the album lookup method."""
+        return MockPlexMediaItem(album, mediatype="album")
+
+    def track(self, track):
+        """Mock the track lookup method."""
+        return MockPlexMediaTrack()
+
+    def tracks(self):
+        """Mock the tracks lookup method."""
+        for index in range(1, 10):
+            yield MockPlexMediaTrack(index)
+
+    def episode(self, episode):
+        """Mock the episode lookup method."""
+        return MockPlexMediaItem(episode, mediatype="episode")
+
+    def season(self, season):
+        """Mock the season lookup method."""
+        return MockPlexMediaItem(season, mediatype="season")
+
+    def searchTracks(self, track_name, maxresults):
+        """Mock the searchTracks method."""
+        return MockPlexMediaTrack()
+
+
+class MockPlexMediaTrack(MockPlexMediaItem):
+    """Mock a Plex Track instance."""
+
+    def __init__(self, index=1):
+        """Initialize the object."""
+        super().__init__(f"Track {index}", "track")
+        self.index = index


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
All lookup logic for finding the media to play in a `media_player.play_media` call is now decoupled from the service call and moved to the Plex server class which is more appropriate. Adds tests for the media lookups which didn't exist before.

Will make the new feature considered in #35590 easier to develop and iterate.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #35590
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
