### PR TITLE
Add support for InputSelector trait

### DIFF
--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -61,7 +61,6 @@ YOUTUBE_PLAYER_SUPPORT = (
     | SUPPORT_PLAY
     | SUPPORT_SHUFFLE_SET
     | SUPPORT_SELECT_SOUND_MODE
-    | SUPPORT_SELECT_SOURCE
     | SUPPORT_SEEK
 )
 
@@ -397,6 +396,7 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
         self._cur_episode = 1
         self._episode_count = 13
         self._source = "dvd"
+        self._source_list = ["dvd", "youtube"]
 
     @property
     def media_content_id(self):
@@ -447,6 +447,11 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
     def source(self):
         """Return the current input source."""
         return self._source
+
+    @property
+    def source_list(self):
+        """List of available sources."""
+        return self._source_list
 
     @property
     def supported_features(self):

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -86,6 +86,7 @@ TRAIT_TEMPERATURE_SETTING = f"{PREFIX_TRAITS}TemperatureSetting"
 TRAIT_LOCKUNLOCK = f"{PREFIX_TRAITS}LockUnlock"
 TRAIT_FANSPEED = f"{PREFIX_TRAITS}FanSpeed"
 TRAIT_MODES = f"{PREFIX_TRAITS}Modes"
+TRAIT_INPUTSELECTOR = f"{PREFIX_TRAITS}InputSelector"
 TRAIT_OPENCLOSE = f"{PREFIX_TRAITS}OpenClose"
 TRAIT_VOLUME = f"{PREFIX_TRAITS}Volume"
 TRAIT_ARMDISARM = f"{PREFIX_TRAITS}ArmDisarm"
@@ -112,6 +113,7 @@ COMMAND_THERMOSTAT_SET_MODE = f"{PREFIX_COMMANDS}ThermostatSetMode"
 COMMAND_LOCKUNLOCK = f"{PREFIX_COMMANDS}LockUnlock"
 COMMAND_FANSPEED = f"{PREFIX_COMMANDS}SetFanSpeed"
 COMMAND_MODES = f"{PREFIX_COMMANDS}SetModes"
+COMMAND_INPUT = f"{PREFIX_COMMANDS}SetInput"
 COMMAND_OPENCLOSE = f"{PREFIX_COMMANDS}OpenClose"
 COMMAND_SET_VOLUME = f"{PREFIX_COMMANDS}setVolume"
 COMMAND_VOLUME_RELATIVE = f"{PREFIX_COMMANDS}volumeRelative"
@@ -1213,7 +1215,6 @@ class ModesTrait(_Trait):
     commands = [COMMAND_MODES]
 
     SYNONYMS = {
-        "input source": ["input source", "input", "source"],
         "sound mode": ["sound mode", "effects"],
         "option": ["option", "setting", "mode", "value"],
     }
@@ -1230,10 +1231,7 @@ class ModesTrait(_Trait):
         if domain != media_player.DOMAIN:
             return False
 
-        return (
-            features & media_player.SUPPORT_SELECT_SOURCE
-            or features & media_player.SUPPORT_SELECT_SOUND_MODE
-        )
+        return features & media_player.SUPPORT_SELECT_SOUND_MODE
 
     def sync_attributes(self):
         """Return mode attributes for a sync request."""
@@ -1266,13 +1264,6 @@ class ModesTrait(_Trait):
         attrs = self.state.attributes
         modes = []
         if self.state.domain == media_player.DOMAIN:
-            if media_player.ATTR_INPUT_SOURCE_LIST in attrs:
-                modes.append(
-                    _generate(
-                        "input source", attrs[media_player.ATTR_INPUT_SOURCE_LIST]
-                    )
-                )
-
             if media_player.ATTR_SOUND_MODE_LIST in attrs:
                 modes.append(
                     _generate("sound mode", attrs[media_player.ATTR_SOUND_MODE_LIST])
@@ -1294,11 +1285,6 @@ class ModesTrait(_Trait):
         mode_settings = {}
 
         if self.state.domain == media_player.DOMAIN:
-            if media_player.ATTR_INPUT_SOURCE_LIST in attrs:
-                mode_settings["input source"] = attrs.get(
-                    media_player.ATTR_INPUT_SOURCE
-                )
-
             if media_player.ATTR_SOUND_MODE_LIST in attrs:
                 mode_settings["sound mode"] = attrs.get(media_player.ATTR_SOUND_MODE)
         elif self.state.domain == input_select.DOMAIN:
@@ -1352,20 +1338,7 @@ class ModesTrait(_Trait):
             )
             return
 
-        requested_source = settings.get("input source")
         sound_mode = settings.get("sound mode")
-
-        if requested_source:
-            await self.hass.services.async_call(
-                media_player.DOMAIN,
-                media_player.SERVICE_SELECT_SOURCE,
-                {
-                    ATTR_ENTITY_ID: self.state.entity_id,
-                    media_player.ATTR_INPUT_SOURCE: requested_source,
-                },
-                blocking=True,
-                context=data.context,
-            )
 
         if sound_mode:
             await self.hass.services.async_call(
@@ -1378,6 +1351,61 @@ class ModesTrait(_Trait):
                 blocking=True,
                 context=data.context,
             )
+
+
+@register_trait
+class InputSelectorTrait(_Trait):
+    """Trait to set modes.
+
+    https://developers.google.com/assistant/smarthome/traits/inputselector
+    """
+
+    name = TRAIT_INPUTSELECTOR
+    commands = [COMMAND_INPUT]
+
+    SYNONYMS = {}
+
+    @staticmethod
+    def supported(domain, features, device_class):
+        """Test if state is supported."""
+        if domain == media_player.DOMAIN and (
+            features & media_player.SUPPORT_SELECT_SOURCE
+        ):
+            return True
+
+        return False
+
+    def sync_attributes(self):
+        """Return mode attributes for a sync request."""
+        attrs = self.state.attributes
+        inputs = [
+            {"key": source, "names": [{"name_synonym": [source], "lang": "en"}]}
+            for source in attrs.get(media_player.ATTR_INPUT_SOURCE_LIST, [])
+        ]
+
+        payload = {"availableInputs": inputs, "orderedInputs": False}
+
+        return payload
+
+    def query_attributes(self):
+        """Return current modes."""
+        attrs = self.state.attributes
+        return {"currentInput": attrs.get(media_player.ATTR_INPUT_SOURCE, "")}
+
+    async def execute(self, command, data, params, challenge):
+        """Execute an SetInputSource command."""
+        requested_source = params.get("newInput")
+
+        await self.hass.services.async_call(
+            media_player.DOMAIN,
+            media_player.SERVICE_SELECT_SOURCE,
+            {
+                ATTR_ENTITY_ID: self.state.entity_id,
+                media_player.ATTR_INPUT_SOURCE: requested_source,
+            },
+            blocking=True,
+            context=data.context,
+        )
 
 
 @register_trait

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1383,7 +1383,7 @@ class InputSelectorTrait(_Trait):
             for source in attrs.get(media_player.ATTR_INPUT_SOURCE_LIST, [])
         ]
 
-        payload = {"availableInputs": inputs, "orderedInputs": False}
+        payload = {"availableInputs": inputs, "orderedInputs": True}
 
         return payload
 

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -190,6 +190,7 @@ DEMO_DEVICES = [
         "id": "media_player.lounge_room",
         "name": {"name": "Lounge room"},
         "traits": [
+            "action.devices.traits.InputSelector",
             "action.devices.traits.OnOff",
             "action.devices.traits.Modes",
             "action.devices.traits.TransportControl",

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1313,14 +1313,14 @@ async def test_fan_speed(hass):
     assert calls[0].data == {"entity_id": "fan.living_room_fan", "speed": "medium"}
 
 
-async def test_modes_media_player(hass):
-    """Test Media Player Mode trait."""
+async def test_inputselector(hass):
+    """Test input selector trait."""
     assert helpers.get_google_type(media_player.DOMAIN, None) is not None
-    assert trait.ModesTrait.supported(
+    assert trait.InputSelectorTrait.supported(
         media_player.DOMAIN, media_player.SUPPORT_SELECT_SOURCE, None
     )
 
-    trt = trait.ModesTrait(
+    trt = trait.InputSelectorTrait(
         hass,
         State(
             "media_player.living_room",
@@ -1340,56 +1340,29 @@ async def test_modes_media_player(hass):
 
     attribs = trt.sync_attributes()
     assert attribs == {
-        "availableModes": [
+        "availableInputs": [
+            {"key": "media", "names": [{"name_synonym": ["media"], "lang": "en"}]},
+            {"key": "game", "names": [{"name_synonym": ["game"], "lang": "en"}]},
             {
-                "name": "input source",
-                "name_values": [
-                    {"name_synonym": ["input source", "input", "source"], "lang": "en"}
-                ],
-                "settings": [
-                    {
-                        "setting_name": "media",
-                        "setting_values": [
-                            {"setting_synonym": ["media"], "lang": "en"}
-                        ],
-                    },
-                    {
-                        "setting_name": "game",
-                        "setting_values": [{"setting_synonym": ["game"], "lang": "en"}],
-                    },
-                    {
-                        "setting_name": "chromecast",
-                        "setting_values": [
-                            {"setting_synonym": ["chromecast"], "lang": "en"}
-                        ],
-                    },
-                    {
-                        "setting_name": "plex",
-                        "setting_values": [{"setting_synonym": ["plex"], "lang": "en"}],
-                    },
-                ],
-                "ordered": False,
-            }
-        ]
+                "key": "chromecast",
+                "names": [{"name_synonym": ["chromecast"], "lang": "en"}],
+            },
+            {"key": "plex", "names": [{"name_synonym": ["plex"], "lang": "en"}]},
+        ],
+        "orderedInputs": False,
     }
 
     assert trt.query_attributes() == {
-        "currentModeSettings": {"input source": "game"},
-        "on": True,
+        "currentInput": "game",
     }
 
-    assert trt.can_execute(
-        trait.COMMAND_MODES, params={"updateModeSettings": {"input source": "media"}},
-    )
+    assert trt.can_execute(trait.COMMAND_INPUT, params={"newInput": "media"},)
 
     calls = async_mock_service(
         hass, media_player.DOMAIN, media_player.SERVICE_SELECT_SOURCE
     )
     await trt.execute(
-        trait.COMMAND_MODES,
-        BASIC_DATA,
-        {"updateModeSettings": {"input source": "media"}},
-        {},
+        trait.COMMAND_INPUT, BASIC_DATA, {"newInput": "media"}, {},
     )
 
     assert len(calls) == 1

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1349,7 +1349,7 @@ async def test_inputselector(hass):
             },
             {"key": "plex", "names": [{"name_synonym": ["plex"], "lang": "en"}]},
         ],
-        "orderedInputs": False,
+        "orderedInputs": True,
     }
 
     assert trt.query_attributes() == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
A sync will be required for source selection to work after this update. They keyword to select source will also have changed from something like "Set mode on TV to.." to "Set input on TV to.."

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for InputSelector trait
This remove source selection from Modes trait

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
