### PR TITLE
Mark homekit accessories unavailable if the underlying entity is unavailable

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -327,9 +327,7 @@ class HomeAccessory(Accessory):
     def available(self):
         """Return if accessory is available."""
         state = self.hass.states.get(self.entity_id)
-        if state is None or state.state == STATE_UNAVAILABLE:
-            return False
-        return True
+        return state is not None and state.state != STATE_UNAVAILABLE
 
     async def run(self):
         """Handle accessory driver started event.

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_TEMPERATURE,
     STATE_ON,
+    STATE_UNAVAILABLE,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
     UNIT_PERCENTAGE,
@@ -321,6 +322,14 @@ class HomeAccessory(Accessory):
         self._char_low_battery = serv_battery.configure_char(
             CHAR_STATUS_LOW_BATTERY, value=0
         )
+
+    @property
+    def available(self):
+        """Return if accessory is available."""
+        state = self.hass.states.get(self.entity_id)
+        if state is None or state.state == STATE_UNAVAILABLE:
+            return False
+        return True
 
     async def run(self):
         """Handle accessory driver started event.

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -2,7 +2,7 @@
   "domain": "homekit",
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
-  "requirements": ["HAP-python==2.8.4","fnvhash==0.1.0","PyQRCode==1.2.1","base36==0.1.1","PyTurboJPEG==1.4.0"],
+  "requirements": ["HAP-python==2.8.5","fnvhash==0.1.0","PyQRCode==1.2.1","base36==0.1.1","PyTurboJPEG==1.4.0"],
   "dependencies": ["http", "camera", "ffmpeg"],
   "after_dependencies": ["logbook", "zeroconf"],
   "codeowners": ["@bdraco"],

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -2,7 +2,7 @@
   "domain": "homekit",
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
-  "requirements": ["HAP-python==2.9.0","fnvhash==0.1.0","PyQRCode==1.2.1","base36==0.1.1","PyTurboJPEG==1.4.0"],
+  "requirements": ["HAP-python==2.9.1","fnvhash==0.1.0","PyQRCode==1.2.1","base36==0.1.1","PyTurboJPEG==1.4.0"],
   "dependencies": ["http", "camera", "ffmpeg"],
   "after_dependencies": ["logbook", "zeroconf"],
   "codeowners": ["@bdraco"],

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -2,7 +2,7 @@
   "domain": "homekit",
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
-  "requirements": ["HAP-python==2.8.5","fnvhash==0.1.0","PyQRCode==1.2.1","base36==0.1.1","PyTurboJPEG==1.4.0"],
+  "requirements": ["HAP-python==2.9.0","fnvhash==0.1.0","PyQRCode==1.2.1","base36==0.1.1","PyTurboJPEG==1.4.0"],
   "dependencies": ["http", "camera", "ffmpeg"],
   "after_dependencies": ["logbook", "zeroconf"],
   "codeowners": ["@bdraco"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==2.8.4
+HAP-python==2.8.5
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==2.9.0
+HAP-python==2.9.1
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==2.8.5
+HAP-python==2.9.0
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -4,7 +4,7 @@
 -r requirements_test.txt
 
 # homeassistant.components.homekit
-HAP-python==2.8.4
+HAP-python==2.8.5
 
 # homeassistant.components.plugwise
 Plugwise_Smile==0.2.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -4,7 +4,7 @@
 -r requirements_test.txt
 
 # homeassistant.components.homekit
-HAP-python==2.8.5
+HAP-python==2.9.0
 
 # homeassistant.components.plugwise
 Plugwise_Smile==0.2.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -4,7 +4,7 @@
 -r requirements_test.txt
 
 # homeassistant.components.homekit
-HAP-python==2.9.0
+HAP-python==2.9.1
 
 # homeassistant.components.plugwise
 Plugwise_Smile==0.2.10

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -42,6 +42,7 @@ from homeassistant.const import (
     EVENT_TIME_CHANGED,
     STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
     __version__,
 )
 import homeassistant.util.dt as dt_util
@@ -88,7 +89,7 @@ async def test_home_accessory(hass, hk_driver):
     entity_id2 = "light.accessory"
 
     hass.states.async_set(entity_id, None)
-    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, STATE_UNAVAILABLE)
 
     await hass.async_block_till_done()
 
@@ -98,6 +99,7 @@ async def test_home_accessory(hass, hk_driver):
     assert acc.hass == hass
     assert acc.display_name == "Home Accessory"
     assert acc.aid == 2
+    assert acc.available is True
     assert acc.category == 1  # Category.OTHER
     assert len(acc.services) == 1
     serv = acc.services[0]  # SERV_ACCESSORY_INFO
@@ -127,6 +129,7 @@ async def test_home_accessory(hass, hk_driver):
             ATTR_INTERGRATION: "luxe",
         },
     )
+    assert acc3.available is False
     serv = acc3.services[0]  # SERV_ACCESSORY_INFO
     assert serv.get_characteristic(CHAR_NAME).value == "Home Accessory"
     assert serv.get_characteristic(CHAR_MANUFACTURER).value == "Lux Brands"


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mark homekit accessories unavailable if the underlying entity is unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
