### PR TITLE
Fix emulated_hue compatibility with older devices

### DIFF
--- a/homeassistant/components/emulated_hue/const.py
+++ b/homeassistant/components/emulated_hue/const.py
@@ -1,0 +1,4 @@
+"""Constants for emulated_hue."""
+
+HUE_SERIAL_NUMBER = "001788FFFE23BFC2"
+HUE_UUID = "2f402f80-da50-11e1-9b23-001788255acc"

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -145,12 +145,12 @@ class UPNPResponderThread(threading.Thread):
             return self._prepare_response(
                 "upnp:rootdevice", f"uuid:{HUE_UUID}::upnp:rootdevice"
             )
-        else:
-            return self._prepare_response(
-                "urn:schemas-upnp-org:device:basic:1", f"uuid:{HUE_UUID}"
-            )
 
-    def _prepare_response(self, st, usn):
+        return self._prepare_response(
+            "urn:schemas-upnp-org:device:basic:1", f"uuid:{HUE_UUID}"
+        )
+
+    def _prepare_response(self, search_target, unique_service_name):
         # Note that the double newline at the end of
         # this string is required per the SSDP spec
         response = f"""HTTP/1.1 200 OK
@@ -159,8 +159,8 @@ EXT:
 LOCATION: http://{self.advertise_ip}:{self.advertise_port}/description.xml
 SERVER: FreeRTOS/6.0.5, UPnP/1.0, IpBridge/1.16.0
 hue-bridgeid: {HUE_SERIAL_NUMBER}
-ST: {st}
-USN: {usn}
+ST: {search_target}
+USN: {unique_service_name}
 
 """
         return response.replace("\n", "\r\n").encode("utf-8")

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -9,6 +9,8 @@ from aiohttp import web
 from homeassistant import core
 from homeassistant.components.http import HomeAssistantView
 
+from .const import HUE_SERIAL_NUMBER, HUE_UUID
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -42,8 +44,8 @@ class DescriptionXmlView(HomeAssistantView):
 <modelName>Philips hue bridge 2015</modelName>
 <modelNumber>BSB002</modelNumber>
 <modelURL>http://www.meethue.com</modelURL>
-<serialNumber>001788FFFE23BFC2</serialNumber>
-<UDN>uuid:2f402f80-da50-11e1-9b23-001788255acc</UDN>
+<serialNumber>{HUE_SERIAL_NUMBER}</serialNumber>
+<UDN>uuid:{HUE_UUID}</UDN>
 </device>
 </root>
 """
@@ -70,21 +72,8 @@ class UPNPResponderThread(threading.Thread):
         self.host_ip_addr = host_ip_addr
         self.listen_port = listen_port
         self.upnp_bind_multicast = upnp_bind_multicast
-
-        # Note that the double newline at the end of
-        # this string is required per the SSDP spec
-        resp_template = f"""HTTP/1.1 200 OK
-CACHE-CONTROL: max-age=60
-EXT:
-LOCATION: http://{advertise_ip}:{advertise_port}/description.xml
-SERVER: FreeRTOS/6.0.5, UPnP/1.0, IpBridge/1.16.0
-hue-bridgeid: 001788FFFE23BFC2
-ST: upnp:rootdevice
-USN: uuid:2f402f80-da50-11e1-9b23-00178829d301::upnp:rootdevice
-
-"""
-
-        self.upnp_response = resp_template.replace("\n", "\r\n").encode("utf-8")
+        self.advertise_ip = advertise_ip
+        self.advertise_port = advertise_port
 
     def run(self):
         """Run the server."""
@@ -136,10 +125,13 @@ USN: uuid:2f402f80-da50-11e1-9b23-00178829d301::upnp:rootdevice
                 continue
 
             if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
+                _LOGGER.debug("UPNP Responder M-SEARCH method received: %s", data)
                 # SSDP M-SEARCH method received, respond to it with our info
-                resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                response = self._handle_request(data)
 
-                resp_socket.sendto(self.upnp_response, addr)
+                resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                resp_socket.sendto(response, addr)
+                _LOGGER.debug("UPNP Responder responding with: %s", response)
                 resp_socket.close()
 
     def stop(self):
@@ -147,6 +139,31 @@ USN: uuid:2f402f80-da50-11e1-9b23-00178829d301::upnp:rootdevice
         # Request for server
         self._interrupted = True
         self.join()
+
+    def _handle_request(self, data):
+        if "upnp:rootdevice" in data.decode("utf-8", errors="ignore"):
+            return self._prepare_response(
+                "upnp:rootdevice", f"uuid:{HUE_UUID}::upnp:rootdevice"
+            )
+        else:
+            return self._prepare_response(
+                "urn:schemas-upnp-org:device:basic:1", f"uuid:{HUE_UUID}"
+            )
+
+    def _prepare_response(self, st, usn):
+        # Note that the double newline at the end of
+        # this string is required per the SSDP spec
+        response = f"""HTTP/1.1 200 OK
+CACHE-CONTROL: max-age=60
+EXT:
+LOCATION: http://{self.advertise_ip}:{self.advertise_port}/description.xml
+SERVER: FreeRTOS/6.0.5, UPnP/1.0, IpBridge/1.16.0
+hue-bridgeid: {HUE_SERIAL_NUMBER}
+ST: {st}
+USN: {usn}
+
+"""
+        return response.replace("\n", "\r\n").encode("utf-8")
 
 
 def clean_socket_close(sock):

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -48,6 +48,72 @@ class TestEmulatedHue(unittest.TestCase):
         """Stop the class."""
         cls.hass.stop()
 
+    def test_upnp_discovery_basic(self):
+        """Tests the UPnP basic discovery response."""
+        with patch("threading.Thread.__init__"):
+            upnp_responder_thread = emulated_hue.UPNPResponderThread(
+                "0.0.0.0", 80, True, "192.0.2.42", 8080
+            )
+
+            """Original request emitted by the Hue Bridge v1 app."""
+            request = """M-SEARCH * HTTP/1.1
+HOST:239.255.255.250:1900
+ST:ssdp:all
+Man:"ssdp:discover"
+MX:3
+
+""".replace(
+                "\n", "\r\n"
+            ).encode(
+                "utf-8"
+            )
+
+            response = upnp_responder_thread._handle_request(request)
+            expected_response = """HTTP/1.1 200 OK
+CACHE-CONTROL: max-age=60
+EXT:
+LOCATION: http://192.0.2.42:8080/description.xml
+SERVER: FreeRTOS/6.0.5, UPnP/1.0, IpBridge/1.16.0
+hue-bridgeid: 001788FFFE23BFC2
+ST: urn:schemas-upnp-org:device:basic:1
+USN: uuid:2f402f80-da50-11e1-9b23-001788255acc
+
+"""
+            assert expected_response.replace("\n", "\r\n").encode("utf-8") == response
+
+    def test_upnp_discovery_rootdevice(self):
+        """Tests the UPnP rootdevice discovery response."""
+        with patch("threading.Thread.__init__"):
+            upnp_responder_thread = emulated_hue.UPNPResponderThread(
+                "0.0.0.0", 80, True, "192.0.2.42", 8080
+            )
+
+            """Original request emitted by Busch-Jaeger free@home SysAP."""
+            request = """M-SEARCH * HTTP/1.1
+HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+MX: 40
+ST: upnp:rootdevice
+
+""".replace(
+                "\n", "\r\n"
+            ).encode(
+                "utf-8"
+            )
+
+            response = upnp_responder_thread._handle_request(request)
+            expected_response = """HTTP/1.1 200 OK
+CACHE-CONTROL: max-age=60
+EXT:
+LOCATION: http://192.0.2.42:8080/description.xml
+SERVER: FreeRTOS/6.0.5, UPnP/1.0, IpBridge/1.16.0
+hue-bridgeid: 001788FFFE23BFC2
+ST: upnp:rootdevice
+USN: uuid:2f402f80-da50-11e1-9b23-001788255acc::upnp:rootdevice
+
+"""
+            assert expected_response.replace("\n", "\r\n").encode("utf-8") == response
+
     def test_description_xml(self):
         """Test the description."""
         result = requests.get(BRIDGE_URL_BASE.format("/description.xml"), timeout=5)

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -62,13 +62,10 @@ ST:ssdp:all
 Man:"ssdp:discover"
 MX:3
 
-""".replace(
-                "\n", "\r\n"
-            ).encode(
-                "utf-8"
-            )
+"""
+            encoded_request = request.replace("\n", "\r\n").encode("utf-8")
 
-            response = upnp_responder_thread._handle_request(request)
+            response = upnp_responder_thread._handle_request(encoded_request)
             expected_response = """HTTP/1.1 200 OK
 CACHE-CONTROL: max-age=60
 EXT:
@@ -95,13 +92,10 @@ MAN: "ssdp:discover"
 MX: 40
 ST: upnp:rootdevice
 
-""".replace(
-                "\n", "\r\n"
-            ).encode(
-                "utf-8"
-            )
+"""
+            encoded_request = request.replace("\n", "\r\n").encode("utf-8")
 
-            response = upnp_responder_thread._handle_request(request)
+            response = upnp_responder_thread._handle_request(encoded_request)
             expected_response = """HTTP/1.1 200 OK
 CACHE-CONTROL: max-age=60
 EXT:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Restore `emulated_hue` compatibility with older devices, especially Logitech Harmony Hubs.

#35148 changed the `emulated_hue` discovery process to work with newer devices. It responds to UPnP queries with a `ST: upnp:rootdevice`, which was assumed to be supported by all devices. However, older devices only work with `ST: urn:schemas-upnp-org:device:basic:1`.

This also adds a desperately needed test for the discovery response packet.

Tested with the following devices:

* Amazon Alexa
* Philips Hue Bridge v1 App (Android, discovery only)
* Busch-Jaeger free@home SysAP

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Fixes #35998
- See [ha-bridge documentation](https://github.com/bwssytems/ha-bridge#upnp-emulation-of-hue) for further information about the Hue discovery process.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
