### PR TITLE
Add OpenGarage config flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -557,6 +557,7 @@ omit =
     homeassistant/components/openevse/sensor.py
     homeassistant/components/openexchangerates/sensor.py
     homeassistant/components/opengarage/cover.py
+    homeassistant/components/opengarage/__init__.py
     homeassistant/components/openhome/media_player.py
     homeassistant/components/opensensemap/air_quality.py
     homeassistant/components/opensky/sensor.py

--- a/homeassistant/components/opengarage/__init__.py
+++ b/homeassistant/components/opengarage/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_DEVICE_KEY, DOMAIN  # pylint:disable=unused-import
+from .const import CONF_DEVICE_KEY, DOMAIN
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/opengarage/__init__.py
+++ b/homeassistant/components/opengarage/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_DEVICE_KEY, DOMAIN
+from .const import CONF_DEVICE_KEY, DOMAIN  # pylint:disable=unused-import
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/opengarage/__init__.py
+++ b/homeassistant/components/opengarage/__init__.py
@@ -18,6 +18,7 @@ PLATFORMS = ["cover"]
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the OpenGarage component."""
+    hass.data.setdefault(DOMAIN, {})
     return True
 
 
@@ -29,10 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry.data[CONF_VERIFY_SSL],
         async_get_clientsession(hass),
     )
-
-    # status = await open_garage.update_state()
-
-    hass.data[DOMAIN] = open_garage
+    hass.data[DOMAIN][entry.entry_id] = open_garage
 
     for component in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/opengarage/__init__.py
+++ b/homeassistant/components/opengarage/__init__.py
@@ -1,1 +1,58 @@
-"""The opengarage component."""
+"""The OpenGarage integration."""
+import asyncio
+
+import opengarage
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import CONF_DEVICE_KEY, DOMAIN
+
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+
+PLATFORMS = ["cover"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the OpenGarage component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up OpenGarage from a config entry."""
+    open_garage = opengarage.OpenGarage(
+        f"{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}",
+        entry.data[CONF_DEVICE_KEY],
+        entry.data[CONF_VERIFY_SSL],
+        async_get_clientsession(hass),
+    )
+
+    # status = await open_garage.update_state()
+
+    hass.data[DOMAIN] = open_garage
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/opengarage/config_flow.py
+++ b/homeassistant/components/opengarage/config_flow.py
@@ -1,0 +1,81 @@
+"""Config flow for OpenGarage integration."""
+import logging
+
+import aiohttp
+import opengarage
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import slugify
+
+from .const import CONF_DEVICE_KEY, DEFAULT_PORT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_KEY): str,
+        vol.Required(CONF_HOST): str,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Optional(CONF_VERIFY_SSL, default=False): bool,
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    open_garage = opengarage.OpenGarage(
+        f"{data[CONF_HOST]}:{data[CONF_PORT]}",
+        data[CONF_DEVICE_KEY],
+        data[CONF_VERIFY_SSL],
+        async_get_clientsession(hass),
+    )
+
+    status = await open_garage.update_state()
+    if status is None:
+        raise InvalidAuth
+
+    return {"title": status.get("name"), "unique_id": slugify(status["mac"])}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for OpenGarage."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            info = None
+            try:
+                info = await validate_input(self.hass, user_input)
+            except (aiohttp.ClientError, aiohttp.ClientConnectorError):
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+            if info:
+                await self.async_set_unique_id(info["unique_id"])
+                self._abort_if_unique_id_configured(
+                    updates={CONF_HOST: user_input[CONF_HOST]}
+                )
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/opengarage/config_flow.py
+++ b/homeassistant/components/opengarage/config_flow.py
@@ -66,9 +66,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if info:
                 await self.async_set_unique_id(info["unique_id"])
-                self._abort_if_unique_id_configured(
-                    updates={CONF_HOST: user_input[CONF_HOST]}
-                )
+                self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(title=info["title"], data=user_input)
 

--- a/homeassistant/components/opengarage/config_flow.py
+++ b/homeassistant/components/opengarage/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util import slugify
+from homeassistant.helpers.device_registry import format_mac
 
 from .const import CONF_DEVICE_KEY, DEFAULT_PORT, DOMAIN
 
@@ -40,7 +40,7 @@ async def validate_input(hass: core.HomeAssistant, data):
     if status is None:
         raise InvalidAuth
 
-    return {"title": status.get("name"), "unique_id": slugify(status["mac"])}
+    return {"title": status.get("name"), "unique_id": format_mac(status["mac"])}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/opengarage/config_flow.py
+++ b/homeassistant/components/opengarage/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
 
-from .const import CONF_DEVICE_KEY, DEFAULT_PORT, DOMAIN
+from .const import CONF_DEVICE_KEY, DEFAULT_PORT, DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/opengarage/const.py
+++ b/homeassistant/components/opengarage/const.py
@@ -1,0 +1,11 @@
+"""Constants for the OpenGarage integration."""
+
+ATTR_DISTANCE_SENSOR = "distance_sensor"
+ATTR_DOOR_STATE = "door_state"
+ATTR_SIGNAL_STRENGTH = "wifi_signal"
+
+CONF_DEVICE_KEY = "device_key"
+
+DEFAULT_NAME = "OpenGarage"
+DEFAULT_PORT = 80
+DOMAIN = "opengarage"

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -29,7 +29,7 @@ class OpenGarageCover(CoverEntity):
     def __init__(self, open_garage, device_id):
         """Initialize the cover."""
         self._open_garage = open_garage
-        self._name = ""
+        self._name = None
         self._state = None
         self._state_before_move = None
         self._device_state_attributes = {}
@@ -95,8 +95,6 @@ class OpenGarageCover(CoverEntity):
         _LOGGER.debug("%s status: %s", self._name, self._state)
         if status.get("rssi") is not None:
             self._device_state_attributes[ATTR_SIGNAL_STRENGTH] = status.get("rssi")
-        if status.get("name") is not None:
-            self._name = status.get("name")
         if status.get("dist") is not None:
             self._device_state_attributes[ATTR_DISTANCE_SENSOR] = status.get("dist")
         if self._state is not None:
@@ -131,14 +129,9 @@ class OpenGarageCover(CoverEntity):
         return SUPPORT_OPEN | SUPPORT_CLOSE
 
     @property
-    def device_id(self):
-        """Return the ID of the physical device this sensor is part of."""
-        return self._device_id
-
-    @property
     def unique_id(self):
         """Return a unique ID."""
-        return f"{self.device_id}_cover"
+        return self._device_id
 
     @property
     def device_info(self):

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -7,15 +7,7 @@ from homeassistant.components.cover import (
     SUPPORT_OPEN,
     CoverEntity,
 )
-from homeassistant.const import (
-    CONF_COVERS,
-    CONF_NAME,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-)
-from homeassistant.util import slugify
+from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
 
 from .const import ATTR_DISTANCE_SENSOR, ATTR_DOOR_STATE, ATTR_SIGNAL_STRENGTH, DOMAIN
 
@@ -27,20 +19,14 @@ STATES_MAP = {0: STATE_CLOSED, 1: STATE_OPEN}
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the OpenGarage covers."""
-    covers = []
-    open_garage = hass.data.get(DOMAIN)
-    devices = entry.data[CONF_COVERS]
-
-    for device_config in devices.values():
-        covers.append(OpenGarageCover(device_config.get(CONF_NAME), open_garage))
-
-    async_add_entities(covers, True)
+    open_garage = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([OpenGarageCover(open_garage, entry.unique_id)], True)
 
 
 class OpenGarageCover(CoverEntity):
     """Representation of a OpenGarage cover."""
 
-    def __init__(self, open_garage, mac):
+    def __init__(self, open_garage, device_id):
         """Initialize the cover."""
         self._open_garage = open_garage
         self._name = ""
@@ -48,7 +34,7 @@ class OpenGarageCover(CoverEntity):
         self._state_before_move = None
         self._device_state_attributes = {}
         self._available = True
-        self._device_id = slugify(mac)
+        self._device_id = device_id
 
     @property
     def name(self):
@@ -161,6 +147,4 @@ class OpenGarageCover(CoverEntity):
             "name": self.name,
             "manufacturer": "Open Garage",
         }
-        if self.model is not None:
-            device_info["model"] = self.model
         return device_info

--- a/homeassistant/components/opengarage/manifest.json
+++ b/homeassistant/components/opengarage/manifest.json
@@ -1,9 +1,16 @@
 {
   "domain": "opengarage",
   "name": "OpenGarage",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/opengarage",
+  "requirements": [
+    "open-garage==0.1.4"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
   "codeowners": [
     "@danielhiversen"
-  ],
-  "requirements": ["open-garage==0.1.4"]
+  ]
 }

--- a/homeassistant/components/opengarage/manifest.json
+++ b/homeassistant/components/opengarage/manifest.json
@@ -6,10 +6,6 @@
   "requirements": [
     "open-garage==0.1.4"
   ],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
   "codeowners": [
     "@danielhiversen"
   ]

--- a/homeassistant/components/opengarage/strings.json
+++ b/homeassistant/components/opengarage/strings.json
@@ -1,0 +1,24 @@
+{
+  "title": "OpenGarage",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "device_key": "Device key",
+          "verify_ssl": "Verify ssl"
+        },
+      "description": "Host should start with http or https"
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -106,6 +106,7 @@ FLOWS = [
     "nut",
     "nws",
     "onvif",
+    "opengarage",
     "opentherm_gw",
     "openuv",
     "owntracks",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -422,6 +422,9 @@ oauth2client==4.0.0
 # homeassistant.components.onvif
 onvif-zeep-async==0.3.0
 
+# homeassistant.components.opengarage
+open-garage==0.1.2
+
 # homeassistant.components.openerz
 openerz-api==0.1.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -423,7 +423,7 @@ oauth2client==4.0.0
 onvif-zeep-async==0.3.0
 
 # homeassistant.components.opengarage
-open-garage==0.1.2
+open-garage==0.1.4
 
 # homeassistant.components.openerz
 openerz-api==0.1.0

--- a/tests/components/opengarage/__init__.py
+++ b/tests/components/opengarage/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the OpenGarage integration."""

--- a/tests/components/opengarage/test_config_flow.py
+++ b/tests/components/opengarage/test_config_flow.py
@@ -1,0 +1,101 @@
+"""Test the OpenGarage config flow."""
+import aiohttp
+
+from homeassistant import config_entries, setup
+from homeassistant.components.opengarage.const import DOMAIN
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "opengarage.OpenGarage.update_state",
+        return_value={"name": "Name of the device", "mac": "unique"},
+    ), patch(
+        "homeassistant.components.opengarage.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.opengarage.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "http://1.1.1.1", "device_key": "AfsasdnfkjDD"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "http://1.1.1.1",
+        "device_key": "AfsasdnfkjDD",
+        "port": 80,
+        "verify_ssl": False,
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "opengarage.OpenGarage.update_state", side_effect=aiohttp.ClientError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "http://1.1.1.1", "device_key": "AfsasdnfkjDD"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "opengarage.OpenGarage.update_state", return_value=None,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "http://1.1.1.1", "device_key": "AfsasdnfkjDD"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_flow_entry_already_exists(hass):
+    """Test user input for config_entry that already exists."""
+    first_entry = MockConfigEntry(
+        domain="opengarage",
+        data={"host": "http://1.1.1.1", "device_key": "AfsasdnfkjDD"},
+        unique_id="unique",
+    )
+    first_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "opengarage.OpenGarage.update_state",
+        return_value={"name": "Name of the device", "mac": "unique"},
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "http://1.1.1.1", "device_key": "AfsasdnfkjDD"},
+        )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
OpenGarage can no longer be configured via configuration.yaml, configuration is now done though UI



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add OpenGarage config flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13562

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
