### PR TITLE
Prevent updater from delaying startup

### DIFF
--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -105,7 +105,8 @@ async def async_setup(hass, config):
         update_interval=timedelta(days=1),
     )
 
-    await coordinator.async_refresh()
+    # This can take up to 15s which can delay startup
+    hass.loop.create_task(coordinator.async_refresh())
 
     hass.async_create_task(
         discovery.async_load_platform(hass, "binary_sensor", DOMAIN, {}, config)

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -1,4 +1,5 @@
 """Support to check for available updates."""
+import asyncio
 from datetime import timedelta
 from distutils.version import StrictVersion
 import logging
@@ -106,7 +107,7 @@ async def async_setup(hass, config):
     )
 
     # This can take up to 15s which can delay startup
-    hass.loop.create_task(coordinator.async_refresh())
+    asyncio.create_task(coordinator.async_refresh())
 
     hass.async_create_task(
         discovery.async_load_platform(hass, "binary_sensor", DOMAIN, {}, config)

--- a/homeassistant/components/updater/binary_sensor.py
+++ b/homeassistant/components/updater/binary_sensor.py
@@ -33,6 +33,8 @@ class UpdaterBinary(BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
+        if not self.coordinator.data:
+            return None
         return self.coordinator.data.update_available
 
     @property
@@ -48,6 +50,8 @@ class UpdaterBinary(BinarySensorEntity):
     @property
     def device_state_attributes(self) -> dict:
         """Return the optional state attributes."""
+        if not self.coordinator.data:
+            return None
         data = {}
         if self.coordinator.data.release_notes:
             data[ATTR_RELEASE_NOTES] = self.coordinator.data.release_notes
@@ -57,11 +61,9 @@ class UpdaterBinary(BinarySensorEntity):
 
     async def async_added_to_hass(self):
         """Register update dispatcher."""
-        self.coordinator.async_add_listener(self.async_write_ha_state)
-
-    async def async_will_remove_from_hass(self):
-        """When removed from hass."""
-        self.coordinator.async_remove_listener(self.async_write_ha_state)
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )
 
     async def async_update(self):
         """Update the entity.


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
 The updater sometimes times out as seen in #33833 and the linked issues. 

The issue was presenting today as it appears the service is overloaded again.

It doesn't seem like there is bandwidth to fix the issue on the server side anytime soon so this seems like the best way to mitigate the issue.


Before timings (average of 10 restarts)
`Home Assistant initialized in 39.23s`

After  timings (average of 10 restarts)
`Home Assistant initialized in 23.18s`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
