### PR TITLE
Use a single service browser for zeroconf discovery

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -224,7 +224,7 @@ def setup(hass, config):
                 )
             )
 
-    types = list(ZEROCONF.keys())
+    types = list(ZEROCONF)
 
     if HOMEKIT_TYPE not in ZEROCONF:
         types.append(HOMEKIT_TYPE)

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -98,7 +98,7 @@ class HaServiceBrowser(ServiceBrowser):
         # To avoid overwhemling the system we pre-filter here and only process
         # DNSPointers for the configured record name (type)
         #
-        if record.name != self.type or not isinstance(record, DNSPointer):
+        if record.name not in self.types or not isinstance(record, DNSPointer):
             return
         super().update_record(zc, now, record)
 
@@ -224,11 +224,12 @@ def setup(hass, config):
                 )
             )
 
-    for service in ZEROCONF:
-        HaServiceBrowser(zeroconf, service, handlers=[service_update])
+    types = list(ZEROCONF.keys())
 
     if HOMEKIT_TYPE not in ZEROCONF:
-        HaServiceBrowser(zeroconf, HOMEKIT_TYPE, handlers=[service_update])
+        types.append(HOMEKIT_TYPE)
+
+    HaServiceBrowser(zeroconf, types, handlers=[service_update])
 
     return True
 

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.26.1"],
+  "requirements": ["zeroconf==0.26.2"],
   "dependencies": ["api"],
   "codeowners": ["@robbiet480", "@Kane610"],
   "quality_scale": "internal"

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -25,7 +25,7 @@ ruamel.yaml==0.15.100
 sqlalchemy==1.3.17
 voluptuous-serialize==2.3.0
 voluptuous==0.11.7
-zeroconf==0.26.1
+zeroconf==0.26.2
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2239,7 +2239,7 @@ youtube_dl==2020.05.08
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.26.1
+zeroconf==0.26.2
 
 # homeassistant.components.zha
 zha-quirks==0.0.39

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -906,7 +906,7 @@ xmltodict==0.12.0
 ya_ma==0.3.8
 
 # homeassistant.components.zeroconf
-zeroconf==0.26.1
+zeroconf==0.26.2
 
 # homeassistant.components.zha
 zha-quirks==0.0.39

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -29,9 +29,10 @@ def mock_zeroconf():
         yield mock_zc.return_value
 
 
-def service_update_mock(zeroconf, service, handlers):
+def service_update_mock(zeroconf, services, handlers):
     """Call service update handler."""
-    handlers[0](zeroconf, service, f"name.{service}", ServiceStateChange.Added)
+    for service in services:
+        handlers[0](zeroconf, service, f"name.{service}", ServiceStateChange.Added)
 
 
 def get_service_info_mock(service_type, name):
@@ -76,7 +77,7 @@ async def test_setup(hass, mock_zeroconf):
         mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
-    assert len(mock_service_browser.mock_calls) == len(zc_gen.ZEROCONF)
+    assert len(mock_service_browser.mock_calls) == 1
     expected_flow_calls = 0
     for matching_components in zc_gen.ZEROCONF.values():
         expected_flow_calls += len(matching_components)


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Currently we start a service browser thread for every
zeroconf type. Support was added to upstream
python-zeroconf to allow a single service browser to
listen for multiple types.

This solves the problem where each new integration that
is discovered by zeroconf requires another thread and
has to process the incoming data another time which
did not scale.

Additionally, the upstream changes include a fix for a zeroconf
race condition that takes down the service.

Upstream changes
Race Fix: https://github.com/jstasiak/python-zeroconf/commit/24a06191ea35469948d12124a07429207b3c1b3b
Service Browsers: https://github.com/jstasiak/python-zeroconf/commit/a6ad100a60e8434cef6b411208eef98f68d594d3
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
