### PR TITLE
Add spider config flow

### DIFF
--- a/homeassistant/components/spider/__init__.py
+++ b/homeassistant/components/spider/__init__.py
@@ -1,6 +1,5 @@
 """Support for Spider Smart devices."""
 import asyncio
-from datetime import timedelta
 import logging
 
 from spiderpy.spiderapi import SpiderApi, UnauthorizedException
@@ -10,11 +9,9 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN, PLATFORMS
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
-
-SCAN_INTERVAL = timedelta(seconds=120)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -22,7 +19,9 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Required(CONF_USERNAME): cv.string,
-                vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                ): cv.time_period,
             }
         )
     },

--- a/homeassistant/components/spider/__init__.py
+++ b/homeassistant/components/spider/__init__.py
@@ -45,7 +45,7 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    conf = config.get(DOMAIN, {})
+    conf = config[DOMAIN]
 
     if not hass.config_entries.async_entries(DOMAIN):
         hass.async_create_task(
@@ -63,16 +63,16 @@ async def async_setup_entry(hass, entry):
         hass.data[DOMAIN][entry.entry_id] = await hass.async_add_executor_job(
             _spider_startup_wrapper, entry
         )
-
-        for component in PLATFORMS:
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, component)
-            )
-
-        return True
     except UnauthorizedException:
         _LOGGER.error("Can't connect to the Spider API")
         return False
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
 
 
 async def async_unload_entry(hass, entry):

--- a/homeassistant/components/spider/climate.py
+++ b/homeassistant/components/spider/climate.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 
-from . import DOMAIN as SPIDER_DOMAIN
+from .const import DOMAIN
 
 SUPPORT_FAN = ["Auto", "Low", "Medium", "High", "Boost 10", "Boost 20", "Boost 30"]
 
@@ -29,16 +29,13 @@ SPIDER_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_SPIDER.items()}
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Spider thermostat."""
-    if discovery_info is None:
-        return
+async def async_setup_entry(hass, config, async_add_entities):
+    """Initialize a Spider thermostat."""
+    api = hass.data[DOMAIN][config.entry_id]
 
-    devices = [
-        SpiderThermostat(hass.data[SPIDER_DOMAIN]["controller"], device)
-        for device in hass.data[SPIDER_DOMAIN]["thermostats"]
-    ]
-    add_entities(devices, True)
+    devices = [SpiderThermostat(api, device) for device in api.get_thermostats()]
+
+    async_add_entities(devices)
 
 
 class SpiderThermostat(ClimateEntity):

--- a/homeassistant/components/spider/climate.py
+++ b/homeassistant/components/spider/climate.py
@@ -33,9 +33,9 @@ async def async_setup_entry(hass, config, async_add_entities):
     """Initialize a Spider thermostat."""
     api = hass.data[DOMAIN][config.entry_id]
 
-    devices = [SpiderThermostat(api, device) for device in api.get_thermostats()]
+    entities = [SpiderThermostat(api, entity) for entity in api.get_thermostats()]
 
-    async_add_entities(devices)
+    async_add_entities(entities)
 
 
 class SpiderThermostat(ClimateEntity):

--- a/homeassistant/components/spider/config_flow.py
+++ b/homeassistant/components/spider/config_flow.py
@@ -30,7 +30,7 @@ class SpiderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
         if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
+            return self.async_abort(reason="single_instance_allowed")
 
         errors = {}
         if user_input is not None:

--- a/homeassistant/components/spider/config_flow.py
+++ b/homeassistant/components/spider/config_flow.py
@@ -1,0 +1,67 @@
+"""Config flow for Spider."""
+import logging
+
+from spiderpy.spiderapi import SpiderApi, SpiderApiException, UnauthorizedException
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SpiderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Spider config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize the Spider flow."""
+        self.data = {
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+            "login_response": None,
+        }
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        errors = {}
+        if user_input is not None:
+            self.data[CONF_USERNAME] = user_input["username"]
+            self.data[CONF_PASSWORD] = user_input["password"]
+
+            if CONF_SCAN_INTERVAL in user_input:
+                self.data[CONF_SCAN_INTERVAL] = user_input["scan_interval"]
+
+            try:
+                SpiderApi(
+                    self.data[CONF_USERNAME],
+                    self.data[CONF_PASSWORD],
+                    self.data[CONF_SCAN_INTERVAL],
+                )
+                return self.async_create_entry(title=DOMAIN, data=self.data,)
+            except UnauthorizedException:
+                errors["base"] = "invalid_auth"
+            except SpiderApiException:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        data_schema = {
+            vol.Required("username"): str,
+            vol.Required("password"): str,
+        }
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors,
+        )
+
+    async def async_step_import(self, import_data):
+        """Import spider config from configuration.yaml."""
+        return await self.async_step_user(import_data)

--- a/homeassistant/components/spider/config_flow.py
+++ b/homeassistant/components/spider/config_flow.py
@@ -37,9 +37,6 @@ class SpiderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.data[CONF_USERNAME] = user_input["username"]
             self.data[CONF_PASSWORD] = user_input["password"]
 
-            if CONF_SCAN_INTERVAL in user_input:
-                self.data[CONF_SCAN_INTERVAL] = user_input["scan_interval"]
-
             try:
                 SpiderApi(
                     self.data[CONF_USERNAME],

--- a/homeassistant/components/spider/config_flow.py
+++ b/homeassistant/components/spider/config_flow.py
@@ -51,8 +51,8 @@ class SpiderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
 
         data_schema = {
-            vol.Required("username"): str,
-            vol.Required("password"): str,
+            vol.Required(CONF_USERNAME): str,
+            vol.Required(CONF_PASSWORD): str,
         }
 
         return self.async_show_form(

--- a/homeassistant/components/spider/const.py
+++ b/homeassistant/components/spider/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Spider integration."""
+
+DOMAIN = "spider"
+DEFAULT_SCAN_INTERVAL = 300
+
+PLATFORMS = ("climate", "switch")

--- a/homeassistant/components/spider/const.py
+++ b/homeassistant/components/spider/const.py
@@ -3,4 +3,4 @@
 DOMAIN = "spider"
 DEFAULT_SCAN_INTERVAL = 300
 
-PLATFORMS = ("climate", "switch")
+PLATFORMS = ["climate", "switch"]

--- a/homeassistant/components/spider/manifest.json
+++ b/homeassistant/components/spider/manifest.json
@@ -2,6 +2,11 @@
   "domain": "spider",
   "name": "Itho Daalderop Spider",
   "documentation": "https://www.home-assistant.io/integrations/spider",
-  "requirements": ["spiderpy==1.3.1"],
-  "codeowners": ["@peternijssen"]
+  "requirements": [
+    "spiderpy==1.3.1"
+  ],
+  "codeowners": [
+    "@peternijssen"
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/spider/strings.json
+++ b/homeassistant/components/spider/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Sign-in with mijn.ithodaalderop.nl account",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/spider/strings.json
+++ b/homeassistant/components/spider/strings.json
@@ -14,7 +14,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   }
 }

--- a/homeassistant/components/spider/switch.py
+++ b/homeassistant/components/spider/switch.py
@@ -12,9 +12,9 @@ async def async_setup_entry(hass, config, async_add_entities):
     """Initialize a Spider thermostat."""
     api = hass.data[DOMAIN][config.entry_id]
 
-    devices = [SpiderPowerPlug(api, device) for device in api.get_power_plugs()]
+    entities = [SpiderPowerPlug(api, entity) for entity in api.get_power_plugs()]
 
-    async_add_entities(devices)
+    async_add_entities(entities)
 
 
 class SpiderPowerPlug(SwitchEntity):

--- a/homeassistant/components/spider/switch.py
+++ b/homeassistant/components/spider/switch.py
@@ -3,22 +3,18 @@ import logging
 
 from homeassistant.components.switch import SwitchEntity
 
-from . import DOMAIN as SPIDER_DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Spider thermostat."""
-    if discovery_info is None:
-        return
+async def async_setup_entry(hass, config, async_add_entities):
+    """Initialize a Spider thermostat."""
+    api = hass.data[DOMAIN][config.entry_id]
 
-    devices = [
-        SpiderPowerPlug(hass.data[SPIDER_DOMAIN]["controller"], device)
-        for device in hass.data[SPIDER_DOMAIN]["power_plugs"]
-    ]
+    devices = [SpiderPowerPlug(api, device) for device in api.get_power_plugs()]
 
-    add_entities(devices, True)
+    async_add_entities(devices)
 
 
 class SpiderPowerPlug(SwitchEntity):

--- a/homeassistant/components/spider/translations/en.json
+++ b/homeassistant/components/spider/translations/en.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
+    "error": {
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        },
+        "title": "Sign-in with your mijn.ithodaalderop.nl account"
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -158,6 +158,7 @@ FLOWS = [
     "songpal",
     "sonos",
     "speedtestdotnet",
+    "spider",
     "spotify",
     "squeezebox",
     "starline",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -904,6 +904,9 @@ speak2mary==1.4.0
 # homeassistant.components.speedtestdotnet
 speedtest-cli==2.1.2
 
+# homeassistant.components.spider
+spiderpy==1.3.1
+
 # homeassistant.components.spotify
 spotipy==2.12.0
 

--- a/tests/components/spider/__init__.py
+++ b/tests/components/spider/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spider component."""

--- a/tests/components/spider/test_config_flow.py
+++ b/tests/components/spider/test_config_flow.py
@@ -1,0 +1,100 @@
+"""Tests for the Spider config flow."""
+import pytest
+
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.spider.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from tests.async_mock import Mock, patch
+from tests.common import MockConfigEntry
+
+USERNAME = "spider-username"
+PASSWORD = "spider-password"
+
+SPIDER_USER_DATA = {
+    CONF_USERNAME: USERNAME,
+    CONF_PASSWORD: PASSWORD,
+}
+
+
+@pytest.fixture(name="spider")
+def spider_fixture() -> Mock:
+    """Patch libraries."""
+    with patch("homeassistant.components.spider.config_flow.SpiderApi") as spider:
+        yield spider
+
+
+async def test_user(hass, spider):
+    """Test user config."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.spider.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.spider.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=SPIDER_USER_DATA
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == DOMAIN
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert not result["result"].unique_id
+
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import(hass, spider):
+    """Test import step."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch(
+        "homeassistant.components.spider.async_setup", return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.spider.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=SPIDER_USER_DATA,
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == DOMAIN
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert not result["result"].unique_id
+
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_abort_if_already_setup(hass, spider):
+    """Test we abort if Spider is already setup."""
+    MockConfigEntry(domain=DOMAIN, data=SPIDER_USER_DATA).add_to_hass(hass)
+
+    # Should fail, config exist (import)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=SPIDER_USER_DATA
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+    # Should fail, config exist (flow)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=SPIDER_USER_DATA
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/spider/test_config_flow.py
+++ b/tests/components/spider/test_config_flow.py
@@ -89,7 +89,7 @@ async def test_abort_if_already_setup(hass, spider):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
 
     # Should fail, config exist (flow)
     result = await hass.config_entries.flow.async_init(
@@ -97,4 +97,4 @@ async def test_abort_if_already_setup(hass, spider):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"


### PR DESCRIPTION
## Proposed change
I moved the spider integration to the GUI configurator. The yaml version still works and data is imported. I still see some IO blocking events, so that is something I need to brush away in a following iteration.

As I am not a python developer, any input is welcome on this piece. I mainly took a look on the Blink and Tuya integration and got my inspiration from them. (So credits to those maintainers).

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/13720

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml
spider:
    username: test@test.com
    password: test
```

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
