### PR TITLE
Change version check in forked-daapd zeroconf step

### DIFF
--- a/homeassistant/components/forked_daapd/config_flow.py
+++ b/homeassistant/components/forked_daapd/config_flow.py
@@ -158,7 +158,8 @@ class ForkedDaapdFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Prepare configuration for a discovered forked-daapd device."""
         if not (
             discovery_info.get("properties")
-            and float(discovery_info["properties"].get("mtd-version", 0)) >= 27.0
+            and int(discovery_info["properties"].get("mtd-version", "0").split(".")[0])
+            >= 27
             and discovery_info["properties"].get("Machine Name")
         ):
             return self.async_abort(reason="not_forked_daapd")

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -103,7 +103,7 @@ async def test_zeroconf_updates_title(hass, config_entry):
     discovery_info = {
         "host": "192.168.1.1",
         "port": 23,
-        "properties": {"mtd-version": 27.0, "Machine Name": "zeroconf_test"},
+        "properties": {"mtd-version": "27.0", "Machine Name": "zeroconf_test"},
     }
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
@@ -143,7 +143,7 @@ async def test_config_flow_zeroconf_valid(hass):
         "host": "192.168.1.1",
         "port": 23,
         "properties": {
-            "mtd-version": 27.0,
+            "mtd-version": "27.0",
             "Machine Name": "zeroconf_test",
             "Machine ID": "5E55EEFF",
         },

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -129,7 +129,30 @@ async def test_config_flow_no_websocket(hass, config_entry):
 
 async def test_config_flow_zeroconf_invalid(hass):
     """Test that an invalid zeroconf entry doesn't work."""
+    # test with no discovery properties
     discovery_info = {"host": "127.0.0.1", "port": 23}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+    )  # doesn't create the entry, tries to show form but gets abort
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "not_forked_daapd"
+    # test with forked-daapd version < 27
+    discovery_info = {
+        "host": "127.0.0.1",
+        "port": 23,
+        "properties": {"mtd-version": "26.3", "Machine Name": "forked-daapd"},
+    }
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+    )  # doesn't create the entry, tries to show form but gets abort
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "not_forked_daapd"
+    # test with verbose mtd-version from Firefly
+    discovery_info = {
+        "host": "127.0.0.1",
+        "port": 23,
+        "properties": {"mtd-version": "0.2.4.1", "Machine Name": "firefly"},
+    }
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )  # doesn't create the entry, tries to show form but gets abort


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Firefly media server, the software used in the Synology iTunes package and the predecessor to forked-daapd, reports version numbers in the format w.x.y.z, which breaks the current version check in the zeroconf config. Changed the version check to take this into account.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35614
- This PR is related to issue: 35642
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
