### PR TITLE
Fallback lg_soundbar sound mode on unknown value

### DIFF
--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -114,6 +114,7 @@ class LGDevice(MediaPlayerEntity):
         self._device.get_settings()
         self._device.get_product_info()
 
+        # Temporary fix until handling of unknown equaliser settings is integrated in the temescal library
         for equaliser in self._equalisers:
             if equaliser >= len(temescal.equalisers):
                 temescal.equalisers.append("unknown " + str(equaliser))

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -114,6 +114,10 @@ class LGDevice(MediaPlayerEntity):
         self._device.get_settings()
         self._device.get_product_info()
 
+        for equaliser in self._equalisers:
+            if equaliser >= len(temescal.equalisers):
+                temescal.equalisers.append("unknown " + str(equaliser))
+
     @property
     def name(self):
         """Return the name of the device."""
@@ -139,10 +143,8 @@ class LGDevice(MediaPlayerEntity):
     @property
     def sound_mode(self):
         """Return the current sound mode."""
-        if self._equaliser == -1:
-            return ""
-        if self._equaliser >= len(temescal.equalisers):
-            return ""
+        if self._equaliser == -1 or self._equaliser >= len(temescal.equalisers):
+            return None
         return temescal.equalisers[self._equaliser]
 
     @property
@@ -150,8 +152,6 @@ class LGDevice(MediaPlayerEntity):
         """Return the available sound modes."""
         modes = []
         for equaliser in self._equalisers:
-            if equaliser >= len(temescal.equalisers):
-                temescal.equalisers.append("unknown " + str(equaliser))
             modes.append(temescal.equalisers[equaliser])
         return sorted(modes)
 
@@ -159,7 +159,7 @@ class LGDevice(MediaPlayerEntity):
     def source(self):
         """Return the current input source."""
         if self._function == -1:
-            return ""
+            return None
         return temescal.functions[self._function]
 
     @property

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -139,8 +139,9 @@ class LGDevice(MediaPlayerEntity):
     @property
     def sound_mode(self):
         """Return the current sound mode."""
-
         if self._equaliser == -1:
+            return ""
+        if self._equaliser >= len(temescal.equalisers):
             return ""
         return temescal.equalisers[self._equaliser]
 
@@ -149,6 +150,8 @@ class LGDevice(MediaPlayerEntity):
         """Return the available sound modes."""
         modes = []
         for equaliser in self._equalisers:
+            if equaliser >= len(temescal.equalisers):
+                temescal.equalisers.append("unknown " + str(equaliser))
             modes.append(temescal.equalisers[equaliser])
         return sorted(modes)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Make the "lg_soundbar" component crash free in case of equaliser settings that the temescal library does not know. 

A issue has been created in the temescal repro to fix the unknown equaliser.
https://github.com/google/python-temescal/issues/2

It´s most likley that LG will extend the equalisers in their soundbar(s) in future again. This fix or something similar should be applied in order to prevent bad user experience in that case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
discovery:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
https://github.com/home-assistant/core/issues/35825
https://github.com/home-assistant/core/issues/32832
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
