### PR TITLE
Register 'androidtv.learn_sendevent' service

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -44,7 +44,7 @@ from homeassistant.const import (
     STATE_STANDBY,
 )
 from homeassistant.exceptions import PlatformNotReady
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.storage import STORAGE_DIR
 
 ANDROIDTV_DOMAIN = "androidtv"
@@ -242,6 +242,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if hass.services.has_service(ANDROIDTV_DOMAIN, SERVICE_ADB_COMMAND):
         return
 
+    platform = entity_platform.current_platform.get()
+
     def service_adb_command(service):
         """Dispatch service calls to target entities."""
         cmd = service.data[ATTR_COMMAND]
@@ -283,11 +285,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         for target_device in target_devices:
             target_device.learn_sendevent()
 
-    hass.services.async_register(
-        ANDROIDTV_DOMAIN,
-        SERVICE_LEARN_SENDEVENT,
-        service_learn_sendevent,
-        schema=SERVICE_LEARN_SENDEVENT_SCHEMA,
+    platform.async_register_entity_service(
+        SERVICE_LEARN_SENDEVENT, SERVICE_LEARN_SENDEVENT_SCHEMA, "learn_sendevent",
     )
 
     def service_download(service):

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -273,18 +273,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         schema=SERVICE_ADB_COMMAND_SCHEMA,
     )
 
-    def service_learn_sendevent(service):
-        """Translate a key press on a remote to ADB 'sendevent' commands."""
-        entity_id = service.data[ATTR_ENTITY_ID]
-        target_devices = [
-            dev
-            for dev in hass.data[ANDROIDTV_DOMAIN].values()
-            if dev.entity_id in entity_id
-        ]
-
-        for target_device in target_devices:
-            target_device.learn_sendevent()
-
     platform.async_register_entity_service(
         SERVICE_LEARN_SENDEVENT, SERVICE_LEARN_SENDEVENT_SCHEMA, "learn_sendevent",
     )

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -103,6 +103,7 @@ DEVICE_CLASSES = [DEFAULT_DEVICE_CLASS, DEVICE_ANDROIDTV, DEVICE_FIRETV]
 
 SERVICE_ADB_COMMAND = "adb_command"
 SERVICE_DOWNLOAD = "download"
+SERVICE_LEARN_SENDEVENT = "learn_sendevent"
 SERVICE_UPLOAD = "upload"
 
 SERVICE_ADB_COMMAND_SCHEMA = vol.Schema(
@@ -115,6 +116,10 @@ SERVICE_DOWNLOAD_SCHEMA = vol.Schema(
         vol.Required(ATTR_DEVICE_PATH): cv.string,
         vol.Required(ATTR_LOCAL_PATH): cv.string,
     }
+)
+
+SERVICE_LEARN_SENDEVENT_SCHEMA = vol.Schema(
+    {vol.Required(ATTR_ENTITY_ID): cv.entity_ids}
 )
 
 SERVICE_UPLOAD_SCHEMA = vol.Schema(
@@ -285,6 +290,33 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         SERVICE_ADB_COMMAND,
         service_adb_command,
         schema=SERVICE_ADB_COMMAND_SCHEMA,
+    )
+
+    def service_learn_sendevent(service):
+        """Translate a key press on a remote to ADB 'sendevent' commands."""
+        entity_id = service.data[ATTR_ENTITY_ID]
+        target_devices = [
+            dev
+            for dev in hass.data[ANDROIDTV_DOMAIN].values()
+            if dev.entity_id in entity_id
+        ]
+
+        for target_device in target_devices:
+            output = target_device.learn_sendevent()
+
+            # log the output, if there is any
+            if output:
+                _LOGGER.info(
+                    "Output of 'learn_sendevent' service from '%s': %s",
+                    target_device.entity_id,
+                    output,
+                )
+
+    hass.services.register(
+        ANDROIDTV_DOMAIN,
+        SERVICE_LEARN_SENDEVENT,
+        service_learn_sendevent,
+        schema=SERVICE_LEARN_SENDEVENT_SCHEMA,
     )
 
     def service_download(service):
@@ -591,6 +623,12 @@ class ADBDevice(MediaPlayerEntity):
 
         self.schedule_update_ha_state()
         return self._adb_response
+
+    @adb_decorator()
+    def learn_sendevent(self):
+        """Translate a key press on a remote to ADB 'sendevent' commands."""
+        self._adb_response = self.aftv.learn_sendevent()
+        self.schedule_update_ha_state()
 
     @adb_decorator()
     def adb_pull(self, local_path, device_path):

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -572,6 +572,11 @@ class ADBDevice(MediaPlayerEntity):
             self.schedule_update_ha_state()
             return self._adb_response
 
+        if cmd == "LEARN_SENDEVENT":
+            self._adb_response = str(self.aftv.learn_sendevent())
+            self.schedule_update_ha_state()
+            return self._adb_response
+
         try:
             response = self.aftv.adb_shell(cmd)
         except UnicodeDecodeError:

--- a/homeassistant/components/androidtv/services.yaml
+++ b/homeassistant/components/androidtv/services.yaml
@@ -33,3 +33,9 @@ upload:
     local_path:
       description: The filepath on your Home Assistant instance.
       example: "/config/www/example.txt"
+learn_sendevent:
+  description: Translate a key press on a remote into ADB 'sendevent' commands.  You must press one button on the remote within 8 seconds of calling this service.
+  fields:
+    entity_id:
+      description: Name(s) of Android TV / Fire TV entities.
+      example: "media_player.android_tv_living_room"

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -863,20 +863,20 @@ async def test_learn_sendevent(hass):
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
         await hass.async_block_till_done()
 
-    with patch(
-        "androidtv.basetv.BaseTV.learn_sendevent", return_value=response
-    ) as patch_learn_sendevent:
-        await hass.services.async_call(
-            ANDROIDTV_DOMAIN,
-            SERVICE_LEARN_SENDEVENT,
-            {ATTR_ENTITY_ID: entity_id},
-            blocking=True,
-        )
+        with patch(
+            "androidtv.basetv.BaseTV.learn_sendevent", return_value=response
+        ) as patch_learn_sendevent:
+            await hass.services.async_call(
+                ANDROIDTV_DOMAIN,
+                SERVICE_LEARN_SENDEVENT,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
-        patch_learn_sendevent.assert_called()
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.attributes["adb_response"] == response
+            patch_learn_sendevent.assert_called()
+            state = hass.states.get(entity_id)
+            assert state is not None
+            assert state.attributes["adb_response"] == response
 
 
 async def test_update_lock_not_acquired(hass):

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -16,6 +16,7 @@ from homeassistant.components.androidtv.media_player import (
     KEYS,
     SERVICE_ADB_COMMAND,
     SERVICE_DOWNLOAD,
+    SERVICE_LEARN_SENDEVENT,
     SERVICE_UPLOAD,
 )
 from homeassistant.components.media_player.const import (
@@ -850,11 +851,10 @@ async def test_adb_command_get_properties(hass):
         assert state.attributes["adb_response"] == str(response)
 
 
-async def test_adb_command_learn_sendevent(hass):
-    """Test sending the "learn_sendevent" command via the `androidtv.adb_command` service."""
+async def test_learn_sendevent(hass):
+    """Test the `androidtv.learn_sendevent` service."""
     patch_key = "server"
     entity_id = "media_player.android_tv"
-    command = "LEARN_SENDEVENT"
     response = "sendevent 1 2 3 4"
 
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
@@ -868,8 +868,8 @@ async def test_adb_command_learn_sendevent(hass):
     ) as patch_learn_sendevent:
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
-            SERVICE_ADB_COMMAND,
-            {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: command},
+            SERVICE_LEARN_SENDEVENT,
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
 

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -861,10 +861,11 @@ async def test_adb_command_learn_sendevent(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patch(
         "androidtv.basetv.BaseTV.learn_sendevent", return_value=response
-    ) as patch_get_props:
+    ) as patch_learn_sendevent:
         await hass.services.async_call(
             ANDROIDTV_DOMAIN,
             SERVICE_ADB_COMMAND,
@@ -872,7 +873,7 @@ async def test_adb_command_learn_sendevent(hass):
             blocking=True,
         )
 
-        patch_get_props.assert_called()
+        patch_learn_sendevent.assert_called()
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.attributes["adb_response"] == response


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When sending commands like UP, DOWN, HOME, etc. via ADB, the device can be slow to respond. The problem isn't ADB, but rather the Android command `input` that is used to perform those actions. A faster way to send these commands is using the Android `sendevent` command. The challenge is that these commands are device-specific. To assist users in learning commands for their device, the `androidtv.adb_command` service provides a custom target: `LEARN_SENDEVENT`. Its usage is as follows:

1. Call the `androidtv.adb_command` service with the parameter `command: LEARN_SENDEVENT`. 
2. Within 8 seconds, hit a single button on your Android TV / Fire TV remote. 
3. After 8 seconds, check the `adb_response` attribute of the media player in Home Assistant. This will be the equivalent command that can be sent via the `androidtv.adb_command` service. 

As an example, a service call in a script could be changed from this:

```yaml
# Send the "UP" command (slow)
- service: androidtv.adb_command
  data:
    entity_id: media_player.fire_tv_living_room
    command: UP
```

to this:

```yaml
# Send the "UP" command using `sendevent` (faster)
- service: androidtv.adb_command
  data:
    entity_id: media_player.fire_tv_living_room
    command: "sendevent /dev/input/event4 4 4 786979 && sendevent /dev/input/event4 1 172 1 && sendevent /dev/input/event4 0 0 0 && sendevent /dev/input/event4 4 4 786979 && sendevent /dev/input/event4 1 172 0 && sendevent /dev/input/event4 0 0 0"
```

### Dependency git diff

It looks like HA now wants to see a changelog or link to a git diff when changing a dependency version, so here it is: https://github.com/JeffLIrion/python-androidtv/compare/v0.0.41...v0.0.42

The coverage was 100% at v0.0.41 and it's still 100% at v0.0.42. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13465

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
