### PR TITLE
Clean up vizio translation strings

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -229,7 +229,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         user_input[CONF_DEVICE_CLASS],
                         session=async_get_clientsession(self.hass, False),
                     ):
-                        errors["base"] = "cant_connect"
+                        errors["base"] = "cannot_connect"
 
                     if not errors:
                         unique_id = await VizioAsync.get_unique_id(
@@ -323,7 +323,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     return self.async_abort(reason="updated_entry")
 
-                return self.async_abort(reason="already_setup")
+                return self.async_abort(reason="already_configured_device")
 
         self._must_show_form = True
         # Store config key/value pairs that are not configurable in user step so they
@@ -354,7 +354,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 continue
 
             if _host_is_same(entry.data[CONF_HOST], discovery_info[CONF_HOST]):
-                return self.async_abort(reason="already_setup")
+                return self.async_abort(reason="already_configured_device")
 
         # Set default name to discovered device name by stripping zeroconf service
         # (`type`) from `name`
@@ -400,7 +400,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user",
                 data_schema=_get_config_schema(self._data),
-                errors={"base": "cant_connect"},
+                errors={"base": "cannot_connect"},
             )
 
         # Complete pairing process if PIN has been provided

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Setup VIZIO SmartCast Device",
+        "title": "VIZIO SmartCast Device",
         "description": "An [%key:common::config_flow::data::access_token%] is only needed for TVs. If you are configuring a TV and do not have an [%key:common::config_flow::data::access_token%] yet, leave it blank to go through a pairing process.",
         "data": {
           "name": "Name",
@@ -20,28 +20,28 @@
       },
       "pairing_complete": {
         "title": "Pairing Complete",
-        "description": "Your VIZIO SmartCast device is now connected to Home Assistant."
+        "description": "Your [%key:component::vizio::config::step::user::title%] is now connected to Home Assistant."
       },
       "pairing_complete_import": {
         "title": "Pairing Complete",
-        "description": "Your VIZIO SmartCast TV is now connected to Home Assistant.\n\nYour [%key:common::config_flow::data::access_token%] is '**{access_token}**'."
+        "description": "Your [%key:component::vizio::config::step::user::title%] is now connected to Home Assistant.\n\nYour [%key:common::config_flow::data::access_token%] is '**{access_token}**'."
       }
     },
     "error": {
-      "host_exists": "VIZIO device with specified host already configured.",
-      "name_exists": "VIZIO device with specified name already configured.",
+      "host_exists": "[%key:component::vizio::config::step::user::title%] with specified host already configured.",
+      "name_exists": "[%key:component::vizio::config::step::user::title%] with specified name already configured.",
       "complete_pairing_failed": "Unable to complete pairing. Ensure the PIN you provided is correct and the TV is still powered and connected to the network before resubmitting.",
-      "cant_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "already_setup": "This entry has already been setup.",
+      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",
       "updated_entry": "This entry has already been setup but the name, apps, and/or options defined in the configuration do not match the previously imported configuration, so the configuration entry has been updated accordingly."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Update VIZIO SmartCast Options",
+        "title": "Update [%key:component::vizio::config::step::user::title%] Options",
         "description": "If you have a Smart TV, you can optionally filter your source list by choosing which apps to include or exclude in your source list.",
         "data": {
           "volume_step": "Volume Step Size",

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -308,7 +308,7 @@ async def test_user_esn_already_exists(
 
 
 async def test_user_error_on_could_not_connect(
-    hass: HomeAssistantType, vizio_cannot_connect: pytest.fixture
+    hass: HomeAssistantType, vizio_cant_connect: pytest.fixture
 ) -> None:
     """Test with could_not_connect during user_setup."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -308,7 +308,7 @@ async def test_user_esn_already_exists(
 
 
 async def test_user_error_on_could_not_connect(
-    hass: HomeAssistantType, vizio_cant_connect: pytest.fixture
+    hass: HomeAssistantType, vizio_cannot_connect: pytest.fixture
 ) -> None:
     """Test with could_not_connect during user_setup."""
     result = await hass.config_entries.flow.async_init(
@@ -316,7 +316,7 @@ async def test_user_error_on_could_not_connect(
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "cant_connect"}
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_user_tv_pairing_no_apps(
@@ -363,7 +363,7 @@ async def test_user_start_pairing_failure(
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cant_connect"}
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_user_invalid_pin(
@@ -471,7 +471,7 @@ async def test_import_entity_already_configured(
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_setup"
+    assert result["reason"] == "already_configured_device"
 
 
 async def test_import_flow_update_options(
@@ -778,7 +778,7 @@ async def test_zeroconf_flow_already_configured(
 
     # Flow should abort because device is already setup
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_setup"
+    assert result["reason"] == "already_configured_device"
 
 
 async def test_zeroconf_dupe_fail(


### PR DESCRIPTION
## Proposed change
In #35487 I made substring key references which has worked. In this PR I am changing key names to use the commonly defined ones and adding more key references where appropriate to minimize the number of places that text has to be updated.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
