### PR TITLE
Bump Atag dependency to 0.3.1.2

### DIFF
--- a/homeassistant/components/atag/manifest.json
+++ b/homeassistant/components/atag/manifest.json
@@ -3,6 +3,6 @@
   "name": "Atag",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/atag/",
-  "requirements": ["pyatag==0.3.1.1"],
+  "requirements": ["pyatag==0.3.1.2"],
   "codeowners": ["@MatsNL"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1212,7 +1212,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.1.1
+pyatag==0.3.1.2
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -521,7 +521,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.1.1
+pyatag==0.3.1.2
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1


### PR DESCRIPTION
## Proposed change
Dependency bump to fix an error causing state to be incorrectly reported.

## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Changelog: https://github.com/MatsNl/pyatag/blob/master/CHANGELOG.md

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
