### PR TITLE
Fix device_registry cleanup behavior

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -399,17 +399,27 @@ def async_cleanup(
     ent_reg: "entity_registry.EntityRegistry",
 ) -> None:
     """Clean up device registry."""
-    # Find all devices that are no longer referenced in the entity registry.
-    referenced = {entry.device_id for entry in ent_reg.entities.values()}
-    orphan = set(dev_reg.devices) - referenced
+    # Find all devices that are referenced by a config_entry.
+    config_entry_ids = {entry.entry_id for entry in hass.config_entries.async_entries()}
+    referenced_by_config_entries = {
+        device.id
+        for device in dev_reg.devices.values()
+        for config_entry_id in device.config_entries
+        if config_entry_id in config_entry_ids
+    }
+
+    # Find all devices that are referenced in the entity registry.
+    referenced_by_entities = {entry.device_id for entry in ent_reg.entities.values()}
+
+    orphan = (
+        set(dev_reg.devices) - referenced_by_entities - referenced_by_config_entries
+    )
 
     for dev_id in orphan:
         dev_reg.async_remove_device(dev_id)
 
     # Find all referenced config entries that no longer exist
     # This shouldn't happen but have not been able to track down the bug :(
-    config_entry_ids = {entry.entry_id for entry in hass.config_entries.async_entries()}
-
     for device in list(dev_reg.devices.values()):
         for config_entry_id in device.config_entries:
             if config_entry_id not in config_entry_ids:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -401,7 +401,7 @@ def async_cleanup(
     """Clean up device registry."""
     # Find all devices that are referenced by a config_entry.
     config_entry_ids = {entry.entry_id for entry in hass.config_entries.async_entries()}
-    referenced_by_config_entries = {
+    references_config_entries = {
         device.id
         for device in dev_reg.devices.values()
         for config_entry_id in device.config_entries
@@ -409,11 +409,9 @@ def async_cleanup(
     }
 
     # Find all devices that are referenced in the entity registry.
-    referenced_by_entities = {entry.device_id for entry in ent_reg.entities.values()}
+    references_entities = {entry.device_id for entry in ent_reg.entities.values()}
 
-    orphan = (
-        set(dev_reg.devices) - referenced_by_entities - referenced_by_config_entries
-    )
+    orphan = set(dev_reg.devices) - references_entities - references_config_entries
 
     for dev_id in orphan:
         dev_reg.async_remove_device(dev_id)

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -539,7 +539,7 @@ async def test_cleanup_device_registry(hass, registry):
     device_registry.async_cleanup(hass, registry, ent_reg)
 
     assert registry.async_get_device({("hue", "d1")}, set()) is not None
-    assert registry.async_get_device({("hue", "d2")}, set()) is None
+    assert registry.async_get_device({("hue", "d2")}, set()) is not None
     assert registry.async_get_device({("hue", "d3")}, set()) is not None
     assert registry.async_get_device({("something", "d4")}, set()) is None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
PR #35106 introduced the `async_cleanup` callback in `device_registry.py` which ensures that all devices without reference to an entity or reference to a config_entry are removed from the device registry.
Other than stated in the PR, all devices are removed which are not referenced by an entity.
Currently there is no check if instead they are referenced by a config_entry. The latter occurs for example for hubs or hardware devices containing many sensors. Those devices are usually not directly linked to an entity but managed by a config_entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35940
- This PR is related to issue: #35851
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
