### PR TITLE
Squeezebox config flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -757,7 +757,8 @@ omit =
     homeassistant/components/spotcrime/sensor.py
     homeassistant/components/spotify/__init__.py
     homeassistant/components/spotify/media_player.py
-    homeassistant/components/squeezebox/*
+    homeassistant/components/squeezebox/__init__.py
+    homeassistant/components/squeezebox/media_player.py
     homeassistant/components/starline/*
     homeassistant/components/starlingbank/sensor.py
     homeassistant/components/steam_online/sensor.py

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -47,6 +47,7 @@ SERVICE_XIAOMI_GW = "xiaomi_gw"
 CONFIG_ENTRY_HANDLERS = {
     SERVICE_DAIKIN: "daikin",
     SERVICE_TELLDUSLIVE: "tellduslive",
+    "logitech_mediaserver": "squeezebox",
 }
 
 SERVICE_HANDLERS = {
@@ -65,7 +66,6 @@ SERVICE_HANDLERS = {
     SERVICE_FREEBOX: ("freebox", None),
     SERVICE_YEELIGHT: ("yeelight", None),
     "yamaha": ("media_player", "yamaha"),
-    "logitech_mediaserver": ("media_player", "squeezebox"),
     "frontier_silicon": ("media_player", "frontier_silicon"),
     "openhome": ("media_player", "openhome"),
     "bose_soundtouch": ("media_player", "soundtouch"),

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -33,8 +33,6 @@ async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Logitech Squeezebox component."""
     conf = config.get(DOMAIN)
 
-    hass.data[DOMAIN] = conf or {}
-
     if conf is not None:
         hass.async_create_task(
             hass.config_entries.flow.async_init(

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -64,17 +64,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     # Stop player discovery task for this config entry.
-    hass.data[DOMAIN][entry.unique_id][PLAYER_DISCOVERY_UNSUB]()
+    hass.data[DOMAIN][entry.entry_id][PLAYER_DISCOVERY_UNSUB]()
 
     # Remove config entry's players from list of known players
-    entry_players = hass.data[DOMAIN][entry.unique_id][ENTRY_PLAYERS]
+    entry_players = hass.data[DOMAIN][entry.entry_id][ENTRY_PLAYERS]
     if entry_players:
         for player in entry_players:
             _LOGGER.debug("Remove entry player %s from list of known players.", player)
             hass.data[DOMAIN][KNOWN_PLAYERS].remove(player)
 
     # Remove stored data for this config entry
-    hass.data[DOMAIN].pop(entry.unique_id)
+    hass.data[DOMAIN].pop(entry.entry_id)
 
     # Stop server discovery task if this is the last config entry.
     current_entries = hass.config_entries.async_entries(DOMAIN)

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -57,3 +57,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.config_entries.async_forward_entry_setup(entry, MP_DOMAIN)
     )
     return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.config_entries.async_forward_entry_unload(entry, MP_DOMAIN)

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -1,11 +1,42 @@
 """The Logitech Squeezebox integration."""
 
+import asyncio
+
+from pysqueezebox import async_discover
+
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.config_entries import SOURCE_DISCOVERY, ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant
 
-from .media_player import start_server_discovery
+from .const import DOMAIN
+from .media_player import _LOGGER
+
+DISCOVERY_TASK = "discovery_task"
+
+
+async def start_server_discovery(hass):
+    """Start a server discovery task."""
+
+    def _discovered_server(server):
+        asyncio.create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_DISCOVERY},
+                data={
+                    CONF_HOST: server.host,
+                    CONF_PORT: int(server.port),
+                    "uuid": server.uuid,
+                },
+            )
+        )
+
+    hass.data.setdefault(DOMAIN, {})
+    if DISCOVERY_TASK not in hass.data[DOMAIN]:
+        _LOGGER.debug("Adding server discovery task for squeezebox")
+        hass.data[DOMAIN][DISCOVERY_TASK] = hass.async_create_task(
+            async_discover(_discovered_server)
+        )
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -61,4 +61,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
+    # Stop server discovery task if this is the last config entry.
+    current_entries = hass.config_entries.async_entries(DOMAIN)
+    if len(current_entries) == 1 and current_entries[0] == entry:
+        _LOGGER.debug("Stopping server discovery task")
+        hass.data[DOMAIN][DISCOVERY_TASK].cancel()
+
     return await hass.config_entries.async_forward_entry_unload(entry, MP_DOMAIN)

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -2,11 +2,21 @@
 
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant
+
+from .media_player import start_server_discovery
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Logitech Squeezebox component."""
+    if hass.is_running:
+        await start_server_discovery(hass)
+    else:
+        hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START, start_server_discovery(hass)
+        )
+
     return True
 
 

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import SOURCE_DISCOVERY, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, PLAYER_DISCOVERY_UNSUBS
+from .const import DOMAIN, ENTRY_PLAYERS, KNOWN_PLAYERS, PLAYER_DISCOVERY_UNSUB
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +64,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     # Stop player discovery task for this config entry.
-    hass.data[DOMAIN][PLAYER_DISCOVERY_UNSUBS][entry.unique_id]()
+    hass.data[DOMAIN][entry.unique_id][PLAYER_DISCOVERY_UNSUB]()
+
+    # Remove config entry's players from list of known players
+    entry_players = hass.data[DOMAIN][entry.unique_id][ENTRY_PLAYERS]
+    if entry_players:
+        for player in entry_players:
+            _LOGGER.debug("Remove entry player %s from list of known players.", player)
+            hass.data[DOMAIN][KNOWN_PLAYERS].remove(player)
+
+    # Remove stored data for this config entry
+    hass.data[DOMAIN].pop(entry.unique_id)
 
     # Stop server discovery task if this is the last config entry.
     current_entries = hass.config_entries.async_entries(DOMAIN)

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -44,7 +44,7 @@ async def start_server_discovery(hass):
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Logitech Squeezebox component."""
     if hass.is_running:
-        await start_server_discovery(hass)
+        asyncio.create_task(start_server_discovery(hass))
     else:
         hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_START, start_server_discovery(hass)

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -1,1 +1,53 @@
-"""The squeezebox component."""
+"""The Logitech Squeezebox integration."""
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+
+from .const import DEFAULT_PORT, DOMAIN
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                MP_DOMAIN: vol.Schema(
+                    {
+                        vol.Required(CONF_HOST): cv.string,
+                        vol.Optional(CONF_PASSWORD): cv.string,
+                        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                        vol.Optional(CONF_USERNAME): cv.string,
+                    }
+                )
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Logitech Squeezebox component."""
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = conf or {}
+
+    if conf is not None:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Logitech Squeezebox from a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, MP_DOMAIN)
+    )
+    return True

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -1,45 +1,12 @@
 """The Logitech Squeezebox integration."""
-import voluptuous as vol
 
-from homeassistant import config_entries
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-
-from .const import DEFAULT_PORT, DOMAIN
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                MP_DOMAIN: vol.Schema(
-                    {
-                        vol.Required(CONF_HOST): cv.string,
-                        vol.Optional(CONF_PASSWORD): cv.string,
-                        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                        vol.Optional(CONF_USERNAME): cv.string,
-                    }
-                )
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Logitech Squeezebox component."""
-    conf = config.get(DOMAIN)
-
-    if conf is not None:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
-            )
-        )
-
     return True
 
 

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -146,11 +146,7 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await asyncio.wait_for(self._discover(), timeout=TIMEOUT)
             return await self.async_step_edit()
         except asyncio.TimeoutError:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema({vol.Optional(CONF_HOST): str}),
-                errors={"base": "no_server_found"},
-            )
+            errors["base"] = "no_server_found"
 
         # display the form
         return self.async_show_form(

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -32,7 +32,8 @@ TIMEOUT = 5
 
 
 async def validate_input(hass: core.HomeAssistant, data):
-    """Validate the user input allows us to connect.
+    """
+    Validate the user input allows us to connect.
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
@@ -61,7 +62,6 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize an instance of the squeezebox config flow."""
-        # a private version of the schema allows us to update suggested values
         self.data_schema = DATA_SCHEMA
         self.data = None
 
@@ -106,14 +106,13 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "uuid": server.uuid,
                     }
                     _LOGGER.debug("Discovered server: %s", self.data)
-                return None
 
             discovery_task = self.hass.async_create_task(
                 async_discover(_discovery_callback)
             )
             while not self.data:
                 await asyncio.sleep(1)
-            discovery_task.cancel()  # stop searching for LMS servers
+            discovery_task.cancel()  # stop searching as soon as we find a server
             return self.data
 
         try:
@@ -140,7 +139,7 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_server_found")
 
     async def async_step_edit(self, user_input=None):
-        """Edit a discovered or manually inputted configuration."""
+        """Edit a discovered or manually inputted server."""
         errors = {}
         if user_input:
             try:
@@ -180,47 +179,43 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_discovery(self, discovery_info):
         """Handle discovery."""
         _LOGGER.debug("Reached discovery flow with info: %s", discovery_info)
-        try:
-            if "uuid" not in discovery_info:
-                DATA_SCHEMA(discovery_info)
+        if "uuid" not in discovery_info:
+            DATA_SCHEMA(discovery_info)
+            try:
                 info = await validate_input(self.hass, discovery_info)
                 discovery_info.update(info)
-            if "uuid" in discovery_info:
-                try:
-                    await self.async_set_unique_id(discovery_info["uuid"])
-                    self._abort_if_unique_id_configured()
-                except data_entry_flow.AbortFlow:
-                    # ignore already discovered servers
-                    return self.async_abort(reason="already_configured")
+            except CannotConnect:
+                return self.async_abort(reason="cannot_connect")
+            except InvalidAuth:
+                return self.async_abort(reason="invalid_auth")
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                return self.async_abort(reason="unknown")
+        if "uuid" in discovery_info:
+            try:
+                await self.async_set_unique_id(discovery_info["uuid"])
+                self._abort_if_unique_id_configured()
+            except data_entry_flow.AbortFlow:
+                # ignore already discovered servers
+                return self.async_abort(reason="already_configured")
 
-                # update with suggested values from discovery
-                self.data_schema = vol.Schema(
-                    {
-                        vol.Required(
-                            CONF_HOST,
-                            description={
-                                "suggested_value": discovery_info.get(CONF_HOST)
-                            },
-                        ): str,
-                        vol.Required(
-                            CONF_PORT,
-                            default=DEFAULT_PORT,
-                            description={
-                                "suggested_value": discovery_info.get(CONF_PORT)
-                            },
-                        ): int,
-                        vol.Optional(CONF_USERNAME): str,
-                        vol.Optional(CONF_PASSWORD): str,
-                    }
-                )
-                return await self.async_step_edit()
-        except CannotConnect:
-            return self.async_abort(reason="cannot_connect")
-        except InvalidAuth:
-            return self.async_abort(reason="invalid_auth")
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            return self.async_abort(reason="unknown")
+            # update schema with suggested values from discovery
+            self.data_schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST,
+                        description={"suggested_value": discovery_info.get(CONF_HOST)},
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=DEFAULT_PORT,
+                        description={"suggested_value": discovery_info.get(CONF_PORT)},
+                    ): int,
+                    vol.Optional(CONF_USERNAME): str,
+                    vol.Optional(CONF_PASSWORD): str,
+                }
+            )
+            return await self.async_step_edit()
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -104,21 +104,7 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         discovery_task.cancel()  # stop searching as soon as we find server
 
         # update with suggested values from discovery
-        self.data_schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_HOST,
-                    description={"suggested_value": self.discovery_info[CONF_HOST]},
-                ): str,
-                vol.Required(
-                    CONF_PORT,
-                    default=DEFAULT_PORT,
-                    description={"suggested_value": self.discovery_info[CONF_PORT]},
-                ): int,
-                vol.Optional(CONF_USERNAME): str,
-                vol.Optional(CONF_PASSWORD): str,
-            }
-        )
+        self.data_schema = _base_schema(self.discovery_info)
 
     async def _validate_input(self, data):
         """
@@ -152,17 +138,7 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input and CONF_HOST in user_input:
             # update with host provided by user
-            self.data_schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST,
-                        description={"suggested_value": user_input.get(CONF_HOST)},
-                    ): str,
-                    vol.Required(CONF_PORT, default=DEFAULT_PORT,): int,
-                    vol.Optional(CONF_USERNAME): str,
-                    vol.Optional(CONF_PASSWORD): str,
-                }
-            )
+            self.data_schema = _base_schema(user_input)
             return await self.async_step_edit()
 
         # no host specified, see if we can discover an unconfigured LMS server

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -5,7 +5,7 @@ import logging
 from pysqueezebox import Server, async_discover
 import voluptuous as vol
 
-from homeassistant import config_entries, exceptions
+from homeassistant import config_entries
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -187,11 +187,3 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.context.update({"title_placeholders": {"host": discovery_info[CONF_HOST]}})
 
         return await self.async_step_edit()
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(exceptions.HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -1,0 +1,79 @@
+"""Config flow for Logitech Squeezebox integration."""
+import logging
+
+from pysqueezebox import Server
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DEFAULT_PORT, DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Optional(CONF_USERNAME): str,
+        vol.Optional(CONF_PASSWORD): str,
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    server = Server(
+        async_get_clientsession(hass),
+        data[CONF_HOST],
+        data[CONF_PORT],
+        data.get(CONF_USERNAME),
+        data.get(CONF_PASSWORD),
+    )
+
+    status = await server.async_query("serverstatus")
+    if not status:
+        raise CannotConnect
+
+    return status
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Logitech Squeezebox."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+                if "uuid" in info:
+                    self.async_set_unique_id(info["uuid"])
+                    self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=info.get("ip"), data=user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -147,8 +147,9 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(status["uuid"])
             self._abort_if_unique_id_configured()
 
-    async def async_step_user(self, user_input=None, errors=None):
+    async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
+        errors = {}
         if user_input and CONF_HOST in user_input:
             # update with host provided by user
             self.data_schema = vol.Schema(
@@ -198,7 +199,7 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="edit", data_schema=self.data_schema, errors=errors
         )
 
-    async def async_step_import(self, config, errors=None):
+    async def async_step_import(self, config):
         """Import a config flow from configuration."""
         _base_schema()(config)
         error = await self._validate_input(config)

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -63,7 +63,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 info = await validate_input(self.hass, user_input)
                 if "uuid" in info:
-                    self.async_set_unique_id(info["uuid"])
+                    await self.async_set_unique_id(info["uuid"])
                     self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=info.get("ip"), data=user_input)
             except CannotConnect:

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -181,12 +181,9 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             DATA_SCHEMA(config)
             info = await validate_input(self.hass, config)
             if "uuid" in info:
-                try:
-                    await self.async_set_unique_id(info["uuid"])
-                    # update with info from configuration.yaml
-                    self._abort_if_unique_id_configured(info)
-                except data_entry_flow.AbortFlow as error:
-                    return self.async_abort(reason=error.reason)
+                await self.async_set_unique_id(info["uuid"])
+                # update with info from configuration.yaml
+                self._abort_if_unique_id_configured(info)
             return self.async_create_entry(title=info.get("ip"), data=config)
         except CannotConnect:
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+# pylint: disable=unused-import
 from .const import DEFAULT_PORT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -5,10 +5,16 @@ from pysqueezebox import Server
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    HTTP_UNAUTHORIZED,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DEFAULT_PORT, DOMAIN  # pylint:disable=unused-import
+from .const import DEFAULT_PORT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +43,8 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     status = await server.async_query("serverstatus")
     if not status:
+        if server.http_status == HTTP_UNAUTHORIZED:
+            raise InvalidAuth
         raise CannotConnect
 
     return status

--- a/homeassistant/components/squeezebox/const.py
+++ b/homeassistant/components/squeezebox/const.py
@@ -1,10 +1,3 @@
 """Constants for the Squeezebox component."""
-from homeassistant.const import STATE_IDLE, STATE_PAUSED, STATE_PLAYING
-
 DOMAIN = "squeezebox"
-SERVICE_CALL_METHOD = "call_method"
-SQUEEZEBOX_MODE = {
-    "pause": STATE_PAUSED,
-    "play": STATE_PLAYING,
-    "stop": STATE_IDLE,
-}
+DEFAULT_PORT = 9000

--- a/homeassistant/components/squeezebox/const.py
+++ b/homeassistant/components/squeezebox/const.py
@@ -1,3 +1,4 @@
 """Constants for the Squeezebox component."""
 DOMAIN = "squeezebox"
+PLAYER_DISCOVERY_UNSUBS = "player_discovery_unsubs"
 DEFAULT_PORT = 9000

--- a/homeassistant/components/squeezebox/const.py
+++ b/homeassistant/components/squeezebox/const.py
@@ -1,4 +1,6 @@
 """Constants for the Squeezebox component."""
 DOMAIN = "squeezebox"
-PLAYER_DISCOVERY_UNSUBS = "player_discovery_unsubs"
+ENTRY_PLAYERS = "entry_players"
+KNOWN_PLAYERS = "known_players"
+PLAYER_DISCOVERY_UNSUB = "player_discovery_unsub"
 DEFAULT_PORT = 9000

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -6,7 +6,7 @@
     "@rajlaud"
   ],
   "requirements": [
-    "pysqueezebox==0.2.2"
+    "pysqueezebox==0.2.3"
   ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -3,5 +3,6 @@
   "name": "Logitech Squeezebox",
   "documentation": "https://www.home-assistant.io/integrations/squeezebox",
   "codeowners": ["@rajlaud"],
-  "requirements": ["pysqueezebox==0.2.1"]
+  "requirements": ["pysqueezebox==0.2.1"],
+  "config_flow": true
 }

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -6,7 +6,7 @@
     "@rajlaud"
   ],
   "requirements": [
-    "pysqueezebox==0.2.1"
+    "pysqueezebox==0.2.2"
   ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -2,7 +2,11 @@
   "domain": "squeezebox",
   "name": "Logitech Squeezebox",
   "documentation": "https://www.home-assistant.io/integrations/squeezebox",
-  "codeowners": ["@rajlaud"],
-  "requirements": ["pysqueezebox==0.2.1"],
+  "codeowners": [
+    "@rajlaud"
+  ],
+  "requirements": [
+    "pysqueezebox==0.2.1"
+  ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -6,7 +6,7 @@
     "@rajlaud"
   ],
   "requirements": [
-    "pysqueezebox==0.2.3"
+    "pysqueezebox==0.2.4"
   ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -127,13 +127,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     port = config[CONF_PORT]
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault(config_entry.unique_id, {})
+    hass.data[DOMAIN].setdefault(config_entry.entry_id, {})
 
     known_players = hass.data[DOMAIN].get(KNOWN_PLAYERS)
     if known_players is None:
         hass.data[DOMAIN][KNOWN_PLAYERS] = known_players = []
 
-    entry_players = hass.data[DOMAIN][config_entry.unique_id].setdefault(
+    entry_players = hass.data[DOMAIN][config_entry.entry_id].setdefault(
         ENTRY_PLAYERS, []
     )
 
@@ -169,7 +169,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             for player in players:
                 hass.async_create_task(_discovered_player(player))
 
-        hass.data[DOMAIN][config_entry.unique_id][
+        hass.data[DOMAIN][config_entry.entry_id][
             PLAYER_DISCOVERY_UNSUB
         ] = hass.helpers.event.async_call_later(DISCOVERY_INTERVAL, _discovery)
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -95,7 +95,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     if config:
         conf = {
-            CONF_HOST: config.get(CONF_HOST),
+            CONF_HOST: config[CONF_HOST],
             CONF_PORT: config.get(CONF_PORT) if config.get(CONF_PORT) else DEFAULT_PORT,
         }
         for attr in [CONF_USERNAME, CONF_PASSWORD]:

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -96,7 +96,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if config:
         conf = {
             CONF_HOST: config[CONF_HOST],
-            CONF_PORT: config.get(CONF_PORT) if config.get(CONF_PORT) else DEFAULT_PORT,
+            CONF_PORT: config.get(CONF_PORT, DEFAULT_PORT),
         }
         for attr in [CONF_USERNAME, CONF_PASSWORD]:
             if attr in config:

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -132,7 +132,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     player_discovery_unsubs = hass.data[DOMAIN].setdefault(PLAYER_DISCOVERY_UNSUBS, {})
     player_discovery_unsubs.setdefault(config_entry.unique_id)
 
-    async def _discovery():
+    async def _discovery(now=None):
         """Discover squeezebox players by polling server."""
 
         async def _discovered_player(player):

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -157,7 +157,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if entity and not entity.available:
                 # check if previously unavailable player has connected
                 await player.async_update()
-                entity.available = player.available
+                entity.available = player.connected
             if not entity:
                 _LOGGER.debug("Adding new entity: %s", player)
                 entity = SqueezeBoxEntity(player)

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -165,8 +165,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 async_add_entities([entity])
 
         players = await lms.async_get_players()
-        for player in players:
-            hass.async_create_task(_discovered_player(player))
+        if players:
+            for player in players:
+                hass.async_create_task(_discovered_player(player))
 
         hass.helpers.event.async_call_later(DISCOVERY_INTERVAL, _discovery)
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -111,7 +111,6 @@ async def start_server_discovery(hass):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up squeezebox platform from platform entry in configuration.yaml (deprecated)."""
-    _LOGGER.warning("Loading Squeezebox via platform config is deprecated.")
 
     if config:
         conf = {

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -195,7 +195,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     platform.async_register_entity_service(SERVICE_UNSYNC, None, "async_unsync")
 
     # Start server discovery task if not already running
-    await start_server_discovery(hass)
+    asyncio.create_task(start_server_discovery(hass))
 
     return True
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -113,7 +113,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
     port = config.get(CONF_PORT)
 
     if DOMAIN not in hass.data:

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -89,7 +89,7 @@ async def start_server_discovery(hass):
     """Start a server discovery task."""
 
     def _discovered_server(server):
-        hass.loop.create_task(
+        asyncio.create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_DISCOVERY},

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -301,9 +301,6 @@ class SqueezeBoxEntity(MediaPlayerEntity):
             last_media_position = self.media_position
             await self._player.async_update()
             if self.media_position != last_media_position:
-                _LOGGER.debug(
-                    "Media position updated for %s: %s", self, self.media_position
-                )
                 self._last_update = utcnow()
             if self._player.connected is False:
                 _LOGGER.info("Player %s is not available", self.name)

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -114,7 +114,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     host = config[CONF_HOST]
-    port = config.get(CONF_PORT)
+    port = config[CONF_PORT]
 
     hass.data.setdefault(DOMAIN, {})
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
+    EVENT_HOMEASSISTANT_START,
     STATE_IDLE,
     STATE_OFF,
     STATE_PAUSED,
@@ -195,7 +196,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     platform.async_register_entity_service(SERVICE_UNSYNC, None, "async_unsync")
 
     # Start server discovery task if not already running
-    asyncio.create_task(start_server_discovery(hass))
+    if hass.is_running:
+        asyncio.create_task(start_server_discovery(hass))
+    else:
+        hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START, start_server_discovery(hass)
+        )
 
     return True
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -88,8 +88,8 @@ SQUEEZEBOX_MODE = {
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the squeezebox platform."""
-    _LOGGER.error(
-        "Loading Squeezebox by media_player platform configuration is no longer supported"
+    _LOGGER.info(
+        "Setting up squeezebox platform in configuration.yaml is deprecated. Consider using config flow in frontend."
     )
 
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -116,8 +116,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     host = config[CONF_HOST]
     port = config.get(CONF_PORT)
 
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
+    hass.data.setdefault(DOMAIN, {})
 
     known_servers = hass.data[DOMAIN].get(KNOWN_SERVERS)
     if known_servers is None:

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -104,15 +104,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up squeezebox platform from platform entry in configuration.yaml (deprecated)."""
 
     if config:
-        conf = {
-            CONF_HOST: config[CONF_HOST],
-            CONF_PORT: config.get(CONF_PORT, DEFAULT_PORT),
-        }
-        for attr in [CONF_USERNAME, CONF_PASSWORD]:
-            if attr in config:
-                conf.update(attr, config.get(attr))
         await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=conf
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
         )
 
 

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -21,7 +21,8 @@
     "error": {
       "cannot_connect": "Failed to connect, please try again",
       "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "unknown": "Unexpected error",
+      "no_server_found": "Could not automatically discovery server"
     },
     "abort": {
       "already_configured": "Server is already configured",

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -24,7 +24,7 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "Device is already configured",
+      "already_configured": "Server is already configured",
       "no_server_found": "No LMS server found"
     }
   }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -1,0 +1,24 @@
+{
+  "title": "Logitech Squeezebox",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to LMS",
+        "data": {
+          "host": "Host",
+	  "port": "Port",
+	  "username": "Username (optional)",
+	  "password": "Password (optional)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  }
+}

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -5,28 +5,28 @@
       "user": {
 	"title": "Configure Logitech Media Server",
 	"data": {
-	  "host": "Host (optional - leave blank to discover)"
+	  "host": "[%key:common::config_flow::data::host%]"
 	}
       },
       "edit": {
         "title": "Edit connection information",
         "data": {
-          "host": "Host",
-	  "port": "Port",
-	  "username": "Username (optional)",
-	  "password": "Password (optional)"
+          "host": "[%key:common::config_flow::data::host%]",
+	  "port": "[%key:common::config_flow::data::port%]",
+	  "username": "[%key:common::config_flow::data::username%]",
+	  "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect, please try again",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error",
-      "no_server_found": "Could not automatically discovery server"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "no_server_found": "Could not automatically discover server."
     },
     "abort": {
-      "already_configured": "Server is already configured",
-      "no_server_found": "No LMS server found"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "no_server_found": "No LMS server found."
     }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -3,7 +3,13 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to LMS",
+	"title": "Configure Logitech Media Server",
+	"data": {
+	  "host": "Host (optional - leave blank to discover)"
+	}
+      },
+      "edit": {
+        "title": "Edit connection information",
         "data": {
           "host": "Host",
 	  "port": "Port",
@@ -18,7 +24,8 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "no_server_found": "No LMS server found"
     }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -1,6 +1,7 @@
 {
   "title": "Logitech Squeezebox",
   "config": {
+    "flow_title": "Logitech Squeezebox: {host}",
     "step": {
       "user": {
 	"title": "Configure Logitech Media Server",

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -1,28 +1,28 @@
 {
     "config": {
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+            "already_configured": "Device is already configured",
             "no_server_found": "No LMS server found."
         },
         "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
             "no_server_found": "Could not automatically discover server.",
-            "unknown": "[%key:common::config_flow::error::unknown%]"
+            "unknown": "Unexpected error"
         },
         "step": {
             "edit": {
                 "data": {
-                    "host": "[%key:common::config_flow::data::host%]",
-                    "password": "[%key:common::config_flow::data::password%]",
-                    "port": "[%key:common::config_flow::data::port%]",
-                    "username": "[%key:common::config_flow::data::username%]"
+                    "host": "Host",
+                    "password": "Password",
+                    "port": "Port",
+                    "username": "Username"
                 },
                 "title": "Edit connection information"
             },
             "user": {
                 "data": {
-                    "host": "[%key:common::config_flow::data::host%]"
+                    "host": "Host"
                 },
                 "title": "Configure Logitech Media Server"
             }

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -1,28 +1,28 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Server is already configured",
-            "no_server_found": "No LMS server found"
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+            "no_server_found": "No LMS server found."
         },
         "error": {
-            "cannot_connect": "Failed to connect, please try again",
-            "invalid_auth": "Invalid authentication",
-            "no_server_found": "Could not automatically discovery server",
-            "unknown": "Unexpected error"
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "no_server_found": "Could not automatically discover server.",
+            "unknown": "[%key:common::config_flow::error::unknown%]"
         },
         "step": {
             "edit": {
                 "data": {
-                    "host": "Host",
-                    "password": "Password (optional)",
-                    "port": "Port",
-                    "username": "Username (optional)"
+                    "host": "[%key:common::config_flow::data::host%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "port": "[%key:common::config_flow::data::port%]",
+                    "username": "[%key:common::config_flow::data::username%]"
                 },
                 "title": "Edit connection information"
             },
             "user": {
                 "data": {
-                    "host": "Host (optional - leave blank to discover)"
+                    "host": "[%key:common::config_flow::data::host%]"
                 },
                 "title": "Configure Logitech Media Server"
             }

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -1,31 +1,31 @@
 {
-  "title": "Logitech Squeezebox",
-  "config": {
-    "step": {
-      "user": {
-	"title": "Configure Logitech Media Server",
-	"data": {
-	  "host": "Host (optional - leave blank to discover)"
-	}
-      },
-      "edit": {
-        "title": "Edit connection information",
-        "data": {
-          "host": "Host",
-	  "port": "Port",
-	  "username": "Username (optional)",
-	  "password": "Password (optional)"
+    "config": {
+        "abort": {
+            "already_configured": "Server is already configured",
+            "no_server_found": "No LMS server found"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect, please try again",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "edit": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password (optional)",
+                    "port": "Port",
+                    "username": "Username (optional)"
+                },
+                "title": "Edit connection information"
+            },
+            "user": {
+                "data": {
+                    "host": "Host (optional - leave blank to discover)"
+                },
+                "title": "Configure Logitech Media Server"
+            }
         }
-      }
     },
-    "error": {
-      "cannot_connect": "Failed to connect, please try again",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
-    },
-    "abort": {
-      "already_configured": "Device is already configured",
-      "no_server_found": "No LMS server found"
-    }
-  }
+    "title": "Logitech Squeezebox"
 }

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -7,6 +7,7 @@
         "error": {
             "cannot_connect": "Failed to connect, please try again",
             "invalid_auth": "Invalid authentication",
+            "no_server_found": "Could not automatically discovery server",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -1,5 +1,6 @@
 {
     "config": {
+	"flow_title": "Logitech Squeezebox: {host}",
         "abort": {
             "already_configured": "Device is already configured",
             "no_server_found": "No LMS server found."

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -1,0 +1,24 @@
+{
+  "title": "Logitech Squeezebox",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to LMS",
+        "data": {
+          "host": "Host",
+	  "port": "Port",
+	  "username": "Username (optional)",
+	  "password": "Password (optional)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  }
+}

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -3,7 +3,13 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to LMS",
+	"title": "Configure Logitech Media Server",
+	"data": {
+	  "host": "Host (optional - leave blank to discover)"
+	}
+      },
+      "edit": {
+        "title": "Edit connection information",
         "data": {
           "host": "Host",
 	  "port": "Port",
@@ -18,7 +24,8 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "no_server_found": "No LMS server found"
     }
   }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -147,6 +147,7 @@ FLOWS = [
     "sonos",
     "speedtestdotnet",
     "spotify",
+    "squeezebox",
     "starline",
     "synology_dsm",
     "tado",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1637,7 +1637,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.1
+pysqueezebox==0.2.2
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1638,10 +1638,14 @@ pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
 <<<<<<< HEAD
+<<<<<<< HEAD
 pysqueezebox==0.2.1
 =======
 pysqueezebox==0.1.5
 >>>>>>> Fixes to config flow
+=======
+pysqueezebox==0.1.6
+>>>>>>> Unavailable player detection and recovery
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1640,6 +1640,7 @@ pyspcwebgw==0.4.0
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 pysqueezebox==0.2.1
 =======
 pysqueezebox==0.1.5
@@ -1650,6 +1651,9 @@ pysqueezebox==0.1.6
 =======
 pysqueezebox==0.1.7
 >>>>>>> Improved error message for auth failure
+=======
+pysqueezebox==0.2.0
+>>>>>>> Internal server discovery
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1637,7 +1637,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.2
+pysqueezebox==0.2.3
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1637,7 +1637,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.3
+pysqueezebox==0.2.4
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1639,6 +1639,7 @@ pyspcwebgw==0.4.0
 # homeassistant.components.squeezebox
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 pysqueezebox==0.2.1
 =======
 pysqueezebox==0.1.5
@@ -1646,6 +1647,9 @@ pysqueezebox==0.1.5
 =======
 pysqueezebox==0.1.6
 >>>>>>> Unavailable player detection and recovery
+=======
+pysqueezebox==0.1.7
+>>>>>>> Improved error message for auth failure
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1637,7 +1637,11 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
+<<<<<<< HEAD
 pysqueezebox==0.2.1
+=======
+pysqueezebox==0.1.5
+>>>>>>> Fixes to config flow
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1637,23 +1637,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 pysqueezebox==0.2.1
-=======
-pysqueezebox==0.1.5
->>>>>>> Fixes to config flow
-=======
-pysqueezebox==0.1.6
->>>>>>> Unavailable player detection and recovery
-=======
-pysqueezebox==0.1.7
->>>>>>> Improved error message for auth failure
-=======
-pysqueezebox==0.2.0
->>>>>>> Internal server discovery
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -720,6 +720,9 @@ pysonos==0.0.31
 # homeassistant.components.spc
 pyspcwebgw==0.4.0
 
+# homeassistant.components.squeezebox
+pysqueezebox==0.1.4
+
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.1
+pysqueezebox==0.2.2
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.1.7
+pysqueezebox==0.2.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.0
+pysqueezebox==0.2.1
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.3
+pysqueezebox==0.2.4
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.1.6
+pysqueezebox==0.1.7
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.1.5
+pysqueezebox==0.1.6
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.1.4
+pysqueezebox==0.1.5
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -721,7 +721,7 @@ pysonos==0.0.31
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.2
+pysqueezebox==0.2.3
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.5

--- a/tests/components/squeezebox/__init__.py
+++ b/tests/components/squeezebox/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Logitech Squeezebox integration."""

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -16,8 +16,8 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.squeezebox.config_flow.PlaceholderHub.authenticate",
-        return_value=True,
+        "homeassistant.components.squeezebox.config_flow.validate_input",
+        return_value={"uuid": "test-uuid", "ip": "1.1.1.1"},
     ), patch(
         "homeassistant.components.squeezebox.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -25,19 +25,15 @@ async def test_form(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
+            {"host": "1.1.1.1", "port": 9000, "username": "", "password": ""},
         )
-
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "Name of the device"
+    assert result2["title"] == "1.1.1.1"
     assert result2["data"] == {
         "host": "1.1.1.1",
-        "username": "test-username",
-        "password": "test-password",
+        "port": 9000,
+        "username": "",
+        "password": "",
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -51,7 +47,7 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "homeassistant.components.squeezebox.config_flow.PlaceholderHub.authenticate",
+        "homeassistant.components.squeezebox.config_flow.validate_input",
         side_effect=InvalidAuth,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -74,7 +70,7 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.squeezebox.config_flow.PlaceholderHub.authenticate",
+        "homeassistant.components.squeezebox.config_flow.validate_input",
         side_effect=CannotConnect,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -1,0 +1,90 @@
+"""Test the Logitech Squeezebox config flow."""
+from asynctest import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.squeezebox.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.squeezebox.const import DOMAIN
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.squeezebox.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.squeezebox.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.PlaceholderHub.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.PlaceholderHub.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -4,83 +4,103 @@ from asynctest import patch
 from homeassistant import config_entries, setup
 from homeassistant.components.squeezebox.config_flow import CannotConnect, InvalidAuth
 from homeassistant.components.squeezebox.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 
 
 async def test_form(hass):
-    """Test we get the form."""
+    """Test user-initiated flow."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == "form"
-    assert result["errors"] == {}
+    assert result["step_id"] == "user"
 
     with patch(
         "homeassistant.components.squeezebox.config_flow.validate_input",
-        return_value={"uuid": "test-uuid", "ip": "1.1.1.1"},
+        return_value={
+            "uuid": "test-uuid",
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 9000,
+            "ip": "1.1.1.1",
+        },
     ), patch(
         "homeassistant.components.squeezebox.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.squeezebox.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"host": "1.1.1.1", "port": 9000, "username": "", "password": ""},
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.1.1.1"}
         )
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == "1.1.1.1"
-    assert result2["data"] == {
-        "host": "1.1.1.1",
-        "port": 9000,
-        "username": "",
-        "password": "",
-    }
-    await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
+        assert result["type"] == "form"
+        assert result["step_id"] == "edit"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.1.1.1",
+                CONF_PORT: 9000,
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+            },
+        )
+        assert result["type"] == "create_entry"
+        assert result["title"] == "1.1.1.1"
+        assert result["data"] == {
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 9000,
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+        }
+
+        await hass.async_block_till_done()
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_form_invalid_auth(hass):
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": "edit"}
     )
 
     with patch(
         "homeassistant.components.squeezebox.config_flow.validate_input",
         side_effect=InvalidAuth,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+                CONF_HOST: "1.1.1.1",
+                CONF_PORT: 9000,
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
             },
         )
 
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "invalid_auth"}
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_form_cannot_connect(hass):
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": "edit"}
     )
 
     with patch(
         "homeassistant.components.squeezebox.config_flow.validate_input",
         side_effect=CannotConnect,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+                CONF_HOST: "1.1.1.1",
+                CONF_PORT: 9000,
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
             },
         )
 
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -1,54 +1,60 @@
 """Test the Logitech Squeezebox config flow."""
 from asynctest import patch
+from pysqueezebox import Server
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.squeezebox.config_flow import CannotConnect, InvalidAuth
 from homeassistant.components.squeezebox.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
+
+HOST = "1.1.1.1"
+PORT = 9000
+UUID = "test-uuid"
 
 
-async def test_form(hass):
-    """Test user-initiated flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == "form"
-    assert result["step_id"] == "user"
+async def mock_discover(_discovery_callback):
+    """Mock discovering a Logitech Media Server."""
+    _discovery_callback(Server(None, HOST, PORT, uuid=UUID))
 
+
+async def mock_failed_discover(_discovery_callback):
+    """Mock unsuccessful discovery by doing nothing."""
+    pass
+
+
+async def test_user_form(hass):
+    """Test user-initiated flow, including discovery and the edit step."""
     with patch(
         "homeassistant.components.squeezebox.config_flow.validate_input",
-        return_value={
-            "uuid": "test-uuid",
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 9000,
-            "ip": "1.1.1.1",
-        },
+        return_value={"uuid": UUID, CONF_HOST: HOST, CONF_PORT: PORT, "ip": HOST},
     ), patch(
         "homeassistant.components.squeezebox.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.squeezebox.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "1.1.1.1"}
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.squeezebox.config_flow.async_discover", mock_discover
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == "form"
+        assert result["type"] == RESULT_TYPE_FORM
         assert result["step_id"] == "edit"
+        assert CONF_HOST in result["data_schema"].schema
+        for key in result["data_schema"].schema:
+            if key == CONF_HOST:
+                assert key.description == {"suggested_value": HOST}
 
+        # test the edit step
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_HOST: "1.1.1.1",
-                CONF_PORT: 9000,
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "",
-            },
+            {CONF_HOST: HOST, CONF_PORT: PORT, CONF_USERNAME: "", CONF_PASSWORD: ""},
         )
         assert result["type"] == "create_entry"
-        assert result["title"] == "1.1.1.1"
+        assert result["title"] == HOST
         assert result["data"] == {
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 9000,
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
             CONF_USERNAME: "",
             CONF_PASSWORD: "",
         }
@@ -56,6 +62,19 @@ async def test_form(hass):
         await hass.async_block_till_done()
         assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_form_timeout(hass):
+    """Test we handle server search timeout."""
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.async_discover",
+        mock_failed_discover,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "no_server_found"}
 
 
 async def test_form_invalid_auth(hass):
@@ -71,14 +90,14 @@ async def test_form_invalid_auth(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: "1.1.1.1",
-                CONF_PORT: 9000,
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
                 CONF_USERNAME: "test-username",
                 CONF_PASSWORD: "test-password",
             },
         )
 
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
 
@@ -95,20 +114,30 @@ async def test_form_cannot_connect(hass):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: "1.1.1.1",
-                CONF_PORT: 9000,
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
                 CONF_USERNAME: "test-username",
                 CONF_PASSWORD: "test-password",
             },
         )
 
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_discovery(hass):
     """Test handling of discovered server."""
-    # TODO
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.validate_input",
+        return_value={"uuid": UUID, CONF_HOST: HOST, CONF_PORT: PORT, "ip": HOST},
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DISCOVERY},
+            data={CONF_HOST: HOST, CONF_PORT: PORT},
+        )
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["step_id"] == "edit"
 
 
 async def test_import_bad_host(hass):
@@ -120,9 +149,9 @@ async def test_import_bad_host(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: "1.1.1.1", CONF_PORT: 9000},
+            data={CONF_HOST: HOST, CONF_PORT: PORT},
         )
-        assert result["type"] == "abort"
+        assert result["type"] == RESULT_TYPE_ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -136,13 +165,13 @@ async def test_import_bad_auth(hass):
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
             data={
-                CONF_HOST: "1.1.1.1",
-                CONF_PORT: 9000,
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
                 CONF_USERNAME: "test",
                 CONF_PASSWORD: "bad",
             },
         )
-        assert result["type"] == "abort"
+        assert result["type"] == RESULT_TYPE_ABORT
         assert result["reason"] == "invalid_auth"
 
 
@@ -154,23 +183,22 @@ async def test_import_existing(hass):
             config_entries.ConfigEntry(
                 version="1",
                 domain=DOMAIN,
-                title="1.1.1.1",
+                title=HOST,
                 data={},
                 options={},
                 system_options={},
                 source=config_entries.SOURCE_IMPORT,
                 connection_class=config_entries.CONN_CLASS_LOCAL_POLL,
-                unique_id="test-uuid",
+                unique_id=UUID,
             )
         ],
     ), patch(
-        "pysqueezebox.Server.async_query",
-        return_value={"ip": "1.1.1.1", "uuid": "test-uuid"},
+        "pysqueezebox.Server.async_query", return_value={"ip": HOST, "uuid": UUID},
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: "1.1.1.1", CONF_PORT: 9000},
+            data={CONF_HOST: HOST, CONF_PORT: PORT},
         )
-        assert result["type"] == "abort"
+        assert result["type"] == RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -3,7 +3,6 @@ from asynctest import patch
 from pysqueezebox import Server
 
 from homeassistant import config_entries
-from homeassistant.components.squeezebox.config_flow import CannotConnect, InvalidAuth
 from homeassistant.components.squeezebox.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
@@ -25,8 +24,8 @@ async def mock_failed_discover(_discovery_callback):
 async def test_user_form(hass):
     """Test user-initiated flow, including discovery and the edit step."""
     with patch(
-        "homeassistant.components.squeezebox.config_flow.validate_input",
-        return_value={"uuid": UUID, CONF_HOST: HOST, CONF_PORT: PORT, "ip": HOST},
+        "homeassistant.components.squeezebox.config_flow.SqueezeboxConfigFlow._validate_input",
+        return_value=None,
     ), patch(
         "homeassistant.components.squeezebox.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -83,8 +82,8 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "homeassistant.components.squeezebox.config_flow.validate_input",
-        side_effect=InvalidAuth,
+        "homeassistant.components.squeezebox.config_flow.SqueezeboxConfigFlow._validate_input",
+        return_value="invalid_auth",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -107,8 +106,8 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.squeezebox.config_flow.validate_input",
-        side_effect=CannotConnect,
+        "homeassistant.components.squeezebox.config_flow.SqueezeboxConfigFlow._validate_input",
+        return_value="cannot_connect",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -127,8 +126,8 @@ async def test_form_cannot_connect(hass):
 async def test_discovery(hass):
     """Test handling of discovered server."""
     with patch(
-        "homeassistant.components.squeezebox.config_flow.validate_input",
-        return_value={"uuid": UUID, CONF_HOST: HOST, CONF_PORT: PORT, "ip": HOST},
+        "homeassistant.components.squeezebox.config_flow.SqueezeboxConfigFlow._validate_input",
+        return_value=None,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -142,8 +141,8 @@ async def test_discovery(hass):
 async def test_import_bad_host(hass):
     """Test handling of configuration imported with bad host."""
     with patch(
-        "homeassistant.components.squeezebox.config_flow.validate_input",
-        side_effect=CannotConnect,
+        "homeassistant.components.squeezebox.config_flow.SqueezeboxConfigFlow._validate_input",
+        return_value="cannot_connect",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -157,8 +156,8 @@ async def test_import_bad_host(hass):
 async def test_import_bad_auth(hass):
     """Test handling of configuration import with bad authentication."""
     with patch(
-        "homeassistant.components.squeezebox.config_flow.validate_input",
-        side_effect=InvalidAuth,
+        "homeassistant.components.squeezebox.config_flow.SqueezeboxConfigFlow._validate_input",
+        return_value="invalid_auth",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -67,7 +67,7 @@ async def test_user_form_timeout(hass):
     with patch(
         "homeassistant.components.squeezebox.config_flow.async_discover",
         mock_failed_discover,
-    ):
+    ), patch("homeassistant.components.squeezebox.config_flow.TIMEOUT", 0):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -20,7 +20,6 @@ async def mock_discover(_discovery_callback):
 
 async def mock_failed_discover(_discovery_callback):
     """Mock unsuccessful discovery by doing nothing."""
-    pass
 
 
 async def test_user_form(hass):

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -17,17 +17,13 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
+from tests.common import MockConfigEntry
+
 HOST = "1.1.1.1"
 HOST2 = "2.2.2.2"
 PORT = 9000
 UUID = "test-uuid"
 UNKNOWN_ERROR = "1234"
-
-
-class MockEntry:
-    """Mock a config_entry."""
-
-    unique_id = UUID
 
 
 async def mock_discover(_discovery_callback):
@@ -110,7 +106,7 @@ async def test_user_form_duplicate(hass):
         "homeassistant.components.squeezebox.config_flow.async_discover", mock_discover,
     ), patch(
         "homeassistant.components.squeezebox.config_flow.SqueezeboxConfigFlow._async_current_entries",
-        return_value=[MockEntry],
+        return_value=[MockConfigEntry(unique_id=UUID)],
     ), patch(
         "homeassistant.components.squeezebox.config_flow.TIMEOUT", 0.1
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Configuration of the squeezebox integration through configuration.yaml is now deprecated. Please consider using the frontend to configure the squeezebox integration instead. 


## Proposed change
This moves the squeezebox integration to the configuration flow so that it can be configured from the frontend and loaded without restarting home assistant. Servers will automatically be discovered by the "discovery" integration, or by this integration once it is loaded. If the user adds this integration from frontend, it will attempt to automatically discover the server as well.

Relatedly, the squeezebox integration will now handle individual players coming online or going offline while home assistant is running. Previously, the integration would only detect players that were present during startup.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
Tests have been added for the configuration flow.

- This PR fixes or closes issue: fixes #36843
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13452

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
