### PR TITLE
Ensure homekit functions if numpy is unavailable

### DIFF
--- a/homeassistant/components/homekit/img_util.py
+++ b/homeassistant/components/homekit/img_util.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from turbojpeg import TurboJPEG
-
 SUPPORTED_SCALING_FACTORS = [(7, 8), (3, 4), (5, 8), (1, 2), (3, 8), (1, 4), (1, 8)]
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,6 +52,12 @@ class TurboJPEGSingleton:
     def __init__(self):
         """Try to create TurboJPEG only once."""
         try:
+            # TurboJPEG checks for libturbojpeg
+            # when its created, but it imports
+            # numpy which may or may not work so
+            # we have to guard the import here.
+            from turbojpeg import TurboJPEG  # pylint: disable=import-outside-toplevel
+
             TurboJPEGSingleton.__instance = TurboJPEG()
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception(

--- a/tests/components/homekit/test_img_util.py
+++ b/tests/components/homekit/test_img_util.py
@@ -23,25 +23,19 @@ def test_scale_jpeg_camera_image():
     camera_image = Image("image/jpeg", EMPTY_16_12_JPEG)
 
     turbo_jpeg = mock_turbo_jpeg(first_width=16, first_height=12)
-    with patch(
-        "homeassistant.components.homekit.img_util.TurboJPEG", return_value=False
-    ):
+    with patch("turbojpeg.TurboJPEG", return_value=False):
         TurboJPEGSingleton()
         assert scale_jpeg_camera_image(camera_image, 16, 12) == camera_image.content
 
     turbo_jpeg = mock_turbo_jpeg(first_width=16, first_height=12)
-    with patch(
-        "homeassistant.components.homekit.img_util.TurboJPEG", return_value=turbo_jpeg
-    ):
+    with patch("turbojpeg.TurboJPEG", return_value=turbo_jpeg):
         TurboJPEGSingleton()
         assert scale_jpeg_camera_image(camera_image, 16, 12) == EMPTY_16_12_JPEG
 
     turbo_jpeg = mock_turbo_jpeg(
         first_width=16, first_height=12, second_width=8, second_height=6
     )
-    with patch(
-        "homeassistant.components.homekit.img_util.TurboJPEG", return_value=turbo_jpeg
-    ):
+    with patch("turbojpeg.TurboJPEG", return_value=turbo_jpeg):
         TurboJPEGSingleton()
         jpeg_bytes = scale_jpeg_camera_image(camera_image, 8, 6)
 
@@ -51,12 +45,10 @@ def test_scale_jpeg_camera_image():
 def test_turbojpeg_load_failure():
     """Handle libjpegturbo not being installed."""
 
-    with patch(
-        "homeassistant.components.homekit.img_util.TurboJPEG", side_effect=Exception
-    ):
+    with patch("turbojpeg.TurboJPEG", side_effect=Exception):
         TurboJPEGSingleton()
         assert TurboJPEGSingleton.instance() is False
 
-    with patch("homeassistant.components.homekit.img_util.TurboJPEG"):
+    with patch("turbojpeg.TurboJPEG"):
         TurboJPEGSingleton()
         assert TurboJPEGSingleton.instance()

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -193,9 +193,7 @@ async def test_camera_stream_source_configured(hass, run_driver, events):
     turbo_jpeg = mock_turbo_jpeg(
         first_width=16, first_height=12, second_width=300, second_height=200
     )
-    with patch(
-        "homeassistant.components.homekit.img_util.TurboJPEG", return_value=turbo_jpeg
-    ):
+    with patch("turbojpeg.TurboJPEG", return_value=turbo_jpeg):
         TurboJPEGSingleton()
         assert await hass.async_add_executor_job(
             acc.get_snapshot, {"aid": 2, "image-width": 300, "image-height": 200}


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Defer importing TurboJPEG until we need it as it
imports numpy which may not be functional.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35834
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
