### PR TITLE
Add Xiaomi miio vaccum goto service

### DIFF
--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -49,6 +49,7 @@ SERVICE_MOVE_REMOTE_CONTROL_STEP = "vacuum_remote_control_move_step"
 SERVICE_START_REMOTE_CONTROL = "vacuum_remote_control_start"
 SERVICE_STOP_REMOTE_CONTROL = "vacuum_remote_control_stop"
 SERVICE_CLEAN_ZONE = "vacuum_clean_zone"
+SERVICE_GOTO = "vacuum_goto"
 
 # AirQuality Model
 MODEL_AIRQUALITYMONITOR_V1 = "zhimi.airmonitor.v1"

--- a/homeassistant/components/xiaomi_miio/services.yaml
+++ b/homeassistant/components/xiaomi_miio/services.yaml
@@ -330,3 +330,16 @@ vacuum_clean_zone:
     repeats:
       description: Number of cleaning repeats for each zone between 1 and 3.
       example: "1"
+
+vacuum_goto:
+  description: Go to the specified coordinates.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+    x_coord:
+      description: x-coordinate.
+      example: 27500
+    y_coord:
+      description: y-coordinate.
+      example: 32000

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -416,7 +416,6 @@ class MiroboVacuum(StateVacuumEntity):
 
     async def async_send_command(self, command, params=None, **kwargs):
         """Send raw command."""
-        _LOGGER.debug("Raw command")
         await self._try_command(
             "Unable to send command to the vacuum: %s",
             self._vacuum.raw_command,

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -5,7 +5,6 @@ import logging
 from miio import DeviceException, Vacuum  # pylint: disable=import-error
 import voluptuous as vol
 
-# import homeassistant.helpers.config_validation as cv
 from homeassistant.components.vacuum import (
     ATTR_CLEANED_AREA,
     PLATFORM_SCHEMA,
@@ -27,14 +26,7 @@ from homeassistant.components.vacuum import (
     SUPPORT_STOP,
     StateVacuumEntity,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    CONF_HOST,
-    CONF_NAME,
-    CONF_TOKEN,
-    STATE_OFF,
-    STATE_ON,
-)
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON
 from homeassistant.helpers import config_validation as cv, entity_platform
 
 from .const import (
@@ -80,59 +72,6 @@ ATTR_RC_VELOCITY = "velocity"
 ATTR_STATUS = "status"
 ATTR_ZONE_ARRAY = "zone"
 ATTR_ZONE_REPEATER = "repeats"
-
-VACUUM_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids})
-
-SERVICE_SCHEMA_REMOTE_CONTROL = VACUUM_SERVICE_SCHEMA.extend(
-    {
-        vol.Optional(ATTR_RC_VELOCITY): vol.All(
-            vol.Coerce(float), vol.Clamp(min=-0.29, max=0.29)
-        ),
-        vol.Optional(ATTR_RC_ROTATION): vol.All(
-            vol.Coerce(int), vol.Clamp(min=-179, max=179)
-        ),
-        vol.Optional(ATTR_RC_DURATION): cv.positive_int,
-    }
-)
-
-SERVICE_SCHEMA_CLEAN_ZONE = VACUUM_SERVICE_SCHEMA.extend(
-    {
-        vol.Required(ATTR_ZONE_ARRAY): vol.All(
-            list,
-            [
-                vol.ExactSequence(
-                    [vol.Coerce(int), vol.Coerce(int), vol.Coerce(int), vol.Coerce(int)]
-                )
-            ],
-        ),
-        vol.Required(ATTR_ZONE_REPEATER): vol.All(
-            vol.Coerce(int), vol.Clamp(min=1, max=3)
-        ),
-    }
-)
-
-SERVICE_SCHEMA_CLEAN_ZONE = VACUUM_SERVICE_SCHEMA.extend(
-    {
-        vol.Required(ATTR_ZONE_ARRAY): vol.All(
-            list,
-            [
-                vol.ExactSequence(
-                    [vol.Coerce(int), vol.Coerce(int), vol.Coerce(int), vol.Coerce(int)]
-                )
-            ],
-        ),
-        vol.Required(ATTR_ZONE_REPEATER): vol.All(
-            vol.Coerce(int), vol.Clamp(min=1, max=3)
-        ),
-    }
-)
-
-SERVICE_SCHEMA_GOTO = VACUUM_SERVICE_SCHEMA.extend(
-    {
-        vol.Required("x_coord"): vol.Coerce(int),
-        vol.Required("y_coord"): vol.Coerce(int),
-    }
-)
 
 SUPPORT_XIAOMI = (
     SUPPORT_STATE
@@ -188,31 +127,74 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     platform.async_register_entity_service(
         SERVICE_START_REMOTE_CONTROL,
-        VACUUM_SERVICE_SCHEMA,
+        {},
         MiroboVacuum.async_remote_control_start.__name__,
     )
+
     platform.async_register_entity_service(
         SERVICE_STOP_REMOTE_CONTROL,
-        VACUUM_SERVICE_SCHEMA,
+        {},
         MiroboVacuum.async_remote_control_stop.__name__,
     )
+
     platform.async_register_entity_service(
         SERVICE_MOVE_REMOTE_CONTROL,
-        SERVICE_SCHEMA_REMOTE_CONTROL,
+        {
+            vol.Optional(ATTR_RC_VELOCITY): vol.All(
+                vol.Coerce(float), vol.Clamp(min=-0.29, max=0.29)
+            ),
+            vol.Optional(ATTR_RC_ROTATION): vol.All(
+                vol.Coerce(int), vol.Clamp(min=-179, max=179)
+            ),
+            vol.Optional(ATTR_RC_DURATION): cv.positive_int,
+        },
         MiroboVacuum.async_remote_control_move.__name__,
     )
+
     platform.async_register_entity_service(
         SERVICE_MOVE_REMOTE_CONTROL_STEP,
-        SERVICE_SCHEMA_REMOTE_CONTROL,
+        {
+            vol.Optional(ATTR_RC_VELOCITY): vol.All(
+                vol.Coerce(float), vol.Clamp(min=-0.29, max=0.29)
+            ),
+            vol.Optional(ATTR_RC_ROTATION): vol.All(
+                vol.Coerce(int), vol.Clamp(min=-179, max=179)
+            ),
+            vol.Optional(ATTR_RC_DURATION): cv.positive_int,
+        },
         MiroboVacuum.async_remote_control_move_step.__name__,
     )
+
     platform.async_register_entity_service(
         SERVICE_CLEAN_ZONE,
-        SERVICE_SCHEMA_CLEAN_ZONE,
+        {
+            vol.Required(ATTR_ZONE_ARRAY): vol.All(
+                list,
+                [
+                    vol.ExactSequence(
+                        [
+                            vol.Coerce(int),
+                            vol.Coerce(int),
+                            vol.Coerce(int),
+                            vol.Coerce(int),
+                        ]
+                    )
+                ],
+            ),
+            vol.Required(ATTR_ZONE_REPEATER): vol.All(
+                vol.Coerce(int), vol.Clamp(min=1, max=3)
+            ),
+        },
         MiroboVacuum.async_clean_zone.__name__,
     )
+
     platform.async_register_entity_service(
-        SERVICE_GOTO, SERVICE_SCHEMA_GOTO, MiroboVacuum.async_goto.__name__
+        SERVICE_GOTO,
+        {
+            vol.Required("x_coord"): vol.Coerce(int),
+            vol.Required("y_coord"): vol.Coerce(int),
+        },
+        MiroboVacuum.async_goto.__name__,
     )
 
 

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -202,22 +202,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     async_add_entities([mirobo], update_before_add=True)
 
-    async def async_service_handler(entity, service):
-        """Map services to methods on MiroboVacuum."""
-        method = SERVICE_TO_METHOD.get(service.service)
-        params = {
-            key: value for key, value in service.data.items() if key != ATTR_ENTITY_ID
-        }
-
-        await getattr(entity, method["method"])(**params)
-
     platform = entity_platform.current_platform.get()
 
     for vacuum_service, method in SERVICE_TO_METHOD.items():
         schema = method.get("schema", VACUUM_SERVICE_SCHEMA)
-        platform.async_register_entity_service(
-            vacuum_service, schema, async_service_handler
-        )
+        method_name = method["method"]
+        platform.async_register_entity_service(vacuum_service, schema, method_name)
 
 
 class MiroboVacuum(StateVacuumEntity):

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -40,6 +40,7 @@ import homeassistant.helpers.config_validation as cv
 from .const import (
     DOMAIN,
     SERVICE_CLEAN_ZONE,
+    SERVICE_GOTO,
     SERVICE_MOVE_REMOTE_CONTROL,
     SERVICE_MOVE_REMOTE_CONTROL_STEP,
     SERVICE_START_REMOTE_CONTROL,
@@ -127,6 +128,13 @@ SERVICE_SCHEMA_CLEAN_ZONE = VACUUM_SERVICE_SCHEMA.extend(
     }
 )
 
+SERVICE_SCHEMA_GOTO = VACUUM_SERVICE_SCHEMA.extend(
+    {
+        vol.Required("x_coord"): vol.Coerce(int),
+        vol.Required("y_coord"): vol.Coerce(int),
+    }
+)
+
 SERVICE_TO_METHOD = {
     SERVICE_START_REMOTE_CONTROL: {"method": "async_remote_control_start"},
     SERVICE_STOP_REMOTE_CONTROL: {"method": "async_remote_control_stop"},
@@ -142,6 +150,7 @@ SERVICE_TO_METHOD = {
         "method": "async_clean_zone",
         "schema": SERVICE_SCHEMA_CLEAN_ZONE,
     },
+    SERVICE_GOTO: {"method": "async_goto", "schema": SERVICE_SCHEMA_GOTO},
 }
 
 SUPPORT_XIAOMI = (
@@ -407,6 +416,7 @@ class MiroboVacuum(StateVacuumEntity):
 
     async def async_send_command(self, command, params=None, **kwargs):
         """Send raw command."""
+        _LOGGER.debug("Raw command")
         await self._try_command(
             "Unable to send command to the vacuum: %s",
             self._vacuum.raw_command,
@@ -448,6 +458,15 @@ class MiroboVacuum(StateVacuumEntity):
             velocity=velocity,
             rotation=rotation,
             duration=duration,
+        )
+
+    async def async_goto(self, x_coord: int = 25500, y_coord: int = 25500):
+        """Goto the specified coordinates."""
+        await self._try_command(
+            "Unable to remote control the vacuum: %s",
+            self._vacuum.goto,
+            x_coord=x_coord,
+            y_coord=y_coord,
         )
 
     def update(self):

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -1,5 +1,4 @@
 """Support for the Xiaomi vacuum cleaner robot."""
-import asyncio
 from functools import partial
 import logging
 
@@ -211,11 +210,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         }
 
         await getattr(entity, method["method"])(**params)
-        _LOGGER.debug("Service awaited")
-
-        update_coro = entity.async_update_ha_state(True)
-        await asyncio.wait({update_coro})
-        _LOGGER.debug("State update awaited")
 
     platform = entity_platform.current_platform.get()
 

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -134,24 +134,6 @@ SERVICE_SCHEMA_GOTO = VACUUM_SERVICE_SCHEMA.extend(
     }
 )
 
-SERVICE_TO_METHOD = {
-    SERVICE_START_REMOTE_CONTROL: {"method": "async_remote_control_start"},
-    SERVICE_STOP_REMOTE_CONTROL: {"method": "async_remote_control_stop"},
-    SERVICE_MOVE_REMOTE_CONTROL: {
-        "method": "async_remote_control_move",
-        "schema": SERVICE_SCHEMA_REMOTE_CONTROL,
-    },
-    SERVICE_MOVE_REMOTE_CONTROL_STEP: {
-        "method": "async_remote_control_move_step",
-        "schema": SERVICE_SCHEMA_REMOTE_CONTROL,
-    },
-    SERVICE_CLEAN_ZONE: {
-        "method": "async_clean_zone",
-        "schema": SERVICE_SCHEMA_CLEAN_ZONE,
-    },
-    SERVICE_GOTO: {"method": "async_goto", "schema": SERVICE_SCHEMA_GOTO},
-}
-
 SUPPORT_XIAOMI = (
     SUPPORT_STATE
     | SUPPORT_PAUSE
@@ -204,10 +186,34 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     platform = entity_platform.current_platform.get()
 
-    for vacuum_service, method in SERVICE_TO_METHOD.items():
-        schema = method.get("schema", VACUUM_SERVICE_SCHEMA)
-        method_name = method["method"]
-        platform.async_register_entity_service(vacuum_service, schema, method_name)
+    platform.async_register_entity_service(
+        SERVICE_START_REMOTE_CONTROL,
+        VACUUM_SERVICE_SCHEMA,
+        MiroboVacuum.async_remote_control_start.__name__,
+    )
+    platform.async_register_entity_service(
+        SERVICE_STOP_REMOTE_CONTROL,
+        VACUUM_SERVICE_SCHEMA,
+        MiroboVacuum.async_remote_control_stop.__name__,
+    )
+    platform.async_register_entity_service(
+        SERVICE_MOVE_REMOTE_CONTROL,
+        SERVICE_SCHEMA_REMOTE_CONTROL,
+        MiroboVacuum.async_remote_control_move.__name__,
+    )
+    platform.async_register_entity_service(
+        SERVICE_MOVE_REMOTE_CONTROL_STEP,
+        SERVICE_SCHEMA_REMOTE_CONTROL,
+        MiroboVacuum.async_remote_control_move_step.__name__,
+    )
+    platform.async_register_entity_service(
+        SERVICE_CLEAN_ZONE,
+        SERVICE_SCHEMA_CLEAN_ZONE,
+        MiroboVacuum.async_clean_zone.__name__,
+    )
+    platform.async_register_entity_service(
+        SERVICE_GOTO, SERVICE_SCHEMA_GOTO, MiroboVacuum.async_goto.__name__
+    )
 
 
 class MiroboVacuum(StateVacuumEntity):

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -416,6 +416,7 @@ class MiroboVacuum(StateVacuumEntity):
 
     async def async_send_command(self, command, params=None, **kwargs):
         """Send raw command."""
+        _LOGGER.debug("Raw command")
         await self._try_command(
             "Unable to send command to the vacuum: %s",
             self._vacuum.raw_command,

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -459,10 +459,10 @@ class MiroboVacuum(StateVacuumEntity):
             duration=duration,
         )
 
-    async def async_goto(self, x_coord: int = 25500, y_coord: int = 25500):
+    async def async_goto(self, x_coord: int, y_coord: int):
         """Goto the specified coordinates."""
         await self._try_command(
-            "Unable to remote control the vacuum: %s",
+            "Unable to send the vacuum cleaner to the specified coordinates: %s",
             self._vacuum.goto,
             x_coord=x_coord,
             y_coord=y_coord,

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -391,16 +391,6 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_on.reset_mock()
 
-    coordinates = {"x_coord": 25500, "y_coord": 25500}
-    await hass.services.async_call(
-        XIAOMI_DOMAIN, SERVICE_GOTO, coordinates, blocking=True
-    )
-    mock_mirobo_is_on.goto.assert_has_calls(
-        [mock.call(x_coord=25500, y_coord=25500)], any_order=True
-    )
-    mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
-    mock_mirobo_is_on.reset_mock()
-
 
 async def test_xiaomi_vacuum_fanspeeds(hass, caplog, mock_mirobo_fanspeeds):
     """Test Xiaomi vacuum fanspeeds."""

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -37,6 +37,7 @@ from homeassistant.components.xiaomi_miio.vacuum import (
     CONF_TOKEN,
     DOMAIN as XIAOMI_DOMAIN,
     SERVICE_CLEAN_ZONE,
+    SERVICE_GOTO,
     SERVICE_MOVE_REMOTE_CONTROL,
     SERVICE_MOVE_REMOTE_CONTROL_STEP,
     SERVICE_START_REMOTE_CONTROL,
@@ -386,6 +387,16 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     )
     mock_mirobo_is_on.zoned_clean.assert_has_calls(
         [mock.call([[123, 123, 123, 123, 2]])], any_order=True
+    )
+    mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
+    mock_mirobo_is_on.reset_mock()
+
+    coordinates = {"x_coord": 25500, "y_coord": 25500}
+    await hass.services.async_call(
+        XIAOMI_DOMAIN, SERVICE_GOTO, coordinates, blocking=True
+    )
+    mock_mirobo_is_on.goto.assert_has_calls(
+        [mock.call(x_coord=25500, y_coord=25500)], any_order=True
     )
     mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_on.reset_mock()

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -19,6 +19,7 @@ from homeassistant.components.vacuum import (
     STATE_CLEANING,
     STATE_ERROR,
 )
+from homeassistant.components.xiaomi_miio.const import DOMAIN as XIAOMI_DOMAIN
 from homeassistant.components.xiaomi_miio.vacuum import (
     ATTR_CLEANED_AREA,
     ATTR_CLEANED_TOTAL_AREA,
@@ -35,7 +36,6 @@ from homeassistant.components.xiaomi_miio.vacuum import (
     CONF_HOST,
     CONF_NAME,
     CONF_TOKEN,
-    DOMAIN as XIAOMI_DOMAIN,
     SERVICE_CLEAN_ZONE,
     SERVICE_GOTO,
     SERVICE_MOVE_REMOTE_CONTROL,
@@ -356,7 +356,10 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
 
     control = {"duration": 1000, "rotation": -40, "velocity": -0.1}
     await hass.services.async_call(
-        XIAOMI_DOMAIN, SERVICE_MOVE_REMOTE_CONTROL, control, blocking=True
+        XIAOMI_DOMAIN,
+        SERVICE_MOVE_REMOTE_CONTROL,
+        dict(**control, **{ATTR_ENTITY_ID: entity_id}),
+        blocking=True,
     )
     mock_mirobo_is_on.manual_control.assert_has_calls(
         [mock.call(**control)], any_order=True
@@ -365,7 +368,10 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.reset_mock()
 
     await hass.services.async_call(
-        XIAOMI_DOMAIN, SERVICE_STOP_REMOTE_CONTROL, {}, blocking=True
+        XIAOMI_DOMAIN,
+        SERVICE_STOP_REMOTE_CONTROL,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
     )
     mock_mirobo_is_on.assert_has_calls([mock.call.manual_stop()], any_order=True)
     mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
@@ -373,7 +379,10 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
 
     control_once = {"duration": 2000, "rotation": 120, "velocity": 0.1}
     await hass.services.async_call(
-        XIAOMI_DOMAIN, SERVICE_MOVE_REMOTE_CONTROL_STEP, control_once, blocking=True
+        XIAOMI_DOMAIN,
+        SERVICE_MOVE_REMOTE_CONTROL_STEP,
+        dict(**control_once, **{ATTR_ENTITY_ID: entity_id}),
+        blocking=True,
     )
     mock_mirobo_is_on.manual_control_once.assert_has_calls(
         [mock.call(**control_once)], any_order=True
@@ -383,7 +392,10 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
 
     control = {"zone": [[123, 123, 123, 123]], "repeats": 2}
     await hass.services.async_call(
-        XIAOMI_DOMAIN, SERVICE_CLEAN_ZONE, control, blocking=True
+        XIAOMI_DOMAIN,
+        SERVICE_CLEAN_ZONE,
+        dict(**control, **{ATTR_ENTITY_ID: entity_id}),
+        blocking=True,
     )
     mock_mirobo_is_on.zoned_clean.assert_has_calls(
         [mock.call([[123, 123, 123, 123, 2]])], any_order=True

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -358,7 +358,7 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     await hass.services.async_call(
         XIAOMI_DOMAIN,
         SERVICE_MOVE_REMOTE_CONTROL,
-        dict(**control, **{ATTR_ENTITY_ID: entity_id}),
+        {**control, ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_mirobo_is_on.manual_control.assert_has_calls(
@@ -381,7 +381,7 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     await hass.services.async_call(
         XIAOMI_DOMAIN,
         SERVICE_MOVE_REMOTE_CONTROL_STEP,
-        dict(**control_once, **{ATTR_ENTITY_ID: entity_id}),
+        {**control_once, ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_mirobo_is_on.manual_control_once.assert_has_calls(
@@ -394,7 +394,7 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     await hass.services.async_call(
         XIAOMI_DOMAIN,
         SERVICE_CLEAN_ZONE,
-        dict(**control, **{ATTR_ENTITY_ID: entity_id}),
+        {**control, ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_mirobo_is_on.zoned_clean.assert_has_calls(

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -391,6 +391,16 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_on.reset_mock()
 
+    coordinates = {"x_coord": 25500, "y_coord": 25500}
+    await hass.services.async_call(
+        XIAOMI_DOMAIN, SERVICE_GOTO, coordinates, blocking=True
+    )
+    mock_mirobo_is_on.goto.assert_has_calls(
+        [mock.call(x_coord=25500, y_coord=25500)], any_order=True
+    )
+    mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
+    mock_mirobo_is_on.reset_mock()
+
 
 async def test_xiaomi_vacuum_fanspeeds(hass, caplog, mock_mirobo_fanspeeds):
     """Test Xiaomi vacuum fanspeeds."""

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -391,16 +391,6 @@ async def test_xiaomi_specific_services(hass, caplog, mock_mirobo_is_on):
     mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
     mock_mirobo_is_on.reset_mock()
 
-    coordinates = {"x_coord": 25500, "y_coord": 25500}
-    await hass.services.async_call(
-        XIAOMI_DOMAIN, SERVICE_GOTO, coordinates, blocking=True
-    )
-    mock_mirobo_is_on.goto.assert_has_calls(
-        [mock.call(x_coord=25500, y_coord=25500)], any_order=True
-    )
-    mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)
-    mock_mirobo_is_on.reset_mock()
-
 
 async def test_xiaomi_vacuum_fanspeeds(hass, caplog, mock_mirobo_fanspeeds):
     """Test Xiaomi vacuum fanspeeds."""
@@ -464,3 +454,30 @@ async def test_xiaomi_vacuum_fanspeeds(hass, caplog, mock_mirobo_fanspeeds):
         blocking=True,
     )
     assert "ERROR" in caplog.text
+
+
+async def test_xiaomi_vacuum_goto_service(hass, caplog, mock_mirobo_is_on):
+    """Test vacuum supported features."""
+    entity_name = "test_vacuum_cleaner_2"
+    entity_id = f"{DOMAIN}.{entity_name}"
+
+    await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_PLATFORM: PLATFORM,
+                CONF_HOST: "192.168.1.100",
+                CONF_NAME: entity_name,
+                CONF_TOKEN: "12345678901234567890123456789012",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    data = {"entity_id": entity_id, "x_coord": 25500, "y_coord": 25500}
+    await hass.services.async_call(XIAOMI_DOMAIN, SERVICE_GOTO, data, blocking=True)
+    mock_mirobo_is_on.goto.assert_has_calls(
+        [mock.call(x_coord=data["x_coord"], y_coord=data["y_coord"])], any_order=True
+    )
+    mock_mirobo_is_on.assert_has_calls(STATUS_CALLS, any_order=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Due to general code updates to the xiaomi_miio vacuum component there are breaking changes to the existing services 
- `xiaomi_miio.vacuum_remote_control_start`
- `xiaomi_miio.vacuum_remote_control_stop`
- `xiaomi_miio.vacuum_remote_control_move`
- `xiaomi_miio.vacuum_remote_control_move_step`
- `xiaomi_miio.vacuum_clean_zone`

They all require now that either `entity_id` or `area_id` are passed when calling the service. Users need to update all usages (such as automations and scripts) of these services that doesn't already pass `entity_id` or `area_id`. For example, change the existing automation:
```yaml
automation:
  - alias: Test vacuum zone
    trigger:
    - event: start
      platform: homeassistant
    condition: []
    action:
    - service: xiaomi_miio.vacuum_clean_zone
      data_template:
        repeats: '{{states('input_number.vacuum_passes')|int}}'
        zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
```
to
```yaml
automation:
  - alias: Test vacuum zone
    trigger:
    - event: start
      platform: homeassistant
    condition: []
    action:
    - service: xiaomi_miio.vacuum_clean_zone
      data_template:
        entity_id: vacuum.xiaomi_vacuum
        repeats: '{{states('input_number.vacuum_passes')|int}}'
        zone: [[30914,26007,35514,28807], [20232,22496,26032,26496]]
```


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have added the "Go to (coordinates)" action as a service to the xiaomi_miio platform. This service makes your xiaomi vacuum cleaner go to the specified coordinates


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
vacuum:
  - platform: xiaomi_miio
    host: 192.168.0.10
    token: 123456789abcdef123456789abcdef
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [https://github.com/home-assistant/home-assistant.io/pull/13496](https://github.com/home-assistant/home-assistant.io/pull/13496)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
