### PR TITLE
Add scan_interval configuration for apcupsd

### DIFF
--- a/homeassistant/components/apcupsd/__init__.py
+++ b/homeassistant/components/apcupsd/__init__.py
@@ -4,17 +4,15 @@ import logging
 from apcaccess import status
 import voluptuous as vol
 
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_POLL_INTERVAL = "poll_interval"
-
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 3551
-DEFAULT_POLL_INTERVAL = 60
+DEFAULT_SCAN_INTERVAL = 60
 DOMAIN = "apcupsd"
 
 KEY_STATUS = "STATFLAG"
@@ -28,7 +26,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                 vol.Optional(
-                    CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): cv.time_period_seconds,
             }
         )
@@ -42,9 +40,9 @@ def setup(hass, config):
     conf = config[DOMAIN]
     host = conf[CONF_HOST]
     port = conf[CONF_PORT]
-    poll_time = conf[CONF_POLL_INTERVAL]
+    scan_interval = conf[CONF_SCAN_INTERVAL]
 
-    apcups_data = APCUPSdData(host, port, poll_time)
+    apcups_data = APCUPSdData(host, port, scan_interval)
     hass.data[DOMAIN] = apcups_data
 
     # It doesn't really matter why we're not able to get the status, just that
@@ -64,7 +62,7 @@ class APCUPSdData:
     updates from the server.
     """
 
-    def __init__(self, host, port, poll_time):
+    def __init__(self, host, port, scan_interval):
         """Initialize the data object."""
 
         self._host = host
@@ -72,7 +70,7 @@ class APCUPSdData:
         self._status = None
         self._get = status.get
         self._parse = status.parse
-        self.update = Throttle(poll_time)(self._update)
+        self.update = Throttle(scan_interval)(self._update)
 
     @property
     def status(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add scanning interval configuration to the apcupsd component. Right now it's hard set to 60 seconds, which means reacting to serious events can take longer than desired. See #15383, [here](https://community.home-assistant.io/t/apcupsd-poll-time-too-long/167640), and [here](https://community.home-assistant.io/t/new-apcupsd-hass-io-add-on/35149/114?u=korylprince)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
apcupsd:
  host: <ip>
  scan_interval: 10 # added option, in seconds
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15383
- Link to documentation pull request: [13458](https://github.com/home-assistant/home-assistant.io/pull/13458)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io