### PR TITLE
Fix timezone issues for db fields in recorder

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -1,5 +1,4 @@
 """Models for SQLAlchemy."""
-from datetime import datetime
 import json
 import logging
 
@@ -39,7 +38,7 @@ class Events(Base):  # type: ignore
     event_data = Column(Text)
     origin = Column(String(32))
     time_fired = Column(DateTime(timezone=True), index=True)
-    created = Column(DateTime(timezone=True), default=datetime.utcnow)
+    created = Column(DateTime(timezone=True), default=dt_util.utcnow)
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
     # context_parent_id = Column(String(36), index=True)
@@ -84,9 +83,9 @@ class States(Base):  # type: ignore
     state = Column(String(255))
     attributes = Column(Text)
     event_id = Column(Integer, ForeignKey("events.event_id"), index=True)
-    last_changed = Column(DateTime(timezone=True), default=datetime.utcnow)
-    last_updated = Column(DateTime(timezone=True), default=datetime.utcnow, index=True)
-    created = Column(DateTime(timezone=True), default=datetime.utcnow)
+    last_changed = Column(DateTime(timezone=True), default=dt_util.utcnow)
+    last_updated = Column(DateTime(timezone=True), default=dt_util.utcnow, index=True)
+    created = Column(DateTime(timezone=True), default=dt_util.utcnow)
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
     # context_parent_id = Column(String(36), index=True)
@@ -152,10 +151,10 @@ class RecorderRuns(Base):  # type: ignore
 
     __tablename__ = "recorder_runs"
     run_id = Column(Integer, primary_key=True)
-    start = Column(DateTime(timezone=True), default=datetime.utcnow)
+    start = Column(DateTime(timezone=True), default=dt_util.utcnow)
     end = Column(DateTime(timezone=True))
     closed_incorrect = Column(Boolean, default=False)
-    created = Column(DateTime(timezone=True), default=datetime.utcnow)
+    created = Column(DateTime(timezone=True), default=dt_util.utcnow)
 
     __table_args__ = (Index("ix_recorder_runs_start_end", "start", "end"),)
 
@@ -191,7 +190,7 @@ class SchemaChanges(Base):  # type: ignore
     __tablename__ = "schema_changes"
     change_id = Column(Integer, primary_key=True)
     schema_version = Column(Integer)
-    changed = Column(DateTime(timezone=True), default=datetime.utcnow)
+    changed = Column(DateTime(timezone=True), default=dt_util.utcnow)
 
 
 def _process_timestamp(ts):


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The database fields are timezoned via DateTime(timezone=True), so the
default value should be timezoned too. When using cockroachdb this is
fatal and results in the recorder crashing.

Been running a while now with `sed -i 's/datetime.utcnow/dt_util.utcnow/' /usr/src/homeassistant/homeassistant/components/recorder/models.py && /init` in the docker container, and it works fine...


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
