### PR TITLE
Handle StorageError in the Broadlink integration

### DIFF
--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import logging
 import re
 
-from broadlink.exceptions import BroadlinkException, ReadError
+from broadlink.exceptions import BroadlinkException, ReadError, StorageError
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST
@@ -87,7 +87,7 @@ async def async_setup_service(hass, host, device):
         while (utcnow() - start_time) < timedelta(seconds=20):
             try:
                 packet = await device.async_request(device.api.check_data)
-            except ReadError:
+            except (ReadError, StorageError):
                 await asyncio.sleep(1)
             except BroadlinkException as err_msg:
                 _LOGGER.error("Failed to learn: %s", err_msg)

--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -85,10 +85,11 @@ async def async_setup_service(hass, host, device):
         _LOGGER.info("Press the key you want Home Assistant to learn")
         start_time = utcnow()
         while (utcnow() - start_time) < timedelta(seconds=20):
+            await asyncio.sleep(1)
             try:
                 packet = await device.async_request(device.api.check_data)
             except (ReadError, StorageError):
-                await asyncio.sleep(1)
+                continue
             except BroadlinkException as err_msg:
                 _LOGGER.error("Failed to learn: %s", err_msg)
                 return

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -322,10 +322,11 @@ class BroadlinkRemote(RemoteEntity):
         code = None
         start_time = utcnow()
         while (utcnow() - start_time) < timedelta(seconds=timeout):
+            await asyncio.sleep(1)
             try:
                 code = await self.device.async_request(self.device.api.check_data)
             except (ReadError, StorageError):
-                await asyncio.sleep(1)
+                continue
             else:
                 break
 

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -14,6 +14,7 @@ from broadlink.exceptions import (
     BroadlinkException,
     DeviceOfflineError,
     ReadError,
+    StorageError,
 )
 import voluptuous as vol
 
@@ -323,7 +324,7 @@ class BroadlinkRemote(RemoteEntity):
         while (utcnow() - start_time) < timedelta(seconds=timeout):
             try:
                 code = await self.device.async_request(self.device.api.check_data)
-            except ReadError:
+            except (ReadError, StorageError):
                 await asyncio.sleep(1)
             else:
                 break


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In learning mode, devices of type 0x2737, 0x5f36 and RM4 series raise a StorageError when we try to read the code before it is stored in memory. It is simple to deal with this error, we just need to wait and retry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
script:
  learn_tv_power_button:
    sequence:
      - service: remote.learn_command
        data:
          entity_id: remote.bedroom
          device: tv
          command: power
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/35875
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
