### PR TITLE
[WIP] Add vaillant integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -435,6 +435,7 @@ homeassistant/components/upnp/* @StevenLooman
 homeassistant/components/uptimerobot/* @ludeeus
 homeassistant/components/usgs_earthquakes_feed/* @exxamalte
 homeassistant/components/utility_meter/* @dgomes
+homeassistant/components/vaillant/* @thomasgermain
 homeassistant/components/velbus/* @Cereal2nd @brefra
 homeassistant/components/velux/* @Julius2342
 homeassistant/components/vera/* @vangorra

--- a/homeassistant/components/vaillant/__init__.py
+++ b/homeassistant/components/vaillant/__init__.py
@@ -1,0 +1,66 @@
+"""The vaillant integration."""
+import asyncio
+from datetime import timedelta
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_SERIAL_NUMBER, DOMAIN, PLATFORMS
+from .hub import ApiHub, DomainData
+from .service import SERVICES, VaillantServiceHandler
+
+SCAN_INTERVAL = timedelta(minutes=1)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the vaillant component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up vaillant from a config entry."""
+
+    username = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+    serial = entry.data.get(CONF_SERIAL_NUMBER)
+    api: ApiHub = ApiHub(hass, username, password, serial)
+    await api.authenticate()
+    await api.update_system()
+
+    hass.data[DOMAIN] = DomainData(api, entry)
+
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+
+    service_handler = VaillantServiceHandler(api, hass)
+    for vaillant_service in SERVICES:
+        schema = SERVICES[vaillant_service]["schema"]
+        method_name = SERVICES[vaillant_service]["method"]
+        method = getattr(service_handler, method_name)
+        hass.services.async_register(DOMAIN, vaillant_service, method, schema=schema)
+
+    async def logout(param):
+        await api.logout()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, logout)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data.pop(DOMAIN)
+
+    return unload_ok

--- a/homeassistant/components/vaillant/binary_sensor.py
+++ b/homeassistant/components/vaillant/binary_sensor.py
@@ -1,0 +1,474 @@
+"""Interfaces with Vaillant binary sensors."""
+
+from abc import ABC
+import logging
+
+from pymultimatic.model import (
+    BoilerStatus,
+    Circulation,
+    Device,
+    Error,
+    HolidayMode,
+    OperatingModes,
+    QuickMode,
+    QuickModes,
+    Room,
+    SettingModes,
+    SystemInfo,
+)
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_LOCK,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_PROBLEM,
+    DEVICE_CLASS_WINDOW,
+    DOMAIN,
+    BinarySensorEntity,
+)
+from homeassistant.util import Throttle
+
+from . import ApiHub
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN as VAILLANT
+from .entities import (
+    VaillantBoilerEntity,
+    VaillantBoxEntity,
+    VaillantEntity,
+    VaillantRoomEntity,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Vaillant binary sensor platform."""
+    sensors = []
+    hub: ApiHub = hass.data[VAILLANT].api
+    if hub.system:
+        if hub.system.dhw and hub.system.dhw.circulation:
+            sensors.append(CirculationSensor(hub.system.dhw.circulation))
+
+        if hub.system.boiler_status:
+            sensors.append(BoilerError(hub.system.boiler_status))
+
+        if hub.system.info:
+            sensors.append(BoxOnline(hub.system.info))
+            sensors.append(BoxUpdate(hub.system.info))
+
+        for room in hub.system.rooms:
+            sensors.append(RoomWindow(room))
+            for device in room.devices:
+                if device.device_type == "VALVE":
+                    sensors.append(RoomDeviceChildLock(device, room))
+
+                sensors.append(RoomDeviceBattery(device, room))
+                sensors.append(RoomDeviceConnectivity(device, room))
+
+        entity = HolidayModeSensor(hub.system.holiday)
+        sensors.append(entity)
+
+        entity = QuickModeSensor(hub.system.quick_mode)
+        sensors.append(entity)
+
+        handler = VaillantSystemErrorHandler(
+            hub, hass, async_add_entities, DEFAULT_SCAN_INTERVAL
+        )
+        await handler.update()
+
+    _LOGGER.info("Adding %s binary sensor entities", len(sensors))
+
+    async_add_entities(sensors, True)
+    return True
+
+
+class CirculationSensor(VaillantEntity, BinarySensorEntity):
+    """Binary sensor for circulation running on or not."""
+
+    def __init__(self, circulation: Circulation):
+        """Initialize entity."""
+        super().__init__(
+            DOMAIN, DEVICE_CLASS_POWER, circulation.id, circulation.name, False
+        )
+        self._circulation = circulation
+        self._active_mode = None
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+
+        return (
+            self._active_mode.current == OperatingModes.ON
+            or self._active_mode.sub == SettingModes.ON
+            or self._active_mode.current == QuickModes.HOTWATER_BOOST
+        )
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._circulation is not None
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        self._circulation = self.hub.system.dhw.circulation
+        self._active_mode = self.hub.system.get_active_mode_circulation()
+
+
+class RoomWindow(VaillantEntity, BinarySensorEntity):
+    """Vaillant window binary sensor."""
+
+    def __init__(self, room: Room):
+        """Initialize entity."""
+        super().__init__(DOMAIN, DEVICE_CLASS_WINDOW, room.name, room.name)
+        self._room = room
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._room.window_open
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._room is not None
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        new_room: Room = self.hub.find_component(self._room)
+
+        if new_room:
+            _LOGGER.debug(
+                "New / old state: %s / %s", new_room.child_lock, self._room.child_lock
+            )
+        else:
+            _LOGGER.debug("Room %s doesn't exist anymore", self._room.id)
+        self._room = new_room
+
+
+class RoomDevice(VaillantEntity, VaillantRoomEntity, BinarySensorEntity, ABC):
+    """Base class for device in room."""
+
+    def __init__(self, device: Device, room: Room, device_class):
+        """Initialize entity."""
+        VaillantEntity.__init__(self, DOMAIN, device_class, device.sgtin, device.name)
+        VaillantRoomEntity.__init__(self, device)
+        self._room = room
+        self._device_class = device_class
+
+    # pylint: disable=no-self-use
+    def _find_device(self, new_room: Room, sgtin: str):
+        """Find a device in a room."""
+        if new_room:
+            for device in new_room.devices:
+                if device.sgtin == sgtin:
+                    return device
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.device is not None
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        new_room: Room = self.hub.find_component(self._room)
+        new_device: Device = self._find_device(new_room, self.device.sgtin)
+
+        if new_room:
+            if new_device:
+                _LOGGER.debug(
+                    "New / old state: %s / %s",
+                    new_device.battery_low,
+                    self.device.battery_low,
+                )
+            else:
+                _LOGGER.debug("Device %s doesn't exist anymore", self.device.sgtin)
+        else:
+            _LOGGER.debug("Room %s doesn't exist anymore", self._room.id)
+        self._room = new_room
+        self.device = new_device
+
+
+class RoomDeviceChildLock(RoomDevice, BinarySensorEntity):
+    """Binary sensor for valve child lock.
+
+    At vaillant API, the lock is set at a room level, but it applies to all
+    device inside the room.
+    """
+
+    def __init__(self, device: Device, room: Room):
+        """Initialize entity."""
+        super().__init__(device, room, DEVICE_CLASS_LOCK)
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._room is not None
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        new_room: Room = self.hub.find_component(self._room)
+
+        if new_room:
+            _LOGGER.debug(
+                "New / old state: %s / %s", new_room.child_lock, self._room.child_lock
+            )
+        else:
+            _LOGGER.debug("Room %s doesn't exist anymore", self._room.id)
+        self._room = new_room
+        self.device = self._find_device(new_room, self.device.sgtin)
+
+    @property
+    def is_on(self):
+        """According to the doc, true means unlock, false lock."""
+        return not self._room.child_lock
+
+
+class RoomDeviceBattery(RoomDevice):
+    """Represent a device battery."""
+
+    def __init__(self, device: Device, room: Room):
+        """Initialize entity."""
+        super().__init__(device, room, DEVICE_CLASS_BATTERY)
+
+    @property
+    def is_on(self):
+        """According to the doc, true means normal, false low."""
+        return self.device.battery_low
+
+
+class RoomDeviceConnectivity(RoomDevice):
+    """Device in room is out of reach or not."""
+
+    def __init__(self, device: Device, room: Room):
+        """Initialize entity."""
+        super().__init__(device, room, DEVICE_CLASS_CONNECTIVITY)
+
+    @property
+    def is_on(self):
+        """According to the doc, true means connected, false disconnected."""
+        return not self.device.radio_out_of_reach
+
+
+class BaseVaillantSystem(VaillantEntity, VaillantBoxEntity, BinarySensorEntity):
+    """Base class for system wide binary sensor."""
+
+    def __init__(self, info: SystemInfo, device_class, name, comp_id):
+        """Initialize entity."""
+        VaillantEntity.__init__(self, DOMAIN, device_class, name, comp_id, False)
+        VaillantBoxEntity.__init__(self, info)
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.system_info is not None
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        system_info: SystemInfo = self.hub.system.info
+
+        if system_info:
+            _LOGGER.debug(
+                "Found new system status " "online? %s, up to date? %s",
+                system_info.is_online,
+                system_info.is_up_to_date,
+            )
+        else:
+            _LOGGER.debug("System status doesn't exist anymore")
+        self.system_info = system_info
+
+
+class BoxUpdate(BaseVaillantSystem):
+    """Update binary sensor."""
+
+    def __init__(self, info: SystemInfo):
+        """Init."""
+        super().__init__(info, DEVICE_CLASS_POWER, "System update", "system_update")
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return not self.system_info.is_up_to_date
+
+
+class BoxOnline(BaseVaillantSystem):
+    """Check if box is online."""
+
+    def __init__(self, info: SystemInfo):
+        """Init."""
+        BaseVaillantSystem.__init__(
+            self, info, DEVICE_CLASS_CONNECTIVITY, "System Online", "system_online",
+        )
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self.system_info.is_online
+
+
+class BoilerError(VaillantEntity, BinarySensorEntity, VaillantBoilerEntity):
+    """Check if there is some error."""
+
+    def __init__(self, boiler_status: BoilerStatus):
+        """Initialize entity."""
+        VaillantEntity.__init__(
+            self,
+            DOMAIN,
+            DEVICE_CLASS_PROBLEM,
+            boiler_status.device_name,
+            boiler_status.device_name,
+            False,
+        )
+        VaillantBoilerEntity.__init__(self, boiler_status)
+        self._state_attrs = {}
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self.boiler_status is not None and self.boiler_status.is_error
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        if self.boiler_status is not None:
+            self._state_attrs = {
+                "status_code": self.boiler_status.status_code,
+                "title": self.boiler_status.title,
+                "timestamp": self.boiler_status.timestamp,
+            }
+        return self._state_attrs
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        _LOGGER.debug("new boiler status is %s", self.hub.system.boiler_status)
+        self.boiler_status = self.hub.system.boiler_status
+
+
+class VaillantSystemErrorHandler:
+    """Handler responsible for creating dynamically error binary sensor."""
+
+    def __init__(self, hub, hass, async_add_entities, scan_interval) -> None:
+        """Init."""
+        self.hub = hub
+        self._hass = hass
+        self._async_add_entities = async_add_entities
+        self.update = Throttle(scan_interval)(self._update)
+
+    async def _update(self):
+        if self.hub.system.errors:
+            reg = await self._hass.helpers.entity_registry.async_get_registry()
+
+            sensors = []
+            for error in self.hub.system.errors:
+                binary_sensor = VaillantSystemError(error)
+                if not reg.async_is_registered(binary_sensor.entity_id):
+                    sensors.append(binary_sensor)
+
+            if sensors:
+                self._async_add_entities(sensors)
+
+
+class VaillantSystemError(VaillantEntity, BinarySensorEntity):
+    """Check if there is any error message from system."""
+
+    def __init__(self, error: Error):
+        """Init."""
+        self._error = error
+        super().__init__(
+            DOMAIN,
+            DEVICE_CLASS_PROBLEM,
+            "error_" + error.status_code,
+            error.title,
+            False,
+        )
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        return {
+            "status_code": self._error.status_code,
+            "title": self._error.title,
+            "timestamp": self._error.timestamp,
+            "description": self._error.description,
+            "device_name": self._error.device_name,
+        }
+
+    async def vaillant_update(self):
+        """Update specific for vaillant.
+
+        Special attention during the update, the entity can remove itself
+        from registry if the error disappear from vaillant system.
+        """
+        errors = {e.status_code: e for e in self.hub.system.errors}
+
+        if self._error.status_code in [e.status_code for e in list(errors.values())]:
+            self._error = errors.get(self._error.status_code)
+        else:
+            self.hass.async_create_task(self._remove())
+
+    async def _remove(self):
+        """Remove entity itself."""
+        await self.async_remove()
+
+        reg = await self.hass.helpers.entity_registry.async_get_registry()
+        entity_id = reg.async_get_entity_id(DOMAIN, VAILLANT, self.unique_id)
+        if entity_id:
+            reg.async_remove(entity_id)
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return True
+
+
+class HolidayModeSensor(VaillantEntity, BinarySensorEntity):
+    """Binary sensor for holiday mode."""
+
+    def __init__(self, holiday_mode: HolidayMode):
+        """Init."""
+        super().__init__(DOMAIN, DEVICE_CLASS_POWER, "holiday", "holiday", False)
+        self._holiday = holiday_mode
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._holiday is not None and self._holiday.is_applied
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        if self.is_on:
+            return {
+                "start_date": self._holiday.start_date.isoformat(),
+                "end_date": self._holiday.end_date.isoformat(),
+                "temperature": self._holiday.target,
+            }
+        return {}
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        self._holiday = self.hub.system.holiday
+
+
+class QuickModeSensor(VaillantEntity, BinarySensorEntity):
+    """Binary sensor for holiday mode."""
+
+    def __init__(self, quick_mode: QuickMode):
+        """Init."""
+        super().__init__(DOMAIN, DEVICE_CLASS_POWER, "quick_mode", "quick_mode", False)
+        self._quick_mode = quick_mode
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._quick_mode is not None
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        if self.is_on:
+            return {"quick_mode": self._quick_mode.name}
+        return {}
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        self._quick_mode = self.hub.system.quick_mode

--- a/homeassistant/components/vaillant/climate.py
+++ b/homeassistant/components/vaillant/climate.py
@@ -1,0 +1,371 @@
+"""Interfaces with Vaillant climate."""
+
+import abc
+import logging
+from typing import Any, Dict, List, Optional
+
+from pymultimatic.model import (
+    ActiveMode,
+    Component,
+    Mode,
+    OperatingModes,
+    QuickModes,
+    Room,
+    System,
+    Zone,
+)
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    DOMAIN,
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+
+from .const import DOMAIN as VAILLANT
+from .entities import VaillantEntity
+from .utils import gen_state_attrs
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Vaillant climate platform."""
+    climates = []
+    hub = hass.data[VAILLANT].api
+
+    if hub.system:
+        if hub.system.zones:
+            for zone in hub.system.zones:
+                if not zone.rbr:
+                    entity = ZoneClimate(hub.system, zone)
+                    climates.append(entity)
+
+        if hub.system.rooms:
+            for room in hub.system.rooms:
+                entity = RoomClimate(hub.system, room)
+                climates.append(entity)
+
+    _LOGGER.info("Adding %s climate entities", len(climates))
+
+    async_add_entities(climates, True)
+    return True
+
+
+class VaillantClimate(VaillantEntity, ClimateEntity, abc.ABC):
+    """Base class for climate."""
+
+    def __init__(self, system: System, comp_name, comp_id, component: Component):
+        """Initialize entity."""
+        super().__init__(DOMAIN, None, comp_name, comp_id)
+        self._system = None
+        self.component = None
+        self._refresh(system, component)
+
+    @property
+    @abc.abstractmethod
+    def active_mode(self) -> ActiveMode:
+        """Get active mode of the climate."""
+
+    @property
+    def listening(self):
+        """Return whether this entity is listening for system changes or not."""
+        return True
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.component is not None
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement used by the platform."""
+        return TEMP_CELSIUS
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        _LOGGER.debug("Target temp is %s", self.active_mode.target)
+        return self.active_mode.target
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self.component.temperature
+
+    @property
+    def is_aux_heat(self) -> Optional[bool]:
+        """Return true if aux heater."""
+        return False
+
+    @property
+    def fan_mode(self) -> Optional[str]:
+        """Return the fan setting."""
+        return None
+
+    @property
+    def fan_modes(self) -> Optional[List[str]]:
+        """Return the list of available fan modes."""
+        return None
+
+    @property
+    def swing_mode(self) -> Optional[str]:
+        """Return the swing setting."""
+        return None
+
+    @property
+    def swing_modes(self) -> Optional[List[str]]:
+        """Return the list of available swing modes."""
+        return None
+
+    def set_humidity(self, humidity: int) -> None:
+        """Set new target humidity."""
+
+    def set_fan_mode(self, fan_mode: str) -> None:
+        """Set new target fan mode."""
+
+    def set_swing_mode(self, swing_mode: str) -> None:
+        """Set new target swing operation."""
+
+    def turn_aux_heat_on(self) -> None:
+        """Turn auxiliary heater on."""
+
+    def turn_aux_heat_off(self) -> None:
+        """Turn auxiliary heater off."""
+
+    @property
+    def target_temperature_high(self) -> Optional[float]:
+        """Return the highbound target temperature we try to reach."""
+        return None
+
+    @property
+    def target_temperature_low(self) -> Optional[float]:
+        """Return the lowbound target temperature we try to reach."""
+        return None
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+
+        hvac_mode = self.mode_to_hvac(self.active_mode.current)
+
+        if hvac_mode is None:
+            if self.active_mode.current in [
+                OperatingModes.QUICK_VETO,
+                OperatingModes.MANUAL,
+            ]:
+                if self._is_heating():
+                    hvac_mode = HVAC_MODE_HEAT
+                else:
+                    hvac_mode = HVAC_MODE_COOL
+            else:
+                _LOGGER.warning(
+                    "Unknown mode %s, will return None", self.active_mode.current
+                )
+        return hvac_mode
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        self._refresh(self.hub.system, self.hub.find_component(self.component))
+
+    def _refresh(self, system, component):
+        """Refresh the entity."""
+        self._system = system
+        self.component = component
+
+    def _is_heating(self):
+        return self.active_mode.target > self.component.temperature
+
+    @abc.abstractmethod
+    def mode_to_hvac(self, mode):
+        """Get the hvac mode based on vaillant mode."""
+
+
+class RoomClimate(VaillantClimate):
+    """Climate for a room."""
+
+    _MODE_TO_HVAC: Dict[Mode, str] = {
+        OperatingModes.AUTO: HVAC_MODE_AUTO,
+        OperatingModes.OFF: HVAC_MODE_OFF,
+        QuickModes.HOLIDAY: HVAC_MODE_OFF,
+        QuickModes.SYSTEM_OFF: HVAC_MODE_OFF,
+    }
+
+    _HVAC_TO_MODE: Dict[str, Mode] = {
+        HVAC_MODE_AUTO: OperatingModes.AUTO,
+        HVAC_MODE_OFF: OperatingModes.OFF,
+    }
+
+    _SUPPORTED_HVAC_MODE = list(set(_MODE_TO_HVAC.values()))
+
+    def __init__(self, system: System, room: Room):
+        """Initialize entity."""
+        super().__init__(system, room.name, room.name, room)
+
+    def mode_to_hvac(self, mode):
+        """Get the hvac mode based on vaillant mode."""
+        return self._MODE_TO_HVAC.get(mode, None)
+
+    @property
+    def hvac_modes(self) -> List[str]:
+        """Return the list of available hvac operation modes."""
+        return self._SUPPORTED_HVAC_MODE
+
+    @property
+    def preset_mode(self) -> Optional[str]:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return None
+
+    @property
+    def preset_modes(self) -> Optional[List[str]]:
+        """Return a list of available preset modes."""
+        return None
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_TARGET_TEMPERATURE
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return Room.MIN_TARGET_TEMP
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return Room.MAX_TARGET_TEMP
+
+    @property
+    def active_mode(self) -> ActiveMode:
+        """Get active mode of the climate."""
+        return self._system.get_active_mode_room(self.component)
+
+    async def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        await self.hub.set_room_target_temperature(
+            self, float(kwargs.get(ATTR_TEMPERATURE))
+        )
+
+    def set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        mode = self._HVAC_TO_MODE[hvac_mode]
+        await self.hub.set_room_operating_mode(self, self.component, mode)
+
+    @property
+    def state_attributes(self) -> Dict[str, Any]:
+        """Return the optional state attributes."""
+        attributes = super().state_attributes
+        attributes.update(
+            gen_state_attrs(self.component, self.component, self.active_mode)
+        )
+        return attributes
+
+
+class ZoneClimate(VaillantClimate):
+    """Climate for a zone."""
+
+    _MODE_TO_HVAC: Dict[Mode, str] = {
+        OperatingModes.DAY: HVAC_MODE_HEAT,
+        QuickModes.PARTY: HVAC_MODE_HEAT,
+        OperatingModes.NIGHT: HVAC_MODE_COOL,
+        OperatingModes.AUTO: HVAC_MODE_AUTO,
+        QuickModes.ONE_DAY_AT_HOME: HVAC_MODE_AUTO,
+        OperatingModes.OFF: HVAC_MODE_OFF,
+        QuickModes.ONE_DAY_AWAY: HVAC_MODE_OFF,
+        QuickModes.HOLIDAY: HVAC_MODE_OFF,
+        QuickModes.SYSTEM_OFF: HVAC_MODE_OFF,
+        QuickModes.VENTILATION_BOOST: HVAC_MODE_FAN_ONLY,
+    }
+
+    _HVAC_TO_MODE: Dict[str, Mode] = {
+        HVAC_MODE_AUTO: OperatingModes.AUTO,
+        HVAC_MODE_OFF: OperatingModes.OFF,
+        HVAC_MODE_HEAT: OperatingModes.DAY,
+        HVAC_MODE_COOL: OperatingModes.NIGHT,
+    }
+
+    _SUPPORTED_HVAC_MODE = list(set(_HVAC_TO_MODE.keys()))
+
+    def __init__(self, system: System, zone: Zone):
+        """Initialize entity."""
+        super().__init__(system, zone.id, zone.name, zone)
+
+    def mode_to_hvac(self, mode):
+        """Get the hvac mode based on vaillant mode."""
+        return self._MODE_TO_HVAC.get(mode, None)
+
+    @property
+    def hvac_modes(self) -> List[str]:
+        """Return the list of available hvac operation modes."""
+        return self._SUPPORTED_HVAC_MODE
+
+    @property
+    def preset_mode(self) -> Optional[str]:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return None
+
+    @property
+    def preset_modes(self) -> Optional[List[str]]:
+        """Return a list of available preset modes."""
+        return None
+
+    def set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_TARGET_TEMPERATURE
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return Zone.MIN_TARGET_TEMP
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return Zone.MAX_TARGET_TEMP
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self.active_mode.target
+
+    @property
+    def active_mode(self) -> ActiveMode:
+        """Get active mode of the climate."""
+        return self._system.get_active_mode_zone(self.component)
+
+    async def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temp = kwargs.get(ATTR_TEMPERATURE)
+
+        if temp and temp != self.active_mode.target:
+            _LOGGER.debug("Setting target temp to %s", temp)
+            await self.hub.set_zone_target_temperature(self, temp)
+        else:
+            _LOGGER.debug("Nothing to do")
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Set new target hvac mode."""
+        mode = self._HVAC_TO_MODE[hvac_mode]
+        await self.hub.set_zone_operating_mode(self, mode)
+
+    @property
+    def state_attributes(self) -> Dict[str, Any]:
+        """Return the optional state attributes."""
+        attributes = super().state_attributes
+        attributes.update(
+            gen_state_attrs(self.component, self.component.heating, self.active_mode)
+        )
+        return attributes

--- a/homeassistant/components/vaillant/config_flow.py
+++ b/homeassistant/components/vaillant/config_flow.py
@@ -1,0 +1,85 @@
+"""Config flow for vaillant integration."""
+import logging
+
+from pymultimatic.api import ApiError
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from . import ApiHub
+from .const import CONF_SERIAL_NUMBER, DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_SERIAL_NUMBER): str,
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+
+    await validate_authentication(
+        hass, data[CONF_USERNAME], data[CONF_PASSWORD], data.get(CONF_SERIAL_NUMBER)
+    )
+
+    return {"title": "Vaillant"}
+
+
+async def validate_authentication(hass, username, password, serial):
+    """Ensure provided credentials are working."""
+    hub: ApiHub = ApiHub(hass, username, password, serial)
+    try:
+        if not await hub.authenticate():
+            raise InvalidAuth
+    except ApiError as err:
+        resp = await err.response.json()
+        _LOGGER.exception(
+            "Unable to authenticate, API says: %s, status: %s",
+            resp,
+            err.response.status,
+        )
+        raise InvalidAuth from err
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for vaillant."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/vaillant/const.py
+++ b/homeassistant/components/vaillant/const.py
@@ -1,0 +1,38 @@
+"""Vaillant component constants."""
+from datetime import timedelta
+
+# constants used in hass.data
+DOMAIN = "vaillant"
+HUB = "hub"
+ENTITIES = "entities"
+
+# list of platforms into entity are created
+# PLATFORMS = ["binary_sensor", "sensor", "climate", "water_heater"]
+PLATFORMS = ["binary_sensor", "sensor", "water_heater", "climate"]
+
+# default values for configuration
+DEFAULT_EMPTY = ""
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=2)
+DEFAULT_QUICK_VETO_DURATION = 3 * 60
+DEFAULT_SMART_PHONE_ID = "homeassistant"
+
+# max and min values for configuration
+MIN_SCAN_INTERVAL = timedelta(minutes=1)
+MIN_QUICK_VETO_DURATION = 0.5 * 60
+MAX_QUICK_VETO_DURATION = 24 * 60
+
+# configuration keys
+CONF_QUICK_VETO_DURATION = "quick_veto_duration"
+CONF_SMARTPHONE_ID = "smartphoneid"
+CONF_SERIAL_NUMBER = "serial_number"
+
+# constants for states_attributes
+ATTR_VAILLANT_MODE = "vaillant_mode"
+ATTR_VAILLANT_SETTING = "setting"
+ATTR_VAILLANT_NEXT_SETTING = "next_setting"
+ATTR_ENDS_AT = "ends_at"
+ATTR_QUICK_MODE = "quick_mode"
+ATTR_START_DATE = "start_date"
+ATTR_END_DATE = "end_date"
+ATTR_TEMPERATURE = "temperature"
+ATTR_DURATION = "duration"

--- a/homeassistant/components/vaillant/entities.py
+++ b/homeassistant/components/vaillant/entities.py
@@ -1,0 +1,160 @@
+"""Common entities."""
+from abc import ABC, abstractmethod
+import logging
+from typing import Optional
+
+from pymultimatic.model import BoilerStatus, Device, SystemInfo
+
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import slugify
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VaillantEntity(Entity, ABC):
+    """Define base class for vaillant."""
+
+    def __init__(self, domain, device_class, comp_id, comp_name, class_in_id=True):
+        """Initialize entity."""
+        self._device_class = device_class
+        if device_class and class_in_id:
+            id_format = domain + "." + DOMAIN + "_{}_" + device_class
+        else:
+            id_format = domain + "." + DOMAIN + "_{}"
+
+        self.entity_id = id_format.format(slugify(comp_id)).lower()
+        self._vaillant_name = comp_name
+        self.hub = None
+        self._unique_id = self.entity_id
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the entity."""
+        return self._vaillant_name
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return a unique ID."""
+        return self._unique_id
+
+    async def async_update(self):
+        """Update the entity."""
+        _LOGGER.debug("Time to update %s", self.entity_id)
+        if not self.hub:
+            self.hub = self.hass.data[DOMAIN].api
+        await self.hub.update_system()
+
+        await self.vaillant_update()
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return self._device_class
+
+    @abstractmethod
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+
+    @property
+    def listening(self):
+        """Return whether this entity is listening for system changes or not.
+
+        System changes are quick mode or holiday mode.
+        """
+        return False
+
+    async def async_added_to_hass(self):
+        """Call when entity is added to hass."""
+        self.hass.data[DOMAIN].entities.append(self)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        self.hass.data[DOMAIN].entities.remove(self)
+
+
+class VaillantBoilerEntity(Entity):
+    """Base class for boiler device."""
+
+    def __init__(self, boiler_status: BoilerStatus) -> None:
+        """Initialize device."""
+        self.boiler_status = boiler_status
+        if self.boiler_status is not None:
+            self.boiler_id = slugify(self.boiler_status.device_name)
+
+    @property
+    def device_info(self):
+        """Return device specific attributes."""
+        if self.boiler_status is not None:
+            return {
+                "identifiers": {(DOMAIN, self.boiler_id)},
+                "name": self.boiler_status.device_name,
+                "manufacturer": "Vaillant",
+                "model": self.boiler_status.device_name,
+            }
+        return None
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self.boiler_status is not None:
+            return {"device_id": self.boiler_id, "error": self.boiler_status.is_error}
+        return None
+
+
+class VaillantRoomEntity(Entity):
+    """Base class for ambisense device."""
+
+    def __init__(self, device: Device) -> None:
+        """Initialize device."""
+        self.device = device
+
+    @property
+    def device_info(self):
+        """Return device specific attributes."""
+        return {
+            "identifiers": {(DOMAIN, self.device.sgtin)},
+            "name": self.device.name,
+            "manufacturer": "Vaillant",
+            "model": self.device.device_type,
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            "device_id": self.device.sgtin,
+            "battery_low": self.device.battery_low,
+            "connected": not self.device.radio_out_of_reach,
+        }
+
+
+class VaillantBoxEntity(Entity):
+    """Vaillant gateway device (ex: VR920)."""
+
+    def __init__(self, info: SystemInfo):
+        """Init."""
+        self.system_info = info
+
+    @property
+    def device_info(self):
+        """Return device specific attributes."""
+        return {
+            "identifiers": {(DOMAIN, self.system_info.serial_number)},
+            "connections": {(CONNECTION_NETWORK_MAC, self.system_info.mac_ethernet)},
+            "name": self.system_info.gateway,
+            "manufacturer": "Vaillant",
+            "model": self.system_info.gateway,
+            "sw_version": self.system_info.firmware,
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            "serial_number": self.system_info.serial_number,
+            "connected": self.system_info.is_online,
+            "up_to_date": self.system_info.is_up_to_date,
+        }

--- a/homeassistant/components/vaillant/hub.py
+++ b/homeassistant/components/vaillant/hub.py
@@ -1,0 +1,374 @@
+"""Api hub and integration data."""
+import logging
+
+from pymultimatic.api import ApiError
+from pymultimatic.model import (
+    Circulation,
+    HolidayMode,
+    HotWater,
+    OperatingModes,
+    QuickModes,
+    QuickVeto,
+    Room,
+    System,
+    Zone,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.util import Throttle
+
+from .const import (
+    DEFAULT_QUICK_VETO_DURATION,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SMART_PHONE_ID,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ApiHub:
+    """Vaillant entry point for home-assistant."""
+
+    def __init__(self, hass, username, password, serial):
+        """Initialize hub."""
+        # pylint: disable=import-outside-toplevel
+        from pymultimatic.systemmanager import SystemManager
+
+        session = async_create_clientsession(hass)
+        self._manager = SystemManager(
+            username, password, session, DEFAULT_SMART_PHONE_ID, serial
+        )
+        self.system: System = None
+        self.update_system = Throttle(DEFAULT_SCAN_INTERVAL)(self._update_system)
+        self._hass = hass
+
+    async def authenticate(self):
+        """Try to authenticate to the API."""
+        try:
+            return await self._manager.login(True)
+        except ApiError as err:
+            await self._handle_api_error(err)
+            return False
+
+    async def request_hvac_update(self):
+        """Request is not on the classic update since it won't fetch data.
+
+        The request update will trigger something at vaillant API and it will
+        ask data to your system.
+        """
+        try:
+            _LOGGER.debug("Will request_hvac_update")
+            await self._manager.request_hvac_update()
+        except ApiError as err:
+            if err.response.status == 409:
+                _LOGGER.warning("request_hvac_update is done too often")
+            else:
+                await self._handle_api_error(err)
+                await self.authenticate()
+
+    async def _update_system(self):
+        """Fetch vaillant system."""
+
+        try:
+            self.system = await self._manager.get_system()
+            _LOGGER.debug("update_system successfully fetched")
+        except ApiError as err:
+            # update_system is called by all entities, if it fails for
+            # one entity, it will certainly fail for others.
+            # catching exception so the throttling is occurring
+            await self._handle_api_error(err)
+            await self.authenticate()
+
+    async def logout(self):
+        """Logout from API."""
+
+        try:
+            await self._manager.logout()
+        except ApiError:
+            _LOGGER.warning("Cannot logout from vaillant API", exc_info=True)
+            return False
+        return True
+
+    async def _handle_api_error(self, api_err):
+        resp = await api_err.response.json()
+        _LOGGER.exception(
+            "Unable to fetch data from vaillant, API says: %s, status: %s",
+            resp,
+            api_err.response.status,
+        )
+
+    def find_component(self, comp):
+        """Find a component in the system with the given id, no IO is done."""
+
+        if isinstance(comp, Zone):
+            for zone in self.system.zones:
+                if zone.id == comp.id:
+                    return zone
+        if isinstance(comp, Room):
+            for room in self.system.rooms:
+                if room.id == comp.id:
+                    return room
+        if isinstance(comp, HotWater):
+            if self.system.dhw.hotwater and self.system.dhw.hotwater.id == comp.id:
+                return self.system.dhw.hotwater
+        if isinstance(comp, Circulation):
+            if (
+                self.system.dhw.circulation
+                and self.system.dhw.circulation.id == comp.id
+            ):
+                return self.system.dhw.circulation
+
+        return None
+
+    async def set_hot_water_target_temperature(self, entity, target_temp):
+        """Set hot water target temperature.
+
+        * If there is a quick mode that impact dhw running on or holiday mode,
+        remove it.
+
+        * If dhw is ON or AUTO, modify the target temperature
+
+        * If dhw is OFF, change to ON and set target temperature
+        """
+
+        hotwater = entity.component
+
+        touch_system = await self._remove_quick_mode_or_holiday(entity)
+
+        current_mode = self.system.get_active_mode_hot_water(hotwater).current
+
+        if current_mode == OperatingModes.OFF or touch_system:
+            await self._manager.set_hot_water_operating_mode(
+                hotwater.id, OperatingModes.ON
+            )
+        await self._manager.set_hot_water_setpoint_temperature(hotwater.id, target_temp)
+
+        self.system.hot_water = hotwater
+        await self._refresh(touch_system, entity)
+
+    async def set_room_target_temperature(self, entity, target_temp):
+        """Set target temperature for a room.
+
+        * If there is a quick mode that impact room running on or holiday mode,
+        remove it.
+
+        * If the room is in MANUAL mode, simply modify the target temperature.
+
+        * if the room is not in MANUAL mode, create à quick veto.
+        """
+
+        touch_system = await self._remove_quick_mode_or_holiday(entity)
+
+        room = entity.component
+        current_mode = self.system.get_active_mode_room(room).current
+
+        if current_mode == OperatingModes.MANUAL:
+            await self._manager.set_room_setpoint_temperature(room.id, target_temp)
+            room.target_temperature = target_temp
+        else:
+            if current_mode == OperatingModes.QUICK_VETO:
+                await self._manager.remove_room_quick_veto(room.id)
+
+            qveto = QuickVeto(DEFAULT_QUICK_VETO_DURATION, target_temp)
+            await self._manager.set_room_quick_veto(room.id, qveto)
+            room.quick_veto = qveto
+        self.system.set_room(room.id, room)
+
+        await self._refresh(touch_system, entity)
+
+    async def set_zone_target_temperature(self, entity, target_temp):
+        """Set target temperature for a zone.
+
+        * If there is a quick mode related to zone running or holiday mode,
+        remove it.
+
+        * If quick veto running on, remove it and create a new one with the
+            new target temp
+
+        * If any other mode, create a quick veto
+        """
+
+        touch_system = await self._remove_quick_mode_or_holiday(entity)
+        zone = entity.component
+        current_mode = self.system.get_active_mode_zone(zone).current
+
+        if current_mode == OperatingModes.QUICK_VETO:
+            await self._manager.remove_zone_quick_veto(zone.id)
+
+        veto = QuickVeto(None, target_temp)
+        await self._manager.set_zone_quick_veto(zone.id, veto)
+        zone.quick_veto = veto
+
+        self.system.set_zone(zone.id, zone)
+        await self._refresh(touch_system, entity)
+
+    async def set_hot_water_operating_mode(self, entity, mode):
+        """Set hot water operation mode.
+
+        If there is a quick mode that impact hot warter running on or holiday
+        mode, remove it.
+        """
+        hotwater = entity.component
+        touch_system = await self._remove_quick_mode_or_holiday(entity)
+
+        await self._manager.set_hot_water_operating_mode(hotwater.id, mode)
+        hotwater.operating_mode = mode
+
+        self.system.dhw.hotwater = hotwater
+        await self._refresh(touch_system, entity)
+
+    async def set_room_operating_mode(self, entity, room, mode):
+        """Set room operation mode.
+
+        If there is a quick mode that impact room running on or holiday mode,
+        remove it.
+        """
+        touch_system = await self._remove_quick_mode_or_holiday(entity)
+        if room.quick_veto is not None:
+            await self._manager.remove_room_quick_veto(room.id)
+            room.quick_veto = None
+
+        await self._manager.set_room_operating_mode(room.id, mode)
+        room.operating_mode = mode
+
+        self.system.set_room(room.id, room)
+        await self._refresh(touch_system, entity)
+
+    async def set_zone_operating_mode(self, entity, mode):
+        """Set zone operation mode.
+
+        If there is a quick mode that impact zone running on or holiday mode,
+        remove it.
+        """
+        touch_system = await self._remove_quick_mode_or_holiday(entity)
+        zone = entity.component
+
+        if zone.quick_veto is not None:
+            await self._manager.remove_zone_quick_veto(zone.id)
+            zone.quick_veto = None
+
+        await self._manager.set_zone_operating_mode(zone.id, mode)
+        zone.heating.operating_mode = mode
+
+        self.system.set_zone(zone.id, zone)
+        await self._refresh(touch_system, entity)
+
+    async def remove_quick_mode(self, entity=None):
+        """Remove quick mode.
+
+        If entity is not None, only remove if the quick mode applies to the
+        given entity.
+        """
+        if await self._remove_quick_mode_no_refresh(entity):
+            await self._refresh_entities()
+
+    async def remove_holiday_mode(self):
+        """Remove holiday mode."""
+        if await self._remove_holiday_mode_no_refresh():
+            await self._refresh_entities()
+
+    async def set_holiday_mode(self, start_date, end_date, temperature):
+        """Set holiday mode."""
+        await self._manager.set_holiday_mode(start_date, end_date, temperature)
+        await self._refresh_entities()
+
+    async def set_quick_mode(self, mode):
+        """Set quick mode (remove evious one)."""
+        await self._remove_quick_mode_no_refresh()
+        await self._manager.set_quick_mode(QuickModes.get(mode))
+        await self._refresh_entities()
+
+    async def set_quick_veto(self, entity, temperature, duration=None):
+        """Set quick veto for the given entity."""
+        comp = self.find_component(entity.component)
+
+        q_duration = duration if duration else DEFAULT_QUICK_VETO_DURATION
+        qveto = QuickVeto(q_duration, temperature)
+
+        if isinstance(comp, Zone):
+            if comp.quick_veto:
+                await self._manager.remove_zone_quick_veto(comp.id)
+            await self._manager.set_zone_quick_veto(comp.id, qveto)
+        else:
+            if comp.quick_veto:
+                await self._manager.remove_room_quick_veto(comp.id)
+            await self._manager.set_room_quick_veto(comp.id, qveto)
+        comp.quick_veto = qveto
+        await self._refresh(False, entity)
+
+    async def remove_quick_veto(self, entity):
+        """Remove quick veto for the given entity."""
+        comp = self.find_component(entity.component)
+
+        if comp and comp.quick_veto:
+            if isinstance(comp, Zone):
+                await self._manager.remove_zone_quick_veto(comp.id)
+            else:
+                await self._manager.remove_room_quick_veto(comp.id)
+            comp.quick_veto = None
+            await self._refresh(False, entity)
+
+    def get_entity(self, entity_id):
+        """Get entity owned by this component."""
+        for entity in self._hass.data[DOMAIN].entities:
+            if entity.entity_id == entity_id:
+                return entity
+        return None
+
+    async def _remove_quick_mode_no_refresh(self, entity=None):
+        removed = False
+
+        if self.system.quick_mode is not None:
+            qmode = self.system.quick_mode
+
+            if entity:
+                if qmode.is_for(entity.component):
+                    await self._hard_remove_quick_mode()
+                    removed = True
+            else:
+                await self._hard_remove_quick_mode()
+                removed = True
+        return removed
+
+    async def _hard_remove_quick_mode(self):
+        await self._manager.remove_quick_mode()
+        self.system.quick_mode = None
+
+    async def _remove_holiday_mode_no_refresh(self):
+        removed = False
+
+        if self.system.holiday is not None and self.system.holiday.is_applied:
+            removed = True
+            await self._manager.remove_holiday_mode()
+            self.system.holiday = HolidayMode(False)
+        return removed
+
+    async def _remove_quick_mode_or_holiday(self, entity):
+        return await self._remove_holiday_mode_no_refresh() | await self._remove_quick_mode_no_refresh(
+            entity
+        )
+
+    async def _refresh_entities(self):
+        """Fetch vaillant data and force refresh of all listening entities."""
+        await self.update_system(no_throttle=True)
+        for entity in self._hass.data[DOMAIN].entities:
+            if entity.listening:
+                entity.async_schedule_update_ha_state(True)
+
+    async def _refresh(self, touch_system, entity):
+        if touch_system:
+            await self._refresh_entities()
+        else:
+            entity.async_schedule_update_ha_state(True)
+
+
+class DomainData:
+    """Data for the integration."""
+
+    def __init__(self, api: ApiHub, entry: ConfigEntry) -> None:
+        """Init."""
+        self.api = api
+        self.entry = entry
+        self.entities = []

--- a/homeassistant/components/vaillant/manifest.json
+++ b/homeassistant/components/vaillant/manifest.json
@@ -1,0 +1,16 @@
+{
+  "domain": "vaillant",
+  "name": "Vaillant",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/vaillant",
+  "requirements": [
+    "pymultimatic==0.1.2"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@thomasgermain"
+  ]
+}

--- a/homeassistant/components/vaillant/sensor.py
+++ b/homeassistant/components/vaillant/sensor.py
@@ -1,0 +1,123 @@
+"""Interfaces with Vaillant sensors."""
+import logging
+
+from pymultimatic.model import Report
+
+from homeassistant.components.sensor import (
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    DOMAIN,
+)
+from homeassistant.const import TEMP_CELSIUS
+
+from .const import DOMAIN as VAILLANT
+from .entities import VaillantEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+UNIT_TO_DEVICE_CLASS = {
+    "bar": DEVICE_CLASS_PRESSURE,
+    "ppm": "",
+    "°C": DEVICE_CLASS_TEMPERATURE,
+}
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Vaillant sensors."""
+    sensors = []
+    hub = hass.data[VAILLANT].api
+
+    if hub.system:
+        if hub.system.outdoor_temperature:
+            sensors.append(OutdoorTemperatureSensor(hub.system.outdoor_temperature))
+
+        for report in hub.system.reports:
+            sensors.append(ReportSensor(report))
+
+    _LOGGER.info("Adding %s sensor entities", len(sensors))
+
+    async_add_entities(sensors)
+    return True
+
+
+class OutdoorTemperatureSensor(VaillantEntity):
+    """Outdoor temperature sensor."""
+
+    def __init__(self, outdoor_temp):
+        """Initialize entity."""
+        super().__init__(DOMAIN, DEVICE_CLASS_TEMPERATURE, "outdoor", "Outdoor")
+        self._outdoor_temp = outdoor_temp
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._outdoor_temp
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._outdoor_temp is not None
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return TEMP_CELSIUS
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        _LOGGER.debug(
+            "New / old temperature: %s / %s",
+            self.hub.system.outdoor_temperature,
+            self._outdoor_temp,
+        )
+        self._outdoor_temp = self.hub.system.outdoor_temperature
+
+
+class ReportSensor(VaillantEntity):
+    """Report sensor."""
+
+    def __init__(self, report: Report):
+        """Init entity."""
+        device_class = UNIT_TO_DEVICE_CLASS.get(report.unit, None)
+        if not device_class:
+            _LOGGER.warning("No device class for %s", report.unit)
+        VaillantEntity.__init__(
+            self, DOMAIN, device_class, report.id, report.name, False
+        )
+        self.report = report
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        self.report = self._find_report()
+
+    def _find_report(self):
+        for report in self.hub.system.reports:
+            if self.report.id == report.id:
+                return report
+        return None
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self.report.value
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self.report is not None
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self.report.unit
+
+    @property
+    def device_info(self):
+        """Return device specific attributes."""
+        if self.report is not None:
+            return {
+                "identifiers": {(DOMAIN, self.report.device_id)},
+                "name": self.report.device_name,
+                "manufacturer": "Vaillant",
+            }
+        return None

--- a/homeassistant/components/vaillant/service.py
+++ b/homeassistant/components/vaillant/service.py
@@ -1,0 +1,155 @@
+"""Vaillant service."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.util.dt import parse_date
+
+from .const import (
+    ATTR_DURATION,
+    ATTR_END_DATE,
+    ATTR_QUICK_MODE,
+    ATTR_START_DATE,
+    ATTR_TEMPERATURE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+QUICK_MODES_LIST = [
+    "QM_HOTWATER_BOOST",
+    "QM_VENTILATION_BOOST",
+    "QM_PARTY",
+    "QM_ONE_DAY_AWAY",
+    "QM_SYSTEM_OFF",
+    "QM_ONE_DAY_AT_HOME",
+]
+
+SERVICE_REMOVE_QUICK_MODE = "remove_quick_mode"
+SERVICE_REMOVE_HOLIDAY_MODE = "remove_holiday_mode"
+SERVICE_SET_QUICK_MODE = "set_quick_mode"
+SERVICE_SET_HOLIDAY_MODE = "set_holiday_mode"
+SERVICE_SET_QUICK_VETO = "set_quick_veto"
+SERVICE_REMOVE_QUICK_VETO = "remove_quick_veto"
+SERVICE_REQUEST_HVAC_UPDATE = "request_hvac_update"
+
+SERVICE_REMOVE_QUICK_MODE_SCHEMA = vol.Schema({})
+SERVICE_REMOVE_HOLIDAY_MODE_SCHEMA = vol.Schema({})
+SERVICE_REMOVE_QUICK_VETO_SCHEMA = vol.Schema(
+    {vol.Required(ATTR_ENTITY_ID): vol.All(vol.Coerce(str))}
+)
+SERVICE_SET_QUICK_MODE_SCHEMA = vol.Schema(
+    {vol.Required(ATTR_QUICK_MODE): vol.All(vol.Coerce(str), vol.In(QUICK_MODES_LIST))}
+)
+SERVICE_SET_HOLIDAY_MODE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_START_DATE): vol.All(vol.Coerce(str)),
+        vol.Required(ATTR_END_DATE): vol.All(vol.Coerce(str)),
+        vol.Required(ATTR_TEMPERATURE): vol.All(
+            vol.Coerce(float), vol.Clamp(min=5, max=30)
+        ),
+    }
+)
+SERVICE_SET_QUICK_VETO_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): vol.All(vol.Coerce(str)),
+        vol.Required(ATTR_TEMPERATURE): vol.All(
+            vol.Coerce(float), vol.Clamp(min=5, max=30)
+        ),
+        vol.Required(ATTR_DURATION): vol.All(
+            vol.Coerce(int), vol.Clamp(min=30, max=1440)
+        ),
+    }
+)
+SERVICE_REQUEST_HVAC_UPDATE_SCHEMA = vol.Schema({})
+
+SERVICES = {
+    SERVICE_REMOVE_QUICK_MODE: {
+        "method": SERVICE_REMOVE_QUICK_MODE,
+        "schema": SERVICE_REMOVE_QUICK_MODE_SCHEMA,
+    },
+    SERVICE_REMOVE_HOLIDAY_MODE: {
+        "method": SERVICE_REMOVE_HOLIDAY_MODE,
+        "schema": SERVICE_REMOVE_HOLIDAY_MODE_SCHEMA,
+    },
+    SERVICE_REMOVE_QUICK_VETO: {
+        "method": SERVICE_REMOVE_QUICK_VETO,
+        "schema": SERVICE_REMOVE_QUICK_VETO_SCHEMA,
+    },
+    SERVICE_SET_QUICK_MODE: {
+        "method": SERVICE_SET_QUICK_MODE,
+        "schema": SERVICE_SET_QUICK_MODE_SCHEMA,
+    },
+    SERVICE_SET_HOLIDAY_MODE: {
+        "method": SERVICE_SET_HOLIDAY_MODE,
+        "schema": SERVICE_SET_HOLIDAY_MODE_SCHEMA,
+    },
+    SERVICE_SET_QUICK_VETO: {
+        "method": SERVICE_SET_QUICK_VETO,
+        "schema": SERVICE_SET_QUICK_VETO_SCHEMA,
+    },
+    SERVICE_REQUEST_HVAC_UPDATE: {
+        "method": SERVICE_REQUEST_HVAC_UPDATE,
+        "schema": SERVICE_REQUEST_HVAC_UPDATE_SCHEMA,
+    },
+}
+
+
+class VaillantServiceHandler:
+    """Service implementation."""
+
+    def __init__(self, hub, hass) -> None:
+        """Init."""
+        self._hub = hub
+        self._hass = hass
+
+    async def remove_quick_mode(self, call):
+        """Remove quick mode. It has impact on all components."""
+        await self._hub.remove_quick_mode()
+
+    async def set_holiday_mode(self, call):
+        """Set holiday mode."""
+        start_str = call.data.get(ATTR_START_DATE, None)
+        end_str = call.data.get(ATTR_END_DATE, None)
+        temp = call.data.get(ATTR_TEMPERATURE)
+        start = parse_date(start_str.split("T")[0])
+        end = parse_date(end_str.split("T")[0])
+        if end is None or start is None:
+            raise ValueError(f"dates are incorrect {start_str} {end_str}")
+        await self._hub.set_holiday_mode(start, end, temp)
+
+    async def remove_holiday_mode(self, call):
+        """Remove holiday mode."""
+        await self._hub.remove_holiday_mode()
+
+    async def set_quick_mode(self, call):
+        """Set quick mode, it may impact the whole system."""
+        quick_mode = call.data.get(ATTR_QUICK_MODE, None)
+        await self._hub.set_quick_mode(quick_mode)
+
+    async def set_quick_veto(self, call):
+        """Set quick veto (and remove the existing one) for a given entity."""
+        temp = call.data.get(ATTR_TEMPERATURE, None)
+        duration = call.data.get(ATTR_DURATION, None)
+
+        entity_id = call.data.get(ATTR_ENTITY_ID, None)
+        entity = self._hub.get_entity(entity_id)
+
+        if entity is not None:
+            await self._hub.set_quick_veto(entity, temp, duration)
+        else:
+            _LOGGER.debug("Not entity found for id %s", entity_id)
+
+    async def remove_quick_veto(self, call):
+        """Remove quick veto (if any) for a given entity."""
+        entity_id = call.data.get(ATTR_ENTITY_ID, None)
+        entity = self._hub.get_entity(entity_id)
+
+        if entity is not None:
+            await self._hub.remove_quick_veto(entity)
+        else:
+            _LOGGER.debug("Not entity found for id %s", entity_id)
+
+    async def request_hvac_update(self, call):
+        """Ask vaillant API to get data from your installation."""
+        await self._hub.request_hvac_update()

--- a/homeassistant/components/vaillant/services.yaml
+++ b/homeassistant/components/vaillant/services.yaml
@@ -1,0 +1,48 @@
+remove_quick_mode:
+  description: Remove quick mode
+
+remove_holiday_mode:
+  description: Remove holiday mode
+
+set_quick_mode:
+  description: Set a quick mode to vaillant system.
+  fields:
+    quick_mode:
+      description: Name of the quick mode (required)
+      example: QM_HOTWATER_BOOST, QM_VENTILATION_BOOST, QM_ONE_DAY_AWAY, QM_SYSTEM_OFF, QM_ONE_DAY_AT_HOME, QM_PARTY
+
+set_holiday_mode:
+  description: Set holiday mode
+  fields:
+    start_date:
+      description: Start date of the holiday mode YYYY-MM-DD format (required)
+      example: "2019-11-25"
+    end_date:
+      description: End date of the holiday mode, YYYY-MM-DD format (required)
+      example: "2019-11-26"
+    temperature:
+      description: temperature to maintin while holiday mode is active (required)
+      example: 15
+
+set_quick_veto:
+  description: Set a quick veto for a climate entity
+  fields:
+    entity_id:
+      description: Entity id from where to set a quick veto
+      example: climate.vaillant_bathroom
+    temperature:
+      description: Target temperature to be applied while quick veto is running on
+      example: 25
+    duration:
+      description: Duration (in minutes) of the quick veto. Min 30min, max 1440 (24 hours). If not specified, the default (configured) duration is applied.
+      example: "60"
+
+remove_quick_veto:
+  description: Remove a quick veto for a climate entity
+  fields:
+    entity_id:
+      description: Entity id from where to remove quick veto
+      example: climate.vaillant_bathroom
+
+request_hvac_update:
+  description: Ask vaillant API to get data from your installation.

--- a/homeassistant/components/vaillant/strings.json
+++ b/homeassistant/components/vaillant/strings.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/bg.json
+++ b/homeassistant/components/vaillant/translations/bg.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/ca.json
+++ b/homeassistant/components/vaillant/translations/ca.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/cs.json
+++ b/homeassistant/components/vaillant/translations/cs.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/da.json
+++ b/homeassistant/components/vaillant/translations/da.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/de.json
+++ b/homeassistant/components/vaillant/translations/de.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/en.json
+++ b/homeassistant/components/vaillant/translations/en.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/es.json
+++ b/homeassistant/components/vaillant/translations/es.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/fr.json
+++ b/homeassistant/components/vaillant/translations/fr.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/it.json
+++ b/homeassistant/components/vaillant/translations/it.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/ko.json
+++ b/homeassistant/components/vaillant/translations/ko.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/lb.json
+++ b/homeassistant/components/vaillant/translations/lb.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/nl.json
+++ b/homeassistant/components/vaillant/translations/nl.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/nn.json
+++ b/homeassistant/components/vaillant/translations/nn.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/no.json
+++ b/homeassistant/components/vaillant/translations/no.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/pl.json
+++ b/homeassistant/components/vaillant/translations/pl.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Hasło",
+          "username": "Nazwa użytkownika",
+          "serial_number": "Serial number"
+        },
+        "title": "Informacje o połączeniu (takie same jak w aplikacji multiMATIC)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Nie udało się połączyć, spróbuj ponownie",
+      "invalid_auth": "Niepoprawne uwierzytelnienie",
+      "unknown": "Niespodziewany błąd"
+    },
+    "abort": {
+      "already_configured": "Dozwolona jest tylko jedna konfiguracja"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/pt-BR.json
+++ b/homeassistant/components/vaillant/translations/pt-BR.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/pt.json
+++ b/homeassistant/components/vaillant/translations/pt.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/ru.json
+++ b/homeassistant/components/vaillant/translations/ru.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/sl.json
+++ b/homeassistant/components/vaillant/translations/sl.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/translations/zh-Hant.json
+++ b/homeassistant/components/vaillant/translations/zh-Hant.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vaillant",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "serial_number": "Serial number"
+        },
+        "title": "Connection information (same as multiMATIC application)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Only one configuration is allowed"
+    }
+  }
+}

--- a/homeassistant/components/vaillant/utils.py
+++ b/homeassistant/components/vaillant/utils.py
@@ -1,0 +1,64 @@
+"""Utilities for HA."""
+from datetime import timedelta
+
+from pymultimatic.model import OperatingModes
+
+from homeassistant.util import dt
+
+from .const import (
+    ATTR_ENDS_AT,
+    ATTR_VAILLANT_MODE,
+    ATTR_VAILLANT_NEXT_SETTING,
+    ATTR_VAILLANT_SETTING,
+)
+
+
+def gen_state_attrs(component, function, active_mode):
+    """Generate state_attrs."""
+    attrs = {}
+    attrs.update({ATTR_VAILLANT_MODE: active_mode.current.name})
+
+    if active_mode.current == OperatingModes.QUICK_VETO:
+        if component.quick_veto.duration:
+            qveto_end = _get_quick_veto_end(component)
+            if qveto_end:
+                attrs.update({ATTR_ENDS_AT: qveto_end.isoformat()})
+    elif active_mode.current == OperatingModes.AUTO:
+        setting = _get_next_setting(function)
+        value = setting.setting.name if setting.setting else setting.target_temperature
+        attrs.update(
+            {
+                ATTR_VAILLANT_NEXT_SETTING: value,
+                ATTR_ENDS_AT: setting.start.isoformat(),
+            }
+        )
+
+        if active_mode.sub is not None:
+            attrs.update({ATTR_VAILLANT_SETTING: active_mode.sub.name})
+
+    return attrs
+
+
+def _get_quick_veto_end(component):
+    end_time = None
+    # there is no remaining duration for zone
+    if component.quick_veto.duration:
+        millis = component.quick_veto.duration * 60 * 1000
+        end_time = dt.now() + timedelta(milliseconds=millis)
+        end_time = end_time.replace(second=0, microsecond=0)
+    return end_time
+
+
+def _get_next_setting(function):
+    now = dt.now()
+    setting = function.time_program.get_next(now)
+
+    abs_min = now.hour * 60 + now.minute
+
+    if setting.absolute_minutes < abs_min:
+        now += timedelta(days=1)
+
+    setting.start = now.replace(
+        hour=setting.hour, minute=setting.minute, second=0, microsecond=0
+    )
+    return setting

--- a/homeassistant/components/vaillant/water_heater.py
+++ b/homeassistant/components/vaillant/water_heater.py
@@ -1,0 +1,185 @@
+"""Interfaces with Vaillant water heater."""
+import logging
+
+from pymultimatic.model import HotWater, OperatingModes, QuickModes
+
+from homeassistant.components.water_heater import (
+    DOMAIN,
+    SUPPORT_AWAY_MODE,
+    SUPPORT_OPERATION_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+    WaterHeaterEntity,
+)
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+
+from .const import DOMAIN as VAILLANT
+from .entities import VaillantEntity
+from .utils import gen_state_attrs
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_FLAGS = (
+    SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE
+)
+ATTR_CURRENT_TEMPERATURE = "current_temperature"
+ATTR_TIME_PROGRAM = "time_program"
+
+AWAY_MODES = [
+    OperatingModes.OFF,
+    QuickModes.HOLIDAY,
+    QuickModes.ONE_DAY_AWAY,
+    QuickModes.SYSTEM_OFF,
+]
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up water_heater platform."""
+    entities = []
+    hub = hass.data[VAILLANT].api
+
+    if hub.system and hub.system.dhw and hub.system.dhw.hotwater:
+        entity = VaillantWaterHeater(hub.system.dhw.hotwater)
+        entities.append(entity)
+
+    _LOGGER.info("Added water heater? %s", len(entities) > 0)
+    async_add_entities(entities, True)
+    return True
+
+
+class VaillantWaterHeater(VaillantEntity, WaterHeaterEntity):
+    """Represent the vaillant water heater."""
+
+    def __init__(self, hotwater: HotWater):
+        """Initialize entity."""
+        super().__init__(DOMAIN, None, hotwater.id, hotwater.name)
+        self._hotwater = hotwater
+        self._active_mode = None
+        self._operations = {mode.name: mode for mode in HotWater.MODES}
+
+    @property
+    def listening(self):
+        """Return whether this entity is listening for system changes or not."""
+        return True
+
+    @property
+    def component(self):
+        """Return vaillant component."""
+        return self._hotwater
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features.
+
+        !! It could be misleading here, since when heater is not heating,
+        target temperature if fixed (35 °C) - The API doesn't allow to change
+        this setting. It means if the user wants to change the target
+        temperature, it will always be the target temperature when the
+        heater is on function. See example below:
+
+        1. Target temperature when heater is off is 35 (this is a fixed
+        setting)
+        2. Target temperature when heater is on is for instance 50 (this is a
+        configurable setting)
+        3. While heater is off, user changes target_temperature to 45. It will
+        actually change the target temperature from 50 to 45
+        4. While heater is off, user will still see 35 in UI
+        (even if he changes to 45 before)
+        5. When heater will go on, user will see the target temperature he set
+         at point 3 -> 45.
+
+        Maybe I can remove the SUPPORT_TARGET_TEMPERATURE flag if the heater
+        is off, but it means the user will be able to change the target
+         temperature only when the heater is ON (which seems odd to me)
+        """
+        if self._active_mode.current != QuickModes.HOLIDAY:
+            return SUPPORTED_FLAGS
+        return 0
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._hotwater is not None
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement used by the platform."""
+        return TEMP_CELSIUS
+
+    @property
+    def state_attributes(self):
+        """Return the optional state attributes.
+
+        Adding current temperature
+        """
+        attrs = super().state_attributes
+        attrs.update(gen_state_attrs(self.component, self.component, self._active_mode))
+        return attrs
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        _LOGGER.debug("target temperature is %s", self._active_mode.target)
+        return self._active_mode.target
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        _LOGGER.debug("current temperature is %s", self._hotwater.temperature)
+        return self._hotwater.temperature
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return HotWater.MIN_TARGET_TEMP
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return HotWater.MAX_TARGET_TEMP
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. eco, electric, performance, ..."""
+        _LOGGER.debug("current_operation is %s", self._active_mode.current)
+        return self._active_mode.current.name
+
+    @property
+    def operation_list(self):
+        """Return current operation ie. eco, electric, performance, ..."""
+        if self._active_mode.current != QuickModes.HOLIDAY:
+            return list(self._operations.keys())
+        return []
+
+    @property
+    def is_away_mode_on(self):
+        """Return true if away mode is on."""
+        return self._active_mode.current in AWAY_MODES
+
+    async def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        target_temp = float(kwargs.get(ATTR_TEMPERATURE))
+        _LOGGER.debug("Trying to set target temp to %s", target_temp)
+        # HUB will call sync update
+        await self.hub.set_hot_water_target_temperature(self, target_temp)
+
+    async def async_set_operation_mode(self, operation_mode):
+        """Set new target operation mode."""
+        _LOGGER.debug("Will set new operation_mode %s", operation_mode)
+        if operation_mode in self._operations.keys():
+            mode = self._operations[operation_mode]
+            await self.hub.set_hot_water_operating_mode(self, mode)
+        else:
+            _LOGGER.debug("Operation mode is unknown")
+
+    async def async_turn_away_mode_on(self):
+        """Turn away mode on."""
+        await self.hub.set_hot_water_operating_mode(self, OperatingModes.OFF)
+
+    async def async_turn_away_mode_off(self):
+        """Turn away mode off."""
+        await self.hub.set_hot_water_operating_mode(self, OperatingModes.AUTO)
+
+    async def vaillant_update(self):
+        """Update specific for vaillant."""
+        self._hotwater = self.hub.system.dhw.hotwater
+        self._active_mode = self.hub.system.get_active_mode_hot_water()

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -154,6 +154,7 @@ FLOWS = [
     "unifi",
     "upb",
     "upnp",
+    "vaillant",
     "velbus",
     "vera",
     "vesync",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1464,6 +1464,9 @@ pymonoprice==0.3
 # homeassistant.components.msteams
 pymsteams==0.1.12
 
+# homeassistant.components.vaillant
+pymultimatic==0.1.2
+
 # homeassistant.components.yamaha_musiccast
 pymusiccast==0.1.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -632,6 +632,9 @@ pymodbus==2.3.0
 # homeassistant.components.monoprice
 pymonoprice==0.3
 
+# homeassistant.components.vaillant
+pymultimatic==0.1.2
+
 # homeassistant.components.myq
 pymyq==2.0.2
 

--- a/tests/components/vaillant/__init__.py
+++ b/tests/components/vaillant/__init__.py
@@ -1,0 +1,230 @@
+"""The tests for vaillant integration."""
+import datetime
+from unittest import mock
+
+from asynctest import CoroutineMock, patch
+from pymultimatic.model import (
+    BoilerStatus,
+    Circulation,
+    Device,
+    Dhw,
+    HolidayMode,
+    HotWater,
+    OperatingModes,
+    Report,
+    Room,
+    SettingModes,
+    System,
+    SystemInfo,
+    TimePeriodSetting,
+    TimeProgram,
+    TimeProgramDay,
+    Zone,
+    ZoneHeating,
+)
+from pymultimatic.systemmanager import SystemManager
+
+from homeassistant import config_entries
+from homeassistant.components.vaillant import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.util import utcnow
+
+from tests.common import async_fire_time_changed
+
+VALID_MINIMAL_CONFIG = {CONF_USERNAME: "test", CONF_PASSWORD: "test"}
+
+
+class SystemManagerMock(SystemManager):
+    """Mock implementation of SystemManager."""
+
+    instance = None
+    system = None
+    _methods = [f for f in dir(SystemManager) if not f.startswith("_")]
+
+    @classmethod
+    def reset_mock(cls):
+        """Reset mock, clearing instance and system."""
+        cls.instance = None
+        cls.system = None
+
+    def __init__(self, user, password, smart_phone_id, session, serial):
+        """Mock the constructor."""
+        self.system = self.__class__.system
+        self._init()
+        self.__class__.instance = self
+
+    def _init(self):
+        for method in self.__class__._methods:
+            setattr(self, method, CoroutineMock())
+
+        setattr(self, "get_system", CoroutineMock(return_value=self.system))
+
+        get_zone = mock.MagicMock(
+            return_value=lambda: self.system.zones[0]
+            if self.system and self.system.zones
+            else None
+        )
+        get_room = mock.MagicMock(
+            return_value=lambda: self.system.rooms[0]
+            if self.system and self.system.rooms
+            else None
+        )
+        setattr(self, "get_zone", get_zone)
+        setattr(self, "get_room", get_room)
+
+
+def get_system():
+    """Return default system."""
+    boiler_status = BoilerStatus(
+        "boiler",
+        "short description",
+        "S.31",
+        "Long description",
+        datetime.datetime.now(),
+        "hint",
+    )
+
+    heating = ZoneHeating(
+        time_program=time_program(SettingModes.NIGHT, None),
+        operating_mode=OperatingModes.AUTO,
+        target_low=22,
+        target_high=30,
+    )
+    zone = Zone(
+        id="zone_1",
+        name="Zone 1",
+        temperature=25,
+        active_function="heating",
+        rbr=False,
+        heating=heating,
+    )
+
+    room_device = Device("Device 1", "123456789", "VALVE", False, False)
+    room = Room(
+        id="1",
+        name="Room 1",
+        time_program=time_program(),
+        temperature=22,
+        target_high=24,
+        operating_mode=OperatingModes.AUTO,
+        child_lock=False,
+        window_open=False,
+        devices=[room_device],
+    )
+
+    hot_water = HotWater(
+        id="dhw",
+        name="Hot water",
+        time_program=time_program(temp=None),
+        temperature=45,
+        target_high=40,
+        operating_mode=OperatingModes.AUTO,
+    )
+
+    circulation = Circulation(
+        id="dhw",
+        name="Circulation",
+        time_program=time_program(temp=None),
+        operating_mode=OperatingModes.AUTO,
+    )
+    dhw = Dhw(hotwater=hot_water, circulation=circulation)
+
+    outdoor_temp = 18
+
+    info = SystemInfo(
+        "VR920",
+        "666777888",
+        "System name",
+        "01:01:AA:CC:CC:CC",
+        "01:01:AA:DD:DD:DD",
+        "1.6.8",
+        "ONLINE",
+        "UPDATE_NOT_PENDING",
+    )
+
+    reports = [
+        Report(
+            device_name="VRC700 MultiMatic",
+            device_id="Control_SYS_MultiMatic",
+            unit="bar",
+            value=1.9,
+            name="Water pressure",
+            id="WaterPressureSensor",
+        )
+    ]
+    return System(
+        holiday=HolidayMode(False),
+        quick_mode=None,
+        info=info,
+        zones=[zone],
+        rooms=[room],
+        dhw=dhw,
+        reports=reports,
+        outdoor_temperature=outdoor_temp,
+        boiler_status=boiler_status,
+        errors=[],
+        ventilation=None,
+    )
+
+
+def active_holiday_mode():
+    """Return a active holiday mode."""
+    start = datetime.date.today() - datetime.timedelta(days=1)
+    end = datetime.date.today() + datetime.timedelta(days=1)
+    return HolidayMode(True, start, end, 15)
+
+
+def time_program(heating_mode=SettingModes.OFF, temp=20):
+    """Create a default time program."""
+    tp_day_setting = TimePeriodSetting("00:00", temp, heating_mode)
+    tp_day = TimeProgramDay([tp_day_setting])
+    tp_days = {
+        "monday": tp_day,
+        "tuesday": tp_day,
+        "wednesday": tp_day,
+        "thursday": tp_day,
+        "friday": tp_day,
+        "saturday": tp_day,
+        "sunday": tp_day,
+    }
+    return TimeProgram(tp_days)
+
+
+async def goto_future(hass, future=None):
+    """Move to future."""
+    if not future:
+        future = utcnow() + datetime.timedelta(minutes=5)
+    with mock.patch("homeassistant.util.utcnow", return_value=future):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+
+async def setup_vaillant(hass, config=None, system=None):
+    """Set up vaillant component."""
+    if not config:
+        config = VALID_MINIMAL_CONFIG
+    if not system:
+        system = get_system()
+    SystemManagerMock.system = system
+
+    with patch(
+        "homeassistant.components.vaillant.hub.ApiHub.authenticate", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
+        )
+    await hass.async_block_till_done()
+    return result
+
+
+async def call_service(hass, domain, service, data):
+    """Call hass service."""
+    await hass.services.async_call(domain, service, data)
+    await hass.async_block_till_done()
+
+
+def assert_entities_count(hass, count):
+    """Count entities owned by the component."""
+    assert (
+        len(hass.states.async_entity_ids()) == len(hass.data[DOMAIN].entities) == count
+    )

--- a/tests/components/vaillant/conftest.py
+++ b/tests/components/vaillant/conftest.py
@@ -1,0 +1,15 @@
+"""Fixtures for vaillant tests."""
+
+from unittest import mock
+
+import pytest
+
+from tests.components.vaillant import SystemManagerMock
+
+
+@pytest.fixture(name="mock_system_manager")
+def fixture_mock_system_manager():
+    """Mock the vaillant system manager."""
+    with mock.patch("pymultimatic.systemmanager.SystemManager", new=SystemManagerMock):
+        yield
+    SystemManagerMock.reset_mock()

--- a/tests/components/vaillant/test_binary_sensor.py
+++ b/tests/components/vaillant/test_binary_sensor.py
@@ -1,0 +1,113 @@
+"""Tests for the vaillant sensor."""
+from pymultimatic.model import (
+    Device,
+    HolidayMode,
+    OperatingModes,
+    Room,
+    SettingModes,
+    System,
+)
+import pytest
+
+import homeassistant.components.vaillant as vaillant
+
+from tests.components.vaillant import (
+    SystemManagerMock,
+    active_holiday_mode,
+    assert_entities_count,
+    goto_future,
+    setup_vaillant,
+    time_program,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixture_only_binary_sensor(mock_system_manager):
+    """Mock vaillant to only handle binary_sensor."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = ["binary_sensor"]
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+async def test_valid_config(hass):
+    """Test setup with valid config."""
+    assert await setup_vaillant(hass)
+    assert_entities_count(hass, 10)
+
+
+async def test_empty_system(hass):
+    """Test setup with empty system."""
+    assert await setup_vaillant(hass, system=System())
+    assert_entities_count(hass, 2)
+
+
+async def test_state_update(hass):
+    """Test all sensors are updated accordingly to data."""
+    assert await setup_vaillant(hass)
+    assert_entities_count(hass, 10)
+
+    assert hass.states.is_state("binary_sensor.vaillant_dhw", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_room_1_window", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_123456789_lock", "on")
+    assert hass.states.is_state("binary_sensor.vaillant_123456789_battery", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_boiler", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_123456789_connectivity", "on")
+    assert hass.states.is_state("binary_sensor.vaillant_system_update", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_system_online", "on")
+    assert hass.states.is_state("binary_sensor.vaillant_holiday", "off")
+    state = hass.states.get("binary_sensor.vaillant_holiday")
+    assert state.attributes.get("start_date") is None
+    assert state.attributes.get("end_date") is None
+    assert state.attributes.get("temperature") is None
+    assert hass.states.is_state("binary_sensor.vaillant_quick_mode", "off")
+
+    system = SystemManagerMock.system
+    system.dhw.circulation.time_program = time_program(SettingModes.ON, None)
+    system.dhw.circulation.operating_mode = OperatingModes.AUTO
+
+    room_device = Device("Device 1", "123456789", "VALVE", True, True)
+    system.set_room(
+        "1",
+        Room(
+            id="1",
+            name="Room 1",
+            time_program=time_program(None, 20),
+            temperature=22,
+            target_high=24,
+            operating_mode=OperatingModes.AUTO,
+            quick_veto=None,
+            child_lock=True,
+            window_open=True,
+            devices=[room_device],
+        ),
+    )
+
+    system.boiler_status.status_code = "F11"
+    system.info.online = "OFFLINE"
+    system.info.update = "UPDATE_PENDING"
+    system.holiday = active_holiday_mode()
+    SystemManagerMock.system = system
+
+    await goto_future(hass)
+
+    assert_entities_count(hass, 10)
+    assert hass.states.is_state("binary_sensor.vaillant_dhw", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_room_1_window", "on")
+    assert hass.states.is_state("binary_sensor.vaillant_123456789_lock", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_123456789_battery", "on")
+    assert hass.states.is_state("binary_sensor.vaillant_boiler", "on")
+    assert hass.states.is_state("binary_sensor.vaillant_123456789_connectivity", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_system_update", "on")
+    assert hass.states.is_state("binary_sensor.vaillant_system_online", "off")
+    assert hass.states.is_state("binary_sensor.vaillant_holiday", "on")
+    state = hass.states.get("binary_sensor.vaillant_holiday")
+    assert state.attributes["start_date"] == system.holiday.start_date.isoformat()
+    assert state.attributes["end_date"] == system.holiday.end_date.isoformat()
+    assert state.attributes["temperature"] == system.holiday.target
+    assert hass.states.is_state("binary_sensor.vaillant_quick_mode", "off")
+
+    system.holiday = HolidayMode(False)
+
+    await goto_future(hass)
+    assert hass.states.is_state("binary_sensor.vaillant_dhw", "on")

--- a/tests/components/vaillant/test_climate_room.py
+++ b/tests/components/vaillant/test_climate_room.py
@@ -1,0 +1,209 @@
+"""Tests for the vaillant sensor."""
+
+from pymultimatic.model import (
+    OperatingModes,
+    QuickMode,
+    QuickModes,
+    QuickVeto,
+    Room,
+    System,
+)
+import pytest
+
+from homeassistant.components.climate.const import (
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+)
+import homeassistant.components.vaillant as vaillant
+from homeassistant.components.vaillant.const import ATTR_ENDS_AT, ATTR_VAILLANT_MODE
+
+from tests.components.vaillant import (
+    SystemManagerMock,
+    active_holiday_mode,
+    assert_entities_count,
+    call_service,
+    get_system,
+    goto_future,
+    setup_vaillant,
+    time_program,
+)
+
+
+def _assert_room_state(hass, mode, hvac, current_temp, temp):
+    """Assert room climate state."""
+    state = hass.states.get("climate.vaillant_room_1")
+    print(state)
+
+    assert hass.states.is_state("climate.vaillant_room_1", hvac)
+    assert state.attributes["current_temperature"] == current_temp
+    assert state.attributes["max_temp"] == Room.MAX_TARGET_TEMP
+    assert state.attributes["min_temp"] == Room.MIN_TARGET_TEMP
+
+    assert state.attributes["temperature"] == temp
+
+    assert set(state.attributes["hvac_modes"]) == {
+        HVAC_MODE_AUTO,
+        HVAC_MODE_OFF,
+    }
+
+    assert state.attributes[ATTR_VAILLANT_MODE] == mode.name
+
+
+@pytest.fixture(autouse=True)
+def fixture_only_climate(mock_system_manager):
+    """Mock vaillant to only handle sensor."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = ["climate"]
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+async def test_valid_config(hass):
+    """Test setup with valid config."""
+    assert await setup_vaillant(hass)
+    assert_entities_count(hass, 2)
+    _assert_room_state(hass, OperatingModes.AUTO, HVAC_MODE_AUTO, 22, 20)
+
+
+async def test_empty_system(hass):
+    """Test setup with empty system."""
+    assert await setup_vaillant(hass, system=System())
+    assert_entities_count(hass, 0)
+
+
+async def test_state_update_room(hass):
+    """Test room climate is updated accordingly to data."""
+    assert await setup_vaillant(hass)
+    _assert_room_state(hass, OperatingModes.AUTO, HVAC_MODE_AUTO, 22, 20)
+
+    system = SystemManagerMock.system
+    room = system.rooms[0]
+    room.temperature = 25
+    room.target_high = 30
+    room.time_program = time_program(None, 30)
+    await goto_future(hass)
+
+    _assert_room_state(hass, OperatingModes.AUTO, HVAC_MODE_AUTO, 25, 30)
+
+
+async def _test_mode_hvac(hass, mode, hvac_mode, target_temp):
+    system = get_system()
+
+    if isinstance(mode, QuickMode):
+        system.quick_mode = mode
+    else:
+        system.rooms[0].operating_mode = mode
+
+    assert await setup_vaillant(hass, system=system)
+    room = SystemManagerMock.system.rooms[0]
+    _assert_room_state(hass, mode, hvac_mode, room.temperature, target_temp)
+
+
+async def test_auto_mode_hvac_auto(hass):
+    """Test with auto mode."""
+    room = get_system().rooms[0]
+    await _test_mode_hvac(
+        hass, OperatingModes.AUTO, HVAC_MODE_AUTO, room.active_mode.target
+    )
+
+
+async def test_off_mode_hvac_off(hass):
+    """Test with off mode."""
+    await _test_mode_hvac(hass, OperatingModes.OFF, HVAC_MODE_OFF, Room.MIN_TARGET_TEMP)
+
+
+async def test_quickmode_system_off_mode_hvac_off(hass):
+    """Test with quick mode off."""
+    await _test_mode_hvac(
+        hass, QuickModes.SYSTEM_OFF, HVAC_MODE_OFF, Room.MIN_TARGET_TEMP
+    )
+
+
+async def test_holiday_mode(hass):
+    """Test with holiday mode."""
+    system = get_system()
+    system.holiday = active_holiday_mode()
+
+    assert await setup_vaillant(hass, system=system)
+
+    _assert_room_state(
+        hass, QuickModes.HOLIDAY, HVAC_MODE_OFF, system.rooms[0].temperature, 15
+    )
+
+
+async def test_set_target_temp_cool(hass):
+    """Test hvac is cool with lower target temp."""
+    room = get_system().rooms[0]
+    assert await setup_vaillant(hass)
+
+    await call_service(
+        hass,
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.vaillant_room_1", "temperature": 14},
+    )
+
+    _assert_room_state(
+        hass, OperatingModes.QUICK_VETO, HVAC_MODE_COOL, room.temperature, 14
+    )
+    SystemManagerMock.instance.set_room_quick_veto.assert_called_once()
+
+
+async def test_set_target_temp_heat(hass):
+    """Test hvac is heat with higher target temp."""
+    room = get_system().rooms[0]
+    assert await setup_vaillant(hass)
+
+    await call_service(
+        hass,
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.vaillant_room_1", "temperature": 30},
+    )
+
+    _assert_room_state(
+        hass, OperatingModes.QUICK_VETO, HVAC_MODE_HEAT, room.temperature, 30
+    )
+    SystemManagerMock.instance.set_room_quick_veto.assert_called_once()
+
+
+async def test_room_heating_manual(hass):
+    """Test hvac is heating with higher target temp."""
+    system = get_system()
+    room = system.rooms[0]
+    room.operating_mode = OperatingModes.MANUAL
+    room.temperature = 15
+    room.target_high = 25
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_room_state(hass, OperatingModes.MANUAL, HVAC_MODE_HEAT, 15, 25)
+
+
+async def test_room_cooling_manual(hass):
+    """Test hvac is cool with lower target temp."""
+    system = get_system()
+    room = system.rooms[0]
+    room.operating_mode = OperatingModes.MANUAL
+    room.temperature = 25
+    room.target_high = 15
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_room_state(hass, OperatingModes.MANUAL, HVAC_MODE_COOL, 25, 15)
+
+
+async def test_state_attrs(hass):
+    """Tetst state_attrs are correct."""
+    assert await setup_vaillant(hass)
+    state = hass.states.get("climate.vaillant_room_1")
+    assert state.attributes[ATTR_ENDS_AT] is not None
+
+
+async def test_state_attrs_quick_veto(hass):
+    """Tetst state_attrs are correct."""
+    system = get_system()
+    system.rooms[0].quick_veto = QuickVeto(duration=30, target=15)
+    assert await setup_vaillant(hass, system=system)
+    state = hass.states.get("climate.vaillant_room_1")
+    assert state.attributes[ATTR_ENDS_AT] is not None

--- a/tests/components/vaillant/test_climate_zone.py
+++ b/tests/components/vaillant/test_climate_zone.py
@@ -1,0 +1,308 @@
+"""Tests for the vaillant zone climate."""
+
+from pymultimatic.model import (
+    OperatingModes,
+    QuickMode,
+    QuickModes,
+    QuickVeto,
+    SettingModes,
+    System,
+    Zone,
+)
+import pytest
+
+from homeassistant.components.climate.const import (
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+import homeassistant.components.vaillant as vaillant
+from homeassistant.components.vaillant.const import ATTR_ENDS_AT, ATTR_VAILLANT_MODE
+
+from tests.components.vaillant import (
+    SystemManagerMock,
+    active_holiday_mode,
+    assert_entities_count,
+    call_service,
+    get_system,
+    goto_future,
+    setup_vaillant,
+    time_program,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixture_only_climate(mock_system_manager):
+    """Mock vaillant to only handle sensor."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = ["climate"]
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+def _assert_zone_state(hass, mode, hvac, current_temp, target_temp=None):
+    """Assert zone climate state."""
+    state = hass.states.get("climate.vaillant_zone_1")
+
+    assert hass.states.is_state("climate.vaillant_zone_1", hvac)
+    assert state.attributes["current_temperature"] == current_temp
+    assert state.attributes["max_temp"] == Zone.MAX_TARGET_TEMP
+    assert state.attributes["min_temp"] == Zone.MIN_TARGET_TEMP
+    assert state.attributes["temperature"] == target_temp
+    assert set(state.attributes["hvac_modes"]) == {
+        HVAC_MODE_OFF,
+        HVAC_MODE_AUTO,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_COOL,
+    }
+
+    assert state.attributes["supported_features"] == SUPPORT_TARGET_TEMPERATURE
+
+    assert state.attributes[ATTR_VAILLANT_MODE] == mode.name
+
+
+async def test_valid_config(hass):
+    """Test setup with valid config."""
+    assert await setup_vaillant(hass)
+    # one room, one zone
+    assert_entities_count(hass, 2)
+    zone = SystemManagerMock.system.zones[0]
+    _assert_zone_state(
+        hass,
+        OperatingModes.AUTO,
+        HVAC_MODE_AUTO,
+        zone.temperature,
+        zone.active_mode.target,
+    )
+
+
+async def test_empty_system(hass):
+    """Test setup with empty system."""
+    assert await setup_vaillant(hass, system=System())
+    assert_entities_count(hass, 0)
+
+
+async def _test_mode_hvac(hass, mode, hvac_mode, target_temp):
+    system = get_system()
+
+    if isinstance(mode, QuickMode):
+        system.quick_mode = mode
+    else:
+        system.zones[0].heating.operating_mode = mode
+
+    assert await setup_vaillant(hass, system=system)
+    zone = SystemManagerMock.system.zones[0]
+    _assert_zone_state(hass, mode, hvac_mode, zone.temperature, target_temp)
+
+
+async def _test_set_hvac(hass, hvac, mode, current_temp, target_temp):
+    assert await setup_vaillant(hass)
+
+    await call_service(
+        hass,
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": "climate.vaillant_zone_1", "hvac_mode": hvac},
+    )
+
+    _assert_zone_state(hass, mode, hvac, current_temp, target_temp)
+
+
+async def test_day_mode_hvac_heat(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_mode_hvac(
+        hass, OperatingModes.DAY, HVAC_MODE_HEAT, zone.heating.target_high
+    )
+
+
+async def test_night_mode_hvac_cool(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_mode_hvac(
+        hass, OperatingModes.NIGHT, HVAC_MODE_COOL, zone.heating.target_low
+    )
+
+
+async def test_auto_mode_hvac_auto(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_mode_hvac(
+        hass, OperatingModes.AUTO, HVAC_MODE_AUTO, zone.active_mode.target
+    )
+
+
+async def test_off_mode_hvac_off(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    zone.heating.operating_mode = OperatingModes.OFF
+    await _test_mode_hvac(hass, OperatingModes.OFF, HVAC_MODE_OFF, Zone.MIN_TARGET_TEMP)
+
+
+async def test_quickmode_system_off_mode_hvac_off(hass):
+    """Test mode <> hvac."""
+    await _test_mode_hvac(
+        hass, QuickModes.SYSTEM_OFF, HVAC_MODE_OFF, Zone.MIN_TARGET_TEMP
+    )
+
+
+async def test_quickmode_one_day_away_mode_hvac_off(hass):
+    """Test mode <> hvac."""
+    await _test_mode_hvac(
+        hass, QuickModes.ONE_DAY_AWAY, HVAC_MODE_OFF, Zone.MIN_TARGET_TEMP
+    )
+
+
+async def test_quickmode_party_mode_hvac_heat(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_mode_hvac(
+        hass, QuickModes.PARTY, HVAC_MODE_HEAT, zone.heating.target_high
+    )
+
+
+async def test_quickmode_one_day_home_hvac_auto(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_mode_hvac(
+        hass, QuickModes.ONE_DAY_AT_HOME, HVAC_MODE_AUTO, zone.heating.target_low
+    )
+
+
+async def test_quickmode_ventilation_boost_hvac_fan(hass):
+    """Test mode <> hvac."""
+    await _test_mode_hvac(
+        hass, QuickModes.VENTILATION_BOOST, HVAC_MODE_FAN_ONLY, Zone.MIN_TARGET_TEMP
+    )
+
+
+async def test_holiday_hvac_off(hass):
+    """Test mode <> hvac."""
+    system = get_system()
+    system.holiday = active_holiday_mode()
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_zone_state(
+        hass, QuickModes.HOLIDAY, HVAC_MODE_OFF, system.zones[0].temperature, 15
+    )
+
+
+async def test_set_hvac_heat(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_set_hvac(
+        hass,
+        HVAC_MODE_HEAT,
+        OperatingModes.DAY,
+        zone.temperature,
+        zone.heating.target_high,
+    )
+
+
+async def test_set_hvac_auto(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_set_hvac(
+        hass,
+        HVAC_MODE_AUTO,
+        OperatingModes.AUTO,
+        zone.temperature,
+        zone.active_mode.target,
+    )
+
+
+async def test_set_hvac_cool(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_set_hvac(
+        hass,
+        HVAC_MODE_COOL,
+        OperatingModes.NIGHT,
+        zone.temperature,
+        zone.heating.target_low,
+    )
+
+
+async def test_set_hvac_off(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    await _test_set_hvac(
+        hass, HVAC_MODE_OFF, OperatingModes.OFF, zone.temperature, Zone.MIN_TARGET_TEMP,
+    )
+
+
+async def test_set_target_temp_cool(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    assert await setup_vaillant(hass)
+
+    await call_service(
+        hass,
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.vaillant_zone_1", "temperature": 14},
+    )
+
+    _assert_zone_state(
+        hass, OperatingModes.QUICK_VETO, HVAC_MODE_COOL, zone.temperature, 14
+    )
+    SystemManagerMock.instance.set_zone_quick_veto.assert_called_once()
+
+
+async def test_set_target_temp_heat(hass):
+    """Test mode <> hvac."""
+    zone = get_system().zones[0]
+    assert await setup_vaillant(hass)
+
+    await call_service(
+        hass,
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.vaillant_zone_1", "temperature": 30},
+    )
+
+    _assert_zone_state(
+        hass, OperatingModes.QUICK_VETO, HVAC_MODE_HEAT, zone.temperature, 30
+    )
+    SystemManagerMock.instance.set_zone_quick_veto.assert_called_once()
+
+
+async def test_state_update_room(hass):
+    """Test room climate is updated accordingly to data."""
+    assert await setup_vaillant(hass)
+    zone = SystemManagerMock.system.zones[0]
+    _assert_zone_state(
+        hass,
+        OperatingModes.AUTO,
+        HVAC_MODE_AUTO,
+        zone.temperature,
+        zone.active_mode.target,
+    )
+
+    system = SystemManagerMock.system
+    zone = system.zones[0]
+    zone.heating.target_high = 30
+    zone.heating.time_program = time_program(SettingModes.DAY, None)
+    zone.temperature = 25
+    await goto_future(hass)
+
+    _assert_zone_state(hass, OperatingModes.AUTO, HVAC_MODE_AUTO, 25, 30)
+
+
+async def test_state_attrs(hass):
+    """Tetst state_attrs are correct."""
+    assert await setup_vaillant(hass)
+    state = hass.states.get("climate.vaillant_zone_1")
+    assert state.attributes[ATTR_ENDS_AT] is not None
+
+
+async def test_state_attrs_quick_veto(hass):
+    """Tetst state_attrs are correct."""
+    system = get_system()
+    system.zones[0].quick_veto = QuickVeto(duration=None, target=15)
+    assert await setup_vaillant(hass, system=system)
+    state = hass.states.get("climate.vaillant_zone_1")
+    assert state.attributes.get(ATTR_ENDS_AT, None) is None

--- a/tests/components/vaillant/test_config_flow.py
+++ b/tests/components/vaillant/test_config_flow.py
@@ -1,0 +1,55 @@
+"""Test the vaillant config flow."""
+from asynctest import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.vaillant.const import DOMAIN
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.vaillant.hub.ApiHub.authenticate", return_value=True,
+    ), patch(
+        "homeassistant.components.vaillant.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.vaillant.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-username", "password": "test-password"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Vaillant"
+    assert result2["data"] == {
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.vaillant.hub.ApiHub.authenticate", return_value=False,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-username", "password": "test-password"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}

--- a/tests/components/vaillant/test_dynamic_error.py
+++ b/tests/components/vaillant/test_dynamic_error.py
@@ -1,0 +1,52 @@
+"""Dynamic entity add/remove test."""
+from datetime import datetime
+
+from pymultimatic.model import Error
+import pytest
+
+from homeassistant.components import vaillant
+from homeassistant.components.vaillant import DOMAIN
+
+from tests.components.vaillant import get_system, goto_future, setup_vaillant
+
+
+@pytest.fixture(autouse=True)
+def fixture_only_binary_sensor(mock_system_manager):
+    """Mock vaillant to only handle binary_sensor."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = ["binary_sensor"]
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+async def test_error(hass):
+    """Test entity is created."""
+    system = get_system()
+    system.errors = [
+        Error("device_name", "title", "F152", "description", datetime.now())
+    ]
+    assert await setup_vaillant(hass, system=system)
+    assert (
+        hass.data[DOMAIN].api.get_entity("binary_sensor.vaillant_error_f152")
+        is not None
+    )
+
+
+async def test_error_removed(hass):
+    """Test entity is created and removed."""
+    system = get_system()
+    system.errors = [
+        Error("device_name", "title", "F152", "description", datetime.now())
+    ]
+    assert await setup_vaillant(hass, system=system)
+    assert (
+        hass.data[DOMAIN].api.get_entity("binary_sensor.vaillant_error_f152")
+        is not None
+    )
+    assert "binary_sensor.vaillant_error_f152" in hass.states.async_entity_ids()
+
+    system.errors = []
+    await goto_future(hass)
+
+    assert hass.data[DOMAIN].api.get_entity("binary_sensor.vaillant_error_f152") is None
+    assert "binary_sensor.vaillant_error_f152" not in hass.states.async_entity_ids()

--- a/tests/components/vaillant/test_hub.py
+++ b/tests/components/vaillant/test_hub.py
@@ -1,0 +1,102 @@
+"""Tests for the hub."""
+from asynctest import CoroutineMock
+from pymultimatic.api import ApiError
+import pytest
+
+import homeassistant.components.vaillant as vaillant
+from homeassistant.components.vaillant import ApiHub
+
+from tests.components.vaillant import SystemManagerMock
+from tests.test_util.aiohttp import AiohttpClientMockResponse
+
+
+@pytest.fixture(autouse=True)
+def fixture_nothing(mock_system_manager):
+    """Mock System Manager."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = []
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+async def test_authenticate_error(hass):
+    """Test authentication gives error."""
+    response = AiohttpClientMockResponse("GET", "http://test.com", json={})
+    SystemManagerMock.login = CoroutineMock(side_effect=ApiError("test", response, {}))
+    hub = ApiHub(hass, "user", "pwd", None)
+    hub._manager = SystemManagerMock
+
+    assert not await hub.authenticate()
+
+
+async def test_authenticate_ok(hass):
+    """Test correct credentials."""
+    SystemManagerMock.login = CoroutineMock(return_value=True)
+    hub = ApiHub(hass, "user", "pwd", None)
+
+    assert await hub.authenticate()
+
+
+async def test_request_hvac_ok(hass):
+    """Test hvac request went well."""
+    SystemManagerMock.request_hvac_update = CoroutineMock(return_value=True)
+    hub = ApiHub(hass, "user", "pwd", None)
+    hub._manager = SystemManagerMock
+
+    await hub.request_hvac_update()
+    SystemManagerMock.request_hvac_update.assert_awaited()
+
+
+async def test_request_hvac_error(hass):
+    """Test hvac request gives error and new authentication occurred."""
+    response = AiohttpClientMockResponse("GET", "http://test.com", json={}, status=401)
+    SystemManagerMock.request_hvac_update = CoroutineMock(
+        side_effect=ApiError("test", response, {})
+    )
+    hub = ApiHub(hass, "user", "pwd", None)
+    hub.authenticate = CoroutineMock()
+    hub._manager = SystemManagerMock
+
+    await hub.request_hvac_update()
+    hub.authenticate.assert_awaited()
+
+
+async def test_request_hvac_error_409(hass):
+    """Test hvac request gives HTTP 409 and authentication didn't occur."""
+    response = AiohttpClientMockResponse("GET", "http://test.com", json={}, status=409)
+    SystemManagerMock.request_hvac_update = CoroutineMock(
+        side_effect=ApiError("test", response, {})
+    )
+    hub = ApiHub(hass, "user", "pwd", None)
+    hub.authenticate = CoroutineMock()
+    hub._manager = SystemManagerMock
+
+    await hub.request_hvac_update()
+    hub.authenticate.assert_not_awaited()
+
+
+async def test_update_system_ok(hass):
+    """Test update system is ok."""
+    hub = ApiHub(hass, "user", "pwd", None)
+    hub.authenticate = CoroutineMock()
+
+    SystemManagerMock.get_system = CoroutineMock()
+    hub._manager = SystemManagerMock
+
+    await hub._update_system()
+    hub.authenticate.assert_not_awaited()
+
+
+async def test_update_system_error(hass):
+    """Test system update gives error and triggers authentication."""
+    hub = ApiHub(hass, "user", "pwd", None)
+    hub.authenticate = CoroutineMock()
+
+    response = AiohttpClientMockResponse("GET", "http://test.com", json={}, status=401)
+    SystemManagerMock.get_system = CoroutineMock(
+        side_effect=ApiError("test", response, {})
+    )
+    hub._manager = SystemManagerMock
+
+    await hub._update_system()
+    hub.authenticate.assert_awaited()

--- a/tests/components/vaillant/test_sensor.py
+++ b/tests/components/vaillant/test_sensor.py
@@ -1,0 +1,54 @@
+"""Tests for the vaillant sensor."""
+
+from pymultimatic.model import System
+import pytest
+
+import homeassistant.components.vaillant as vaillant
+
+from tests.components.vaillant import (
+    SystemManagerMock,
+    assert_entities_count,
+    goto_future,
+    setup_vaillant,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixture_only_sensor(mock_system_manager):
+    """Mock vaillant to only handle sensor."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = ["sensor"]
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+async def test_valid_config(hass):
+    """Test setup with valid config."""
+    assert await setup_vaillant(hass)
+    print(hass.states.async_entity_ids())
+    assert_entities_count(hass, 2)
+
+
+async def test_empty_system(hass):
+    """Test setup with empty system."""
+    assert await setup_vaillant(hass, system=System())
+    assert_entities_count(hass, 0)
+
+
+async def test_state_update(hass):
+    """Test all sensors are updated accordingly to data."""
+    assert await setup_vaillant(hass)
+    assert_entities_count(hass, 2)
+
+    assert hass.states.is_state("sensor.vaillant_waterpressuresensor", "1.9")
+    assert hass.states.is_state("sensor.vaillant_outdoor_temperature", "18")
+
+    system = SystemManagerMock.system
+    system.outdoor_temperature = 21
+    system.reports[0].value = 1.6
+    SystemManagerMock.system = system
+
+    await goto_future(hass)
+
+    assert hass.states.is_state("sensor.vaillant_waterpressuresensor", "1.6")
+    assert hass.states.is_state("sensor.vaillant_outdoor_temperature", "21")

--- a/tests/components/vaillant/test_service.py
+++ b/tests/components/vaillant/test_service.py
@@ -1,0 +1,223 @@
+"""Tests for service."""
+from pymultimatic.model import QuickModes, QuickVeto
+import pytest
+import voluptuous
+
+from homeassistant.components import vaillant
+from homeassistant.components.vaillant import DOMAIN
+
+from tests.components.vaillant import (
+    SystemManagerMock,
+    active_holiday_mode,
+    call_service,
+    get_system,
+    setup_vaillant,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixture_only_climate(mock_system_manager):
+    """Mock vaillant to only handle binary_sensor."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = ["climate"]
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+async def test_valid_config(hass):
+    """Test setup with valid config."""
+    assert await setup_vaillant(hass)
+    assert len(hass.services.async_services()[DOMAIN]) == 7
+
+
+async def test_remove_quick_mode(hass):
+    """Test remove existing quick mode."""
+    system = get_system()
+    system.quick_mode = QuickModes.ONE_DAY_AT_HOME
+    assert await setup_vaillant(hass, system=system)
+    await call_service(hass, "vaillant", "remove_quick_mode", None)
+    SystemManagerMock.instance.remove_quick_mode.assert_called_once_with()
+
+
+async def test_remove_quick_mode_wrong_data(hass):
+    """Test remove existing quick mode with wrong data."""
+    assert await setup_vaillant(hass)
+    with pytest.raises(voluptuous.error.MultipleInvalid):
+        await call_service(hass, "vaillant", "remove_quick_mode", {"test": "boom"})
+
+
+async def test_remove_holiday_mode(hass):
+    """Remove existing holiday mode."""
+    system = get_system()
+    system.holiday = active_holiday_mode()
+    assert await setup_vaillant(hass, system=system)
+    await call_service(hass, "vaillant", "remove_holiday_mode", None)
+    SystemManagerMock.instance.remove_holiday_mode.assert_called_once_with()
+
+
+async def test_remove_holiday_mode_wrong_data(hass):
+    """Remove existing holiday mode with wrong data."""
+    assert await setup_vaillant(hass)
+    with pytest.raises(voluptuous.error.MultipleInvalid):
+        await call_service(hass, "vaillant", "remove_holiday_mode", {"test": "boom"})
+
+
+async def test_set_quick_mode(hass):
+    """Set quick mode."""
+    assert await setup_vaillant(hass)
+    await call_service(hass, "vaillant", "set_quick_mode", {"quick_mode": "QM_PARTY"})
+    SystemManagerMock.instance.set_quick_mode.assert_called_once_with(QuickModes.PARTY)
+
+
+async def test_set_quick_mode_wrong_data(hass):
+    """Set quick mode with wrong data."""
+    assert await setup_vaillant(hass)
+    with pytest.raises(voluptuous.error.MultipleInvalid):
+        await call_service(hass, "vaillant", "set_quick_mode", {"test": "boom"})
+
+
+async def test_set_holiday_mode_correct_date(hass):
+    """Test holiday mode."""
+    assert await setup_vaillant(hass)
+    await call_service(
+        hass,
+        "vaillant",
+        "set_holiday_mode",
+        {"start_date": "2010-10-25", "end_date": "2010-10-26", "temperature": "10"},
+    )
+    SystemManagerMock.instance.set_holiday_mode.assert_called_once()
+
+
+async def test_set_holiday_mode_wrong_date_format(hass):
+    """Test holiday mode."""
+    assert await setup_vaillant(hass)
+    await call_service(
+        hass,
+        "vaillant",
+        "set_holiday_mode",
+        {
+            "start_date": "2010-10-25T00:00:00.000Z",
+            "end_date": "2010-10-26T00:00:00.000Z",
+            "temperature": "10",
+        },
+    )
+    SystemManagerMock.instance.set_holiday_mode.assert_called_once()
+
+
+async def test_set_holiday_mode_wrong_data(hass):
+    """Test holiday mode with wrong data."""
+    assert await setup_vaillant(hass)
+    with pytest.raises(voluptuous.error.MultipleInvalid):
+        await call_service(hass, "vaillant", "set_holiday_mode", {"test": "boom"})
+
+
+async def test_remove_quick_veto_wrong_data(hass):
+    """Remove quick veto with wrong entity id."""
+    assert await setup_vaillant(hass)
+    await call_service(
+        hass, "vaillant", "remove_quick_veto", {"entity_id": "climate.vaillant_test123"}
+    )
+    SystemManagerMock.instance.remove_room_quick_veto.assert_not_called()
+    SystemManagerMock.instance.remove_zone_quick_veto.assert_not_called()
+
+
+async def test_remove_quick_veto_room(hass):
+    """Remove quick veto with already existing quick veto."""
+    system = get_system()
+    system.rooms[0].quick_veto = QuickVeto(duration=30, target=10)
+    assert await setup_vaillant(hass, system=system)
+    await call_service(
+        hass, "vaillant", "remove_quick_veto", {"entity_id": "climate.vaillant_room_1"}
+    )
+    SystemManagerMock.instance.remove_room_quick_veto.assert_called_once_with("1")
+
+
+async def test_no_remove_quick_veto_room(hass):
+    """Remove quick veto without quick veto."""
+    assert await setup_vaillant(hass)
+    await call_service(
+        hass, "vaillant", "remove_quick_veto", {"entity_id": "climate.vaillant_room_1"}
+    )
+    SystemManagerMock.instance.remove_room_quick_veto.assert_not_called()
+
+
+async def test_no_remove_quick_veto_zone(hass):
+    """Remove quick veto without quick veto."""
+    assert await setup_vaillant(hass)
+    await call_service(
+        hass, "vaillant", "remove_quick_veto", {"entity_id": "climate.vaillant_zone_1"}
+    )
+    SystemManagerMock.instance.remove_zone_quick_veto.assert_not_called()
+
+
+async def test_remove_quick_veto_zone(hass):
+    """Remove quick veto with already existing quick veto."""
+    system = get_system()
+    system.zones[0].quick_veto = QuickVeto(duration=30, target=10)
+    assert await setup_vaillant(hass, system=system)
+    await call_service(
+        hass, "vaillant", "remove_quick_veto", {"entity_id": "climate.vaillant_zone_1"}
+    )
+    SystemManagerMock.instance.remove_zone_quick_veto.assert_called_once_with("zone_1")
+
+
+async def test_set_quick_veto_room(hass):
+    """Set quick veto without quick veto."""
+    assert await setup_vaillant(hass)
+    await call_service(
+        hass,
+        DOMAIN,
+        "set_quick_veto",
+        {"entity_id": "climate.vaillant_room_1", "duration": 300, "temperature": 25},
+    )
+    SystemManagerMock.instance.set_room_quick_veto.assert_called_once_with(
+        "1", QuickVeto(300, 25.0)
+    )
+
+
+async def test_set_quick_veto_room_with_quick_veto(hass):
+    """Set quick veto with quick veto."""
+    system = get_system()
+    system.rooms[0].quick_veto = QuickVeto(duration=30, target=10)
+    assert await setup_vaillant(hass, system=system)
+    await call_service(
+        hass,
+        DOMAIN,
+        "set_quick_veto",
+        {"entity_id": "climate.vaillant_room_1", "duration": 300, "temperature": 25},
+    )
+    SystemManagerMock.instance.set_room_quick_veto.assert_called_once_with(
+        "1", QuickVeto(300, 25.0)
+    )
+    SystemManagerMock.instance.remove_room_quick_veto.assert_called_once_with("1")
+
+
+async def test_set_quick_veto_zone_with_quick_veto(hass):
+    """Set quick veto with quick veto."""
+    system = get_system()
+    system.zones[0].quick_veto = QuickVeto(duration=30, target=10)
+    assert await setup_vaillant(hass, system=system)
+    await call_service(
+        hass,
+        DOMAIN,
+        "set_quick_veto",
+        {"entity_id": "climate.vaillant_zone_1", "duration": 300, "temperature": 25},
+    )
+    SystemManagerMock.instance.set_zone_quick_veto.assert_called_once_with(
+        "zone_1", QuickVeto(300, 25.0)
+    )
+    SystemManagerMock.instance.remove_zone_quick_veto.assert_called_once_with("zone_1")
+
+
+async def test_set_quick_veto_zone(hass):
+    """Set quick veto without quick veto."""
+    assert await setup_vaillant(hass)
+    await call_service(
+        hass,
+        DOMAIN,
+        "set_quick_veto",
+        {"entity_id": "climate.vaillant_zone_1", "duration": 300, "temperature": 25},
+    )
+    SystemManagerMock.instance.set_zone_quick_veto.assert_called_once_with(
+        "zone_1", QuickVeto(300, 25.0)
+    )

--- a/tests/components/vaillant/test_water_heater.py
+++ b/tests/components/vaillant/test_water_heater.py
@@ -1,0 +1,323 @@
+"""Tests for the vaillant sensor."""
+import datetime
+from unittest.mock import ANY
+
+from pymultimatic.model import (
+    HolidayMode,
+    HotWater,
+    OperatingModes,
+    QuickModes,
+    System,
+    constants,
+)
+import pytest
+
+import homeassistant.components.vaillant as vaillant
+from homeassistant.components.vaillant.const import ATTR_ENDS_AT, ATTR_VAILLANT_MODE
+
+from tests.components.vaillant import (
+    SystemManagerMock,
+    assert_entities_count,
+    call_service,
+    get_system,
+    goto_future,
+    setup_vaillant,
+)
+
+
+def _assert_state(hass, mode, temp, current_temp, away_mode):
+    assert_entities_count(hass, 1)
+
+    state = hass.states.get("water_heater.vaillant_dhw")
+    assert hass.states.is_state("water_heater.vaillant_dhw", mode.name)
+    assert state.attributes["min_temp"] == HotWater.MIN_TARGET_TEMP
+    assert state.attributes["max_temp"] == HotWater.MAX_TARGET_TEMP
+    assert state.attributes["temperature"] == temp
+    assert state.attributes["current_temperature"] == current_temp
+    assert state.attributes[ATTR_VAILLANT_MODE] == mode.name
+
+    if mode == QuickModes.HOLIDAY:
+        assert state.attributes.get("operation_mode") is None
+        assert state.attributes.get("away_mode") is None
+        assert state.attributes.get("operation_list") is None
+    else:
+        assert state.attributes["operation_mode"] == mode.name
+        assert state.attributes["away_mode"] == away_mode
+        assert set(state.attributes["operation_list"]) == {"ON", "OFF", "AUTO"}
+
+
+@pytest.fixture(autouse=True)
+def fixture_only_water_heater(mock_system_manager):
+    """Mock vaillant to only handle sensor."""
+    orig_platforms = vaillant.PLATFORMS
+    vaillant.PLATFORMS = ["water_heater"]
+    yield
+    vaillant.PLATFORMS = orig_platforms
+
+
+async def test_valid_config(hass):
+    """Test setup with valid config."""
+    assert await setup_vaillant(hass)
+    _assert_state(hass, OperatingModes.AUTO, constants.FROST_PROTECTION_TEMP, 45, "off")
+
+
+async def test_empty_system(hass):
+    """Test setup with empty system."""
+    assert await setup_vaillant(hass, system=System())
+    assert_entities_count(hass, 0)
+
+
+async def test_state_update(hass):
+    """Test water heater is updated accordingly to data."""
+    assert await setup_vaillant(hass)
+    _assert_state(hass, OperatingModes.AUTO, constants.FROST_PROTECTION_TEMP, 45, "off")
+
+    system = SystemManagerMock.system
+    system.dhw.hotwater.temperature = 65
+    system.dhw.hotwater.operating_mode = OperatingModes.ON
+    system.dhw.hotwater.target_high = 45
+    SystemManagerMock.system = system
+    await goto_future(hass)
+
+    _assert_state(hass, OperatingModes.ON, 45, 65, "off")
+
+
+async def test_holiday_mode(hass):
+    """Test holiday mode."""
+    system = get_system()
+    system.quick_mode = QuickModes.HOLIDAY
+    system.holiday = HolidayMode(True, datetime.date.today(), datetime.date.today(), 15)
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_state(hass, QuickModes.HOLIDAY, constants.FROST_PROTECTION_TEMP, 45, "on")
+
+
+async def test_away_mode(hass):
+    """Test away mode."""
+    system = get_system()
+    system.dhw.hotwater.operating_mode = OperatingModes.OFF
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_state(hass, OperatingModes.OFF, constants.FROST_PROTECTION_TEMP, 45, "on")
+
+
+async def test_water_boost(hass):
+    """Test hot water boost mode."""
+    system = get_system()
+    system.quick_mode = QuickModes.HOTWATER_BOOST
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_state(hass, QuickModes.HOTWATER_BOOST, 40, 45, "off")
+
+
+async def test_system_off(hass):
+    """Test system off mode."""
+    system = get_system()
+    system.quick_mode = QuickModes.SYSTEM_OFF
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_state(
+        hass, QuickModes.SYSTEM_OFF, constants.FROST_PROTECTION_TEMP, 45, "on"
+    )
+
+
+async def test_one_day_away(hass):
+    """Test one day away mode."""
+    system = get_system()
+    system.quick_mode = QuickModes.ONE_DAY_AWAY
+
+    assert await setup_vaillant(hass, system=system)
+    _assert_state(
+        hass, QuickModes.ONE_DAY_AWAY, constants.FROST_PROTECTION_TEMP, 45, "on"
+    )
+
+
+async def test_turn_away_mode_on(hass):
+    """Test turn away mode on."""
+    assert await setup_vaillant(hass)
+
+    hot_water = SystemManagerMock.system.dhw.hotwater
+    hot_water.operating_mode = OperatingModes.OFF
+    SystemManagerMock.instance.get_hot_water.return_value = hot_water
+
+    await hass.services.async_call(
+        "water_heater",
+        "set_away_mode",
+        {"entity_id": "water_heater.vaillant_dhw", "away_mode": True},
+    )
+    await hass.async_block_till_done()
+
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_called_once_with(
+        ANY, OperatingModes.OFF
+    )
+    _assert_state(hass, OperatingModes.OFF, constants.FROST_PROTECTION_TEMP, 45, "on")
+
+
+async def test_turn_away_mode_off(hass):
+    """Test turn away mode off."""
+    assert await setup_vaillant(hass)
+
+    hot_water = SystemManagerMock.system.dhw.hotwater
+    hot_water.operating_mode = OperatingModes.AUTO
+    SystemManagerMock.instance.get_hot_water.return_value = hot_water
+
+    await hass.services.async_call(
+        "water_heater",
+        "set_away_mode",
+        {"entity_id": "water_heater.vaillant_dhw", "away_mode": False},
+    )
+    await hass.async_block_till_done()
+
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_called_once_with(
+        ANY, OperatingModes.AUTO
+    )
+
+    _assert_state(hass, OperatingModes.AUTO, constants.FROST_PROTECTION_TEMP, 45, "off")
+
+
+async def test_set_operating_mode(hass):
+    """Test set operation mode."""
+    assert await setup_vaillant(hass)
+
+    hot_water = SystemManagerMock.system.dhw.hotwater
+    hot_water.operating_mode = OperatingModes.ON
+    SystemManagerMock.instance.get_hot_water.return_value = hot_water
+
+    await hass.services.async_call(
+        "water_heater",
+        "set_operation_mode",
+        {"entity_id": "water_heater.vaillant_dhw", "operation_mode": "ON"},
+    )
+    await hass.async_block_till_done()
+
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_called_once_with(
+        ANY, OperatingModes.ON
+    )
+    _assert_state(hass, OperatingModes.ON, 40, 45, "off")
+
+
+async def test_set_operating_mode_wrong(hass):
+    """Test set operation mode with wrong mode."""
+    assert await setup_vaillant(hass)
+
+    await hass.services.async_call(
+        "water_heater",
+        "set_operation_mode",
+        {"entity_id": "water_heater.vaillant_dhw", "operation_mode": "wrong"},
+    )
+    await hass.async_block_till_done()
+
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_not_called()
+    _assert_state(hass, OperatingModes.AUTO, constants.FROST_PROTECTION_TEMP, 45, "off")
+
+
+async def test_set_temperature(hass):
+    """Test set target temperature."""
+    system = get_system()
+    system.dhw.hotwater.operating_mode = OperatingModes.AUTO
+    assert await setup_vaillant(hass, system=system)
+
+    SystemManagerMock.instance.get_hot_water.return_value = (
+        SystemManagerMock.system.dhw.hotwater
+    )
+
+    await call_service(
+        hass,
+        "water_heater",
+        "set_temperature",
+        {"entity_id": "water_heater.vaillant_dhw", "temperature": 50},
+    )
+
+    SystemManagerMock.instance.set_hot_water_setpoint_temperature.assert_called_once_with(
+        "dhw", 50
+    )
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_not_called()
+
+
+async def test_set_temperature_already_on(hass):
+    """Test set target temperature."""
+    system = get_system()
+    system.dhw.hotwater.operating_mode = OperatingModes.ON
+    assert await setup_vaillant(hass, system=system)
+
+    SystemManagerMock.instance.get_hot_water.return_value = (
+        SystemManagerMock.system.dhw.hotwater
+    )
+
+    await call_service(
+        hass,
+        "water_heater",
+        "set_temperature",
+        {"entity_id": "water_heater.vaillant_dhw", "temperature": 50},
+    )
+
+    SystemManagerMock.instance.set_hot_water_setpoint_temperature.assert_called_once_with(
+        "dhw", 50
+    )
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_not_called()
+
+
+async def test_set_temperature_already_off(hass):
+    """Test set target temperature."""
+    system = get_system()
+    system.dhw.hotwater.operating_mode = OperatingModes.OFF
+    assert await setup_vaillant(hass, system=system)
+
+    SystemManagerMock.instance.get_hot_water.return_value = (
+        SystemManagerMock.system.dhw.hotwater
+    )
+
+    await call_service(
+        hass,
+        "water_heater",
+        "set_temperature",
+        {"entity_id": "water_heater.vaillant_dhw", "temperature": 50},
+    )
+
+    SystemManagerMock.instance.set_hot_water_setpoint_temperature.assert_called_once_with(
+        "dhw", 50
+    )
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_called_once()
+
+
+async def test_set_operating_mode_while_quick_mode(hass):
+    """Ensure water heater mode is set when unrelated quick mode is active."""
+    system = get_system()
+    system.quick_mode = QuickModes.PARTY
+    assert await setup_vaillant(hass, system=system)
+
+    await call_service(
+        hass,
+        "water_heater",
+        "set_operation_mode",
+        {"entity_id": "water_heater.vaillant_dhw", "operation_mode": "AUTO"},
+    )
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_called_once_with(
+        "dhw", OperatingModes.AUTO
+    )
+    SystemManagerMock.instance.remove_quick_mode.assert_not_called()
+
+
+async def test_set_operating_mode_while_quick_mode_for_dhw(hass):
+    """Ensure water heater mode is not set when related quick mode is active."""
+    system = get_system()
+    system.quick_mode = QuickModes.HOTWATER_BOOST
+    assert await setup_vaillant(hass, system=system)
+
+    await call_service(
+        hass,
+        "water_heater",
+        "set_operation_mode",
+        {"entity_id": "water_heater.vaillant_dhw", "operation_mode": "AUTO"},
+    )
+    SystemManagerMock.instance.set_hot_water_operating_mode.assert_called_once_with(
+        "dhw", OperatingModes.AUTO
+    )
+    SystemManagerMock.instance.remove_quick_mode.assert_called_once_with()
+
+
+async def test_state_attrs(hass):
+    """Tetst state_attrs are correct."""
+    assert await setup_vaillant(hass)
+    state = hass.states.get("water_heater.vaillant_dhw")
+    assert state.attributes[ATTR_ENDS_AT] is not None


### PR DESCRIPTION
## Breaking change
No breaking change


## Proposed change
New component "vaillant", name sill to be defined with your advice, maybe multimatic ?


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
Nothing to add in the yaml


## Additional information
So I guess this is here I have to say it all. 
So first, as you see this is work in progress and I'm rather asking for tips/advice/approval instead of real merging for now.

First, integration is based on the following underlying connector: https://github.com/thomasgermain/pymultiMATIC (also done by me).

It basically allows what this android app can do : https://play.google.com/store/apps/details?id=com.vaillant.android.mobildialog3 (except some configuration like schedule or changing name of room or zone).

This is compatible with VRC700 at VR900/920 (and maybe other devices working with multimatic app).

Here is also a link to the HA forum: https://community.home-assistant.io/t/vaillant-multimatic-component/87240, the component is already used by few people and they are providing feedback.

I don't know if you need more technical descriptions ?

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: there is not yet doc PR, there is a small documentation available here: https://github.com/thomasgermain/vaillant-component

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
Actually, I don't really know, maybe it's up to you to ensure all points for all quality-scale are met ?
The integration met multiples points of multiple quality-scale (handling reconnection, logs when thing goes wrong, full async, configurable with config-flow - through the UI, etc.) I think it can go up to Gold.

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io