### PR TITLE
Fix json overwriting if you have >1 PS4 connected

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -157,9 +157,9 @@ def format_unique_id(creds, mac_address):
     return f"{mac_address}_{suffix}"
 
 
-def load_games(hass: HomeAssistantType) -> dict:
+def load_games(hass: HomeAssistantType, unique_id: str) -> dict:
     """Load games for sources."""
-    g_file = hass.config.path(GAMES_FILE)
+    g_file = hass.config.path(GAMES_FILE.format(unique_id))
     try:
         games = load_json(g_file, dict)
     except HomeAssistantError as error:
@@ -172,20 +172,20 @@ def load_games(hass: HomeAssistantType) -> dict:
 
     # If file exists
     if os.path.isfile(g_file):
-        games = _reformat_data(hass, games)
+        games = _reformat_data(hass, games, unique_id)
     return games
 
 
-def save_games(hass: HomeAssistantType, games: dict):
+def save_games(hass: HomeAssistantType, games: dict, unique_id: str):
     """Save games to file."""
-    g_file = hass.config.path(GAMES_FILE)
+    g_file = hass.config.path(GAMES_FILE.format(unique_id))
     try:
         save_json(g_file, games)
     except OSError as error:
         _LOGGER.error("Could not save game list, %s", error)
 
 
-def _reformat_data(hass: HomeAssistantType, games: dict) -> dict:
+def _reformat_data(hass: HomeAssistantType, games: dict, unique_id: str) -> dict:
     """Reformat data to correct format."""
     data_reformatted = False
 
@@ -204,7 +204,7 @@ def _reformat_data(hass: HomeAssistantType, games: dict) -> dict:
             _LOGGER.debug("Reformatting media data for item: %s, %s", game, data)
 
     if data_reformatted:
-        save_games(hass, games)
+        save_games(hass, games, unique_id)
     return games
 
 

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -5,7 +5,7 @@ DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
 DEFAULT_ALIAS = "Home-Assistant"
 DOMAIN = "ps4"
-GAMES_FILE = ".ps4-games.json"
+GAMES_FILE = ".ps4-games.{}.json"
 PS4_DATA = "ps4_data"
 
 COMMANDS = ("up", "down", "right", "left", "enter", "back", "option", "ps", "ps_hold")

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -163,7 +163,7 @@ class PS4Device(MediaPlayerEntity):
         status = self._ps4.status
 
         if status is not None:
-            self._games = load_games(self.hass)
+            self._games = load_games(self.hass, self._unique_id)
             if self._games:
                 self.get_source_list()
 
@@ -300,7 +300,7 @@ class PS4Device(MediaPlayerEntity):
                 self._media_image,
                 self._media_type,
             )
-            self._games = load_games(self.hass)
+            self._games = load_games(self.hass, self._unique_id)
 
         self.get_source_list()
 
@@ -324,7 +324,7 @@ class PS4Device(MediaPlayerEntity):
                 }
             }
             games.update(game)
-            save_games(self.hass, games)
+            save_games(self.hass, games, self._unique_id)
 
     async def async_get_device_info(self, status):
         """Set device info for registry."""

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -201,7 +201,7 @@ def test_games_reformat_to_dict(hass):
     ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
-        mock_games = ps4.load_games(hass)
+        mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
 
     # New format is a nested dict.
     assert isinstance(mock_games, dict)
@@ -223,7 +223,7 @@ def test_load_games(hass):
     ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
-        mock_games = ps4.load_games(hass)
+        mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
 
     assert isinstance(mock_games, dict)
 
@@ -242,7 +242,7 @@ def test_loading_games_returns_dict(hass):
     ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
-        mock_games = ps4.load_games(hass)
+        mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
 
     assert isinstance(mock_games, dict)
     assert not mock_games
@@ -252,7 +252,7 @@ def test_loading_games_returns_dict(hass):
     ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
-        mock_games = ps4.load_games(hass)
+        mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
 
     assert isinstance(mock_games, dict)
     assert not mock_games
@@ -260,7 +260,7 @@ def test_loading_games_returns_dict(hass):
     with patch("homeassistant.components.ps4.load_json", return_value=[]), patch(
         "homeassistant.components.ps4.save_json", side_effect=MagicMock()
     ), patch("os.path.isfile", return_value=True):
-        mock_games = ps4.load_games(hass)
+        mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
 
     assert isinstance(mock_games, dict)
     assert not mock_games


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
