### PR TITLE
Add huawei_lte sensor for number of unread sms

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -181,7 +181,7 @@ homeassistant/components/homematicip_cloud/* @SukramJ
 homeassistant/components/honeywell/* @zxdavb
 homeassistant/components/html5/* @robbiet480
 homeassistant/components/http/* @home-assistant/core
-homeassistant/components/huawei_lte/* @scop
+homeassistant/components/huawei_lte/* @scop @fphammerle
 homeassistant/components/huawei_router/* @abmantis
 homeassistant/components/hue/* @balloob
 homeassistant/components/hunterdouglas_powerview/* @bdraco

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -68,6 +68,7 @@ from .const import (
     KEY_MONITORING_TRAFFIC_STATISTICS,
     KEY_NET_CURRENT_PLMN,
     KEY_NET_NET_MODE,
+    KEY_SMS_SMS_COUNT,
     KEY_WLAN_HOST_LIST,
     KEY_WLAN_WIFI_FEATURE_SWITCH,
     NOTIFY_SUPPRESS_TIMEOUT,
@@ -243,6 +244,7 @@ class Router:
         )
         self._get_data(KEY_NET_CURRENT_PLMN, self.client.net.current_plmn)
         self._get_data(KEY_NET_NET_MODE, self.client.net.net_mode)
+        self._get_data(KEY_SMS_SMS_COUNT, self.client.sms.sms_count)
         self._get_data(KEY_WLAN_HOST_LIST, self.client.wlan.host_list)
         self._get_data(
             KEY_WLAN_WIFI_FEATURE_SWITCH, self.client.wlan.wifi_feature_switch

--- a/homeassistant/components/huawei_lte/const.py
+++ b/homeassistant/components/huawei_lte/const.py
@@ -32,6 +32,7 @@ KEY_MONITORING_STATUS = "monitoring_status"
 KEY_MONITORING_TRAFFIC_STATISTICS = "monitoring_traffic_statistics"
 KEY_NET_CURRENT_PLMN = "net_current_plmn"
 KEY_NET_NET_MODE = "net_net_mode"
+KEY_SMS_SMS_COUNT = "sms_sms_count"
 KEY_WLAN_HOST_LIST = "wlan_host_list"
 KEY_WLAN_WIFI_FEATURE_SWITCH = "wlan_wifi_feature_switch"
 
@@ -47,6 +48,7 @@ SENSOR_KEYS = {
     KEY_MONITORING_TRAFFIC_STATISTICS,
     KEY_NET_CURRENT_PLMN,
     KEY_NET_NET_MODE,
+    KEY_SMS_SMS_COUNT,
 }
 
 SWITCH_KEYS = {KEY_DIALUP_MOBILE_DATASWITCH}

--- a/homeassistant/components/huawei_lte/manifest.json
+++ b/homeassistant/components/huawei_lte/manifest.json
@@ -15,5 +15,5 @@
       "manufacturer": "Huawei"
     }
   ],
-  "codeowners": ["@scop"]
+  "codeowners": ["@scop", "@fphammerle"]
 }

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -22,6 +22,7 @@ from .const import (
     KEY_MONITORING_TRAFFIC_STATISTICS,
     KEY_NET_CURRENT_PLMN,
     KEY_NET_NET_MODE,
+    KEY_SMS_SMS_COUNT,
     SENSOR_KEYS,
 )
 
@@ -194,6 +195,9 @@ SENSOR_META = {
             }.get(x, "Unknown"),
             None,
         ),
+    ),
+    (KEY_SMS_SMS_COUNT, "LocalUnread"): dict(
+        name="SMS unread", icon="mdi:email-receive",
     ),
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added a sensor counting number of unread SMS via `huawei_lte` integration.

I'd like to trigger an automation when text messages arrive.

API: https://github.com/Salamek/huawei-lte-api/blob/1.4.12/huawei_lte_api/api/Sms.py#L13

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13454/files

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
