### PR TITLE
Retry pioneer connections, raise PlatformNotReady

### DIFF
--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -144,7 +144,7 @@ class PioneerDevice(MediaPlayerDevice):
         """Get the latest details from the device."""
         tries = MAX_TRIES
         while tries > 0:
-            tries = tries - 1
+            tries -= 1
             try:
                 telnet = telnetlib.Telnet(self._host, self._port, self._timeout)
                 break

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -117,7 +117,7 @@ class PioneerDevice(MediaPlayerDevice):
         """Establish a telnet connection and sends command."""
         tries = MAX_TRIES
         while tries > 0:
-            tries = tries - 1
+            tries -= 1
             try:
                 try:
                     telnet = telnetlib.Telnet(self._host, self._port, self._timeout)

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -24,9 +24,8 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -118,7 +117,7 @@ class PioneerDevice(MediaPlayerDevice):
         """Establish a telnet connection and sends command."""
         tries = MAX_TRIES
         while tries > 0:
-            tries = tries -1
+            tries = tries - 1
             try:
                 try:
                     telnet = telnetlib.Telnet(self._host, self._port, self._timeout)
@@ -127,18 +126,25 @@ class PioneerDevice(MediaPlayerDevice):
                     telnet.close()
                     break
                 except (ConnectionRefusedError, OSError):
-                    _LOGGER.warning("telnet_command: Pioneer %s refused connection", self._name)
+                    _LOGGER.warning(
+                        "telnet_command: Pioneer %s refused connection", self._name
+                    )
                     time.sleep(TRY_DELAY)
                     continue
             except telnetlib.socket.timeout:
                 _LOGGER.debug("Pioneer %s command %s timed out", self._name, command)
-        if tries == 0: _LOGGER.warning("Tried %d times, but Pioneer %s still refused connection", MAX_TRIES, self._name)
+        if tries == 0:
+            _LOGGER.warning(
+                "Tried %d times, but Pioneer %s still refused connection",
+                MAX_TRIES,
+                self._name,
+            )
 
     def update(self):
         """Get the latest details from the device."""
         tries = MAX_TRIES
         while tries > 0:
-            tries = tries -1
+            tries = tries - 1
             try:
                 telnet = telnetlib.Telnet(self._host, self._port, self._timeout)
                 break
@@ -146,8 +152,12 @@ class PioneerDevice(MediaPlayerDevice):
                 _LOGGER.debug("update: Pioneer %s refused connection", self._name)
                 time.sleep(TRY_DELAY)
                 continue
-        if tries == 0: 
-            _LOGGER.warning("Tried %d times, but Pioneer %s still refused connection", MAX_TRIES, self._name)
+        if tries == 0:
+            _LOGGER.warning(
+                "Tried %d times, but Pioneer %s still refused connection",
+                MAX_TRIES,
+                self._name,
+            )
             return False
 
         pwstate = self.telnet_request(telnet, "?P", "PWR")

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -26,6 +26,8 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
+from homeassistant.exceptions import PlatformNotReady
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SOURCES = "sources"
@@ -74,6 +76,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if pioneer.update():
         add_entities([pioneer])
+    else:
+        raise PlatformNotReady
 
 
 class PioneerDevice(MediaPlayerDevice):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
I have two general changes for the pioneer platform.
First, try again when a command fails once.
The platform works by establishing telnet connections for every command sent. When you set the volume, an update ist triggered, so update() is called directly afterwards. It seems the receiver (at least mine) cannot handle this, so this subsequent call does not succeed.
This can be really annoying in automations, i.e. when you set the volume and switch the channel and the switch channel command effectively gets ignored. So we should try again.

Second, if the receiver does not have power when hass starts up, the platform does not add itself, because it cannot connect to the receiver. As i want to avoid standby current, i turn of the power outlet when not needed. This change raises a PlatformNotReady exception so hass can try again later.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

