### PR TITLE
Reduce Vizio API calls

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -240,8 +240,7 @@ class VizioDevice(MediaPlayerEntity):
 
         # Create list of available known apps from known app list after
         # filtering by CONF_INCLUDE/CONF_EXCLUDE
-        if not self._available_apps:
-            self._available_apps = self._apps_list(self._device.get_apps_list())
+        self._available_apps = self._sapps_list(self._device.get_apps_list())
 
         self._current_app_config = await self._device.get_current_app_config(
             log_api_exception=False

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -240,7 +240,7 @@ class VizioDevice(MediaPlayerEntity):
 
         # Create list of available known apps from known app list after
         # filtering by CONF_INCLUDE/CONF_EXCLUDE
-        self._available_apps = self._sapps_list(self._device.get_apps_list())
+        self._available_apps = self._apps_list(self._device.get_apps_list())
 
         self._current_app_config = await self._device.get_current_app_config(
             log_api_exception=False

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -137,7 +137,7 @@ class VizioDevice(MediaPlayerEntity):
         self._current_app = None
         self._current_app_config = None
         self._current_sound_mode = None
-        self._available_sound_modes = None
+        self._available_sound_modes = []
         self._available_inputs = []
         self._available_apps = []
         self._conf_apps = config_entry.options.get(CONF_APPS, {})
@@ -192,12 +192,9 @@ class VizioDevice(MediaPlayerEntity):
             self._volume_level = None
             self._is_volume_muted = None
             self._current_input = None
-            self._available_inputs = None
             self._current_app = None
             self._current_app_config = None
-            self._available_apps = None
             self._current_sound_mode = None
-            self._available_sound_modes = None
             return
 
         self._state = STATE_ON
@@ -215,7 +212,7 @@ class VizioDevice(MediaPlayerEntity):
             if VIZIO_SOUND_MODE in audio_settings:
                 self._supported_commands |= SUPPORT_SELECT_SOUND_MODE
                 self._current_sound_mode = audio_settings[VIZIO_SOUND_MODE]
-                if self._available_sound_modes is None:
+                if not self._available_sound_modes:
                     self._available_sound_modes = await self._device.get_setting_options(
                         VIZIO_AUDIO_SETTINGS, VIZIO_SOUND_MODE
                     )
@@ -226,13 +223,14 @@ class VizioDevice(MediaPlayerEntity):
         if input_ is not None:
             self._current_input = input_
 
-        inputs = await self._device.get_inputs_list(log_api_exception=False)
+        if not self._available_inputs:
+            inputs = await self._device.get_inputs_list(log_api_exception=False)
 
-        # If no inputs returned, end update
-        if not inputs:
-            return
+            # If no inputs returned, end update
+            if not inputs:
+                return
 
-        self._available_inputs = [input_.name for input_ in inputs]
+            self._available_inputs = [input_.name for input_ in inputs]
 
         # Return before setting app variables if INPUT_APPS isn't in available inputs
         if self._device_class == DEVICE_CLASS_SPEAKER or not any(


### PR DESCRIPTION
## Proposed change
I've noticed that my device gets into a state where the API doesn't work and the device isn't controllable after some of the latest changes I have made. I suspect that the integration is calling the API too many times and it's causing my device to get into this state, and it seems to happen randomly when I switch to off and on. This change prevents available sound modes and available inputs from having to be queried on every state transition between `STATE_OFF` and `STATE_ON`. I think this is a safe change because none of those lists should change. I've also made it so that the available apps are always queried because these are statically defined and without this change the available apps list wouldn't change with updates to `pyvizio`. I also made the logic of setting and retrieving all "available" lists more consistent

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
