### PR TITLE
Fix lutron_caseta setup options

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -440,7 +440,13 @@ omit =
     homeassistant/components/luftdaten/*
     homeassistant/components/lupusec/*
     homeassistant/components/lutron/*
-    homeassistant/components/lutron_caseta/*
+    homeassistant/components/lutron_caseta/__init__.py
+    homeassistant/components/lutron_caseta/binary_sensor.py
+    homeassistant/components/lutron_caseta/cover.py
+    homeassistant/components/lutron_caseta/fan.py
+    homeassistant/components/lutron_caseta/light.py
+    homeassistant/components/lutron_caseta/scene.py
+    homeassistant/components/lutron_caseta/switch.py
     homeassistant/components/lw12wifi/light.py
     homeassistant/components/lyft/sensor.py
     homeassistant/components/magicseaweed/sensor.py

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -39,11 +39,7 @@ LUTRON_CASETA_COMPONENTS = ["light", "switch", "cover", "scene", "fan", "binary_
 async def async_setup(hass, base_config):
     """Set up the Lutron component."""
 
-    bridge_configs = base_config.get(DOMAIN)
-
-    if not bridge_configs:
-        return True
-
+    bridge_configs = base_config[DOMAIN]
     hass.data.setdefault(DOMAIN, {})
 
     for config in bridge_configs:

--- a/homeassistant/components/lutron_caseta/config_flow.py
+++ b/homeassistant/components/lutron_caseta/config_flow.py
@@ -94,11 +94,6 @@ class LutronCasetaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             await bridge.close()
             return True
-        except (KeyError, ValueError):
-            _LOGGER.error(
-                "Error while checking connectivity to bridge %s", self.data[CONF_HOST],
-            )
-            return False
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception(
                 "Unknown exception while checking connectivity to bridge %s",

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -2,7 +2,10 @@
   "domain": "lutron_caseta",
   "name": "Lutron Caséta",
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
-  "requirements": ["pylutron-caseta==0.6.1"],
-  "codeowners": ["@swails"],
-  "config_flow": true
+  "requirements": [
+    "pylutron-caseta==0.6.1"
+  ],
+  "codeowners": [
+    "@swails"
+  ]
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -85,7 +85,6 @@ FLOWS = [
     "locative",
     "logi_circle",
     "luftdaten",
-    "lutron_caseta",
     "mailgun",
     "melcloud",
     "met",

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -51,7 +51,11 @@ async def test_bridge_import_flow(hass):
 
     with patch(
         "homeassistant.components.lutron_caseta.async_setup_entry", return_value=True,
-    ) as mock_setup_entry, patch.object(Smartbridge, "create_tls") as create_tls:
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.lutron_caseta.async_setup", return_value=True
+    ), patch.object(
+        Smartbridge, "create_tls"
+    ) as create_tls:
         create_tls.return_value = MockBridge(can_connect=True)
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.lutron_caseta.const import (
 )
 from homeassistant.const import CONF_HOST
 
-from tests.async_mock import patch
+from tests.async_mock import AsyncMock, patch
 from tests.common import MockConfigEntry
 
 
@@ -81,9 +81,7 @@ async def test_bridge_cannot_connect(hass):
         CONF_CA_CERTS: "",
     }
 
-    with patch(
-        "homeassistant.components.lutron_caseta.async_setup_entry", return_value=True,
-    ) as mock_setup_entry, patch.object(Smartbridge, "create_tls") as create_tls:
+    with patch.object(Smartbridge, "create_tls") as create_tls:
         create_tls.return_value = MockBridge(can_connect=False)
 
         result = await hass.config_entries.flow.async_init(
@@ -101,8 +99,35 @@ async def test_bridge_cannot_connect(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
-    # validate setup_entry was not called
-    assert len(mock_setup_entry.mock_calls) == 0
+
+async def test_bridge_cannot_connect_unknown_error(hass):
+    """Test checking for connection and encountering an unknown error."""
+
+    entry_mock_data = {
+        CONF_HOST: "",
+        CONF_KEYFILE: "",
+        CONF_CERTFILE: "",
+        CONF_CA_CERTS: "",
+    }
+
+    with patch.object(Smartbridge, "create_tls") as create_tls:
+        mock_bridge = MockBridge()
+        mock_bridge.connect = AsyncMock(side_effect=Exception())
+        create_tls.return_value = mock_bridge
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=entry_mock_data,
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == STEP_IMPORT_FAILED
+    assert result["errors"] == {"base": ERROR_CANNOT_CONNECT}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
 
 async def test_duplicate_bridge_import(hass):

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Lutron Caseta config flow."""
-from asynctest import patch
 from pylutron_caseta.smartbridge import Smartbridge
 
 from homeassistant import config_entries, data_entry_flow
@@ -14,6 +13,7 @@ from homeassistant.components.lutron_caseta.const import (
 )
 from homeassistant.const import CONF_HOST
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 
@@ -95,6 +95,12 @@ async def test_bridge_cannot_connect(hass):
     assert result["type"] == "form"
     assert result["step_id"] == STEP_IMPORT_FAILED
     assert result["errors"] == {"base": ERROR_CANNOT_CONNECT}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
+
     # validate setup_entry was not called
     assert len(mock_setup_entry.mock_calls) == 0
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The lutron_caseta integration does not yet support set up via integrations in the frontend. This PR removes that option since it never was intended to be supported in 0.110.0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35850
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
