### PR TITLE
Add support for multple entity_ids and states for state condition

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -289,12 +289,19 @@ def state_from_config(
     if config_validation:
         config = cv.STATE_CONDITION_SCHEMA(config)
     entity_id = config.get(CONF_ENTITY_ID)
-    req_state = cast(str, config.get(CONF_STATE))
+    req_state = config.get(CONF_STATE)
     for_period = config.get("for")
+
+    entity_ids = entity_id if isinstance(entity_id, list) else [entity_id]
+    req_states = req_state if isinstance(req_state, list) else [req_state]
 
     def if_state(hass: HomeAssistant, variables: TemplateVarsType = None) -> bool:
         """Test if condition."""
-        return state(hass, entity_id, req_state, for_period)
+        for entity_id in entity_ids:
+            for req_state in req_states:
+                if state(hass, entity_id, req_state, for_period):
+                    return True
+        return False
 
     return if_state
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -855,8 +855,8 @@ STATE_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_CONDITION): "state",
-            vol.Required(CONF_ENTITY_ID): entity_id,
-            vol.Required(CONF_STATE): str,
+            vol.Required(CONF_ENTITY_ID): vol.Any(entity_id, [entity_id]),
+            vol.Required(CONF_STATE): vol.Any(str, [str]),
             vol.Optional(CONF_FOR): vol.All(time_period, positive_timedelta),
             # To support use_trigger_value in automation
             # Deprecated 2016/04/25

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -370,3 +370,40 @@ async def test_extract_devices():
             ],
         }
     ) == {"abcd", "qwer", "abcd_not", "qwer_not", "abcd_or", "qwer_or"}
+
+
+async def test_state_from_config(hass):
+    """Test multiple entity_ids and states."""
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "state",
+                    "entity_id": ["cover.door", "binary_sensor.motion"],
+                    "state": ["open", "on"],
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set("cover.door", "open")
+    hass.states.async_set("binary_sensor.motion", "on")
+    assert test(hass)
+
+    hass.states.async_set("cover.door", "closed")
+    hass.states.async_set("binary_sensor.motion", "on")
+    assert test(hass)
+
+    hass.states.async_set("cover.door", "open")
+    hass.states.async_set("binary_sensor.motion", "off")
+    assert test(hass)
+
+    hass.states.async_set("cover.door", "closed")
+    hass.states.async_set("binary_sensor.motion", "off")
+    assert not test(hass)
+
+    hass.states.async_set("cover.door", "open")
+    hass.states.async_set("binary_sensor.motion", "on")
+    assert test(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The state automation trigger supports a str or list type for the entity_id and state attributes. The state condition lacks this consistency.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

automation:
  - id: "test"
    alias: "test"
    trigger:
      - platform: "state"
        entity_id: "binary_sensor.is_sunset"
        to: "on"
    condition:
      - condition: "state"
        entity_id:
          - "cover.door1"
          - "binary_sensor.motion1"
        state:
          - "open"
          - "on"
    action:
      - service: 'system_log.write'
        data_template:
          message: "Entity still open/on after sunset."
          level: info
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
