### PR TITLE
Catch BraviaTV exception for disabled IP Control or non supported TV

### DIFF
--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -135,7 +135,7 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.braviarc.connect, "0000", CLIENTID_PREFIX, NICKNAME,
             )
         except JSONDecodeError:
-            return self.async_abort(reason="unsupported_model")
+            return self.async_abort(reason="no_ip_control")
 
         return self.async_show_form(
             step_id="authorize",

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -1,5 +1,6 @@
 """Adds config flow for Bravia TV integration."""
 import ipaddress
+from json.decoder import JSONDecodeError
 import logging
 import re
 
@@ -129,9 +130,12 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=self.title, data=user_input)
 
         # Connecting with th PIN "0000" to start the pairing process on the TV.
-        await self.hass.async_add_executor_job(
-            self.braviarc.connect, "0000", CLIENTID_PREFIX, NICKNAME,
-        )
+        try:
+            await self.hass.async_add_executor_job(
+                self.braviarc.connect, "0000", CLIENTID_PREFIX, NICKNAME,
+            )
+        except JSONDecodeError:
+            return self.async_abort(reason="unsupported_model")
 
         return self.async_show_form(
             step_id="authorize",

--- a/homeassistant/components/braviatv/strings.json
+++ b/homeassistant/components/braviatv/strings.json
@@ -24,7 +24,7 @@
     "abort": {
       "already_configured": "This TV is already configured.",
       "cannot_connect": "Failed to connect.",
-      "unsupported_model": "Your TV model is not supported."
+      "no_ip_control": "IP Control is disabled on your TV or the TV is not supported."
     }
   },
   "options": {

--- a/homeassistant/components/braviatv/strings.json
+++ b/homeassistant/components/braviatv/strings.json
@@ -23,7 +23,6 @@
     },
     "abort": {
       "already_configured": "This TV is already configured.",
-      "cannot_connect": "Failed to connect.",
       "no_ip_control": "IP Control is disabled on your TV or the TV is not supported."
     }
   },

--- a/homeassistant/components/braviatv/strings.json
+++ b/homeassistant/components/braviatv/strings.json
@@ -22,7 +22,9 @@
       "unsupported_model": "Your TV model is not supported."
     },
     "abort": {
-      "already_configured": "This TV is already configured."
+      "already_configured": "This TV is already configured.",
+      "cannot_connect": "Failed to connect.",
+      "unsupported_model": "Your TV model is not supported."
     }
   },
   "options": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds catching the `JSONDecodeError` exception when IP Control is disabled on the TV or TV is not supported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35126
- This PR is related to issue: #35045
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
