### PR TITLE
DataUpdateCoordinator: add last time of success and optional change in update interval when failed update, use in NWS

### DIFF
--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["weather"]
 
 DEFAULT_SCAN_INTERVAL = datetime.timedelta(minutes=10)
-
+FAILED_SCAN_INTERVAL = datetime.timedelta(minutes=1)
 DEBOUNCE_TIME = 60  # in seconds
 
 
@@ -62,6 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
         ),
+        failed_update_interval=FAILED_SCAN_INTERVAL,
     )
 
     coordinator_forecast = DataUpdateCoordinator(
@@ -73,6 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
         ),
+        failed_update_interval=FAILED_SCAN_INTERVAL,
     )
 
     coordinator_forecast_hourly = DataUpdateCoordinator(
@@ -84,6 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
         ),
+        failed_update_interval=FAILED_SCAN_INTERVAL,
     )
     nws_hass_data = hass.data.setdefault(DOMAIN, {})
     nws_hass_data[entry.entry_id] = {

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -154,6 +154,7 @@ async def test_entity_refresh(hass, mock_simple_nws):
 
 async def test_error_observation(hass, mock_simple_nws):
     """Test error during update observation."""
+
     instance = mock_simple_nws.return_value
     instance.update_observation.side_effect = aiohttp.ClientError
 
@@ -174,8 +175,7 @@ async def test_error_observation(hass, mock_simple_nws):
 
     instance.update_observation.side_effect = None
 
-    future_time = dt_util.utcnow() + timedelta(minutes=15)
-    async_fire_time_changed(hass, future_time)
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=1))
     await hass.async_block_till_done()
 
     assert instance.update_observation.call_count == 2
@@ -207,8 +207,7 @@ async def test_error_forecast(hass, mock_simple_nws):
 
     instance.update_forecast.side_effect = None
 
-    future_time = dt_util.utcnow() + timedelta(minutes=15)
-    async_fire_time_changed(hass, future_time)
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=1))
     await hass.async_block_till_done()
 
     assert instance.update_forecast.call_count == 2
@@ -236,8 +235,7 @@ async def test_error_forecast_hourly(hass, mock_simple_nws):
 
     instance.update_forecast_hourly.side_effect = None
 
-    future_time = dt_util.utcnow() + timedelta(minutes=15)
-    async_fire_time_changed(hass, future_time)
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=1))
     await hass.async_block_till_done()
 
     assert instance.update_forecast_hourly.call_count == 2

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.helpers import update_coordinator
 from homeassistant.util.dt import utcnow
 
-from tests.async_mock import AsyncMock, Mock
+from tests.async_mock import AsyncMock, Mock, patch
 from tests.common import async_fire_time_changed
 
 LOGGER = logging.getLogger(__name__)
@@ -37,12 +37,16 @@ def crd(hass):
 
 async def test_async_refresh(crd):
     """Test async_refresh for update coordinator."""
-    assert crd.data is None
-    await crd.async_refresh()
-    assert crd.data == 1
-    assert crd.last_update_success is True
-    # Make sure we didn't schedule a refresh because we have 0 listeners
-    assert crd._unsub_refresh is None
+    utc_time = utcnow()
+    with patch("homeassistant.helpers.update_coordinator.utcnow") as mock_utc:
+        mock_utc.return_value = utc_time
+        assert crd.data is None
+        await crd.async_refresh()
+        assert crd.data == 1
+        assert crd.last_update_success is True
+        assert crd.last_update_success_time == utc_time
+        # Make sure we didn't schedule a refresh because we have 0 listeners
+        assert crd._unsub_refresh is None
 
     updates = []
 
@@ -124,31 +128,70 @@ async def test_refresh_no_update_method(crd):
 async def test_update_interval(hass, crd):
     """Test update interval works."""
     # Test we don't update without subscriber
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
-    await hass.async_block_till_done()
-    assert crd.data is None
+    utc_time = utcnow()
+    with patch("homeassistant.helpers.update_coordinator.utcnow") as mock_utc:
+        mock_utc.return_value = utc_time + crd.update_interval
+        async_fire_time_changed(hass, mock_utc.return_value)
+        await hass.async_block_till_done()
+        assert crd.data is None
+        assert crd.last_update_success_time is None
 
-    # Add subscriber
-    update_callback = Mock()
-    crd.async_add_listener(update_callback)
+        # Add subscriber
+        update_callback = Mock()
+        crd.async_add_listener(update_callback)
 
-    # Test twice we update with subscriber
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
-    await hass.async_block_till_done()
-    assert crd.data == 1
+        # Test twice we update with subscriber
+        mock_utc.return_value += crd.update_interval
+        async_fire_time_changed(hass, mock_utc.return_value)
+        await hass.async_block_till_done()
+        assert crd.data == 1
+        assert crd.last_update_success_time == mock_utc.return_value
 
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
-    await hass.async_block_till_done()
-    assert crd.data == 2
+        mock_utc.return_value += crd.update_interval
+        async_fire_time_changed(hass, mock_utc.return_value)
+        await hass.async_block_till_done()
+        assert crd.data == 2
+        assert crd.last_update_success_time == mock_utc.return_value
+        last_success_time = mock_utc.return_value
 
-    # Test removing listener
-    crd.async_remove_listener(update_callback)
+        # Test removing listener
+        crd.async_remove_listener(update_callback)
 
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
-    await hass.async_block_till_done()
+        mock_utc.return_value += crd.update_interval
+        async_fire_time_changed(hass, mock_utc.return_value)
+        await hass.async_block_till_done()
 
-    # Test we stop updating after we lose last subscriber
-    assert crd.data == 2
+        # Test we stop updating after we lose last subscriber
+        assert crd.data == 2
+        assert crd.last_update_success_time == last_success_time
+
+
+async def test_failed_update_interval(crd, hass):
+    """Test failed update interval."""
+    utc_time = utcnow()
+    with patch("homeassistant.core.dt_util.utcnow") as mock_utcnow:
+        mock_utcnow.return_value = utc_time
+        old_update_method = crd.update_method
+        crd.update_method = AsyncMock(side_effect=asyncio.TimeoutError)
+        crd.failed_update_interval = timedelta(seconds=5)
+
+        def update_callback():
+            pass
+
+        crd.async_add_listener(update_callback)
+
+        await crd.async_refresh()
+        await hass.async_block_till_done()
+
+        assert crd.data is None
+        assert crd.last_update_success is False
+
+        crd.update_method = old_update_method
+        mock_utcnow.return_value += timedelta(seconds=5)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        await hass.async_block_till_done()
+        assert crd.data == 1
+        assert crd.last_update_success is True
 
 
 async def test_refresh_recover(crd, caplog):


### PR DESCRIPTION
<!--](url)
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
For polling data, the DataUpdateCoordinator currently allows a single fixed update interval.  It can be useful to increase the frequency of updates of there is a failed update.  This is motivated by #35666, where short outages in availability of the NWS servers leads to unavailable data until the next data refresh which occurs in 10 minutes.  This PR allows this time to be reduced when a failed data update occurs.  This functionality is not a breaking change for existing uses as the default interval upon a failed update is the existing update interval.

Additionally, the last successful update time is stored to allow integrations to use cached data if applicable.  In the case of NWS for example, the forecast data does not change much more than hourly, so we can safely cache the data for 30-45 minutes.

Both of these changes allow data to be shown even when a single data update fails, in the case of forecasts it could be many updates.  This logic is applied to NWS integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35666 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal (for core changes)
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum (for NWS changes)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
