### PR TITLE
Unconnected snapclients state STANDBY instead of OFF

### DIFF
--- a/homeassistant/components/snapcast/media_player.py
+++ b/homeassistant/components/snapcast/media_player.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     STATE_IDLE,
+    STATE_STANDBY,
     STATE_OFF,
     STATE_ON,
     STATE_PLAYING,
@@ -258,7 +259,7 @@ class SnapcastClientDevice(MediaPlayerEntity):
         """Return the state of the player."""
         if self._client.connected:
             return STATE_ON
-        return STATE_IDLE
+        return STATE_STANDBY
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/snapcast/media_player.py
+++ b/homeassistant/components/snapcast/media_player.py
@@ -258,7 +258,7 @@ class SnapcastClientDevice(MediaPlayerEntity):
         """Return the state of the player."""
         if self._client.connected:
             return STATE_ON
-        return STATE_OFF
+        return STATE_IDLE
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Proposed change
<!-- 
 The snapserver allows manipulating unconnected snapclients.
Settings are then applied as soon as they connect.
 For example, this allows to switch on the power supply (e.g. remote controlled socket) of a snapclient via Home-Assistant depending on the muted/unmuted state of clients.
 Saves idle electricity costs and the environment if you have a lot of snapclients ;)
-->
The snapserver allows manipulating unconnected snapclients.
Settings are then applied as soon as they connect.
This change allows to manipulate offline snapclients via Home-Assistant.
For example, this allows to switch on the power supply (e.g. remote controlled socket) of a snapclient via Home-Assistant depending on the muted/unmuted state of clients.
Saves idle electricity costs and the environment if you have a lot of snapclients ;)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
