### PR TITLE
Fix roku play/pause support

### DIFF
--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -170,11 +170,11 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         await self.coordinator.roku.remote("poweroff")
 
     async def async_media_pause(self) -> None:
-        """Send play/pause command."""
+        """Send pause command."""
         await self.coordinator.roku.remote("play")
 
     async def async_media_play(self) -> None:
-        """Send play/pause command."""
+        """Send play command."""
         await self.coordinator.roku.remote("play")
 
     async def async_media_play_pause(self) -> None:

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -7,6 +7,7 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_APP,
     MEDIA_TYPE_CHANNEL,
     SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
@@ -29,6 +30,7 @@ SUPPORT_ROKU = (
     | SUPPORT_VOLUME_STEP
     | SUPPORT_VOLUME_MUTE
     | SUPPORT_SELECT_SOURCE
+    | SUPPORT_PAUSE
     | SUPPORT_PLAY
     | SUPPORT_PLAY_MEDIA
     | SUPPORT_TURN_ON
@@ -167,7 +169,11 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         """Turn off the Roku."""
         await self.coordinator.roku.remote("poweroff")
 
-    async def async_media_play_pause(self) -> None:
+    async def async_media_pause(self) -> None:
+        """Send play/pause command."""
+        await self.coordinator.roku.remote("play")
+
+    async def async_media_play(self) -> None:
         """Send play/pause command."""
         await self.coordinator.roku.remote("play")
 

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -177,6 +177,10 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         """Send play/pause command."""
         await self.coordinator.roku.remote("play")
 
+    async def async_media_play_pause(self) -> None:
+        """Send play/pause command."""
+        await self.coordinator.roku.remote("play")
+
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
         await self.coordinator.roku.remote("reverse")

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -15,8 +15,6 @@ from homeassistant.components.media_player.const import (
     DOMAIN as MP_DOMAIN,
     MEDIA_TYPE_APP,
     MEDIA_TYPE_CHANNEL,
-    SERVICE_MEDIA_PAUSE,
-    SERVICE_MEDIA_PLAY,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     SUPPORT_NEXT_TRACK,
@@ -33,6 +31,8 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PLAY_PAUSE,
     SERVICE_MEDIA_PREVIOUS_TRACK,
     SERVICE_TURN_OFF,

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -15,9 +15,11 @@ from homeassistant.components.media_player.const import (
     DOMAIN as MP_DOMAIN,
     MEDIA_TYPE_APP,
     MEDIA_TYPE_CHANNEL,
-    SERVICE_PLAY_MEDIA,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PLAY,
     SERVICE_SELECT_SOURCE,
     SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
@@ -142,6 +144,7 @@ async def test_supported_features(
         | SUPPORT_VOLUME_STEP
         | SUPPORT_VOLUME_MUTE
         | SUPPORT_SELECT_SOURCE
+        | SUPPORT_PAUSE
         | SUPPORT_PLAY
         | SUPPORT_PLAY_MEDIA
         | SUPPORT_TURN_ON
@@ -170,6 +173,7 @@ async def test_tv_supported_features(
         | SUPPORT_VOLUME_STEP
         | SUPPORT_VOLUME_MUTE
         | SUPPORT_SELECT_SOURCE
+        | SUPPORT_PAUSE
         | SUPPORT_PLAY
         | SUPPORT_PLAY_MEDIA
         | SUPPORT_TURN_ON
@@ -270,7 +274,17 @@ async def test_services(
     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(
             MP_DOMAIN,
-            SERVICE_MEDIA_PLAY_PAUSE,
+            SERVICE_MEDIA_PAUSE,
+            {ATTR_ENTITY_ID: MAIN_ENTITY_ID},
+            blocking=True,
+        )
+
+        remote_mock.assert_called_once_with("play")
+
+    with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_MEDIA_PLAY,
             {ATTR_ENTITY_ID: MAIN_ENTITY_ID},
             blocking=True,
         )

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -302,7 +302,7 @@ async def test_services(
 
         remote_mock.assert_called_once_with("play")
 
-     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
+    with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(
             MP_DOMAIN,
             SERVICE_MEDIA_NEXT_TRACK,

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -17,6 +17,7 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
+    SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
@@ -292,6 +293,16 @@ async def test_services(
         remote_mock.assert_called_once_with("play")
 
     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_MEDIA_PLAY_PAUSE,
+            {ATTR_ENTITY_ID: MAIN_ENTITY_ID},
+            blocking=True,
+        )
+
+        remote_mock.assert_called_once_with("play")
+
+     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(
             MP_DOMAIN,
             SERVICE_MEDIA_NEXT_TRACK,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When used by various integrations such as alexa (or in the near future google assistant)  you can't currently easily control device with voice commands like play or pause because the only method that was implemented was media_play_pause which is mostly meant for service calls and has basic support in lovelace components.

Roku only supports a "play" keypress that is really a play/pause behavior and doesn't offer discrete pause support.

This means that the implementation cant promise to actually pause but it can atleast toggle the play state and make available the "pause" action to integrations. In lovelace it should allow the pause icon rather than stop icon which is more accurate to what the actual keypress does.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
