### PR TITLE
Bump PyWeMo version to 0.4.43

### DIFF
--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -4,6 +4,8 @@ import logging
 
 import async_timeout
 
+from pywemo.ouimeaux_device.api.service import ActionException
+
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -98,9 +100,10 @@ class WemoBinarySensor(BinarySensorEntity):
             if not self._available:
                 _LOGGER.info("Reconnected to %s", self.name)
                 self._available = True
-        except AttributeError as err:
+        except (AttributeError, ActionException) as err:
             _LOGGER.warning("Could not update status for %s (%s)", self.name, err)
             self._available = False
+            self.wemo.reconnect_with_device()
 
     @property
     def unique_id(self):
@@ -126,8 +129,8 @@ class WemoBinarySensor(BinarySensorEntity):
     def device_info(self):
         """Return the device info."""
         return {
-            "name": self.wemo.name,
-            "identifiers": {(WEMO_DOMAIN, self.wemo.serialnumber)},
-            "model": self.wemo.model_name,
+            "name": self._name,
+            "identifiers": {(WEMO_DOMAIN, self._serialnumber)},
+            "model": self._model_name,
             "manufacturer": "Belkin",
         }

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 
 import async_timeout
-
 from pywemo.ouimeaux_device.api.service import ActionException
 
 from homeassistant.components.binary_sensor import BinarySensorEntity

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -41,7 +41,7 @@ class WemoBinarySensor(BinarySensorEntity):
         self._update_lock = None
         self._model_name = self.wemo.model_name
         self._name = self.wemo.name
-        self._serialnumber = self.wemo.serialnumber
+        self._serial_number = self.wemo.serialnumber
 
     def _subscription_callback(self, _device, _type, _params):
         """Update the state by the Wemo sensor."""
@@ -107,7 +107,7 @@ class WemoBinarySensor(BinarySensorEntity):
     @property
     def unique_id(self):
         """Return the id of this WeMo sensor."""
-        return self._serialnumber
+        return self._serial_number
 
     @property
     def name(self):
@@ -129,7 +129,7 @@ class WemoBinarySensor(BinarySensorEntity):
         """Return the device info."""
         return {
             "name": self._name,
-            "identifiers": {(WEMO_DOMAIN, self._serialnumber)},
+            "identifiers": {(WEMO_DOMAIN, self._serial_number)},
             "model": self._model_name,
             "manufacturer": "Belkin",
         }

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -130,10 +130,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # Register service(s)
     hass.services.async_register(
-        WEMO_DOMAIN,
-        SERVICE_SET_HUMIDITY,
-        service_handle,
-        schema=SET_HUMIDITY_SCHEMA,
+        WEMO_DOMAIN, SERVICE_SET_HUMIDITY, service_handle, schema=SET_HUMIDITY_SCHEMA,
     )
 
     hass.services.async_register(
@@ -321,7 +318,9 @@ class WemoHumidifier(FanEntity):
         try:
             self.wemo.set_state(HASS_FAN_SPEED_TO_WEMO.get(speed))
         except ActionException as err:
-            _LOGGER.warning("Error while setting speed of device %s (%s)", self.name, err)
+            _LOGGER.warning(
+                "Error while setting speed of device %s (%s)", self.name, err
+            )
             self._available = False
 
     def set_humidity(self, humidity: float) -> None:
@@ -338,7 +337,9 @@ class WemoHumidifier(FanEntity):
             elif humidity >= 100:
                 self.wemo.set_humidity(WEMO_HUMIDITY_100)
         except ActionException as err:
-            _LOGGER.warning("Error while setting humidity of device: %s (%s)", self.name, err)
+            _LOGGER.warning(
+                "Error while setting humidity of device: %s (%s)", self.name, err
+            )
             self._available = False
 
     def reset_filter_life(self) -> None:
@@ -346,5 +347,7 @@ class WemoHumidifier(FanEntity):
         try:
             self.wemo.reset_filter_life()
         except ActionException as err:
-            _LOGGER.warning("Error while resetting filter life on device: %s (%s)", self.name, err)
+            _LOGGER.warning(
+                "Error while resetting filter life on device: %s (%s)", self.name, err
+            )
             self._available = False

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -324,8 +324,6 @@ class WemoHumidifier(FanEntity):
 
     def set_humidity(self, humidity: float) -> None:
         """Set the target humidity level for the Humidifier."""
-        target_humidity = None
-
         if humidity < 50:
             target_humidity = WEMO_HUMIDITY_45
         elif 50 <= humidity < 55:
@@ -338,8 +336,7 @@ class WemoHumidifier(FanEntity):
             target_humidity = WEMO_HUMIDITY_100
 
         try:
-            if target_humidity is not None:
-                self.wemo.set_humidity(target_humidity)
+            self.wemo.set_humidity(target_humidity)
         except ActionException as err:
             _LOGGER.warning(
                 "Error while setting humidity of device: %s (%s)", self.name, err

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -295,14 +295,14 @@ class WemoHumidifier(FanEntity):
 
     def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn the switch on."""
-        try:
-            if speed is None:
+        if speed is None:
+            try:
                 self.wemo.set_state(self._last_fan_on_mode)
-            else:
-                self.set_speed(speed)
-        except ActionException as err:
-            _LOGGER.warning("Error while turning on device %s (%s)", self.name, err)
-            self._available = False
+            except ActionException as err:
+                _LOGGER.warning("Error while turning on device %s (%s)", self.name, err)
+                self._available = False
+        else:
+            self.set_speed(speed)
 
     def turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
@@ -324,17 +324,22 @@ class WemoHumidifier(FanEntity):
 
     def set_humidity(self, humidity: float) -> None:
         """Set the target humidity level for the Humidifier."""
+        target_humidity = None
+
+        if humidity < 50:
+            target_humidity = WEMO_HUMIDITY_45
+        elif 50 <= humidity < 55:
+            target_humidity = WEMO_HUMIDITY_50
+        elif 55 <= humidity < 60:
+            target_humidity = WEMO_HUMIDITY_55
+        elif 60 <= humidity < 100:
+            target_humidity = WEMO_HUMIDITY_60
+        elif humidity >= 100:
+            target_humidity = WEMO_HUMIDITY_100
+
         try:
-            if humidity < 50:
-                self.wemo.set_humidity(WEMO_HUMIDITY_45)
-            elif 50 <= humidity < 55:
-                self.wemo.set_humidity(WEMO_HUMIDITY_50)
-            elif 55 <= humidity < 60:
-                self.wemo.set_humidity(WEMO_HUMIDITY_55)
-            elif 60 <= humidity < 100:
-                self.wemo.set_humidity(WEMO_HUMIDITY_60)
-            elif humidity >= 100:
-                self.wemo.set_humidity(WEMO_HUMIDITY_100)
+            if target_humidity is not None:
+                self.wemo.set_humidity(target_humidity)
         except ActionException as err:
             _LOGGER.warning(
                 "Error while setting humidity of device: %s (%s)", self.name, err

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -4,9 +4,8 @@ from datetime import timedelta
 import logging
 
 import async_timeout
-import voluptuous as vol
-
 from pywemo.ouimeaux_device.api.service import ActionException
+import voluptuous as vol
 
 from homeassistant.components.fan import (
     SPEED_HIGH,

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -6,6 +6,8 @@ import logging
 import async_timeout
 import voluptuous as vol
 
+from pywemo.ouimeaux_device.api.service import ActionException
+
 from homeassistant.components.fan import (
     SPEED_HIGH,
     SPEED_LOW,
@@ -128,7 +130,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # Register service(s)
     hass.services.async_register(
-        WEMO_DOMAIN, SERVICE_SET_HUMIDITY, service_handle, schema=SET_HUMIDITY_SCHEMA
+        WEMO_DOMAIN,
+        SERVICE_SET_HUMIDITY,
+        service_handle,
+        schema=SET_HUMIDITY_SCHEMA,
     )
 
     hass.services.async_register(
@@ -198,9 +203,9 @@ class WemoHumidifier(FanEntity):
     def device_info(self):
         """Return the device info."""
         return {
-            "name": self.wemo.name,
-            "identifiers": {(WEMO_DOMAIN, self.wemo.serialnumber)},
-            "model": self.wemo.model_name,
+            "name": self._name,
+            "identifiers": {(WEMO_DOMAIN, self._serialnumber)},
+            "model": self._model_name,
             "manufacturer": "Belkin",
         }
 
@@ -287,38 +292,59 @@ class WemoHumidifier(FanEntity):
             if not self._available:
                 _LOGGER.info("Reconnected to %s", self.name)
                 self._available = True
-        except AttributeError as err:
+        except (AttributeError, ActionException) as err:
             _LOGGER.warning("Could not update status for %s (%s)", self.name, err)
             self._available = False
+            self.wemo.reconnect_with_device()
 
     def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn the switch on."""
-        if speed is None:
-            self.wemo.set_state(self._last_fan_on_mode)
-        else:
-            self.set_speed(speed)
+        try:
+            if speed is None:
+                self.wemo.set_state(self._last_fan_on_mode)
+            else:
+                self.set_speed(speed)
+        except ActionException as err:
+            _LOGGER.warning("Error while turning on device %s (%s)", self.name, err)
+            self._available = False
 
     def turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
-        self.wemo.set_state(WEMO_FAN_OFF)
+        try:
+            self.wemo.set_state(WEMO_FAN_OFF)
+        except ActionException as err:
+            _LOGGER.warning("Error while turning off device %s (%s)", self.name, err)
+            self._available = False
 
     def set_speed(self, speed: str) -> None:
         """Set the fan_mode of the Humidifier."""
-        self.wemo.set_state(HASS_FAN_SPEED_TO_WEMO.get(speed))
+        try:
+            self.wemo.set_state(HASS_FAN_SPEED_TO_WEMO.get(speed))
+        except ActionException as err:
+            _LOGGER.warning("Error while setting speed of device %s (%s)", self.name, err)
+            self._available = False
 
     def set_humidity(self, humidity: float) -> None:
         """Set the target humidity level for the Humidifier."""
-        if humidity < 50:
-            self.wemo.set_humidity(WEMO_HUMIDITY_45)
-        elif 50 <= humidity < 55:
-            self.wemo.set_humidity(WEMO_HUMIDITY_50)
-        elif 55 <= humidity < 60:
-            self.wemo.set_humidity(WEMO_HUMIDITY_55)
-        elif 60 <= humidity < 100:
-            self.wemo.set_humidity(WEMO_HUMIDITY_60)
-        elif humidity >= 100:
-            self.wemo.set_humidity(WEMO_HUMIDITY_100)
+        try:
+            if humidity < 50:
+                self.wemo.set_humidity(WEMO_HUMIDITY_45)
+            elif 50 <= humidity < 55:
+                self.wemo.set_humidity(WEMO_HUMIDITY_50)
+            elif 55 <= humidity < 60:
+                self.wemo.set_humidity(WEMO_HUMIDITY_55)
+            elif 60 <= humidity < 100:
+                self.wemo.set_humidity(WEMO_HUMIDITY_60)
+            elif humidity >= 100:
+                self.wemo.set_humidity(WEMO_HUMIDITY_100)
+        except ActionException as err:
+            _LOGGER.warning("Error while setting humidity of device: %s (%s)", self.name, err)
+            self._available = False
 
     def reset_filter_life(self) -> None:
         """Reset the filter life to 100%."""
-        self.wemo.reset_filter_life()
+        try:
+            self.wemo.reset_filter_life()
+        except ActionException as err:
+            _LOGGER.warning("Error while resetting filter life on device: %s (%s)", self.name, err)
+            self._available = False

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -162,7 +162,7 @@ class WemoLight(LightEntity):
             xy_color = color_util.color_hs_to_xy(*hs_color)
 
         if ATTR_COLOR_TEMP in kwargs:
-            color_temp = int(kwargs.get(ATTR_COLOR_TEMP))
+            color_temp = kwargs[ATTR_COLOR_TEMP]
 
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import logging
 
 import async_timeout
-
 from pywemo.ouimeaux_device.api.service import ActionException
 
 from homeassistant import util

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -5,6 +5,8 @@ import logging
 
 import async_timeout
 
+from pywemo.ouimeaux_device.api.service import ActionException
+
 from homeassistant import util
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -92,6 +94,7 @@ class WemoLight(LightEntity):
         self._is_on = None
         self._name = self.wemo.name
         self._unique_id = self.wemo.uniqueID
+        self._model_name = type(self.wemo).__name__
 
     async def async_added_to_hass(self):
         """Wemo light added to Home Assistant."""
@@ -112,9 +115,9 @@ class WemoLight(LightEntity):
     def device_info(self):
         """Return the device info."""
         return {
-            "name": self.wemo.name,
-            "identifiers": {(WEMO_DOMAIN, self.wemo.uniqueID)},
-            "model": type(self.wemo).__name__,
+            "name": self._name,
+            "identifiers": {(WEMO_DOMAIN, self._unique_id)},
+            "model": self._model_name,
             "manufacturer": "Belkin",
         }
 
@@ -150,45 +153,59 @@ class WemoLight(LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
-        transitiontime = int(kwargs.get(ATTR_TRANSITION, 0))
+        try:
+            transitiontime = int(kwargs.get(ATTR_TRANSITION, 0))
 
-        hs_color = kwargs.get(ATTR_HS_COLOR)
+            hs_color = kwargs.get(ATTR_HS_COLOR)
 
-        if hs_color is not None:
-            xy_color = color_util.color_hs_to_xy(*hs_color)
-            self.wemo.set_color(xy_color, transition=transitiontime)
+            if hs_color is not None:
+                xy_color = color_util.color_hs_to_xy(*hs_color)
+                self.wemo.set_color(xy_color, transition=transitiontime)
 
-        if ATTR_COLOR_TEMP in kwargs:
-            colortemp = kwargs[ATTR_COLOR_TEMP]
-            self.wemo.set_temperature(mireds=colortemp, transition=transitiontime)
+            if ATTR_COLOR_TEMP in kwargs:
+                colortemp = kwargs[ATTR_COLOR_TEMP]
+                self.wemo.set_temperature(mireds=colortemp, transition=transitiontime)
 
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)
-            self.wemo.turn_on(level=brightness, transition=transitiontime)
-        else:
-            self.wemo.turn_on(transition=transitiontime)
+            if ATTR_BRIGHTNESS in kwargs:
+                brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)
+                self.wemo.turn_on(level=brightness, transition=transitiontime)
+            else:
+                self.wemo.turn_on(transition=transitiontime)
+        except ActionException as err:
+            _LOGGER.warning("Error while turning on device %s (%s)", self.name, err)
+            self._available = False
 
     def turn_off(self, **kwargs):
         """Turn the light off."""
         transitiontime = int(kwargs.get(ATTR_TRANSITION, 0))
-        self.wemo.turn_off(transition=transitiontime)
+
+        try:
+            self.wemo.turn_off(transition=transitiontime)
+        except ActionException as err:
+            _LOGGER.warning("Error while turning off device %s (%s)", self.name, err)
+            self._available = False
 
     def _update(self, force_update=True):
         """Synchronize state with bridge."""
-        self._update_lights(no_throttle=force_update)
-        self._state = self.wemo.state
+        try:
+            self._update_lights(no_throttle=force_update)
+            self._state = self.wemo.state
 
-        self._is_on = self._state.get("onoff") != 0
-        self._brightness = self._state.get("level", 255)
-        self._color_temp = self._state.get("temperature_mireds")
-        self._available = True
+            self._is_on = self._state.get("onoff") != 0
+            self._brightness = self._state.get("level", 255)
+            self._color_temp = self._state.get("temperature_mireds")
+            self._available = True
 
-        xy_color = self._state.get("color_xy")
+            xy_color = self._state.get("color_xy")
 
-        if xy_color:
-            self._hs_color = color_util.color_xy_to_hs(*xy_color)
-        else:
-            self._hs_color = None
+            if xy_color:
+                self._hs_color = color_util.color_xy_to_hs(*xy_color)
+            else:
+                self._hs_color = None
+        except (AttributeError, ActionException) as err:
+            _LOGGER.warning("Could not update status for %s (%s)", self.name, err)
+            self._available = False
+            self.wemo.reconnect_with_device()
 
     async def async_update(self):
         """Synchronize state with bridge."""
@@ -265,7 +282,6 @@ class WemoDimmer(LightEntity):
         except asyncio.TimeoutError:
             _LOGGER.warning("Lost connection to %s", self.name)
             self._available = False
-            self.wemo.reconnect_with_device()
 
     async def _async_locked_update(self, force_update):
         """Try updating within an async lock."""
@@ -281,6 +297,16 @@ class WemoDimmer(LightEntity):
     def name(self):
         """Return the name of the dimmer if any."""
         return self._name
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "name": self._name,
+            "identifiers": {(WEMO_DOMAIN, self._serialnumber)},
+            "model": self._model_name,
+            "manufacturer": "Belkin",
+        }
 
     @property
     def supported_features(self):
@@ -308,26 +334,35 @@ class WemoDimmer(LightEntity):
             if not self._available:
                 _LOGGER.info("Reconnected to %s", self.name)
                 self._available = True
-        except AttributeError as err:
+        except (AttributeError, ActionException) as err:
             _LOGGER.warning("Could not update status for %s (%s)", self.name, err)
             self._available = False
+            self.wemo.reconnect_with_device()
 
     def turn_on(self, **kwargs):
         """Turn the dimmer on."""
-        self.wemo.on()
+        try:
+            self.wemo.on()
 
-        # Wemo dimmer switches use a range of [0, 100] to control
-        # brightness. Level 255 might mean to set it to previous value
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs[ATTR_BRIGHTNESS]
-            brightness = int((brightness / 255) * 100)
-        else:
-            brightness = 255
-        self.wemo.set_brightness(brightness)
+            # Wemo dimmer switches use a range of [0, 100] to control
+            # brightness. Level 255 might mean to set it to previous value
+            if ATTR_BRIGHTNESS in kwargs:
+                brightness = kwargs[ATTR_BRIGHTNESS]
+                brightness = int((brightness / 255) * 100)
+            else:
+                brightness = 255
+            self.wemo.set_brightness(brightness)
+        except ActionException as err:
+            _LOGGER.warning("Error while turning on device %s (%s)", self.name, err)
+            self._available = False
 
     def turn_off(self, **kwargs):
         """Turn the dimmer off."""
-        self.wemo.off()
+        try:
+            self.wemo.off()
+        except ActionException as err:
+            _LOGGER.warning("Error while turning on device %s (%s)", self.name, err)
+            self._available = False
 
     @property
     def available(self):

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -162,7 +162,7 @@ class WemoLight(LightEntity):
             xy_color = color_util.color_hs_to_xy(*hs_color)
 
         if ATTR_COLOR_TEMP in kwargs:
-            color_temp = kwargs[ATTR_COLOR_TEMP]
+            color_temp = int(kwargs.get(ATTR_COLOR_TEMP))
 
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -152,20 +152,15 @@ class WemoLight(LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
-        brightness = None
         xy_color = None
-        color_temp = None
-        transition_time = int(kwargs.get(ATTR_TRANSITION, 0))
+
+        brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)
+        color_temp = kwargs.get(ATTR_COLOR_TEMP)
         hs_color = kwargs.get(ATTR_HS_COLOR)
+        transition_time = int(kwargs.get(ATTR_TRANSITION, 0))
 
         if hs_color is not None:
             xy_color = color_util.color_hs_to_xy(*hs_color)
-
-        if ATTR_COLOR_TEMP in kwargs:
-            color_temp = kwargs[ATTR_COLOR_TEMP]
-
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness or 255)
 
         turn_on_kwargs = {
             "level": brightness,

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Belkin WeMo",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wemo",
-  "requirements": ["pywemo==0.4.34"],
+  "requirements": ["pywemo==0.4.43"],
   "ssdp": [
     {
       "manufacturer": "Belkin International Inc."

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -5,6 +5,8 @@ import logging
 
 import async_timeout
 
+from pywemo.ouimeaux_device.api.service import ActionException
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_STANDBY, STATE_UNKNOWN
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -93,9 +95,9 @@ class WemoSwitch(SwitchEntity):
     def device_info(self):
         """Return the device info."""
         return {
-            "name": self.wemo.name,
-            "identifiers": {(WEMO_DOMAIN, self.wemo.serialnumber)},
-            "model": self.wemo.model_name,
+            "name": self._name,
+            "identifiers": {(WEMO_DOMAIN, self._serialnumber)},
+            "model": self._model_name,
             "manufacturer": "Belkin",
         }
 
@@ -189,11 +191,19 @@ class WemoSwitch(SwitchEntity):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        self.wemo.on()
+        try:
+            self.wemo.on()
+        except ActionException as err:
+            _LOGGER.warning("Error while turning on device %s (%s)", self.name, err)
+            self._available = False
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
-        self.wemo.off()
+        try:
+            self.wemo.off()
+        except ActionException as err:
+            _LOGGER.warning("Error while turning off device %s (%s)", self.name, err)
+            self._available = False
 
     async def async_added_to_hass(self):
         """Wemo switch added to Home Assistant."""
@@ -245,6 +255,7 @@ class WemoSwitch(SwitchEntity):
             if not self._available:
                 _LOGGER.info("Reconnected to %s", self.name)
                 self._available = True
-        except AttributeError as err:
+        except (AttributeError, ActionException) as err:
             _LOGGER.warning("Could not update status for %s (%s)", self.name, err)
             self._available = False
+            self.wemo.reconnect_with_device()

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 import logging
 
 import async_timeout
-
 from pywemo.ouimeaux_device.api.service import ActionException
 
 from homeassistant.components.switch import SwitchEntity

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1805,7 +1805,7 @@ pyvlx==0.2.14
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.4.34
+pywemo==0.4.43
 
 # homeassistant.components.xeoma
 pyxeoma==1.4.1


### PR DESCRIPTION
## Proposed change

Changes necessary to safely upgrade to pyWeMo 0.4.43. This includes catching ActionExceptions that may be thrown by pyWeMo when it is unable to interact with a physical device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
wemo:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34416

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.