### PR TITLE
Add support for zeroconf of Daikin devices

### DIFF
--- a/homeassistant/components/daikin/config_flow.py
+++ b/homeassistant/components/daikin/config_flow.py
@@ -124,3 +124,11 @@ class FlowHandler(config_entries.ConfigFlow):
         self._abort_if_unique_id_configured()
         self.host = discovery_info[KEY_IP]
         return await self.async_step_user()
+
+    async def async_step_zeroconf(self, discovery_info):
+        """Prepare configuration for a discovered Daikin device."""
+        _LOGGER.debug("Zeroconf discovery_info: %s", discovery_info)
+        await self.async_set_unique_id(discovery_info.get(CONF_HOST))
+        self._abort_if_unique_id_configured()
+        self.host = discovery_info.get(CONF_HOST)
+        return await self.async_step_user()

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/daikin",
   "requirements": ["pydaikin==2.0.2"],
   "codeowners": ["@fredrike"],
+  "zeroconf": ["_dkapi._tcp.local."],
   "quality_scale": "platinum"
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -13,6 +13,9 @@ ZEROCONF = {
     "_daap._tcp.local.": [
         "forked_daapd"
     ],
+    "_dkapi._tcp.local.": [
+        "daikin"
+    ],
     "_elg._tcp.local.": [
         "elgato"
     ],

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -7,7 +7,12 @@ from aiohttp.web_exceptions import HTTPForbidden
 import pytest
 
 from homeassistant.components.daikin.const import KEY_IP, KEY_MAC
-from homeassistant.config_entries import SOURCE_DISCOVERY, SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import (
+    SOURCE_DISCOVERY,
+    SOURCE_IMPORT,
+    SOURCE_USER,
+    SOURCE_ZEROCONF,
+)
 from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -104,9 +109,13 @@ async def test_device_abort(hass, mock_daikin, s_effect, reason):
 
 
 @pytest.mark.parametrize(
-    "source, data, unique_id", [(SOURCE_DISCOVERY, {KEY_IP: HOST, KEY_MAC: MAC}, MAC)],
+    "source, data, unique_id",
+    [
+        (SOURCE_DISCOVERY, {KEY_IP: HOST, KEY_MAC: MAC}, MAC),
+        (SOURCE_ZEROCONF, {CONF_HOST: HOST}, HOST),
+    ],
 )
-async def test_discovery(hass, mock_daikin, source, data, unique_id):
+async def test_discovery_zeroconf(hass, mock_daikin, source, data, unique_id):
     """Test discovery/zeroconf step."""
     result = await hass.config_entries.flow.async_init(
         "daikin", context={"source": source}, data=data,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for zeroconf of supported Daikin units.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34551
- This PR is related to issue: #35507
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
