### PR TITLE
Add tests to Atag integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -63,10 +63,6 @@ omit =
     homeassistant/components/arwn/sensor.py
     homeassistant/components/asterisk_cdr/mailbox.py
     homeassistant/components/asterisk_mbox/*
-    homeassistant/components/atag/__init__.py
-    homeassistant/components/atag/climate.py
-    homeassistant/components/atag/sensor.py
-    homeassistant/components/atag/water_heater.py
     homeassistant/components/aten_pe/*
     homeassistant/components/atome/*
     homeassistant/components/aurora_abb_powerone/sensor.py

--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -62,7 +62,7 @@ class AtagDataUpdateCoordinator(DataUpdateCoordinator):
         with async_timeout.timeout(20):
             try:
                 if not await self.atag.update():
-                    raise UpdateFailed("No data received.")
+                    raise UpdateFailed("No data received")
             except AtagException as error:
                 raise UpdateFailed(error)
         return self.atag.report

--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -37,6 +37,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(entry, unique_id=coordinator.atag.id)
 
     for platform in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -31,11 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     session = async_get_clientsession(hass)
 
     coordinator = AtagDataUpdateCoordinator(hass, session, entry)
-    try:
-        await coordinator.async_refresh()
-    except AtagException:
-        raise ConfigEntryNotReady
-
+    await coordinator.async_refresh()
     if not coordinator.last_update_success:
         raise ConfigEntryNotReady
 
@@ -65,9 +61,8 @@ class AtagDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         with async_timeout.timeout(20):
             try:
-                await self.atag.update()
-                if not self.atag.report:
-                    raise UpdateFailed("No data")
+                if not await self.atag.update():
+                    raise UpdateFailed("No data received.")
             except AtagException as error:
                 raise UpdateFailed(error)
         return self.atag.report
@@ -120,11 +115,6 @@ class AtagEntity(Entity):
     def should_poll(self) -> bool:
         """Return the polling requirement of the entity."""
         return False
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity, if any."""
-        return self.coordinator.atag.climate.temp_unit
 
     @property
     def available(self):

--- a/homeassistant/components/atag/climate.py
+++ b/homeassistant/components/atag/climate.py
@@ -66,9 +66,11 @@ class AtagThermostat(AtagEntity, ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        if self.coordinator.atag.climate.temp_unit in [TEMP_CELSIUS, TEMP_FAHRENHEIT]:
-            return self.coordinator.atag.climate.temp_unit
-        return None
+        return (
+            TEMP_CELSIUS
+            if self.coordinator.atag.climate.temp_unit == TEMP_CELSIUS
+            else TEMP_FAHRENHEIT
+        )
 
     @property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/atag/climate.py
+++ b/homeassistant/components/atag/climate.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_TEMPERATURE
 
 from . import CLIMATE, DOMAIN, AtagEntity
 
@@ -66,11 +66,7 @@ class AtagThermostat(AtagEntity, ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return (
-            TEMP_CELSIUS
-            if self.coordinator.atag.climate.temp_unit == TEMP_CELSIUS
-            else TEMP_FAHRENHEIT
-        )
+        return self.coordinator.atag.climate.temp_unit
 
     @property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/atag/manifest.json
+++ b/homeassistant/components/atag/manifest.json
@@ -3,6 +3,6 @@
   "name": "Atag",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/atag/",
-  "requirements": ["pyatag==0.3.1.2"],
+  "requirements": ["pyatag==0.3.2"],
   "codeowners": ["@MatsNL"]
 }

--- a/homeassistant/components/atag/manifest.json
+++ b/homeassistant/components/atag/manifest.json
@@ -3,6 +3,6 @@
   "name": "Atag",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/atag/",
-  "requirements": ["pyatag==0.3.3.2"],
+  "requirements": ["pyatag==0.3.3.3"],
   "codeowners": ["@MatsNL"]
 }

--- a/homeassistant/components/atag/manifest.json
+++ b/homeassistant/components/atag/manifest.json
@@ -3,6 +3,6 @@
   "name": "Atag",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/atag/",
-  "requirements": ["pyatag==0.3.3.3"],
+  "requirements": ["pyatag==0.3.3.4"],
   "codeowners": ["@MatsNL"]
 }

--- a/homeassistant/components/atag/manifest.json
+++ b/homeassistant/components/atag/manifest.json
@@ -3,6 +3,6 @@
   "name": "Atag",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/atag/",
-  "requirements": ["pyatag==0.3.2"],
+  "requirements": ["pyatag==0.3.3.2"],
   "codeowners": ["@MatsNL"]
 }

--- a/homeassistant/components/atag/sensor.py
+++ b/homeassistant/components/atag/sensor.py
@@ -5,6 +5,8 @@ from homeassistant.const import (
     PRESSURE_BAR,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
+    TIME_HOURS,
+    UNIT_PERCENTAGE,
 )
 
 from . import DOMAIN, AtagEntity
@@ -65,6 +67,8 @@ class AtagSensor(AtagEntity):
             PRESSURE_BAR,
             TEMP_CELSIUS,
             TEMP_FAHRENHEIT,
+            UNIT_PERCENTAGE,
+            TIME_HOURS,
         ]:
             return self.coordinator.data[self._id].measure
         return None

--- a/homeassistant/components/atag/strings.json
+++ b/homeassistant/components/atag/strings.json
@@ -12,10 +12,11 @@
       }
     },
     "error": {
+      "unauthorized": "Pairing denied, check device for auth request",
       "connection_error": "Failed to connect, please try again"
     },
     "abort": {
-      "already_configured": "Only one Atag device can be added to Home Assistant"
+      "already_configured": "This device has already been added to HomeAssistant"
     }
   }
 }

--- a/homeassistant/components/atag/water_heater.py
+++ b/homeassistant/components/atag/water_heater.py
@@ -40,9 +40,8 @@ class AtagWaterHeater(AtagEntity, WaterHeaterEntity):
     @property
     def current_operation(self):
         """Return current operation."""
-        if self.coordinator.atag.dhw.status:
-            return STATE_PERFORMANCE
-        return STATE_OFF
+        operation = self.coordinator.atag.dhw.current_operation
+        return operation if operation in self.operation_list else STATE_OFF
 
     @property
     def operation_list(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1212,7 +1212,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.3.3
+pyatag==0.3.3.4
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1212,7 +1212,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.2
+pyatag==0.3.3.2
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1212,7 +1212,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.3.2
+pyatag==0.3.3.3
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1212,7 +1212,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.1.2
+pyatag==0.3.2
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -521,7 +521,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.2
+pyatag==0.3.3.2
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -521,7 +521,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.3.3
+pyatag==0.3.3.4
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -521,7 +521,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.3.2
+pyatag==0.3.3.3
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -521,7 +521,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.1.2
+pyatag==0.3.2
 
 # homeassistant.components.netatmo
 pyatmo==3.3.1

--- a/tests/components/atag/__init__.py
+++ b/tests/components/atag/__init__.py
@@ -1,1 +1,87 @@
-"""Tests for the Atag component."""
+"""Tests for the Atag integration."""
+
+from homeassistant.components.atag import DOMAIN
+from homeassistant.const import CONF_DEVICE, CONF_EMAIL, CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+USER_INPUT = {
+    CONF_HOST: "127.0.0.1",
+    CONF_EMAIL: "atag@domain.com",
+    CONF_PORT: 10000,
+}
+COMPLETE_ENTRY = USER_INPUT.copy()
+COMPLETE_ENTRY[CONF_DEVICE] = CONF_DEVICE
+
+PAIR_REPLY = {"pair_reply": {"status": {"device_id": CONF_DEVICE}, "acc_status": 2}}
+UPDATE_REPLY = {"update_reply": {"status": {"device_id": CONF_DEVICE}, "acc_status": 2}}
+RECEIVE_REPLY = {
+    "retrieve_reply": {
+        "status": {"device_id": CONF_DEVICE},
+        "report": {
+            "burning_hours": 1000,
+            "room_temp": 20,
+            "outside_temp": 15,
+            "dhw_water_temp": 30,
+            "ch_water_temp": 40,
+            "ch_water_pres": 1.8,
+            "ch_return_temp": 35,
+            "boiler_status": 0,
+            "tout_avg": 12,
+            "details": {"rel_mod_level": 0},
+        },
+        "control": {
+            "ch_control_mode": 0,
+            "ch_mode": 1,
+            "ch_mode_duration": 0,
+            "ch_mode_temp": 12,
+            "dhw_temp_setp": 40,
+            "dhw_mode": 1,
+            "dhw_mode_temp": 150,
+            "weather_status": 8,
+        },
+        "configuration": {
+            "download_url": "http://firmware.atag-one.com:80/R58",
+            "temp_unit": 0,
+            "dhw_max_set": 65,
+            "dhw_min_set": 40,
+        },
+        "acc_status": 2,
+    }
+}
+
+
+async def init_integration(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    rgbw: bool = False,
+    skip_setup: bool = False,
+) -> MockConfigEntry:
+    """Set up the Atag integration in Home Assistant."""
+
+    aioclient_mock.get(
+        "http://127.0.0.1:10000/retrieve",
+        json=RECEIVE_REPLY,
+        headers={"Content-Type": "application/json"},
+    )
+    aioclient_mock.post(
+        "http://127.0.0.1:10000/update",
+        json=UPDATE_REPLY,
+        headers={"Content-Type": "application/json"},
+    )
+    aioclient_mock.post(
+        "http://127.0.0.1:10000/pair",
+        json=PAIR_REPLY,
+        headers={"Content-Type": "application/json"},
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data=COMPLETE_ENTRY)
+    entry.add_to_hass(hass)
+
+    if not skip_setup:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry

--- a/tests/components/atag/__init__.py
+++ b/tests/components/atag/__init__.py
@@ -1,7 +1,7 @@
 """Tests for the Atag integration."""
 
 from homeassistant.components.atag import DOMAIN
-from homeassistant.const import CONF_DEVICE, CONF_EMAIL, CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_EMAIL, CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -12,14 +12,12 @@ USER_INPUT = {
     CONF_EMAIL: "atag@domain.com",
     CONF_PORT: 10000,
 }
-COMPLETE_ENTRY = USER_INPUT.copy()
-COMPLETE_ENTRY[CONF_DEVICE] = CONF_DEVICE
-
-PAIR_REPLY = {"pair_reply": {"status": {"device_id": CONF_DEVICE}, "acc_status": 2}}
-UPDATE_REPLY = {"update_reply": {"status": {"device_id": CONF_DEVICE}, "acc_status": 2}}
+UID = "xxxx-xxxx-xxxx_xx-xx-xxx-xxx"
+PAIR_REPLY = {"pair_reply": {"status": {"device_id": UID}, "acc_status": 2}}
+UPDATE_REPLY = {"update_reply": {"status": {"device_id": UID}, "acc_status": 2}}
 RECEIVE_REPLY = {
     "retrieve_reply": {
-        "status": {"device_id": CONF_DEVICE},
+        "status": {"device_id": UID},
         "report": {
             "burning_hours": 1000,
             "room_temp": 20,
@@ -77,7 +75,7 @@ async def init_integration(
         headers={"Content-Type": "application/json"},
     )
 
-    entry = MockConfigEntry(domain=DOMAIN, data=COMPLETE_ENTRY)
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
     entry.add_to_hass(hass)
 
     if not skip_setup:

--- a/tests/components/atag/test_climate.py
+++ b/tests/components/atag/test_climate.py
@@ -15,17 +15,12 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_TEMPERATURE,
-    CONF_DEVICE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import PropertyMock, patch
-from tests.components.atag import init_integration
+from tests.components.atag import UID, init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 CLIMATE_ID = f"{CLIMATE}.{DOMAIN}"
@@ -41,7 +36,7 @@ async def test_climate(
 
         assert registry.async_is_registered(CLIMATE_ID)
         entry = registry.async_get(CLIMATE_ID)
-        assert entry.unique_id == f"{CONF_DEVICE}-{CLIMATE}"
+        assert entry.unique_id == f"{UID}-{CLIMATE}"
         assert (
             hass.states.get(CLIMATE_ID).attributes[ATTR_HVAC_ACTION]
             == CURRENT_HVAC_HEAT

--- a/tests/components/atag/test_climate.py
+++ b/tests/components/atag/test_climate.py
@@ -1,0 +1,113 @@
+"""Tests for the Atag climate platform."""
+
+from homeassistant.components.atag import CLIMATE, DOMAIN
+from homeassistant.components.climate import (
+    ATTR_HVAC_ACTION,
+    ATTR_HVAC_MODE,
+    ATTR_PRESET_MODE,
+    HVAC_MODE_HEAT,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_SET_TEMPERATURE,
+)
+from homeassistant.components.climate.const import CURRENT_HVAC_HEAT, PRESET_AWAY
+from homeassistant.components.homeassistant import (
+    DOMAIN as HA_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    CONF_DEVICE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import PropertyMock, patch
+from tests.components.atag import init_integration
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+CLIMATE_ID = f"{CLIMATE}.{DOMAIN}"
+
+
+async def test_climate(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the creation and values of Atag climate device."""
+    with patch("pyatag.entities.Climate.status"):
+        entry = await init_integration(hass, aioclient_mock)
+        registry = await hass.helpers.entity_registry.async_get_registry()
+
+        assert registry.async_is_registered(CLIMATE_ID)
+        entry = registry.async_get(CLIMATE_ID)
+        assert entry.unique_id == f"{CONF_DEVICE}-{CLIMATE}"
+        assert (
+            hass.states.get(CLIMATE_ID).attributes[ATTR_HVAC_ACTION]
+            == CURRENT_HVAC_HEAT
+        )
+
+
+async def test_setting_climate(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test setting the climate device."""
+    await init_integration(hass, aioclient_mock)
+    with patch("pyatag.entities.Climate.set_temp") as mock_set_temp:
+        await hass.services.async_call(
+            CLIMATE,
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_ENTITY_ID: CLIMATE_ID, ATTR_TEMPERATURE: 15},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_temp.assert_called_once_with(15)
+
+    with patch("pyatag.entities.Climate.set_preset_mode") as mock_set_preset:
+        await hass.services.async_call(
+            CLIMATE,
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_ENTITY_ID: CLIMATE_ID, ATTR_PRESET_MODE: PRESET_AWAY},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_preset.assert_called_once_with(PRESET_AWAY)
+
+    with patch("pyatag.entities.Climate.set_hvac_mode") as mock_set_hvac:
+        await hass.services.async_call(
+            CLIMATE,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: CLIMATE_ID, ATTR_HVAC_MODE: HVAC_MODE_HEAT},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_hvac.assert_called_once_with(HVAC_MODE_HEAT)
+
+
+async def test_incorrect_modes(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test incorrect values are handled correctly."""
+    with patch(
+        "pyatag.entities.Climate.hvac_mode",
+        new_callable=PropertyMock(return_value="bug"),
+    ):
+        await init_integration(hass, aioclient_mock)
+        assert hass.states.get(CLIMATE_ID).state == STATE_UNKNOWN
+
+
+async def test_update_service(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the updater service is called."""
+    await init_integration(hass, aioclient_mock)
+    await async_setup_component(hass, HA_DOMAIN, {})
+    with patch("pyatag.AtagOne.update") as updater:
+        await hass.services.async_call(
+            HA_DOMAIN,
+            SERVICE_UPDATE_ENTITY,
+            {ATTR_ENTITY_ID: CLIMATE_ID},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        updater.assert_called_once()

--- a/tests/components/atag/test_config_flow.py
+++ b/tests/components/atag/test_config_flow.py
@@ -3,18 +3,18 @@ from pyatag import AtagException
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.atag import DOMAIN
-from homeassistant.const import CONF_DEVICE, CONF_EMAIL, CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_DEVICE
+from homeassistant.core import HomeAssistant
 
-from tests.async_mock import PropertyMock, patch
-from tests.common import MockConfigEntry
-
-FIXTURE_USER_INPUT = {
-    CONF_HOST: "127.0.0.1",
-    CONF_EMAIL: "test@domain.com",
-    CONF_PORT: 10000,
-}
-FIXTURE_COMPLETE_ENTRY = FIXTURE_USER_INPUT.copy()
-FIXTURE_COMPLETE_ENTRY[CONF_DEVICE] = "device_identifier"
+from tests.async_mock import patch
+from tests.components.atag import (
+    COMPLETE_ENTRY,
+    PAIR_REPLY,
+    RECEIVE_REPLY,
+    USER_INPUT,
+    init_integration,
+)
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_show_form(hass):
@@ -27,10 +27,11 @@ async def test_show_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_one_config_allowed(hass):
+async def test_one_config_allowed(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that only one Atag configuration is allowed."""
-    MockConfigEntry(domain="atag", data=FIXTURE_USER_INPUT).add_to_hass(hass)
-
+    await init_integration(hass, aioclient_mock)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -41,15 +42,11 @@ async def test_one_config_allowed(hass):
 
 async def test_connection_error(hass):
     """Test we show user form on Atag connection error."""
-
     with patch(
-        "homeassistant.components.atag.config_flow.AtagOne.authorize",
-        side_effect=AtagException(),
+        "pyatag.AtagOne.authorize", side_effect=AtagException(),
     ):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=FIXTURE_USER_INPUT,
+            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=USER_INPUT,
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -57,19 +54,19 @@ async def test_connection_error(hass):
     assert result["errors"] == {"base": "connection_error"}
 
 
-async def test_full_flow_implementation(hass):
+async def test_full_flow_implementation(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test registering an integration and finishing flow works."""
-    with patch("homeassistant.components.atag.AtagOne.authorize",), patch(
-        "homeassistant.components.atag.AtagOne.update",
-    ), patch(
-        "homeassistant.components.atag.AtagOne.id",
-        new_callable=PropertyMock(return_value="device_identifier"),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=FIXTURE_USER_INPUT,
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == FIXTURE_COMPLETE_ENTRY[CONF_DEVICE]
-        assert result["data"] == FIXTURE_COMPLETE_ENTRY
+    aioclient_mock.get(
+        "http://127.0.0.1:10000/retrieve", json=RECEIVE_REPLY,
+    )
+    aioclient_mock.post(
+        "http://127.0.0.1:10000/pair", json=PAIR_REPLY,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=USER_INPUT,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == COMPLETE_ENTRY[CONF_DEVICE]
+    assert result["data"] == COMPLETE_ENTRY

--- a/tests/components/atag/test_init.py
+++ b/tests/components/atag/test_init.py
@@ -1,0 +1,39 @@
+"""Tests for the ATAG integration."""
+import aiohttp
+
+from homeassistant.components.atag import DOMAIN
+from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
+from homeassistant.core import HomeAssistant
+
+from tests.async_mock import patch
+from tests.components.atag import init_integration
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_config_entry_not_ready(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test configuration entry not ready on library error."""
+    aioclient_mock.get("http://127.0.0.1:10000/retrieve", exc=aiohttp.ClientError)
+    entry = await init_integration(hass, aioclient_mock)
+    assert entry.state == ENTRY_STATE_SETUP_RETRY
+
+
+async def test_config_entry_empty_reply(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test configuration entry not ready when library returns False."""
+    with patch("pyatag.AtagOne.update", return_value=False):
+        entry = await init_integration(hass, aioclient_mock)
+        assert entry.state == ENTRY_STATE_SETUP_RETRY
+
+
+async def test_unload_config_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the ATAG configuration entry unloading."""
+    entry = await init_integration(hass, aioclient_mock)
+    assert hass.data[DOMAIN]
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert not hass.data.get(DOMAIN)

--- a/tests/components/atag/test_sensors.py
+++ b/tests/components/atag/test_sensors.py
@@ -12,7 +12,6 @@ async def test_sensors(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the creation of ATAG sensors."""
-
     entry = await init_integration(hass, aioclient_mock)
     registry = await hass.helpers.entity_registry.async_get_registry()
 

--- a/tests/components/atag/test_sensors.py
+++ b/tests/components/atag/test_sensors.py
@@ -1,0 +1,23 @@
+"""Tests for the Atag sensor platform."""
+
+from homeassistant.components.atag.sensor import SENSORS
+from homeassistant.const import CONF_DEVICE
+from homeassistant.core import HomeAssistant
+
+from tests.components.atag import init_integration
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the creation of ATAG sensors."""
+
+    entry = await init_integration(hass, aioclient_mock)
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    for item in SENSORS:
+        sensor_id = "_".join(f"sensor.{item}".lower().split())
+        assert registry.async_is_registered(sensor_id)
+        entry = registry.async_get(sensor_id)
+        assert entry.unique_id in [f"{CONF_DEVICE}-{v}" for v in SENSORS.values()]

--- a/tests/components/atag/test_sensors.py
+++ b/tests/components/atag/test_sensors.py
@@ -1,10 +1,9 @@
 """Tests for the Atag sensor platform."""
 
 from homeassistant.components.atag.sensor import SENSORS
-from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant
 
-from tests.components.atag import init_integration
+from tests.components.atag import UID, init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -19,4 +18,4 @@ async def test_sensors(
         sensor_id = "_".join(f"sensor.{item}".lower().split())
         assert registry.async_is_registered(sensor_id)
         entry = registry.async_get(sensor_id)
-        assert entry.unique_id in [f"{CONF_DEVICE}-{v}" for v in SENSORS.values()]
+        assert entry.unique_id in [f"{UID}-{v}" for v in SENSORS.values()]

--- a/tests/components/atag/test_water_heater.py
+++ b/tests/components/atag/test_water_heater.py
@@ -2,11 +2,11 @@
 
 from homeassistant.components.atag import DOMAIN, WATER_HEATER
 from homeassistant.components.water_heater import SERVICE_SET_TEMPERATURE
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, CONF_DEVICE
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 
 from tests.async_mock import patch
-from tests.components.atag import init_integration
+from tests.components.atag import UID, init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 WATER_HEATER_ID = f"{WATER_HEATER}.{DOMAIN}"
@@ -22,7 +22,7 @@ async def test_water_heater(
 
         assert registry.async_is_registered(WATER_HEATER_ID)
         entry = registry.async_get(WATER_HEATER_ID)
-        assert entry.unique_id == f"{CONF_DEVICE}-{WATER_HEATER}"
+        assert entry.unique_id == f"{UID}-{WATER_HEATER}"
 
 
 async def test_setting_target_temperature(

--- a/tests/components/atag/test_water_heater.py
+++ b/tests/components/atag/test_water_heater.py
@@ -1,0 +1,41 @@
+"""Tests for the Atag water heater platform."""
+
+from homeassistant.components.atag import DOMAIN, WATER_HEATER
+from homeassistant.components.water_heater import SERVICE_SET_TEMPERATURE
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, CONF_DEVICE
+from homeassistant.core import HomeAssistant
+
+from tests.async_mock import patch
+from tests.components.atag import init_integration
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+WATER_HEATER_ID = f"{WATER_HEATER}.{DOMAIN}"
+
+
+async def test_water_heater(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the creation of Atag water heater."""
+    with patch("pyatag.entities.DHW.status"):
+        entry = await init_integration(hass, aioclient_mock)
+        registry = await hass.helpers.entity_registry.async_get_registry()
+
+        assert registry.async_is_registered(WATER_HEATER_ID)
+        entry = registry.async_get(WATER_HEATER_ID)
+        assert entry.unique_id == f"{CONF_DEVICE}-{WATER_HEATER}"
+
+
+async def test_setting_target_temperature(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test setting the water heater device."""
+    await init_integration(hass, aioclient_mock)
+    with patch("pyatag.entities.DHW.set_temp") as mock_set_temp:
+        await hass.services.async_call(
+            WATER_HEATER,
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_ENTITY_ID: WATER_HEATER_ID, ATTR_TEMPERATURE: 50},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_temp.assert_called_once_with(50)


### PR DESCRIPTION
## Proposed change
Add tests to Atag integration to test functionality and reach 100% coverage. Also removes several bugs that were identified setting up the tests.

## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

