### PR TITLE
Fix iaqualink sensors

### DIFF
--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -1,9 +1,10 @@
 """Support for Aqualink temperature sensors."""
 import logging
+from typing import Optional
 
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import AqualinkEntity
@@ -33,15 +34,16 @@ class HassAqualinkSensor(AqualinkEntity):
         return self.dev.label
 
     @property
-    def unit_of_measurement(self) -> str:
+    def unit_of_measurement(self) -> Optional[str]:
         """Return the measurement unit for the sensor."""
         if self.dev.name.endswith("_temp"):
             if self.dev.system.temp_unit == "F":
                 return TEMP_FAHRENHEIT
             return TEMP_CELSIUS
+        return None
 
     @property
-    def state(self) -> str:
+    def state(self) -> Optional[str]:
         """Return the state of the sensor."""
         if self.dev.state == "":
             return None
@@ -51,3 +53,10 @@ class HassAqualinkSensor(AqualinkEntity):
         except ValueError:
             state = float(self.dev.state)
         return state
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of the sensor."""
+        if self.dev.name.endswith("_temp"):
+            return DEVICE_CLASS_TEMPERATURE
+        return None

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -1,10 +1,9 @@
 """Support for Aqualink temperature sensors."""
 import logging
-from typing import Optional
 
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import AqualinkEntity
@@ -36,18 +35,19 @@ class HassAqualinkSensor(AqualinkEntity):
     @property
     def unit_of_measurement(self) -> str:
         """Return the measurement unit for the sensor."""
-        if self.dev.system.temp_unit == "F":
-            return TEMP_FAHRENHEIT
-        return TEMP_CELSIUS
+        if self.dev.name.endswith("_temp"):
+            if self.dev.system.temp_unit == "F":
+                return TEMP_FAHRENHEIT
+            return TEMP_CELSIUS
 
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
-        return int(self.dev.state) if self.dev.state != "" else None
+        if self.dev.state == "":
+            return None
 
-    @property
-    def device_class(self) -> Optional[str]:
-        """Return the class of the sensor."""
-        if self.dev.name.endswith("_temp"):
-            return DEVICE_CLASS_TEMPERATURE
-        return None
+        try:
+            state = int(self.dev.state)
+        except ValueError:
+            state = float(self.dev.state)
+        return state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes two issues with sensors:
- adds support for float-value sensors (causing exceptions at the moment)
- prevents all sensors from being classified as temperature sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes part of #30078
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
