### PR TITLE
Avoid creating multiple sqlalchemy sessions in a single history call

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -46,12 +46,12 @@ IGNORE_DOMAINS = ("zone", "scene")
 def get_significant_states(hass, *args, **kwargs):
     """Wrap _get_significant_states with a sql session."""
     with session_scope(hass=hass) as session:
-        return _get_significant_states(session, hass, *args, **kwargs)
+        return _get_significant_states(hass, session, *args, **kwargs)
 
 
 def _get_significant_states(
-    session,
     hass,
+    session,
     start_time,
     end_time=None,
     entity_ids=None,
@@ -98,8 +98,8 @@ def _get_significant_states(
         _LOGGER.debug("get_significant_states took %fs", elapsed)
 
     return _states_to_json(
-        session,
         hass,
+        session,
         states,
         start_time,
         entity_ids,
@@ -127,7 +127,7 @@ def state_changes_during_period(hass, start_time, end_time=None, entity_id=None)
 
         states = execute(query.order_by(States.last_updated))
 
-        return _states_to_json(session, hass, states, start_time, entity_ids)
+        return _states_to_json(hass, session, states, start_time, entity_ids)
 
 
 def get_last_state_changes(hass, number_of_states, entity_id):
@@ -148,8 +148,8 @@ def get_last_state_changes(hass, number_of_states, entity_id):
         )
 
         return _states_to_json(
-            session,
             hass,
+            session,
             reversed(states),
             start_time,
             entity_ids,
@@ -251,8 +251,8 @@ def _get_states_with_session(
 
 
 def _states_to_json(
-    session,
     hass,
+    session,
     states,
     start_time,
     entity_ids,
@@ -400,8 +400,8 @@ class HistoryPeriodView(HomeAssistantView):
 
         with session_scope(hass=hass) as session:
             result = _get_significant_states(
-                session,
                 hass,
+                session,
                 start_time,
                 end_time,
                 entity_ids,

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -43,7 +43,14 @@ SIGNIFICANT_DOMAINS = ("climate", "device_tracker", "thermostat", "water_heater"
 IGNORE_DOMAINS = ("zone", "scene")
 
 
-def get_significant_states(
+def get_significant_states(hass, *args, **kwargs):
+    """Wrap _get_significant_states with a sql session."""
+    with session_scope(hass=hass) as session:
+        return _get_significant_states(session, hass, *args, **kwargs)
+
+
+def _get_significant_states(
+    session,
     hass,
     start_time,
     end_time=None,
@@ -61,38 +68,43 @@ def get_significant_states(
     """
     timer_start = time.perf_counter()
 
-    with session_scope(hass=hass) as session:
-        if significant_changes_only:
-            query = session.query(States).filter(
-                (
-                    States.domain.in_(SIGNIFICANT_DOMAINS)
-                    | (States.last_changed == States.last_updated)
-                )
-                & (States.last_updated > start_time)
+    if significant_changes_only:
+        query = session.query(States).filter(
+            (
+                States.domain.in_(SIGNIFICANT_DOMAINS)
+                | (States.last_changed == States.last_updated)
             )
-        else:
-            query = session.query(States).filter(States.last_updated > start_time)
-
-        if filters:
-            query = filters.apply(query, entity_ids)
-
-        if end_time is not None:
-            query = query.filter(States.last_updated < end_time)
-
-        query = query.order_by(States.last_updated)
-
-        states = (
-            state
-            for state in execute(query)
-            if (_is_significant(state) and not state.attributes.get(ATTR_HIDDEN, False))
+            & (States.last_updated > start_time)
         )
+    else:
+        query = session.query(States).filter(States.last_updated > start_time)
+
+    if filters:
+        query = filters.apply(query, entity_ids)
+
+    if end_time is not None:
+        query = query.filter(States.last_updated < end_time)
+
+    query = query.order_by(States.last_updated)
+
+    states = (
+        state
+        for state in execute(query)
+        if (_is_significant(state) and not state.attributes.get(ATTR_HIDDEN, False))
+    )
 
     if _LOGGER.isEnabledFor(logging.DEBUG):
         elapsed = time.perf_counter() - timer_start
         _LOGGER.debug("get_significant_states took %fs", elapsed)
 
-    return states_to_json(
-        hass, states, start_time, entity_ids, filters, include_start_time_state
+    return _states_to_json(
+        session,
+        hass,
+        states,
+        start_time,
+        entity_ids,
+        filters,
+        include_start_time_state,
     )
 
 
@@ -115,7 +127,7 @@ def state_changes_during_period(hass, start_time, end_time=None, entity_id=None)
 
         states = execute(query.order_by(States.last_updated))
 
-    return states_to_json(hass, states, start_time, entity_ids)
+        return _states_to_json(session, hass, states, start_time, entity_ids)
 
 
 def get_last_state_changes(hass, number_of_states, entity_id):
@@ -135,91 +147,117 @@ def get_last_state_changes(hass, number_of_states, entity_id):
             query.order_by(States.last_updated.desc()).limit(number_of_states)
         )
 
-    return states_to_json(
-        hass, reversed(states), start_time, entity_ids, include_start_time_state=False
-    )
+        return _states_to_json(
+            session,
+            hass,
+            reversed(states),
+            start_time,
+            entity_ids,
+            include_start_time_state=False,
+        )
 
 
 def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None):
     """Return the states at a specific point in time."""
 
     if run is None:
-        run = recorder.run_information(hass, utc_point_in_time)
+        run = recorder.run_information_from_instance(hass, utc_point_in_time)
 
         # History did not run before utc_point_in_time
         if run is None:
             return []
 
     with session_scope(hass=hass) as session:
-        query = session.query(States)
+        return _get_states_with_session(
+            session, utc_point_in_time, entity_ids, run, filters
+        )
 
-        if entity_ids and len(entity_ids) == 1:
-            # Use an entirely different (and extremely fast) query if we only
-            # have a single entity id
-            query = (
-                query.filter(
-                    States.last_updated >= run.start,
-                    States.last_updated < utc_point_in_time,
-                    States.entity_id.in_(entity_ids),
-                )
-                .order_by(States.last_updated.desc())
-                .limit(1)
+
+def _get_states_with_session(
+    session, utc_point_in_time, entity_ids=None, run=None, filters=None
+):
+    """Return the states at a specific point in time."""
+    if run is None:
+        run = recorder.run_information_with_session(session, utc_point_in_time)
+
+        # History did not run before utc_point_in_time
+        if run is None:
+            return []
+
+    query = session.query(States)
+
+    if entity_ids and len(entity_ids) == 1:
+        # Use an entirely different (and extremely fast) query if we only
+        # have a single entity id
+        query = (
+            query.filter(
+                States.last_updated >= run.start,
+                States.last_updated < utc_point_in_time,
+                States.entity_id.in_(entity_ids),
             )
+            .order_by(States.last_updated.desc())
+            .limit(1)
+        )
 
-        else:
-            # We have more than one entity to look at (most commonly we want
-            # all entities,) so we need to do a search on all states since the
-            # last recorder run started.
+    else:
+        # We have more than one entity to look at (most commonly we want
+        # all entities,) so we need to do a search on all states since the
+        # last recorder run started.
 
-            most_recent_states_by_date = session.query(
-                States.entity_id.label("max_entity_id"),
-                func.max(States.last_updated).label("max_last_updated"),
-            ).filter(
-                (States.last_updated >= run.start)
-                & (States.last_updated < utc_point_in_time)
-            )
+        most_recent_states_by_date = session.query(
+            States.entity_id.label("max_entity_id"),
+            func.max(States.last_updated).label("max_last_updated"),
+        ).filter(
+            (States.last_updated >= run.start)
+            & (States.last_updated < utc_point_in_time)
+        )
 
-            if entity_ids:
-                most_recent_states_by_date.filter(States.entity_id.in_(entity_ids))
+        if entity_ids:
+            most_recent_states_by_date.filter(States.entity_id.in_(entity_ids))
 
-            most_recent_states_by_date = most_recent_states_by_date.group_by(
-                States.entity_id
-            )
+        most_recent_states_by_date = most_recent_states_by_date.group_by(
+            States.entity_id
+        )
 
-            most_recent_states_by_date = most_recent_states_by_date.subquery()
+        most_recent_states_by_date = most_recent_states_by_date.subquery()
 
-            most_recent_state_ids = session.query(
-                func.max(States.state_id).label("max_state_id")
-            ).join(
-                most_recent_states_by_date,
-                and_(
-                    States.entity_id == most_recent_states_by_date.c.max_entity_id,
-                    States.last_updated
-                    == most_recent_states_by_date.c.max_last_updated,
-                ),
-            )
+        most_recent_state_ids = session.query(
+            func.max(States.state_id).label("max_state_id")
+        ).join(
+            most_recent_states_by_date,
+            and_(
+                States.entity_id == most_recent_states_by_date.c.max_entity_id,
+                States.last_updated == most_recent_states_by_date.c.max_last_updated,
+            ),
+        )
 
-            most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
+        most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
 
-            most_recent_state_ids = most_recent_state_ids.subquery()
+        most_recent_state_ids = most_recent_state_ids.subquery()
 
-            query = query.join(
-                most_recent_state_ids,
-                States.state_id == most_recent_state_ids.c.max_state_id,
-            ).filter(~States.domain.in_(IGNORE_DOMAINS))
+        query = query.join(
+            most_recent_state_ids,
+            States.state_id == most_recent_state_ids.c.max_state_id,
+        ).filter(~States.domain.in_(IGNORE_DOMAINS))
 
-            if filters:
-                query = filters.apply(query, entity_ids)
+        if filters:
+            query = filters.apply(query, entity_ids)
 
-        return [
-            state
-            for state in execute(query)
-            if not state.attributes.get(ATTR_HIDDEN, False)
-        ]
+    return [
+        state
+        for state in execute(query)
+        if not state.attributes.get(ATTR_HIDDEN, False)
+    ]
 
 
-def states_to_json(
-    hass, states, start_time, entity_ids, filters=None, include_start_time_state=True
+def _states_to_json(
+    session,
+    hass,
+    states,
+    start_time,
+    entity_ids,
+    filters=None,
+    include_start_time_state=True,
 ):
     """Convert SQL results into JSON friendly data structure.
 
@@ -239,7 +277,10 @@ def states_to_json(
     # Get the states at the start time
     timer_start = time.perf_counter()
     if include_start_time_state:
-        for state in get_states(hass, start_time, entity_ids, filters=filters):
+        run = recorder.run_information_from_instance(hass, start_time)
+        for state in _get_states_with_session(
+            session, start_time, entity_ids, run=run, filters=filters
+        ):
             state.last_changed = start_time
             state.last_updated = start_time
             result[state.entity_id].append(state)
@@ -357,15 +398,18 @@ class HistoryPeriodView(HomeAssistantView):
         """Fetch significant stats from the database as json."""
         timer_start = time.perf_counter()
 
-        result = get_significant_states(
-            hass,
-            start_time,
-            end_time,
-            entity_ids,
-            self.filters,
-            include_start_time_state,
-            significant_changes_only,
-        )
+        with session_scope(hass=hass) as session:
+            result = _get_significant_states(
+                session,
+                hass,
+                start_time,
+                end_time,
+                entity_ids,
+                self.filters,
+                include_start_time_state,
+                significant_changes_only,
+            )
+
         result = list(result.values())
         if _LOGGER.isEnabledFor(logging.DEBUG):
             elapsed = time.perf_counter() - timer_start

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -298,6 +298,7 @@ class HistoryPeriodView(HomeAssistantView):
 
     async def get(self, request, datetime=None):
         """Return history over a period of time."""
+
         if datetime:
             datetime = dt_util.parse_datetime(datetime)
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -123,24 +123,39 @@ def run_information(hass, point_in_time: Optional[datetime] = None):
 
     There is also the run that covers point_in_time.
     """
+    run_info = run_information_from_instance(hass, point_in_time)
+    if run_info:
+        return run_info
+
+    with session_scope(hass=hass) as session:
+        return run_information_with_session(session, point_in_time)
+
+
+def run_information_from_instance(hass, point_in_time: Optional[datetime] = None):
+    """Return information about current run from the existing instance.
+
+    Does not query the database for older runs.
+    """
     ins = hass.data[DATA_INSTANCE]
 
-    recorder_runs = RecorderRuns
     if point_in_time is None or point_in_time > ins.recording_start:
         return ins.run_info
 
-    with session_scope(hass=hass) as session:
-        res = (
-            session.query(recorder_runs)
-            .filter(
-                (recorder_runs.start < point_in_time)
-                & (recorder_runs.end > point_in_time)
-            )
-            .first()
+
+def run_information_with_session(session, point_in_time: Optional[datetime] = None):
+    """Return information about current run from the database."""
+    recorder_runs = RecorderRuns
+
+    res = (
+        session.query(recorder_runs)
+        .filter(
+            (recorder_runs.start < point_in_time) & (recorder_runs.end > point_in_time)
         )
-        if res:
-            session.expunge(res)
-        return res
+        .first()
+    )
+    if res:
+        session.expunge(res)
+    return res
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -103,6 +103,11 @@ class TestComponentHistory(unittest.TestCase):
         # Test get_state here because we have a DB setup
         assert states[0] == history.get_state(self.hass, future, states[0].entity_id)
 
+        time_before_recorder_ran = now - timedelta(days=1000)
+        assert history.get_states(self.hass, time_before_recorder_ran) == []
+
+        assert history.get_state(self.hass, time_before_recorder_ran, "demo.id") is None
+
     def test_state_changes_during_period(self):
         """Test state change during period."""
         self.init_recorder()


### PR DESCRIPTION
Note: this is easier to review with `git diff -w upstream/dev -- homeassistant/components/history`

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `history` function `states_to_json` is now a protected function `_states_to_json` and is not expected to be called from outside the module.

Not sure if this is a breaking change since there were no outside callers in the codebase.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure there is only one sqlalchemy session created per history query.

Functionality should be exactly the same otherwise as the changes
are rearranging and breaking apart functions only to avoid the multiple
sessions.

Most history queries created **three** sqlalchemy sessions which was
especially slow with sqlite since it opens and closes the
database.

In testing the UI is noticeably faster at generating history
graphs for entities.

Requires #35716

Testing: `strace` home assistant and verified the sqlite database was only opened and closed once per history api request instead of 3 times.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
