### PR TITLE
Update proxmoxer to 1.1.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -312,7 +312,7 @@ homeassistant/components/plugwise/* @laetificat @CoMPaTech @bouwew
 homeassistant/components/plum_lightpad/* @ColinHarrington
 homeassistant/components/point/* @fredrike
 homeassistant/components/powerwall/* @bdraco @jrester
-homeassistant/components/proxmoxve/* @k4ds3
+homeassistant/components/proxmoxve/* @k4ds3 @jhollowe
 homeassistant/components/ps4/* @ktnrg45
 homeassistant/components/ptvsd/* @swamp-ig
 homeassistant/components/push/* @dgomes

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -1,7 +1,6 @@
 """Support for Proxmox VE."""
 from enum import Enum
 import logging
-import time
 
 from proxmoxer import ProxmoxAPI
 from proxmoxer.backends.https import AuthenticationError
@@ -147,15 +146,6 @@ class ProxmoxClient:
             verify_ssl=self._verify_ssl,
         )
 
-        self._connection_start_time = time.monotonic()
-
     def get_api_client(self):
-        """Return the ProxmoxAPI client and rebuild it if necessary."""
-
-        connection_age = time.monotonic() - self._connection_start_time
-
-        # Workaround for the Proxmoxer bug where the connection stops working after some time
-        if connection_age > 30 * 60:
-            self.build_client()
-
+        """Return the ProxmoxAPI client."""
         return self._proxmox

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -136,7 +136,7 @@ class ProxmoxClient:
         self._connection_start_time = None
 
     def build_client(self):
-        """Construct the ProxmoxAPI client. Allows inserting the realm withing the `user` value."""
+        """Construct the ProxmoxAPI client. Allows inserting the realm within the `user` value."""
 
         if "@" in self._user:
             user_id = self._user

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -136,12 +136,17 @@ class ProxmoxClient:
         self._connection_start_time = None
 
     def build_client(self):
-        """Construct the ProxmoxAPI client."""
+        """Construct the ProxmoxAPI client. Allows inserting the realm withing the `user` value."""
+
+        if "@" in self._user:
+            user_id = self._user
+        else:
+            user_id = f"{self._user}@{self._realm}"
 
         self._proxmox = ProxmoxAPI(
             self._host,
             port=self._port,
-            user=f"{self._user}@{self._realm}",
+            user=user_id,
             password=self._password,
             verify_ssl=self._verify_ssl,
         )

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -3,5 +3,5 @@
   "name": "Proxmox VE",
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
   "codeowners": ["@k4ds3"],
-  "requirements": ["proxmoxer==1.0.4"]
+  "requirements": ["proxmoxer==1.1.0"]
 }

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -2,6 +2,6 @@
   "domain": "proxmoxve",
   "name": "Proxmox VE",
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
-  "codeowners": ["@k4ds3"],
+  "codeowners": ["@k4ds3", "@jhollowe"],
   "requirements": ["proxmoxer==1.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1115,7 +1115,7 @@ prometheus_client==0.7.1
 protobuf==3.6.1
 
 # homeassistant.components.proxmoxve
-proxmoxer==1.0.4
+proxmoxer==1.1.0
 
 # homeassistant.components.systemmonitor
 psutil==5.7.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the library now handles renewing authentication, the renewing code in the component is redundant.
Additionally, to allow easier configuration, the realm can be added to the `username` which will override the `realm` value.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#13555

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
