### PR TITLE
Use off state when roku tv is in standby

### DIFF
--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -17,7 +17,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.const import STATE_HOME, STATE_IDLE, STATE_PLAYING, STATE_STANDBY
+from homeassistant.const import STATE_HOME, STATE_IDLE, STATE_OFF, STATE_PLAYING
 
 from . import RokuDataUpdateCoordinator, RokuEntity
 from .const import DOMAIN
@@ -67,7 +67,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     def state(self) -> str:
         """Return the state of the device."""
         if self.coordinator.data.state.standby:
-            return STATE_STANDBY
+            return STATE_OFF
 
         if self.coordinator.data.app is None:
             return None

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -42,8 +42,8 @@ from homeassistant.const import (
     SERVICE_VOLUME_UP,
     STATE_HOME,
     STATE_IDLE,
+    STATE_OFF,
     STATE_PLAYING,
-    STATE_STANDBY,
     STATE_UNAVAILABLE,
 )
 from homeassistant.helpers.typing import HomeAssistantType
@@ -75,14 +75,14 @@ async def test_setup(
     assert main.unique_id == UPNP_SERIAL
 
 
-async def test_idle_setup(
+async def test_standby_setup(
     hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test setup with idle device."""
+    """Test setup with device in low power/always on mode."""
     await setup_integration(hass, aioclient_mock, power=False)
 
     state = hass.states.get(MAIN_ENTITY_ID)
-    assert state.state == STATE_STANDBY
+    assert state.state == STATE_OFF
 
 
 async def test_tv_setup(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Roku is now considered off when it is in standby. Please ensure any automations use the "off" state rather than "standby" state 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Roku used STATE_STANDBY to represent when device was in low power/always on mode. This applies most to ROKU TVs. STATE_IDLE was used when any device is displaying screensaver or power saver "app". https://support.roku.com/article/231541927-can-i-power-my-roku-streaming-player-on-or-off-

STATE_STANDBY was never officially supported within the media player component but STATE_IDLE was. This leads to some UI and other integrations to incorrectly handle the state. One example being that once you turn off the device with lovelace power button, you cant turn it back on because it thinks the device is ON.

There is an architecture issue for this but it hasnt gained much traction. Honestly for Roku, STATE_OFF does make sense because the screen is off and only the chip inside the TV is running. Since rokus are normally an always on device, to allow quick control, if you cant reach the API they will be considered STATE_UNAVAILABLE which is basically the Roku's true off state with the exception of TVs which combine a screen with the roku chip meaning there is a state when screen is off and chip is on

ref https://github.com/home-assistant/architecture/issues/352


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
