### PR TITLE
Add Nuki Opener integration

### DIFF
--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -52,7 +52,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     bridge = NukiBridge(
         config[CONF_HOST], config[CONF_TOKEN], config[CONF_PORT], DEFAULT_TIMEOUT
     )
-    devices = [NukiLockEntitiy(lock) for lock in bridge.locks]
+    devices = [NukiLockEntity(lock) for lock in bridge.locks]
 
     def service_handler(service):
         """Service handler for nuki services."""
@@ -68,11 +68,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         DOMAIN, SERVICE_LOCK_N_GO, service_handler, schema=LOCK_N_GO_SERVICE_SCHEMA
     )
 
-    devices.extend([NukiOpenerEntitiy(opener) for opener in bridge.openers])
+    devices.extend([NukiOpenerEntity(opener) for opener in bridge.openers])
     add_entities(devices)
 
 
-class NukiLockEntitiy(LockEntity):
+class NukiLockEntity(LockEntity):
     """Representation of a Nuki lock."""
 
     def __init__(self, nuki_lock):
@@ -150,7 +150,7 @@ class NukiLockEntitiy(LockEntity):
         self._nuki_lock.lock_n_go(unlatch, kwargs)
 
 
-class NukiOpenerEntitiy(LockEntity):
+class NukiOpenerEntity(LockEntity):
     """Representation of a Nuki opener."""
 
     def __init__(self, nuki_opener):
@@ -218,4 +218,3 @@ class NukiOpenerEntitiy(LockEntity):
     def open(self, **kwargs):
         """Activate the electric strike actuation."""
         self._nuki_opener.electric_strike_actuation()
-

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -52,7 +52,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     bridge = NukiBridge(
         config[CONF_HOST], config[CONF_TOKEN], config[CONF_PORT], DEFAULT_TIMEOUT
     )
-    devices = [NukiLock(lock) for lock in bridge.locks]
+    devices = [NukiLockEntitiy(lock) for lock in bridge.locks]
 
     def service_handler(service):
         """Service handler for nuki services."""
@@ -68,10 +68,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         DOMAIN, SERVICE_LOCK_N_GO, service_handler, schema=LOCK_N_GO_SERVICE_SCHEMA
     )
 
+    devices.extend([NukiOpenerEntitiy(opener) for opener in bridge.openers])
     add_entities(devices)
 
 
-class NukiLock(LockEntity):
+class NukiLockEntitiy(LockEntity):
     """Representation of a Nuki lock."""
 
     def __init__(self, nuki_lock):
@@ -147,3 +148,74 @@ class NukiLock(LockEntity):
         amount of time depending on the lock settings) and relock.
         """
         self._nuki_lock.lock_n_go(unlatch, kwargs)
+
+
+class NukiOpenerEntitiy(LockEntity):
+    """Representation of a Nuki opener."""
+
+    def __init__(self, nuki_opener):
+        """Initialize the opener."""
+        self._nuki_opener = nuki_opener
+        self._available = nuki_opener.state not in ERROR_STATES
+
+    @property
+    def name(self):
+        """Return the name of the opener."""
+        return self._nuki_opener.name
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._nuki_opener.nuki_id
+
+    @property
+    def is_locked(self):
+        """Return true if ring-to-open (rto) is deactivated."""
+        return not self._nuki_opener.is_rto_activated
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        data = {
+            ATTR_BATTERY_CRITICAL: self._nuki_opener.battery_critical,
+            ATTR_NUKI_ID: self._nuki_opener.nuki_id,
+        }
+        return data
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
+
+    def update(self):
+        """Update the nuki opener properties."""
+        for level in (False, True):
+            try:
+                self._nuki_opener.update(aggressive=level)
+            except RequestException:
+                _LOGGER.warning("Network issues detect with %s", self.name)
+                self._available = False
+                continue
+
+            # If in error state, we force an update and repoll data
+            self._available = self._nuki_opener.state not in ERROR_STATES
+            if self._available:
+                break
+
+    def lock(self, **kwargs):
+        """Deactivate rto on the opener."""
+        self._nuki_opener.deactivate_rto()
+
+    def unlock(self, **kwargs):
+        """Activate rto on the opener."""
+        self._nuki_opener.activate_rto()
+
+    def open(self, **kwargs):
+        """Activate the electric strike actuation."""
+        self._nuki_opener.electric_strike_actuation()
+

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -2,6 +2,6 @@
   "domain": "nuki",
   "name": "Nuki",
   "documentation": "https://www.home-assistant.io/integrations/nuki",
-  "requirements": ["pynuki==1.3.3"],
+  "requirements": ["pynuki==1.3.5"],
   "codeowners": ["@pvizeli"]
 }

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -2,6 +2,6 @@
   "domain": "nuki",
   "name": "Nuki",
   "documentation": "https://www.home-assistant.io/integrations/nuki",
-  "requirements": ["pynuki==1.3.5"],
+  "requirements": ["pynuki==1.3.6"],
   "codeowners": ["@pvizeli"]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This is an integration request: https://github.com/home-assistant/core/issues/26447


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
There is no change needed to configuration.yaml

```yaml
# Example configuration.yaml
lock:
  - platform: nuki
    host: 192.168.1.120
    token: fe2345ef
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
