### PR TITLE
Add Brand Specific Arming Sequences for AlarmDecoder

### DIFF
--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -59,7 +59,7 @@ SIGNAL_ZONE_RESTORE = "alarmdecoder.zone_restore"
 SIGNAL_RFX_MESSAGE = "alarmdecoder.rfx_message"
 SIGNAL_REL_MESSAGE = "alarmdecoder.rel_message"
 
-BRAND_ADEMCO = "ademco"
+BRAND_HONEYWELL = "honeywell"
 BRAND_DSC = "dsc"
 
 ATTR_PANEL_BRAND = "panel_brand"
@@ -170,7 +170,7 @@ def setup(hass, config):
     def get_panel_brand():
         """Return alarm panel manufacturer from AlarmDecoder config string."""
         nonlocal restart
-        brands = {"A": BRAND_ADEMCO, "D": BRAND_DSC}
+        brands = {"A": BRAND_HONEYWELL, "D": BRAND_DSC}
 
         try:
             config_str = controller.get_config_string()

--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -169,7 +169,6 @@ def setup(hass, config):
 
     def get_panel_brand():
         """Return alarm panel manufacturer from AlarmDecoder config string."""
-        nonlocal restart
         brands = {"A": BRAND_HONEYWELL, "D": BRAND_DSC}
 
         try:

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -23,8 +23,8 @@ import homeassistant.helpers.config_validation as cv
 
 from . import (
     ATTR_PANEL_BRAND,
-    BRAND_ADEMCO,
     BRAND_DSC,
+    BRAND_HONEYWELL,
     CONF_ALT_NIGHT_MODE,
     CONF_AUTO_BYPASS,
     CONF_CODE_ARM_REQUIRED,
@@ -44,7 +44,7 @@ ALARM_KEYPRESS_SCHEMA = vol.Schema({vol.Required(ATTR_KEYPRESS): cv.string})
 
 
 def get_arm_sequences(panel_brand, code_arm_required, alt_night_mode):
-    """Return the arming key sequences for a DSC or Ademco system given the code_arm_require and alt_night_mode settings."""
+    """Return the arming key sequences for a DSC or Honeywell system given the code_arm_require and alt_night_mode settings."""
     dsc_nocode_sequences = {
         "arm_home": lambda code: chr(4) + chr(4) + chr(4),
         "arm_away": lambda code: chr(5) + chr(5) + chr(5),
@@ -59,22 +59,22 @@ def get_arm_sequences(panel_brand, code_arm_required, alt_night_mode):
         "arm_night": lambda code: f"*9{code!s}" if alt_night_mode else str(code),
     }
 
-    ademco_nocode_sequences = {
+    honeywell_nocode_sequences = {
         "arm_home": lambda code: "#3",
         "arm_away": lambda code: "#2",
         "arm_night": lambda code: f"{code!s}33" if alt_night_mode else "#7",
     }
 
-    ademco_code_sequences = {
+    honeywell_code_sequences = {
         "arm_home": lambda code: f"{code!s}3",
         "arm_away": lambda code: f"{code!s}2",
         "arm_night": lambda code: f"{code!s}33" if alt_night_mode else f"{code!s}7",
     }
 
-    if panel_brand == BRAND_ADEMCO:
+    if panel_brand == BRAND_HONEYWELL:
         if code_arm_required:
-            return ademco_code_sequences
-        return ademco_nocode_sequences
+            return honeywell_code_sequences
+        return honeywell_nocode_sequences
 
     if panel_brand == BRAND_DSC:
         if code_arm_required:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR updates the key sequences that are used for arming AlarmDecoder panels. AlarmDecoder supports two alarm panel brands, Honeywell and DSC. Previously, the same arming sequences were incorrectly used for both panel brands. So, for instance, my previous PR #32390 only worked for Honeywell panels and _not_ DSC panels. This is fixed in this PR. The arming sequences are broken out into the following 4 `dict`'s:

- `dsc_code_sequences`
- `dsc_nocode_sequences`
- `honeywell_code_sequences`
- `honeywell_nocode_sequences`

The key sequences used in the above `dict`'s were identified by reading the manuals for each brand and were verified between myself (a Honeywell user) and a DSC user. The results of our collaboration are summarized in [this thread post](https://github.com/home-assistant/core/issues/33199#issuecomment-609913528).

Additionally, a new configuration option, `alt_night_mode` is introduced to enable Honeywell users to switch between using _Instant_ mode and _Night-Stay_ for night arming. There have been some complaints about the switch to _Instant_ mode from my #32292 PR (one in #35728 and another was sent directly to my email). `alt_night_mode` also lets DSC users opt-in to _No-Entry_ mode, which is the DSC equivalent to Honeywell's _Instant_ mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
alarmdecoder:
  device:
    type: socket
    host: 10.0.0.0
    port: 10000
  panel_display: true
  code_arm_required: false
  alt_night_mode: true
  autobypass: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/35728
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13494

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
