### PR TITLE
Proceed with startup if an integration setup blocks for more than 30m

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -422,4 +422,5 @@ async def _async_set_up_integrations(
         await async_setup_multi_components(stage_2_domains)
 
     # Wrap up startup
+    _LOGGER.debug("Waiting for startup to wrap up")
     await hass.async_block_till_done()

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -19,6 +19,9 @@ DATA_SETUP = "setup_tasks"
 DATA_DEPS_REQS = "deps_reqs_processed"
 
 SLOW_SETUP_WARNING = 10
+# Since a pip install can run, we wait
+# 30 minutes to timeout
+SLOW_SETUP_MAX_WAIT = 1800
 
 
 def setup_component(hass: core.HomeAssistant, domain: str, config: ConfigType) -> bool:
@@ -167,16 +170,28 @@ async def _async_setup_component(
 
     try:
         if hasattr(component, "async_setup"):
-            result = await component.async_setup(  # type: ignore
+            task = component.async_setup(  # type: ignore
                 hass, processed_config
             )
         elif hasattr(component, "setup"):
-            result = await hass.async_add_executor_job(
-                component.setup, hass, processed_config  # type: ignore
+            # This should not be replaced with hass.async_add_executor_job because
+            # we don't want to track this task in case it blocks startup.
+            task = hass.loop.run_in_executor(
+                None, component.setup, hass, processed_config  # type: ignore
             )
         else:
-            log_error("No setup function defined.")
+            log_error("No setup function defined for %s", domain)
             return False
+
+        result = await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)
+    except asyncio.TimeoutError:
+        _LOGGER.error(
+            "Setup of component %s is taking longer than %s seconds."
+            " Startup will proceed without waiting any longer.",
+            domain,
+            SLOW_SETUP_MAX_WAIT,
+        )
+        return False
     except Exception:  # pylint: disable=broad-except
         _LOGGER.exception("Error during setup of component %s", domain)
         async_notify_setup_error(hass, domain, integration.documentation)

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -183,7 +183,7 @@ async def _async_setup_component(
             log_error("No setup function defined.")
             return False
 
-        result = await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)
+        result = await asyncio.wait_for(task, SLOW_SETUP_MAX_WAIT)
     except asyncio.TimeoutError:
         _LOGGER.error(
             "Setup of %s is taking longer than %s seconds."

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -186,7 +186,7 @@ async def _async_setup_component(
         result = await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)
     except asyncio.TimeoutError:
         _LOGGER.error(
-            "Setup of component %s is taking longer than %s seconds."
+            "Setup of %s is taking longer than %s seconds."
             " Startup will proceed without waiting any longer.",
             domain,
             SLOW_SETUP_MAX_WAIT,

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -180,7 +180,7 @@ async def _async_setup_component(
                 None, component.setup, hass, processed_config  # type: ignore
             )
         else:
-            log_error("No setup function defined for %s", domain)
+            _LOGGER.error("No setup function defined for %s", domain)
             return False
 
         result = await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -180,7 +180,7 @@ async def _async_setup_component(
                 None, component.setup, hass, processed_config  # type: ignore
             )
         else:
-            _LOGGER.error("No setup function defined for %s", domain)
+            log_error("No setup function defined.")
             return False
 
         result = await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -187,8 +187,8 @@ async def test_platform_warn_slow_setup(hass):
         assert mock_call.called
 
         # mock_calls[0] is the warning message for component setup
-        # mock_calls[3] is the warning message for platform setup
-        timeout, logger_method = mock_call.mock_calls[3][1][:2]
+        # mock_calls[5] is the warning message for platform setup
+        timeout, logger_method = mock_call.mock_calls[5][1][:2]
 
         assert timeout == entity_platform.SLOW_SETUP_WARNING
         assert logger_method == _LOGGER.warning

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -517,19 +517,19 @@ async def test_platform_no_warn_slow(hass):
 async def test_platform_error_slow_setup(hass, caplog):
     """Don't block startup more than SLOW_SETUP_MAX_WAIT."""
 
-    with patch.object(setup, "SLOW_SETUP_MAX_WAIT", 0):
+    with patch.object(setup, "SLOW_SETUP_MAX_WAIT", 1):
         called = []
 
         async def async_setup(*args):
             """Tracking Setup."""
             called.append(1)
-            await asyncio.sleep(1)
+            await asyncio.sleep(2)
 
         mock_integration(hass, MockModule("test_component1", async_setup=async_setup))
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert len(called) == 1
         assert not result
-        assert "test_component1 is taking longer than 0 seconds" in caplog.text
+        assert "test_component1 is taking longer than 1 seconds" in caplog.text
 
 
 async def test_when_setup_already_loaded(hass):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -489,12 +489,15 @@ async def test_component_warn_slow_setup(hass):
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert result
         assert mock_call.called
-        assert len(mock_call.mock_calls) == 3
 
+        assert len(mock_call.mock_calls) == 5
         timeout, logger_method = mock_call.mock_calls[0][1][:2]
 
         assert timeout == setup.SLOW_SETUP_WARNING
         assert logger_method == setup._LOGGER.warning
+
+        timeout, function = mock_call.mock_calls[1][1][:2]
+        assert timeout == setup.SLOW_SETUP_MAX_WAIT
 
         assert mock_call().cancel.called
 
@@ -507,7 +510,26 @@ async def test_platform_no_warn_slow(hass):
     with patch.object(hass.loop, "call_later") as mock_call:
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert result
-        assert not mock_call.called
+        timeout, function = mock_call.mock_calls[0][1][:2]
+        assert timeout == setup.SLOW_SETUP_MAX_WAIT
+
+
+async def test_platform_error_slow_setup(hass, caplog):
+    """Don't block startup more than SLOW_SETUP_MAX_WAIT."""
+
+    with patch.object(setup, "SLOW_SETUP_MAX_WAIT", 0):
+        called = []
+
+        async def async_setup(*args):
+            """Tracking Setup."""
+            called.append(1)
+            await asyncio.sleep(1)
+
+        mock_integration(hass, MockModule("test_component1", async_setup=async_setup))
+        result = await setup.async_setup_component(hass, "test_component1", {})
+        assert len(called) == 1
+        assert not result
+        assert "test_component1 is taking longer than 0 seconds" in caplog.text
 
 
 async def test_when_setup_already_loaded(hass):


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If an integration blocks in `async_setup` or `setup`, Home Assistant will never startup.  You can test this by adding a sleep in `__init__.py` in any integration.

This makes it difficult to figure out which integration is causing the issue because the log message about it taking more than 10s is usually very far away from the end of the log stream and the user does not know which integration is causing the issue especially if there are multiple ones blocking startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35924
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
