### PR TITLE
Bump aiohomekit

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -89,10 +89,6 @@ class HKDevice:
         # mapped to a HA entity.
         self.entities = []
 
-        # There are multiple entities sharing a single connection - only
-        # allow one entity to use pairing at once.
-        self.pairing_lock = asyncio.Lock()
-
         self.available = True
 
         self.signal_state_updated = "_".join((DOMAIN, self.unique_id, "state_updated"))
@@ -333,13 +329,11 @@ class HKDevice:
 
     async def get_characteristics(self, *args, **kwargs):
         """Read latest state from homekit accessory."""
-        async with self.pairing_lock:
-            return await self.pairing.get_characteristics(*args, **kwargs)
+        return await self.pairing.get_characteristics(*args, **kwargs)
 
     async def put_characteristics(self, characteristics):
         """Control a HomeKit device state from Home Assistant."""
-        async with self.pairing_lock:
-            results = await self.pairing.put_characteristics(characteristics)
+        results = await self.pairing.put_characteristics(characteristics)
 
         # Feed characteristics back into HA and update the current state
         # results will only contain failures, so anythin in characteristics

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.37"],
+  "requirements": ["aiohomekit[IP]==0.2.38"],
   "zeroconf": ["_hap._tcp.local."],
   "codeowners": ["@Jc2k"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -175,7 +175,7 @@ aioftp==0.12.0
 aioharmony==0.1.13
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.37
+aiohomekit[IP]==0.2.38
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -82,7 +82,7 @@ aiofreepybox==0.0.8
 aioharmony==0.1.13
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.37
+aiohomekit[IP]==0.2.38
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Proposed change

Bump aiohomekit to pick up some fixes:

 * [Fixes unknown parser state with homebridge](https://github.com/Jc2k/aiohomekit/issues/1)
 * [Fix zeroconf dependency to not conflict with HA](https://github.com/home-assistant/core/issues/35981) (see also https://github.com/Jc2k/aiohomekit/pull/3).
 * [Avoid concurrent subscribe requests as some devices can't handle it by forcing serial (but still async) use of the connection](https://github.com/home-assistant/core/issues/33511). Improves async support on Aqara.
 * Serialize JSON without spaces, as the Tado JSON parser can't handle spaces between tokens in dicts. May fix async support for some devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35981 #33511
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
