### PR TITLE
Fix ONVIF Transport

### DIFF
--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -82,12 +82,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     if device.capabilities.events and await device.events.async_start():
         platforms += ["binary_sensor", "sensor"]
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, device.events.async_stop)
 
     for component in platforms:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, device.async_stop)
 
     return True
 

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -185,6 +185,7 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         device = get_device(
+            self.hass,
             self.onvif_config[CONF_HOST],
             self.onvif_config[CONF_PORT],
             self.onvif_config[CONF_USERNAME],

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -185,7 +185,6 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         device = get_device(
-            self.hass,
             self.onvif_config[CONF_HOST],
             self.onvif_config[CONF_PORT],
             self.onvif_config[CONF_USERNAME],

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -8,7 +8,6 @@ from aiohttp.client_exceptions import ClientConnectionError, ServerDisconnectedE
 import onvif
 from onvif import ONVIFCamera
 from onvif.exceptions import ONVIFError
-from zeep.asyncio import AsyncTransport
 from zeep.exceptions import Fault
 
 from homeassistant.config_entries import ConfigEntry
@@ -20,7 +19,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.util.dt as dt_util
 
 from .const import (
@@ -84,7 +82,6 @@ class ONVIFDevice:
     async def async_setup(self) -> bool:
         """Set up the device."""
         self.device = get_device(
-            self.hass,
             host=self.config_entry.data[CONF_HOST],
             port=self.config_entry.data[CONF_PORT],
             username=self.config_entry.data[CONF_USERNAME],
@@ -421,15 +418,8 @@ class ONVIFDevice:
                 LOGGER.error("Error trying to perform PTZ action: %s", err)
 
 
-def get_device(hass, host, port, username, password) -> ONVIFCamera:
+def get_device(host, port, username, password) -> ONVIFCamera:
     """Get ONVIFCamera instance."""
-    session = async_get_clientsession(hass)
-    transport = AsyncTransport(None, session=session)
     return ONVIFCamera(
-        host,
-        port,
-        username,
-        password,
-        f"{os.path.dirname(onvif.__file__)}/wsdl/",
-        transport=transport,
+        host, port, username, password, f"{os.path.dirname(onvif.__file__)}/wsdl/",
     )

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -91,7 +91,7 @@ class EventManager:
 
         return self.started
 
-    async def async_stop(self, event=None) -> None:
+    async def async_stop(self) -> None:
         """Unsubscribe from events."""
         if not self._subscription:
             return
@@ -110,7 +110,7 @@ class EventManager:
     async def async_pull_messages(self, _now: dt = None) -> None:
         """Pull messages from device."""
         try:
-            pullpoint = self.device.get_service("pullpoint")
+            pullpoint = self.device.create_pullpoint_service()
             req = pullpoint.create_type("PullMessages")
             req.MessageLimit = 100
             req.Timeout = dt.timedelta(seconds=60)

--- a/homeassistant/components/onvif/manifest.json
+++ b/homeassistant/components/onvif/manifest.json
@@ -2,7 +2,7 @@
   "domain": "onvif",
   "name": "ONVIF",
   "documentation": "https://www.home-assistant.io/integrations/onvif",
-  "requirements": ["onvif-zeep-async==0.3.0", "WSDiscovery==2.0.0"],
+  "requirements": ["onvif-zeep-async==0.4.0", "WSDiscovery==2.0.0"],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@hunterjm"],
   "config_flow": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -994,7 +994,7 @@ oemthermostat==1.1
 onkyo-eiscp==1.2.7
 
 # homeassistant.components.onvif
-onvif-zeep-async==0.3.0
+onvif-zeep-async==0.4.0
 
 # homeassistant.components.opengarage
 open-garage==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -420,7 +420,7 @@ numpy==1.18.4
 oauth2client==4.0.0
 
 # homeassistant.components.onvif
-onvif-zeep-async==0.3.0
+onvif-zeep-async==0.4.0
 
 # homeassistant.components.openerz
 openerz-api==0.1.0


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There is an issue that occurs on some devices with re-using the same `AsyncTransport` across multiple services which appears to occur with request queues on pending requests.  The responses appear to be associated with the improper requests when they come back. This was exposed in 0.110.1 when we moved fetching URLs to `async_added_to_hass`. The library already handles creating a new `AsyncTransport` and `ClientSession` if no transport is passed in, so this will let it do so.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35947
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
