### PR TITLE
Fix ONVIF config entry unique ID

### DIFF
--- a/homeassistant/components/onvif/base.py
+++ b/homeassistant/components/onvif/base.py
@@ -2,6 +2,7 @@
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import Entity
 
+from .const import DOMAIN
 from .device import ONVIFDevice
 from .models import Profile
 
@@ -11,8 +12,8 @@ class ONVIFBaseEntity(Entity):
 
     def __init__(self, device: ONVIFDevice, profile: Profile = None) -> None:
         """Initialize the ONVIF entity."""
-        self.device = device
-        self.profile = profile
+        self.device: ONVIFDevice = device
+        self.profile: Profile = profile
 
     @property
     def available(self):
@@ -22,10 +23,17 @@ class ONVIFBaseEntity(Entity):
     @property
     def device_info(self):
         """Return a device description for device registry."""
-        return {
-            "connections": {(CONNECTION_NETWORK_MAC, self.device.info.mac)},
+        device_info = {
+            "identifiers": {(DOMAIN, self.device.info.serial_number)},
             "manufacturer": self.device.info.manufacturer,
             "model": self.device.info.model,
             "name": self.device.name,
             "sw_version": self.device.info.fw_version,
         }
+
+        if self.device.info.mac:
+            device_info["connections"] = {
+                (CONNECTION_NETWORK_MAC, self.device.info.mac)
+            }
+
+        return device_info

--- a/homeassistant/components/onvif/base.py
+++ b/homeassistant/components/onvif/base.py
@@ -24,12 +24,20 @@ class ONVIFBaseEntity(Entity):
     def device_info(self):
         """Return a device description for device registry."""
         device_info = {
-            "identifiers": {(DOMAIN, self.device.info.serial_number)},
             "manufacturer": self.device.info.manufacturer,
             "model": self.device.info.model,
             "name": self.device.name,
             "sw_version": self.device.info.fw_version,
         }
+
+        # MAC address is not always available, and given the number
+        # of non-conformant ONVIF devices we have historically supported,
+        # we can not guarantee serial number either.  Due to this, we have
+        # adopted an either/or approach in the config entry setup, and can
+        # guarantee that one or the other will be populated.
+        # See: https://github.com/home-assistant/core/issues/35883
+        if self.device.info.serial_number:
+            device_info["identifiers"] = {(DOMAIN, self.device.info.serial_number)}
 
         if self.device.info.mac:
             device_info["connections"] = {

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -96,8 +96,8 @@ class ONVIFCameraEntity(ONVIFBaseEntity, Camera):
     def unique_id(self) -> str:
         """Return a unique ID."""
         if self.profile.index:
-            return f"{self.device.info.mac}_{self.profile.index}"
-        return self.device.info.mac
+            return f"{self.device.info.mac or self.device.info.serial_number}_{self.profile.index}"
+        return self.device.info.mac or self.device.info.serial_number
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -198,18 +198,18 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await device.update_xaddrs()
 
         try:
-            devicemgmt = device.create_devicemgmt_service()
+            device_mgmt = device.create_devicemgmt_service()
 
             # Get the MAC address to use as the unique ID for the config flow
             if not self.device_id:
-                network_interfaces = await devicemgmt.GetNetworkInterfaces()
+                network_interfaces = await device_mgmt.GetNetworkInterfaces()
                 for interface in network_interfaces:
                     if interface.Enabled:
                         self.device_id = interface.Info.HwAddress
 
             # If no network interfaces are exposed, fallback to serial number
             if not self.device_id:
-                device_info = await devicemgmt.GetDeviceInformation()
+                device_info = await device_mgmt.GetDeviceInformation()
                 self.device_id = device_info.SerialNumber
 
             if not self.device_id:

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -169,6 +169,9 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.onvif_config[CONF_PASSWORD] = user_input[CONF_PASSWORD]
             return await self.async_step_profiles()
 
+        # Password is optional and default empty due to some cameras not
+        # allowing you to change ONVIF user settings.
+        # See https://github.com/home-assistant/core/issues/35904
         return self.async_show_form(
             step_id="auth",
             data_schema=vol.Schema(

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -172,7 +172,10 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="auth",
             data_schema=vol.Schema(
-                {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+                {
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Optional(CONF_PASSWORD, default=""): str,
+                }
             ),
         )
 

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -214,11 +214,20 @@ class ONVIFDevice:
         """Obtain information about this device."""
         devicemgmt = self.device.create_devicemgmt_service()
         device_info = await devicemgmt.GetDeviceInformation()
+
+        # Grab the last MAC address for backwards compatibility
+        mac = None
+        network_interfaces = await devicemgmt.GetNetworkInterfaces()
+        for interface in network_interfaces:
+            if interface.Enabled:
+                mac = interface.Info.HwAddress
+
         return DeviceInfo(
             device_info.Manufacturer,
             device_info.Model,
             device_info.FirmwareVersion,
-            self.config_entry.unique_id,
+            device_info.SerialNumber,
+            mac,
         )
 
     async def async_get_capabilities(self):

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -148,12 +148,12 @@ class ONVIFDevice:
     async def async_check_date_and_time(self) -> None:
         """Warns if device and system date not synced."""
         LOGGER.debug("Setting up the ONVIF device management service")
-        devicemgmt = self.device.create_devicemgmt_service()
+        device_mgmt = self.device.create_devicemgmt_service()
 
         LOGGER.debug("Retrieving current device date/time")
         try:
             system_date = dt_util.utcnow()
-            device_time = await devicemgmt.GetSystemDateAndTime()
+            device_time = await device_mgmt.GetSystemDateAndTime()
             if not device_time:
                 LOGGER.debug(
                     """Couldn't get device '%s' date/time.
@@ -212,12 +212,12 @@ class ONVIFDevice:
 
     async def async_get_device_info(self) -> DeviceInfo:
         """Obtain information about this device."""
-        devicemgmt = self.device.create_devicemgmt_service()
-        device_info = await devicemgmt.GetDeviceInformation()
+        device_mgmt = self.device.create_devicemgmt_service()
+        device_info = await device_mgmt.GetDeviceInformation()
 
         # Grab the last MAC address for backwards compatibility
         mac = None
-        network_interfaces = await devicemgmt.GetNetworkInterfaces()
+        network_interfaces = await device_mgmt.GetNetworkInterfaces()
         for interface in network_interfaces:
             if interface.Enabled:
                 mac = interface.Info.HwAddress

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -62,7 +62,8 @@ class EventManager:
     @callback
     def async_remove_listener(self, update_callback: CALLBACK_TYPE) -> None:
         """Remove data update."""
-        self._listeners.remove(update_callback)
+        if update_callback in self._listeners:
+            self._listeners.remove(update_callback)
 
         if not self._listeners and self._unsub_refresh:
             self._unsub_refresh()
@@ -93,6 +94,8 @@ class EventManager:
 
     async def async_stop(self) -> None:
         """Unsubscribe from events."""
+        self._listeners = []
+
         if not self._subscription:
             return
 

--- a/homeassistant/components/onvif/models.py
+++ b/homeassistant/components/onvif/models.py
@@ -10,6 +10,7 @@ class DeviceInfo:
     manufacturer: str = None
     model: str = None
     fw_version: str = None
+    serial_number: str = None
     mac: str = None
 
 

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -1,13 +1,11 @@
 """Test ONVIF config flow."""
-from asyncio import Future
-
-from asynctest import MagicMock, patch
 from onvif.exceptions import ONVIFError
 from zeep.exceptions import Fault
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.onvif import config_flow
 
+from tests.async_mock import AsyncMock, MagicMock, patch
 from tests.common import MockConfigEntry
 
 URN = "urn:uuid:123456789"
@@ -49,16 +47,14 @@ def setup_mock_onvif_camera(
 
     device_info = MagicMock()
     device_info.SerialNumber = SERIAL_NUMBER if with_serial else None
-    devicemgmt.GetDeviceInformation.return_value = Future()
-    devicemgmt.GetDeviceInformation.return_value.set_result(device_info)
+    devicemgmt.GetDeviceInformation = AsyncMock(return_value=device_info)
 
     interface = MagicMock()
     interface.Enabled = True
     interface.Info.HwAddress = MAC
 
-    devicemgmt.GetNetworkInterfaces.return_value = Future()
-    devicemgmt.GetNetworkInterfaces.return_value.set_result(
-        [interface] if with_interfaces else []
+    devicemgmt.GetNetworkInterfaces = AsyncMock(
+        return_value=[interface] if with_interfaces else []
     )
 
     media_service = MagicMock()
@@ -68,11 +64,9 @@ def setup_mock_onvif_camera(
     profile2 = MagicMock()
     profile2.VideoEncoderConfiguration.Encoding = "H264" if two_profiles else "MJPEG"
 
-    media_service.GetProfiles.return_value = Future()
-    media_service.GetProfiles.return_value.set_result([profile1, profile2])
+    media_service.GetProfiles = AsyncMock(return_value=[profile1, profile2])
 
-    mock_onvif_camera.update_xaddrs.return_value = Future()
-    mock_onvif_camera.update_xaddrs.return_value.set_result(True)
+    mock_onvif_camera.update_xaddrs = AsyncMock(return_value=True)
     mock_onvif_camera.create_devicemgmt_service = MagicMock(return_value=devicemgmt)
     mock_onvif_camera.create_media_service = MagicMock(return_value=media_service)
 
@@ -126,8 +120,7 @@ def setup_mock_discovery(
 
 def setup_mock_device(mock_device):
     """Prepare mock ONVIFDevice."""
-    mock_device.async_setup.return_value = Future()
-    mock_device.async_setup.return_value.set_result(True)
+    mock_device.async_setup = AsyncMock(return_value=True)
 
     def mock_constructor(hass, config):
         """Fake the controller constructor."""


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes issue where some ONVIF devices do not expose MAC address through the API.  This falls back to the serial number as the config entry Unique ID, fixing #35883

While testing (adding and removing config entries after commenting out portions of code) I realized that the Event subscription is not ended properly when removing a config entry and will continue attempting to poll the device indefinitely until a Home Assistant reboot.  A fix for that is also included in this PR.

While playing around in config flow, I also made password optional which fixes #35904

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35883
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
