### PR TITLE
Add support for showing text on Keba EV chargers

### DIFF
--- a/homeassistant/components/keba/__init__.py
+++ b/homeassistant/components/keba/__init__.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "keba"
-SUPPORTED_COMPONENTS = ["binary_sensor", "sensor", "lock"]
+SUPPORTED_COMPONENTS = ["binary_sensor", "sensor", "lock", "notify"]
 
 CONF_RFID = "rfid"
 CONF_FS = "failsafe"
@@ -238,10 +238,3 @@ class KebaHandler(KebaKeContact):
                 "failsafe_persist value are not correct. %s",
                 ex,
             )
-
-    async def async_set_text(self, param):
-        """Set text in async way."""
-        text = param["text"].replace(" ", "$")
-        min_time = param["min_time"]
-        max_time = param["max_time"]
-        await self.set_text(text, int(min_time), int(max_time))

--- a/homeassistant/components/keba/__init__.py
+++ b/homeassistant/components/keba/__init__.py
@@ -50,7 +50,6 @@ _SERVICE_MAP = {
     "enable": "async_enable_ev",
     "disable": "async_disable_ev",
     "set_failsafe": "async_set_failsafe",
-    "set_text": "async_set_text",
 }
 
 

--- a/homeassistant/components/keba/__init__.py
+++ b/homeassistant/components/keba/__init__.py
@@ -50,6 +50,7 @@ _SERVICE_MAP = {
     "enable": "async_enable_ev",
     "disable": "async_disable_ev",
     "set_failsafe": "async_set_failsafe",
+    "set_text": "async_set_text",
 }
 
 
@@ -237,3 +238,10 @@ class KebaHandler(KebaKeContact):
                 "failsafe_persist value are not correct. %s",
                 ex,
             )
+
+    async def async_set_text(self, param):
+        """Set text in async way."""
+        text = param["text"].replace(" ", "$")
+        min_time = param["min_time"]
+        max_time = param["max_time"]
+        await self.set_text(text, int(min_time), int(max_time))

--- a/homeassistant/components/keba/manifest.json
+++ b/homeassistant/components/keba/manifest.json
@@ -2,6 +2,6 @@
   "domain": "keba",
   "name": "Keba Charging Station",
   "documentation": "https://www.home-assistant.io/integrations/keba",
-  "requirements": ["keba-kecontact==1.0.0"],
+  "requirements": ["keba-kecontact==1.1.0"],
   "codeowners": ["@dannerph"]
 }

--- a/homeassistant/components/keba/notify.py
+++ b/homeassistant/components/keba/notify.py
@@ -26,8 +26,8 @@ class KebaNotificationService(BaseNotificationService):
         """Send the message."""
         text = message.replace(" ", "$")  # Will be translated back by the display
 
-        data = kwargs.get(ATTR_DATA)
-        min_time = float(data.get("min_time", 2) if data else 2)
-        max_time = float(data.get("max_time", 10) if data else 10)
+        data = kwargs[ATTR_DATA] or {}
+        min_time = float(data.get("min_time", 2))
+        max_time = float(data.get("max_time", 10))
 
         await self._client.set_text(text, min_time, max_time)

--- a/homeassistant/components/keba/notify.py
+++ b/homeassistant/components/keba/notify.py
@@ -1,0 +1,33 @@
+"""Support for Keba notifications."""
+import logging
+
+from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_get_service(hass, config, discovery_info=None):
+    """Return the notify service."""
+
+    client = hass.data[DOMAIN]
+    return KebaNotificationService(client)
+
+
+class KebaNotificationService(BaseNotificationService):
+    """Notification service for KEBA EV Chargers."""
+
+    def __init__(self, client):
+        """Initialize the service."""
+        self._client = client
+
+    async def async_send_message(self, message="", **kwargs):
+        """Send the message."""
+        text = message.replace(" ", "$")  # Will be translated back by the display
+
+        data = kwargs.get(ATTR_DATA)
+        min_time = float(data.get("min_time", 2) if data else 2)
+        max_time = float(data.get("max_time", 10) if data else 10)
+
+        await self._client.set_text(text, min_time, max_time)

--- a/homeassistant/components/keba/services.yaml
+++ b/homeassistant/components/keba/services.yaml
@@ -38,6 +38,21 @@ disable:
   description: >
     Stops the charging process if charging station is authorized.
 
+set_text:
+  description: Display a text message on the charger display.
+  fields:
+    text:
+      description: Text to Display. Maximum 23 chars.
+      example: "Hello"
+    min_time:
+      description: >
+        Duration in seconds of the text message before next message will be displayed.
+      example: 2
+    max_time:
+      description:
+        Duration in seconds of the text message if no more messages are set.
+      example: 10
+
 set_failsafe:
   description: >
     Set the failsafe mode of the charging station. If all parameters are 0, the failsafe mode will be disabled.

--- a/homeassistant/components/keba/services.yaml
+++ b/homeassistant/components/keba/services.yaml
@@ -38,21 +38,6 @@ disable:
   description: >
     Stops the charging process if charging station is authorized.
 
-set_text:
-  description: Display a text message on the charger display.
-  fields:
-    text:
-      description: Text to Display. Maximum 23 chars.
-      example: "Hello"
-    min_time:
-      description: >
-        Duration in seconds of the text message before next message will be displayed.
-      example: 2
-    max_time:
-      description:
-        Duration in seconds of the text message if no more messages are set.
-      example: 10
-
 set_failsafe:
   description: >
     Set the failsafe mode of the charging station. If all parameters are 0, the failsafe mode will be disabled.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -807,7 +807,7 @@ jsonrpc-websocket==0.6
 kaiterra-async-client==0.0.2
 
 # homeassistant.components.keba
-keba-kecontact==1.0.0
+keba-kecontact==1.1.0
 
 # homeassistant.scripts.keyring
 keyring==21.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Keba EV Chargers contain a programmable LED text display. This change adds a service for outputting a text message on that display for a specified time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [https://github.com/home-assistant/home-assistant.io/pull/13577](https://github.com/home-assistant/home-assistant.io/pull/13577)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
