### PR TITLE
Use QueuePool for sqlite if threadsafety is available

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -44,8 +44,6 @@ DOMAIN = "recorder"
 
 SERVICE_PURGE = "purge"
 
-SQLITE_POOL_TIMEOUT = 3600
-
 ATTR_KEEP_DAYS = "keep_days"
 ATTR_REPACK = "repack"
 
@@ -575,7 +573,6 @@ def engine_args_for_db_url(db_url):
                 "echo": False,
                 "connect_args": {"check_same_thread": False},
                 "poolclass": SingletonThreadPool,
-                "pool_timeout": SQLITE_POOL_TIMEOUT,
             }
 
     return {"echo": False}

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -561,23 +561,21 @@ def engine_args_for_db_url(db_url):
             "pool_reset_on_return": None,
         }
 
-    db_is_sqlite = db_url.startswith("sqlite://")
-
-    if db_is_sqlite:
+    if db_url.startswith("sqlite://"):
         import sqlite3  # pylint: disable=import-outside-toplevel
 
-    if not db_is_sqlite or not sqlite3.threadsafety:
-        return {"echo": False}
+        if sqlite3.threadsafety:
+            # https://www.sqlite.org/threadsafe.html
+            #
+            # In serialized mode, SQLite can be safely used
+            # by multiple threads with no restriction.
+            #
+            # The default mode is serialized.
+            return {
+                "echo": False,
+                "connect_args": {"check_same_thread": False},
+                "poolclass": QueuePool,
+                "pool_timeout": SQLITE_POOL_TIMEOUT,
+            }
 
-    # https://www.sqlite.org/threadsafe.html
-    #
-    # In serialized mode, SQLite can be safely used
-    # by multiple threads with no restriction.
-    #
-    # The default mode is serialized.
-    return {
-        "echo": False,
-        "connect_args": {"check_same_thread": False},
-        "poolclass": QueuePool,
-        "pool_timeout": SQLITE_POOL_TIMEOUT,
-    }
+    return {"echo": False}

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -520,6 +520,7 @@ class Recorder(threading.Thread):
                 # The default mode is serialized.
                 kwargs["connect_args"] = {"check_same_thread": False}
                 kwargs["poolclass"] = QueuePool
+                kwargs["pool_timeout"] = 900
             kwargs["echo"] = False
         else:
             kwargs["echo"] = False

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -44,6 +44,8 @@ DOMAIN = "recorder"
 
 SERVICE_PURGE = "purge"
 
+SQLITE_POOL_TIMEOUT = 3600
+
 ATTR_KEEP_DAYS = "keep_days"
 ATTR_REPACK = "repack"
 
@@ -484,7 +486,6 @@ class Recorder(threading.Thread):
 
     def _setup_connection(self):
         """Ensure database is ready to fly."""
-        kwargs = {}
 
         def setup_recorder_connection(dbapi_connection, connection_record):
             """Dbapi specific connection settings."""
@@ -504,31 +505,12 @@ class Recorder(threading.Thread):
                 cursor.execute("SET session wait_timeout=28800")
                 cursor.close()
 
-        if self.db_url == "sqlite://" or ":memory:" in self.db_url:
-            kwargs["connect_args"] = {"check_same_thread": False}
-            kwargs["poolclass"] = StaticPool
-            kwargs["pool_reset_on_return"] = None
-        elif self.db_url.startswith("sqlite://"):
-            import sqlite3  # pylint: disable=import-outside-toplevel
-
-            if sqlite3.threadsafety:
-                # https://www.sqlite.org/threadsafe.html
-                #
-                # In serialized mode, SQLite can be safely used
-                # by multiple threads with no restriction.
-                #
-                # The default mode is serialized.
-                kwargs["connect_args"] = {"check_same_thread": False}
-                kwargs["poolclass"] = QueuePool
-                kwargs["pool_timeout"] = 900
-            kwargs["echo"] = False
-        else:
-            kwargs["echo"] = False
+        engine_args = engine_args_for_db_url(self.db_url)
 
         if self.engine is not None:
             self.engine.dispose()
 
-        self.engine = create_engine(self.db_url, **kwargs)
+        self.engine = create_engine(self.db_url, **engine_args)
 
         sqlalchemy_event.listen(self.engine, "connect", setup_recorder_connection)
 
@@ -568,3 +550,31 @@ class Recorder(threading.Thread):
             self.event_session.close()
 
         self.run_info = None
+
+
+def engine_args_for_db_url(db_url):
+    """Build the engine args for given db url."""
+    if db_url == "sqlite://" or ":memory:" in db_url:
+        return {
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+            "pool_reset_on_return": None,
+        }
+    elif db_url.startswith("sqlite://"):
+        import sqlite3  # pylint: disable=import-outside-toplevel
+
+        dbargs = {}
+        if sqlite3.threadsafety:
+            # https://www.sqlite.org/threadsafe.html
+            #
+            # In serialized mode, SQLite can be safely used
+            # by multiple threads with no restriction.
+            #
+            # The default mode is serialized.
+            dbargs["connect_args"] = {"check_same_thread": False}
+            dbargs["poolclass"] = QueuePool
+            dbargs["pool_timeout"] = SQLITE_POOL_TIMEOUT
+        dbargs["echo"] = False
+        return dbargs
+
+    return {"echo": False}

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -573,6 +573,7 @@ def engine_args_for_db_url(db_url):
                 "echo": False,
                 "connect_args": {"check_same_thread": False},
                 "poolclass": SingletonThreadPool,
+                "pool_reset_on_return": None,
             }
 
     return {"echo": False}

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -560,21 +560,24 @@ def engine_args_for_db_url(db_url):
             "poolclass": StaticPool,
             "pool_reset_on_return": None,
         }
-    elif db_url.startswith("sqlite://"):
+
+    db_is_sqlite = db_url.startswith("sqlite://")
+
+    if db_is_sqlite:
         import sqlite3  # pylint: disable=import-outside-toplevel
 
-        dbargs = {}
-        if sqlite3.threadsafety:
-            # https://www.sqlite.org/threadsafe.html
-            #
-            # In serialized mode, SQLite can be safely used
-            # by multiple threads with no restriction.
-            #
-            # The default mode is serialized.
-            dbargs["connect_args"] = {"check_same_thread": False}
-            dbargs["poolclass"] = QueuePool
-            dbargs["pool_timeout"] = SQLITE_POOL_TIMEOUT
-        dbargs["echo"] = False
-        return dbargs
+    if not db_is_sqlite or not sqlite3.threadsafety:
+        return {"echo": False}
 
-    return {"echo": False}
+    # https://www.sqlite.org/threadsafe.html
+    #
+    # In serialized mode, SQLite can be safely used
+    # by multiple threads with no restriction.
+    #
+    # The default mode is serialized.
+    return {
+        "echo": False,
+        "connect_args": {"check_same_thread": False},
+        "poolclass": QueuePool,
+        "pool_timeout": SQLITE_POOL_TIMEOUT,
+    }

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 
 from sqlalchemy import create_engine, event as sqlalchemy_event, exc, select
 from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.pool import QueuePool, StaticPool
+from sqlalchemy.pool import SingletonThreadPool, StaticPool
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification
@@ -574,7 +574,7 @@ def engine_args_for_db_url(db_url):
             return {
                 "echo": False,
                 "connect_args": {"check_same_thread": False},
-                "poolclass": QueuePool,
+                "poolclass": SingletonThreadPool,
                 "pool_timeout": SQLITE_POOL_TIMEOUT,
             }
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -267,6 +267,7 @@ async def test_engine_args_for_db_url(hass):
         "connect_args": {"check_same_thread": False},
         "echo": False,
         "poolclass": SingletonThreadPool,
+        "pool_reset_on_return": None,
     }
 
     assert engine_args_for_db_url("sqlite://") == {

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import unittest
 
 import pytest
-from sqlalchemy.pool import QueuePool, StaticPool
+from sqlalchemy.pool import SingletonThreadPool, StaticPool
 
 from homeassistant.components.recorder import (
     SQLITE_POOL_TIMEOUT,
@@ -271,7 +271,7 @@ async def test_engine_args_for_db_url(hass):
         "connect_args": {"check_same_thread": False},
         "echo": False,
         "pool_timeout": SQLITE_POOL_TIMEOUT,
-        "poolclass": QueuePool,
+        "poolclass": SingletonThreadPool,
     }
 
     assert engine_args_for_db_url("sqlite://") == {

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -6,11 +6,7 @@ import unittest
 import pytest
 from sqlalchemy.pool import SingletonThreadPool, StaticPool
 
-from homeassistant.components.recorder import (
-    SQLITE_POOL_TIMEOUT,
-    Recorder,
-    engine_args_for_db_url,
-)
+from homeassistant.components.recorder import Recorder, engine_args_for_db_url
 from homeassistant.components.recorder.const import DATA_INSTANCE
 from homeassistant.components.recorder.models import Events, States
 from homeassistant.components.recorder.util import session_scope
@@ -270,7 +266,6 @@ async def test_engine_args_for_db_url(hass):
     assert engine_args_for_db_url("sqlite://config/hass.db") == {
         "connect_args": {"check_same_thread": False},
         "echo": False,
-        "pool_timeout": SQLITE_POOL_TIMEOUT,
         "poolclass": SingletonThreadPool,
     }
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use QueuePool for sqlite if threadsafety is available.  This significantly reduces the time to first byte on the history api when coupled with #35721

This also improves the performance of the recorder event thread with sqlite as its no longer open/closing the database every second.  This should increase SD card longevity.

Performance wise this is night and day different for me.  Going from ~3.2s to ~0.2s for TTFB, YMMV (the improvement is most visible on slower disks).  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
