### PR TITLE
Ensure configured logger severity is respected

### DIFF
--- a/homeassistant/components/logger/__init__.py
+++ b/homeassistant/components/logger/__init__.py
@@ -73,7 +73,7 @@ class HomeAssistantLogFilter(logging.Filter):
         # so they take precedence of the shorter names
         # to allow for more granular settings.
         #
-        names_by_len = sorted(list(logs.keys()), key=len, reverse=True)
+        names_by_len = sorted(list(logs), key=len, reverse=True)
         self._log_rx = re.compile("".join(["^(?:", "|".join(names_by_len), ")"]))
         self._logs = logs
 

--- a/homeassistant/components/logger/__init__.py
+++ b/homeassistant/components/logger/__init__.py
@@ -1,6 +1,6 @@
 """Support for setting the level of logging for components."""
-from collections import OrderedDict
 import logging
+import re
 
 import voluptuous as vol
 
@@ -50,33 +50,54 @@ CONFIG_SCHEMA = vol.Schema(
 class HomeAssistantLogFilter(logging.Filter):
     """A log filter."""
 
-    def __init__(self, logfilter):
+    def __init__(self):
         """Initialize the filter."""
         super().__init__()
 
-        self.logfilter = logfilter
+        self._default = None
+        self._logs = None
+        self._log_rx = None
+
+    def update_default_level(self, default_level):
+        """Update the default logger level."""
+        self._default = default_level
+
+    def update_log_filter(self, logs):
+        """Rebuild the internal filter from new config."""
+        #
+        # A precompiled regex is used to avoid
+        # the overhead of a list transversal
+        #
+        # Sort to make sure the longer
+        # names are always matched first
+        # so they take precedence of the shorter names
+        # to allow for more granular settings.
+        #
+        names_by_len = sorted(list(logs.keys()), key=len, reverse=True)
+        self._log_rx = re.compile("".join(["^(?:", "|".join(names_by_len), ")"]))
+        self._logs = logs
 
     def filter(self, record):
         """Filter the log entries."""
         # Log with filtered severity
-        if LOGGER_LOGS in self.logfilter:
-            for filtername in self.logfilter[LOGGER_LOGS]:
-                logseverity = self.logfilter[LOGGER_LOGS][filtername]
-                if record.name.startswith(filtername):
-                    return record.levelno >= logseverity
+        if self._log_rx:
+            match = self._log_rx.match(record.name)
+            if match:
+                return record.levelno >= self._logs[match.group(0)]
 
         # Log with default severity
-        default = self.logfilter[LOGGER_DEFAULT]
-        return record.levelno >= default
+        return record.levelno >= self._default
 
 
 async def async_setup(hass, config):
     """Set up the logger component."""
     logfilter = {}
+    hass_filter = HomeAssistantLogFilter()
 
     def set_default_log_level(level):
         """Set the default log level for components."""
         logfilter[LOGGER_DEFAULT] = LOGSEVERITY[level]
+        hass_filter.update_default_level(LOGSEVERITY[level])
 
     def set_log_levels(logpoints):
         """Set the specified log levels."""
@@ -90,9 +111,9 @@ async def async_setup(hass, config):
         for key, value in logpoints.items():
             logs[key] = LOGSEVERITY[value]
 
-        logfilter[LOGGER_LOGS] = OrderedDict(
-            sorted(logs.items(), key=lambda t: len(t[0]), reverse=True)
-        )
+        logfilter[LOGGER_LOGS] = logs
+
+        hass_filter.update_log_filter(logs)
 
     # Set default log severity
     if LOGGER_DEFAULT in config.get(DOMAIN):
@@ -106,7 +127,7 @@ async def async_setup(hass, config):
     # Set log filter for all log handler
     for handler in logging.root.handlers:
         handler.setLevel(logging.NOTSET)
-        handler.addFilter(HomeAssistantLogFilter(logfilter))
+        handler.addFilter(hass_filter)
 
     if LOGGER_LOGS in config.get(DOMAIN):
         set_log_levels(config.get(DOMAIN)[LOGGER_LOGS])


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the logger severity was lowered for a module
it was not respected.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
logger:
  default: debug
  logs:
      custom_components.synology_dsm: debug
      custom_components.zeroconf: critical
      custom_components.gogogate2: debug
      custom_components.homekit: debug
      custom_components.isy994: debug
      PyISY: debug
      pyisy: debug
      PyISY-beta: debug
      pyhap: debug
      custom_components.hunterdouglas_powerview: debug
      aiounifi: debug
      custom_components.unifi: debug
      custom_components.nut: debug
      custom_components.device_tracker.unifi: debug
      custom_components.switch.unifi: debug
      custom_components.tplink: debug
      pyHS100: debug
      python-kasa: debug
      kasa: debug
      custom_components.tado: debug
      custom_components.lutron_caseta: debug
      custom_components.flume: debug
      custom_components.flume: debug
      PyTado: debug
      custom_components.elkm1: debug
      custom_components.harmony: debug
      elkm1: debug
      custom_components.nexia: debug
      custom_components.homekit: debug
      custom_components.nut: debug
      custom_components.rachio: debug
      custom_components.myq: debug
      pylutron-caseta: debug
      pylutron_caseta: debug
      urllib3: debug
      requests: debug
      pymyq: debug
      aioharmony: debug
      aioharmony.harmonyapi: debug
      aioharmony.harmonyclient: debug
      nexia: debug
      custom_components.august: debug
      custom_components.pvpc_hourly_pricing: debug
      homeassistant.components.zeroconf: debug
      homeassistant.components.homekit: debug
      august.api: debug
      august.async_api: debug
      august.api_async: debug
      aiohttp: debug
      custom_components.recorder: debug
      custom_components.isy994: debug
      homeassistant.components.zwave: debug
      custom_components.sense: debug
      custom_components.rachio: debug
      custom_components.august2: debug
      sense_energy: debug
      PyTado: debug
      pytado: debug
      zeroconf: debug
      homeassistant.components.tado: debug
      custom_components.tado: debug
      custom_components.hd_powerview: debug
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26928 and fixes #35733
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
