### PR TITLE
Notify user if arming or disarming totalconnect alarm fails

### DIFF
--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -1,7 +1,6 @@
 """Interfaces with TotalConnect alarm control panels."""
 import logging
 
-from homeassistant.components import persistent_notification
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
@@ -18,6 +17,7 @@ from homeassistant.const import (
     STATE_ALARM_DISARMING,
     STATE_ALARM_TRIGGERED,
 )
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
@@ -117,39 +117,19 @@ class TotalConnectAlarm(alarm.AlarmControlPanelEntity):
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         if self._client.disarm(self._location_id) is not True:
-            persistent_notification.async_create(
-                self._hass,
-                f"TotalConnect failed to disarm {self._name}.",
-                "TotalConnect",
-                "totalconnect_disarm",
-            )
+            raise HomeAssistantError(f"TotalConnect failed to disarm {self._name}.")
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
         if self._client.arm_stay(self._location_id) is not True:
-            persistent_notification.async_create(
-                self._hass,
-                f"TotalConnect failed to arm home {self._name}.",
-                "TotalConnect",
-                "totalconnect_arm_home",
-            )
+            raise HomeAssistantError(f"TotalConnect failed to arm home {self._name}.")
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
         if self._client.arm_away(self._location_id) is not True:
-            persistent_notification.async_create(
-                self._hass,
-                f"TotalConnect failed to arm away {self._name}.",
-                "TotalConnect",
-                "totalconnect_arm_away",
-            )
+            raise HomeAssistantError(f"TotalConnect failed to arm away {self._name}.")
 
     def alarm_arm_night(self, code=None):
         """Send arm night command."""
         if self._client.arm_stay_night(self._location_id) is not True:
-            persistent_notification.async_create(
-                self._hass,
-                f"TotalConnect failed to arm night {self._name}.",
-                "TotalConnect",
-                "totalconnect_arm_night",
-            )
+            raise HomeAssistantError(f"TotalConnect failed to arm night {self._name}.")

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -32,7 +32,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     for location_id, location in client.locations.items():
         location_name = location.location_name
-        alarms.append(TotalConnectAlarm(location_name, location_id, client, hass))
+        alarms.append(TotalConnectAlarm(location_name, location_id, client))
 
     async_add_entities(alarms, True)
 
@@ -40,12 +40,11 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class TotalConnectAlarm(alarm.AlarmControlPanelEntity):
     """Represent an TotalConnect status."""
 
-    def __init__(self, name, location_id, client, hass):
+    def __init__(self, name, location_id, client):
         """Initialize the TotalConnect status."""
         self._name = name
         self._location_id = location_id
         self._client = client
-        self._hass = hass
         self._state = None
         self._device_state_attributes = {}
 

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "totalconnect",
   "name": "Honeywell Total Connect Alarm",
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
-  "requirements": ["total_connect_client==0.54.1"],
+  "requirements": ["total_connect_client==0.55"],
   "dependencies": [],
   "codeowners": ["@austinmroczek"],
   "config_flow": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2078,7 +2078,7 @@ todoist-python==8.0.0
 toonapilib==3.2.4
 
 # homeassistant.components.totalconnect
-total_connect_client==0.54.1
+total_connect_client==0.55
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -811,7 +811,7 @@ teslajsonpy==0.8.0
 toonapilib==3.2.4
 
 # homeassistant.components.totalconnect
-total_connect_client==0.54.1
+total_connect_client==0.55
 
 # homeassistant.components.transmission
 transmissionrpc==0.11

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -1,7 +1,6 @@
 """Common methods used across tests for TotalConnect."""
 from total_connect_client import TotalConnectClient
 
-import homeassistant.components.persistent_notification as pn
 from homeassistant.components.totalconnect import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
@@ -131,7 +130,6 @@ async def setup_platform(hass, platform):
         return_value=True,
     ):
         assert await async_setup_component(hass, DOMAIN, {})
-        assert await async_setup_component(hass, pn.DOMAIN, {})
         assert mock_request.call_count == 2
     await hass.async_block_till_done()
 

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -50,15 +50,9 @@ PARTITION_ARMED_AWAY = {
     "ArmingState": TotalConnectClient.TotalConnectLocation.ARMED_AWAY,
 }
 
-PARTITION_INFO_DISARMED = {}
-PARTITION_INFO_DISARMED[0] = PARTITION_DISARMED
-
-PARTITION_INFO_ARMED_STAY = {}
-PARTITION_INFO_ARMED_STAY[0] = PARTITION_ARMED_STAY
-
-PARTITION_INFO_ARMED_AWAY = {}
-PARTITION_INFO_ARMED_AWAY[0] = PARTITION_ARMED_AWAY
-
+PARTITION_INFO_DISARMED = {0: PARTITION_DISARMED}
+PARTITION_INFO_ARMED_STAY = {0: PARTITION_ARMED_STAY}
+PARTITION_INFO_ARMED_AWAY = {0: PARTITION_ARMED_AWAY}
 
 PARTITIONS_DISARMED = {"PartitionInfo": PARTITION_INFO_DISARMED}
 PARTITIONS_ARMED_STAY = {"PartitionInfo": PARTITION_INFO_ARMED_STAY}
@@ -71,8 +65,7 @@ ZONE_NORMAL = {
     "PartitionId": "1",
 }
 
-ZONE_INFO = []
-ZONE_INFO.append(ZONE_NORMAL)
+ZONE_INFO = [ZONE_NORMAL]
 ZONES = {"ZoneInfo": ZONE_INFO}
 
 METADATA_DISARMED = {
@@ -118,13 +111,13 @@ async def setup_platform(hass, platform):
     )
     mock_entry.add_to_hass(hass)
 
-    RESPONSES = [RESPONSE_AUTHENTICATE, RESPONSE_DISARMED]
+    responses = [RESPONSE_AUTHENTICATE, RESPONSE_DISARMED]
 
     with patch("homeassistant.components.totalconnect.PLATFORMS", [platform]), patch(
         "zeep.Client", autospec=True
     ), patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
-        side_effect=RESPONSES,
+        side_effect=responses,
     ) as mock_request, patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.get_zone_details",
         return_value=True,

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -1,0 +1,142 @@
+"""Common methods used across tests for TotalConnect."""
+from total_connect_client import TotalConnectClient
+
+import homeassistant.components.persistent_notification as pn
+from homeassistant.components.totalconnect import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+# from homeassistant.components.persistent_notification import (
+#    DOMAIN as PERSISTENT_NOTIFICATION,
+# )
+
+LOCATION_INFO_BASIC_NORMAL = {
+    "LocationID": "123456",
+    "LocationName": "test",
+    "SecurityDeviceID": "987654",
+    "PhotoURL": "http://www.example.com/some/path/to/file.jpg",
+    "LocationModuleFlags": "Security=1,Video=0,Automation=0,GPS=0,VideoPIR=0",
+    "DeviceList": None,
+}
+
+LOCATIONS = {"LocationInfoBasic": [LOCATION_INFO_BASIC_NORMAL]}
+
+MODULE_FLAGS = "Some=0,Fake=1,Flags=2"
+
+USER = {
+    "UserID": "1234567",
+    "Username": "username",
+    "UserFeatureList": "Master=0,User Administration=0,Configuration Administration=0",
+}
+
+RESPONSE_AUTHENTICATE = {
+    "ResultCode": 0,
+    "SessionID": 1,
+    "Locations": LOCATIONS,
+    "ModuleFlags": MODULE_FLAGS,
+    "UserInfo": USER,
+}
+
+PARTITION_DISARMED = {
+    "PartitionID": "1",
+    "ArmingState": TotalConnectClient.TotalConnectLocation.DISARMED,
+}
+
+PARTITION_ARMED_STAY = {
+    "PartitionID": "1",
+    "ArmingState": TotalConnectClient.TotalConnectLocation.ARMED_STAY,
+}
+
+PARTITION_ARMED_AWAY = {
+    "PartitionID": "1",
+    "ArmingState": TotalConnectClient.TotalConnectLocation.ARMED_AWAY,
+}
+
+PARTITION_INFO_DISARMED = {}
+PARTITION_INFO_DISARMED[0] = PARTITION_DISARMED
+
+PARTITION_INFO_ARMED_STAY = {}
+PARTITION_INFO_ARMED_STAY[0] = PARTITION_ARMED_STAY
+
+PARTITION_INFO_ARMED_AWAY = {}
+PARTITION_INFO_ARMED_AWAY[0] = PARTITION_ARMED_AWAY
+
+
+PARTITIONS_DISARMED = {"PartitionInfo": PARTITION_INFO_DISARMED}
+PARTITIONS_ARMED_STAY = {"PartitionInfo": PARTITION_INFO_ARMED_STAY}
+PARTITIONS_ARMED_AWAY = {"PartitionInfo": PARTITION_INFO_ARMED_AWAY}
+
+ZONE_NORMAL = {
+    "ZoneID": "1",
+    "ZoneDescription": "Normal",
+    "ZoneStatus": TotalConnectClient.ZONE_STATUS_NORMAL,
+    "PartitionId": "1",
+}
+
+ZONE_INFO = []
+ZONE_INFO.append(ZONE_NORMAL)
+ZONES = {"ZoneInfo": ZONE_INFO}
+
+METADATA_DISARMED = {
+    "Partitions": PARTITIONS_DISARMED,
+    "Zones": ZONES,
+    "PromptForImportSecuritySettings": False,
+    "IsInACLoss": False,
+    "IsCoverTampered": False,
+    "Bell1SupervisionFailure": False,
+    "Bell2SupervisionFailure": False,
+    "IsInLowBattery": False,
+}
+
+METADATA_ARMED_STAY = METADATA_DISARMED.copy()
+METADATA_ARMED_STAY["Partitions"] = PARTITIONS_ARMED_STAY
+
+METADATA_ARMED_AWAY = METADATA_DISARMED.copy()
+METADATA_ARMED_AWAY["Partitions"] = PARTITIONS_ARMED_AWAY
+
+RESPONSE_DISARMED = {"ResultCode": 0, "PanelMetadataAndStatus": METADATA_DISARMED}
+RESPONSE_ARMED_STAY = {"ResultCode": 0, "PanelMetadataAndStatus": METADATA_ARMED_STAY}
+RESPONSE_ARMED_AWAY = {"ResultCode": 0, "PanelMetadataAndStatus": METADATA_ARMED_AWAY}
+
+RESPONSE_ARM_SUCCESS = {"ResultCode": TotalConnectClient.TotalConnectClient.ARM_SUCCESS}
+RESPONSE_ARM_FAILURE = {
+    "ResultCode": TotalConnectClient.TotalConnectClient.COMMAND_FAILED
+}
+RESPONSE_DISARM_SUCCESS = {
+    "ResultCode": TotalConnectClient.TotalConnectClient.DISARM_SUCCESS
+}
+RESPONSE_DISARM_FAILURE = {
+    "ResultCode": TotalConnectClient.TotalConnectClient.COMMAND_FAILED,
+    "ResultData": "Command Failed",
+}
+
+
+async def setup_platform(hass, platform):
+    """Set up the TotalConnect platform."""
+    # first set up a config entry and add it to hass
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
+    )
+    mock_entry.add_to_hass(hass)
+
+    RESPONSES = [RESPONSE_AUTHENTICATE, RESPONSE_DISARMED]
+
+    with patch("homeassistant.components.totalconnect.PLATFORMS", [platform]), patch(
+        "zeep.Client", autospec=True
+    ), patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        side_effect=RESPONSES,
+    ) as mock_request, patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.get_zone_details",
+        return_value=True,
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        assert await async_setup_component(hass, pn.DOMAIN, {})
+        assert mock_request.call_count == 2
+    await hass.async_block_till_done()
+
+    return mock_entry

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -9,10 +9,6 @@ from homeassistant.setup import async_setup_component
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
-# from homeassistant.components.persistent_notification import (
-#    DOMAIN as PERSISTENT_NOTIFICATION,
-# )
-
 LOCATION_INFO_BASIC_NORMAL = {
     "LocationID": "123456",
     "LocationName": "test",

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -46,10 +46,10 @@ async def test_attributes(hass):
 
 async def test_arm_home_success(hass):
     """Test arm home method success."""
-    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_STAY]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_STAY]
     with patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
-        side_effect=RESPONSES,
+        side_effect=responses,
     ):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
@@ -64,10 +64,10 @@ async def test_arm_home_success(hass):
 
 async def test_arm_home_failure(hass):
     """Test arm home method failure."""
-    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_DISARMED]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_DISARMED]
     with patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
-        side_effect=RESPONSES,
+        side_effect=responses,
     ):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
@@ -83,10 +83,10 @@ async def test_arm_home_failure(hass):
 
 async def test_arm_away_success(hass):
     """Test arm away method success."""
-    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_AWAY]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_AWAY]
     with patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
-        side_effect=RESPONSES,
+        side_effect=responses,
     ):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
@@ -100,10 +100,10 @@ async def test_arm_away_success(hass):
 
 async def test_arm_away_failure(hass):
     """Test arm away method failure."""
-    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_DISARMED]
+    responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_DISARMED]
     with patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
-        side_effect=RESPONSES,
+        side_effect=responses,
     ):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
@@ -119,10 +119,10 @@ async def test_arm_away_failure(hass):
 
 async def test_disarm_success(hass):
     """Test disarm method success."""
-    RESPONSES = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_SUCCESS, RESPONSE_DISARMED]
+    responses = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_SUCCESS, RESPONSE_DISARMED]
     with patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
-        side_effect=RESPONSES,
+        side_effect=responses,
     ):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
@@ -136,10 +136,10 @@ async def test_disarm_success(hass):
 
 async def test_disarm_failure(hass):
     """Test disarm method failure."""
-    RESPONSES = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_FAILURE, RESPONSE_ARMED_AWAY]
+    responses = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_FAILURE, RESPONSE_ARMED_AWAY]
     with patch(
         "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
-        side_effect=RESPONSES,
+        side_effect=responses,
     ):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -1,4 +1,6 @@
 """Tests for the TotalConnect alarm control panel device."""
+import pytest
+
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
@@ -63,8 +65,10 @@ async def test_arm_home_failure(hass):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
-        await common.async_alarm_arm_home(hass)
-        await hass.async_block_till_done()
+        with pytest.raises(Exception) as e:
+            await common.async_alarm_arm_home(hass)
+            await hass.async_block_till_done()
+        assert f"{e.value}" == "TotalConnect failed to arm home test."
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
 
@@ -93,8 +97,10 @@ async def test_arm_away_failure(hass):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
-        await common.async_alarm_arm_away(hass)
-        await hass.async_block_till_done()
+        with pytest.raises(Exception) as e:
+            await common.async_alarm_arm_away(hass)
+            await hass.async_block_till_done()
+        assert f"{e.value}" == "TotalConnect failed to arm away test."
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
 
@@ -123,6 +129,8 @@ async def test_disarm_failure(hass):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
 
-        await common.async_alarm_disarm(hass)
-        await hass.async_block_till_done()
+        with pytest.raises(Exception) as e:
+            await common.async_alarm_disarm(hass)
+            await hass.async_block_till_done()
+        assert f"{e.value}" == "TotalConnect failed to disarm test."
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -1,0 +1,128 @@
+"""Tests for the TotalConnect alarm control panel device."""
+from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_DISARMED,
+)
+
+from .common import (
+    RESPONSE_ARM_FAILURE,
+    RESPONSE_ARM_SUCCESS,
+    RESPONSE_ARMED_AWAY,
+    RESPONSE_ARMED_STAY,
+    RESPONSE_DISARM_FAILURE,
+    RESPONSE_DISARM_SUCCESS,
+    RESPONSE_DISARMED,
+    setup_platform,
+)
+
+from tests.async_mock import patch
+from tests.components.alarm_control_panel import common
+
+ENTITY_ID = "alarm_control_panel.test"
+CODE = "-1"
+
+
+async def test_attributes(hass):
+    """Test the alarm control panel attributes are correct."""
+    with patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        return_value=RESPONSE_DISARMED,
+    ) as mock_request:
+        await setup_platform(hass, ALARM_DOMAIN)
+        state = hass.states.get(ENTITY_ID)
+        assert state.state == STATE_ALARM_DISARMED
+        mock_request.assert_called_once()
+        assert state.attributes.get(ATTR_FRIENDLY_NAME) == "test"
+
+
+async def test_arm_home_success(hass):
+    """Test arm home method success."""
+    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_STAY]
+    with patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        side_effect=RESPONSES,
+    ):
+        await setup_platform(hass, ALARM_DOMAIN)
+        assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
+
+        await common.async_alarm_arm_home(hass)
+        await hass.async_block_till_done()
+        assert STATE_ALARM_ARMED_HOME == hass.states.get(ENTITY_ID).state
+
+
+async def test_arm_home_failure(hass):
+    """Test arm home method failure."""
+    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_DISARMED]
+    with patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        side_effect=RESPONSES,
+    ):
+        await setup_platform(hass, ALARM_DOMAIN)
+        assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
+
+        await common.async_alarm_arm_home(hass)
+        await hass.async_block_till_done()
+        assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
+
+
+async def test_arm_away_success(hass):
+    """Test arm away method success."""
+    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_AWAY]
+    with patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        side_effect=RESPONSES,
+    ):
+        await setup_platform(hass, ALARM_DOMAIN)
+        assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
+
+        await common.async_alarm_arm_away(hass)
+        await hass.async_block_till_done()
+        assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
+
+
+async def test_arm_away_failure(hass):
+    """Test arm away method failure."""
+    RESPONSES = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_DISARMED]
+    with patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        side_effect=RESPONSES,
+    ):
+        await setup_platform(hass, ALARM_DOMAIN)
+        assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
+
+        await common.async_alarm_arm_away(hass)
+        await hass.async_block_till_done()
+        assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
+
+
+async def test_disarm_success(hass):
+    """Test disarm method success."""
+    RESPONSES = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_SUCCESS, RESPONSE_DISARMED]
+    with patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        side_effect=RESPONSES,
+    ):
+        await setup_platform(hass, ALARM_DOMAIN)
+        assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
+
+        await common.async_alarm_disarm(hass)
+        await hass.async_block_till_done()
+        assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
+
+
+async def test_disarm_failure(hass):
+    """Test disarm method failure."""
+    RESPONSES = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_FAILURE, RESPONSE_ARMED_AWAY]
+    with patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.TotalConnectClient.request",
+        side_effect=RESPONSES,
+    ):
+        await setup_platform(hass, ALARM_DOMAIN)
+        assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
+
+        await common.async_alarm_disarm(hass)
+        await hass.async_block_till_done()
+        assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -3,7 +3,11 @@ import pytest
 
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
+    SERVICE_ALARM_ARM_AWAY,
+    SERVICE_ALARM_ARM_HOME,
+    SERVICE_ALARM_DISARM,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
@@ -21,10 +25,10 @@ from .common import (
 )
 
 from tests.async_mock import patch
-from tests.components.alarm_control_panel import common
 
 ENTITY_ID = "alarm_control_panel.test"
 CODE = "-1"
+DATA = {ATTR_ENTITY_ID: ENTITY_ID}
 
 
 async def test_attributes(hass):
@@ -50,7 +54,10 @@ async def test_arm_home_success(hass):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
-        await common.async_alarm_arm_home(hass)
+        await hass.services.async_call(
+            ALARM_DOMAIN, SERVICE_ALARM_ARM_HOME, DATA, blocking=True
+        )
+
         await hass.async_block_till_done()
         assert STATE_ALARM_ARMED_HOME == hass.states.get(ENTITY_ID).state
 
@@ -66,7 +73,9 @@ async def test_arm_home_failure(hass):
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
         with pytest.raises(Exception) as e:
-            await common.async_alarm_arm_home(hass)
+            await hass.services.async_call(
+                ALARM_DOMAIN, SERVICE_ALARM_ARM_HOME, DATA, blocking=True
+            )
             await hass.async_block_till_done()
         assert f"{e.value}" == "TotalConnect failed to arm home test."
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
@@ -82,7 +91,9 @@ async def test_arm_away_success(hass):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
-        await common.async_alarm_arm_away(hass)
+        await hass.services.async_call(
+            ALARM_DOMAIN, SERVICE_ALARM_ARM_AWAY, DATA, blocking=True
+        )
         await hass.async_block_till_done()
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
 
@@ -98,7 +109,9 @@ async def test_arm_away_failure(hass):
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
         with pytest.raises(Exception) as e:
-            await common.async_alarm_arm_away(hass)
+            await hass.services.async_call(
+                ALARM_DOMAIN, SERVICE_ALARM_ARM_AWAY, DATA, blocking=True
+            )
             await hass.async_block_till_done()
         assert f"{e.value}" == "TotalConnect failed to arm away test."
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
@@ -114,7 +127,9 @@ async def test_disarm_success(hass):
         await setup_platform(hass, ALARM_DOMAIN)
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
 
-        await common.async_alarm_disarm(hass)
+        await hass.services.async_call(
+            ALARM_DOMAIN, SERVICE_ALARM_DISARM, DATA, blocking=True
+        )
         await hass.async_block_till_done()
         assert STATE_ALARM_DISARMED == hass.states.get(ENTITY_ID).state
 
@@ -130,7 +145,9 @@ async def test_disarm_failure(hass):
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state
 
         with pytest.raises(Exception) as e:
-            await common.async_alarm_disarm(hass)
+            await hass.services.async_call(
+                ALARM_DOMAIN, SERVICE_ALARM_DISARM, DATA, blocking=True
+            )
             await hass.async_block_till_done()
         assert f"{e.value}" == "TotalConnect failed to disarm test."
         assert STATE_ALARM_ARMED_AWAY == hass.states.get(ENTITY_ID).state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Create a persistent notification to tell a user that their attempt to arm or disarm their TotalConnect alarm system failed.  Add tests for arm/disarm.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
No changes to configuration.
```yaml
# Example configuration.yaml
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33301
- This PR is related to issue: #33172
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [n/a] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [n/a] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
