### PR TITLE
Poll all status data in Vera

### DIFF
--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -99,9 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     controller = veraApi.VeraController(base_url, subscription_registry)
     controller.start()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, lambda event: controller.stop()
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, controller.stop)
 
     try:
         all_devices = await hass.async_add_executor_job(controller.get_devices)

--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import convert, slugify
 from homeassistant.util.dt import utc_from_timestamp
 
-from .common import ControllerData, get_configured_platforms
+from .common import ControllerData, SubscriptionRegistry, get_configured_platforms
 from .config_flow import fix_device_id_list, new_options
 from .const import (
     ATTR_CURRENT_ENERGY_KWH,
@@ -95,7 +95,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
 
     # Initialize the Vera controller.
-    controller = veraApi.VeraController(base_url)
+    subscription_registry = SubscriptionRegistry(hass)
+    controller = veraApi.VeraController(base_url, subscription_registry)
     controller.start()
 
     hass.bus.async_listen_once(

--- a/homeassistant/components/vera/common.py
+++ b/homeassistant/components/vera/common.py
@@ -6,7 +6,7 @@ import pyvera as pv
 
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.event import call_later
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,9 +49,10 @@ class SubscriptionRegistry(pv.AbstractSubscriptionRegistry):
         """Stop polling for data."""
         if self._cancel_poll:
             self._cancel_poll()
+            self._cancel_poll = None
 
     def _schedule_poll(self, delay: float) -> None:
-        self._cancel_poll = async_call_later(self._hass, delay, self._run_poll_server)
+        self._cancel_poll = call_later(self._hass, delay, self._run_poll_server)
 
     def _run_poll_server(self, now) -> None:
         delay = 1

--- a/homeassistant/components/vera/common.py
+++ b/homeassistant/components/vera/common.py
@@ -31,13 +31,6 @@ def get_configured_platforms(controller_data: ControllerData) -> Set[str]:
     return set(platforms)
 
 
-class UpdateCoordinatorData(NamedTuple):
-    """Data provided by the update coordinator."""
-
-    lu_sdata: dict
-    status: dict
-
-
 class SubscriptionRegistry(pv.AbstractSubscriptionRegistry):
     """Manages polling for data from vera."""
 

--- a/homeassistant/components/vera/common.py
+++ b/homeassistant/components/vera/common.py
@@ -1,10 +1,13 @@
 """Common vera code."""
+from datetime import timedelta
 import logging
 from typing import DefaultDict, List, NamedTuple, Set
 
 import pyvera as pv
 
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,3 +30,72 @@ def get_configured_platforms(controller_data: ControllerData) -> Set[str]:
         platforms.append(SCENE_DOMAIN)
 
     return set(platforms)
+
+
+class UpdateCoordinatorData(NamedTuple):
+    """Data provided by the update coordinator."""
+
+    lu_sdata: dict
+    status: dict
+
+
+class SubscriptionRegistry(pv.AbstractSubscriptionRegistry):
+    """Manages polling for data from vera."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the object."""
+        super().__init__()
+        self._hass = hass
+        self._update_coordinator = DataUpdateCoordinator(
+            self._hass,
+            _LOGGER,
+            name="vera",
+            update_interval=timedelta(seconds=1),
+            update_method=self._async_fetch_data,
+        )
+
+    def start(self) -> None:
+        """Start polling for data."""
+        self._update_coordinator.async_add_listener(self._async_on_data_updated)
+
+    def stop(self) -> None:
+        """Stop polling for data."""
+        self._update_coordinator.async_remove_listener(self._async_on_data_updated)
+
+    async def _async_fetch_data(self) -> UpdateCoordinatorData:
+        if not self._controller:
+            raise pv.ControllerNotSetException()
+
+        lu_sdata_respone = await self._hass.async_add_executor_job(
+            self.get_controller().data_request,
+            {"id": "lu_sdata", "output_format": "json"},
+        )
+
+        status_response = await self._hass.async_add_executor_job(
+            self.get_controller().data_request,
+            {"id": "status", "output_format": "json"},
+        )
+
+        return UpdateCoordinatorData(
+            lu_sdata=lu_sdata_respone.json(), status=status_response.json(),
+        )
+
+    def _async_on_data_updated(self) -> None:
+        self._hass.async_add_executor_job(self.poll_server_once)
+
+    def get_device_data(self, last_updated: dict) -> pv.ChangedDevicesValue:
+        """Get device data."""
+        return (
+            self._update_coordinator.data.lu_sdata.get("devices", []),
+            # Return static version data, always_update() renders version checking useless.
+            {"dataversion": 1, "loadtime": 0},
+        )
+
+    def get_alert_data(self, last_updated: dict) -> List[dict]:
+        """Get alert data."""
+        return self._update_coordinator.data.status.get("alerts", [])
+
+    def always_update(self) -> bool:  # pylint: disable=no-self-use
+        """Determine if we should treat every poll as a data change."""
+        # Ignore incremental checks for data changes.
+        return True

--- a/homeassistant/components/vera/manifest.json
+++ b/homeassistant/components/vera/manifest.json
@@ -3,6 +3,6 @@
   "name": "Vera",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/vera",
-  "requirements": ["pyvera==0.3.7"],
+  "requirements": ["pyvera==0.3.9"],
   "codeowners": ["@vangorra"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1778,7 +1778,7 @@ pyuptimerobot==0.0.5
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.3.7
+pyvera==0.3.9
 
 # homeassistant.components.versasense
 pyversasense==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -720,7 +720,7 @@ pytraccar==0.9.0
 pytradfri[async]==6.4.0
 
 # homeassistant.components.vera
-pyvera==0.3.7
+pyvera==0.3.9
 
 # homeassistant.components.vesync
 pyvesync==1.1.0

--- a/tests/components/vera/test_common.py
+++ b/tests/components/vera/test_common.py
@@ -1,12 +1,11 @@
 """Tests for common vera code."""
 from datetime import timedelta
 
-from asynctest import MagicMock
-
 from homeassistant.components.vera import SubscriptionRegistry
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
+from tests.async_mock import MagicMock
 from tests.common import async_fire_time_changed
 
 

--- a/tests/components/vera/test_common.py
+++ b/tests/components/vera/test_common.py
@@ -16,7 +16,7 @@ async def test_subscription_registry(hass: HomeAssistant) -> None:
     subscription_registry.poll_server_once = poll_server_once_mock = MagicMock()
 
     poll_server_once_mock.return_value = True
-    subscription_registry.start()
+    await hass.async_add_executor_job(subscription_registry.start)
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
     poll_server_once_mock.assert_called_once()
@@ -42,7 +42,7 @@ async def test_subscription_registry(hass: HomeAssistant) -> None:
     poll_server_once_mock.assert_called_once()
 
     poll_server_once_mock.reset_mock()
-    subscription_registry.stop()
+    await hass.async_add_executor_job(subscription_registry.stop)
 
     # Assert no further polling is performed.
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=65))

--- a/tests/components/vera/test_common.py
+++ b/tests/components/vera/test_common.py
@@ -1,0 +1,52 @@
+"""Tests for common vera code."""
+from datetime import timedelta
+
+from asynctest import MagicMock
+from pyvera import VeraController
+from requests.adapters import Response
+
+from homeassistant.components.vera import SubscriptionRegistry
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+
+
+async def test_subscription_registry(hass: HomeAssistant) -> None:
+    """Test subscription registry polling."""
+    devices = ["device1"]
+    alerts = ["alert1"]
+    response = MagicMock(spec=Response)
+    response.json.return_value = {"devices": devices, "alerts": alerts}
+
+    controller = MagicMock(spec=VeraController)
+    controller.data_request.return_value = response
+
+    subscription_registry = SubscriptionRegistry(hass)
+    subscription_registry.set_controller(controller)
+    # pylint: disable=protected-access
+    subscription_registry._event = event_mock = MagicMock()
+    subscription_registry.start()
+
+    event_mock.reset_mock()
+    controller.data_request.reset_mock()
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    event_mock.assert_called_once_with(devices, alerts)
+    assert controller.data_request.call_count == 2
+
+    event_mock.reset_mock()
+    controller.data_request.reset_mock()
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    event_mock.assert_called_once_with(devices, alerts)
+    assert controller.data_request.call_count == 2
+
+    subscription_registry.stop()
+
+    event_mock.reset_mock()
+    controller.data_request.reset_mock()
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    event_mock.assert_not_called()
+    controller.data_request.assert_not_called()


### PR DESCRIPTION
Vera polling is not handled using hass event loops with proper backoffs.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many people have reported that the vera component intermittently does not update some devices but eventually works after a few minutes. After reviewing the logs of several reporters, the best conclusion is that the vera controller does not always return accurate incremental status changes. This PR addresses the issue by requesting all the data and allowing HA decide what has changed. Additionally this PR also runs vera polling with HA event loops instead of a separate thread (which could have contributed to race conditions).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
vera:
  vera_controller_url: http://10.40.8.245:3480/
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32231, fixes #33208, fixes #34910, fixes #35140, fixes #31720, fixes #36178
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
