### PR TITLE
Add sw_version and connections to sonos devices

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -40,6 +40,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import ServiceCall, callback
 from homeassistant.helpers import config_validation as cv, entity_platform, service
+import homeassistant.helpers.device_registry as dr
 from homeassistant.util.dt import utcnow
 
 from . import (
@@ -392,6 +393,8 @@ class SonosEntity(MediaPlayerEntity):
         speaker_info = self.soco.get_speaker_info(True)
         self._name = speaker_info["zone_name"]
         self._model = speaker_info["model_name"]
+        self._sw_version = speaker_info["software_version"]
+        self._mac_address = speaker_info["mac_address"]
 
     async def async_added_to_hass(self):
         """Subscribe sonos events."""
@@ -427,6 +430,8 @@ class SonosEntity(MediaPlayerEntity):
             "identifiers": {(SONOS_DOMAIN, self._unique_id)},
             "name": self._name,
             "model": self._model.replace("Sonos ", ""),
+            "sw_version": self._sw_version,
+            "connections": {(dr.CONNECTION_NETWORK_MAC, self._mac_address)},
             "manufacturer": "Sonos",
         }
 

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -69,4 +69,9 @@ def music_library_fixture():
 @pytest.fixture(name="speaker_info")
 def speaker_info_fixture():
     """Create speaker_info fixture."""
-    return {"zone_name": "Zone A", "model_name": "Model Name"}
+    return {
+        "zone_name": "Zone A",
+        "model_name": "Model Name",
+        "software_version": "49.2-64250",
+        "mac_address": "00-11-22-33-44-55",
+    }

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -42,3 +42,18 @@ async def test_services(hass, config_entry, config, hass_read_only_user):
             blocking=True,
             context=Context(user_id=hass_read_only_user.id),
         )
+
+
+async def test_device_registry(hass, config_entry, config, soco):
+    """Test sonos device registered in the device registry."""
+    await setup_platform(hass, config_entry, config)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    reg_device = device_registry.async_get_device(
+        identifiers={("sonos", "RINCON_test")}, connections=set(),
+    )
+    assert reg_device.model == "Model Name"
+    assert reg_device.sw_version == "49.2-64250"
+    assert reg_device.connections == {("mac", "00:11:22:33:44:55")}
+    assert reg_device.manufacturer == "Sonos"
+    assert reg_device.name == "Zone A"


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add sw_version and connections to sonos devices

Shows in the UI now

<img width="326" alt="Screen Shot 2020-05-17 at 11 49 06 AM" src="https://user-images.githubusercontent.com/663432/82154588-7660d400-9834-11ea-8df7-7c5798cf30f8.png">


Also shows in homekit after #35741

<img width="400" alt="Screen Shot 2020-05-17 at 11 48 02 AM" src="https://user-images.githubusercontent.com/663432/82154554-4e717080-9834-11ea-8aba-27e31e942727.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
