### PR TITLE
Implement Keen vents as zha cover devices

### DIFF
--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -98,7 +98,7 @@ DEVICE_CLASS = {
         zigpy.profiles.zha.DeviceType.DIMMABLE_LIGHT: LIGHT,
         zigpy.profiles.zha.DeviceType.DIMMABLE_PLUG_IN_UNIT: LIGHT,
         zigpy.profiles.zha.DeviceType.EXTENDED_COLOR_LIGHT: LIGHT,
-        zigpy.profiles.zha.DeviceType.LEVEL_CONTROLLABLE_OUTPUT: LIGHT,
+        zigpy.profiles.zha.DeviceType.LEVEL_CONTROLLABLE_OUTPUT: COVER,
         zigpy.profiles.zha.DeviceType.ON_OFF_BALLAST: SWITCH,
         zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT: LIGHT,
         zigpy.profiles.zha.DeviceType.ON_OFF_PLUG_IN_UNIT: SWITCH,

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -294,7 +294,7 @@ class KeenVent(Shade):
         return DEVICE_CLASS_DAMPER
 
     async def async_open_cover(self, **kwargs):
-        """Open the window cover."""
+        """Open the cover."""
         position = self._position or 100
         tasks = [
             self._level_channel.move_to_level_with_on_off(position * 255 / 100, 1),

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -1,4 +1,5 @@
 """Support for ZHA covers."""
+import asyncio
 import functools
 import logging
 from typing import List, Optional
@@ -8,6 +9,7 @@ from zigpy.zcl.foundation import Status
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
+    DEVICE_CLASS_DAMPER,
     DEVICE_CLASS_SHADE,
     DOMAIN,
     CoverEntity,
@@ -278,3 +280,31 @@ class Shade(ZhaEntity, CoverEntity):
         if not isinstance(res, list) or res[1] != Status.SUCCESS:
             self.debug("couldn't stop cover: %s", res)
             return
+
+
+@STRICT_MATCH(
+    channel_names={CHANNEL_LEVEL, CHANNEL_ON_OFF}, manufacturers="Keen Home Inc"
+)
+class KeenVent(Shade):
+    """Keen vent cover."""
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_DAMPER
+
+    async def async_open_cover(self, **kwargs):
+        """Open the window cover."""
+        position = self._position or 100
+        tasks = [
+            self._level_channel.move_to_level_with_on_off(position * 255 / 100, 1),
+            self._on_off_channel.on(),
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        if any([isinstance(result, Exception) for result in results]):
+            self.debug("couldn't open cover")
+            return
+
+        self._is_open = True
+        self._position = position
+        self.async_write_ha_state()

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -1036,16 +1036,16 @@ DEVICES = [
             }
         },
         "entities": [
-            "light.keen_home_inc_sv02_610_mp_1_3_77665544_level_on_off",
+            "cover.keen_home_inc_sv02_610_mp_1_3_77665544_level_on_off",
             "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_power",
             "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_pressure",
             "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_temperature",
         ],
         "entity_map": {
-            ("light", "00:11:22:33:44:55:66:77-1"): {
+            ("cover", "00:11:22:33:44:55:66:77-1"): {
                 "channels": ["level", "on_off"],
-                "entity_class": "Light",
-                "entity_id": "light.keen_home_inc_sv02_610_mp_1_3_77665544_level_on_off",
+                "entity_class": "KeenVent",
+                "entity_id": "cover.keen_home_inc_sv02_610_mp_1_3_77665544_level_on_off",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],
@@ -1094,16 +1094,16 @@ DEVICES = [
             }
         },
         "entities": [
-            "light.keen_home_inc_sv02_612_mp_1_2_77665544_level_on_off",
+            "cover.keen_home_inc_sv02_612_mp_1_2_77665544_level_on_off",
             "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_power",
             "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_pressure",
             "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_temperature",
         ],
         "entity_map": {
-            ("light", "00:11:22:33:44:55:66:77-1"): {
+            ("cover", "00:11:22:33:44:55:66:77-1"): {
                 "channels": ["level", "on_off"],
-                "entity_class": "Light",
-                "entity_id": "light.keen_home_inc_sv02_612_mp_1_2_77665544_level_on_off",
+                "entity_class": "KeenVent",
+                "entity_id": "cover.keen_home_inc_sv02_612_mp_1_2_77665544_level_on_off",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],
@@ -1152,16 +1152,16 @@ DEVICES = [
             }
         },
         "entities": [
-            "light.keen_home_inc_sv02_612_mp_1_3_77665544_level_on_off",
+            "cover.keen_home_inc_sv02_612_mp_1_3_77665544_level_on_off",
             "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_power",
             "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_pressure",
             "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_temperature",
         ],
         "entity_map": {
-            ("light", "00:11:22:33:44:55:66:77-1"): {
+            ("cover", "00:11:22:33:44:55:66:77-1"): {
                 "channels": ["level", "on_off"],
-                "entity_class": "Light",
-                "entity_id": "light.keen_home_inc_sv02_612_mp_1_3_77665544_level_on_off",
+                "entity_class": "KeenVent",
+                "entity_id": "cover.keen_home_inc_sv02_612_mp_1_3_77665544_level_on_off",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Yes. In previous versions Keen Vents were presented as `light` entities. In this version those are presented as `cover` "damper" device class entities

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement Keen Vent covers as cover entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
