### PR TITLE
UniFi - Fix disabled entities being enabled after a restart

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -244,17 +244,17 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_track_clients:
-            await self.async_remove()
+            await self.remove_item(self.client.mac)
 
         elif self.is_wired:
             if not self.controller.option_track_wired_clients:
-                await self.async_remove()
+                await self.remove_item(self.client.mac)
 
         elif (
             self.controller.option_ssid_filter
             and self.client.essid not in self.controller.option_ssid_filter
         ):
-            await self.async_remove()
+            await self.remove_item(self.client.mac)
 
 
 class UniFiDeviceTracker(UniFiBase, ScannerEntity):
@@ -383,4 +383,4 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_track_devices:
-            await self.async_remove()
+            await self.remove_item(self.device.mac)

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -244,17 +244,17 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_track_clients:
-            await self.remove_item(self.client.mac)
+            await self.remove_item({self.client.mac})
 
         elif self.is_wired:
             if not self.controller.option_track_wired_clients:
-                await self.remove_item(self.client.mac)
+                await self.remove_item({self.client.mac})
 
         elif (
             self.controller.option_ssid_filter
             and self.client.essid not in self.controller.option_ssid_filter
         ):
-            await self.remove_item(self.client.mac)
+            await self.remove_item({self.client.mac})
 
 
 class UniFiDeviceTracker(UniFiBase, ScannerEntity):
@@ -383,4 +383,4 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_track_devices:
-            await self.remove_item(self.device.mac)
+            await self.remove_item({self.device.mac})

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -73,7 +73,7 @@ class UniFiBandwidthSensor(UniFiClient):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_allow_bandwidth_sensors:
-            await self.async_remove()
+            await self.remove_item(self.client.mac)
 
 
 class UniFiRxBandwidthSensor(UniFiBandwidthSensor):

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -73,7 +73,7 @@ class UniFiBandwidthSensor(UniFiClient):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_allow_bandwidth_sensors:
-            await self.remove_item(self.client.mac)
+            await self.remove_item({self.client.mac})
 
 
 class UniFiRxBandwidthSensor(UniFiBandwidthSensor):

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -239,7 +239,7 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchEntity, RestoreEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_poe_clients:
-            await self.async_remove()
+            await self.remove_item(self.client.mac)
 
 
 class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
@@ -287,4 +287,4 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if self.client.mac not in self.controller.option_block_clients:
-            await self.async_remove()
+            await self.remove_item(self.client.mac)

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -239,7 +239,7 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchEntity, RestoreEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if not self.controller.option_poe_clients:
-            await self.remove_item(self.client.mac)
+            await self.remove_item({self.client.mac})
 
 
 class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
@@ -287,4 +287,4 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
         if self.client.mac not in self.controller.option_block_clients:
-            await self.remove_item(self.client.mac)
+            await self.remove_item({self.client.mac})

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -69,7 +69,7 @@ class UniFiBase(Entity):
         entity_registry = await self.hass.helpers.entity_registry.async_get_registry()
         entity_entry = entity_registry.async_get(self.entity_id)
         if not entity_entry:
-            await super().async_remove()
+            await self.async_remove()
             return
 
         device_registry = await self.hass.helpers.device_registry.async_get_registry()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Async_remove call removed too much, resulting in disabled entities coming back after a restart

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34939
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
