### PR TITLE
Enable rpi_gpio polling

### DIFF
--- a/homeassistant/components/rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/rpi_gpio/binary_sensor.py
@@ -71,8 +71,8 @@ class RPiGPIOBinarySensor(BinarySensorEntity):
 
     @property
     def should_poll(self):
-        """No polling needed."""
-        return False
+        """Polling needed, in case we lose an edge."""
+        return True
 
     @property
     def name(self):


### PR DESCRIPTION
## Proposed change
Solution for issue #10498 and pull #31788 (that has been closed but not solved)

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue: #10498 where is well explained in [my message](https://github.com/home-assistant/core/issues/10498#issuecomment-607899990)
It enable polling on **Raspberry PI GPIO binary_sensor**.
With polling _scan_interval_ will be usable in _configuration.yaml_.

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum