### PR TITLE
Upgrade wled 0.4.1

### DIFF
--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -3,7 +3,7 @@
   "name": "WLED",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wled",
-  "requirements": ["wled==0.3.0"],
+  "requirements": ["wled==0.4.0"],
   "zeroconf": ["_wled._tcp.local."],
   "codeowners": ["@frenck"],
   "quality_scale": "platinum"

--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -3,7 +3,7 @@
   "name": "WLED",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wled",
-  "requirements": ["wled==0.4.0"],
+  "requirements": ["wled==0.4.1"],
   "zeroconf": ["_wled._tcp.local."],
   "codeowners": ["@frenck"],
   "quality_scale": "platinum"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2195,7 +2195,7 @@ wirelesstagpy==0.4.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.4.0
+wled==0.4.1
 
 # homeassistant.components.xbee
 xbee-helper==0.0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2195,7 +2195,7 @@ wirelesstagpy==0.4.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.3.0
+wled==0.4.0
 
 # homeassistant.components.xbee
 xbee-helper==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -898,7 +898,7 @@ wiffi==1.0.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.3.0
+wled==0.4.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -898,7 +898,7 @@ wiffi==1.0.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.4.0
+wled==0.4.1
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest

--- a/tests/components/wled/__init__.py
+++ b/tests/components/wled/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the WLED integration."""
 
+import json
+
 from homeassistant.components.wled.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
@@ -17,27 +19,29 @@ async def init_integration(
     """Set up the WLED integration in Home Assistant."""
 
     fixture = "wled/rgb.json" if not rgbw else "wled/rgbw.json"
+    data = json.loads(load_fixture(fixture))
+
     aioclient_mock.get(
         "http://192.168.1.123:80/json/",
-        text=load_fixture(fixture),
+        json=data,
         headers={"Content-Type": "application/json"},
     )
 
     aioclient_mock.post(
         "http://192.168.1.123:80/json/state",
-        json={},
+        json=data["state"],
         headers={"Content-Type": "application/json"},
     )
 
     aioclient_mock.get(
         "http://192.168.1.123:80/json/info",
-        json={},
+        json=data["info"],
         headers={"Content-Type": "application/json"},
     )
 
     aioclient_mock.get(
         "http://192.168.1.123:80/json/state",
-        json={},
+        json=data["state"],
         headers={"Content-Type": "application/json"},
     )
 

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
+from tests.async_mock import AsyncMock, patch
 from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -59,6 +60,7 @@ async def test_show_zerconf_form(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 
+@patch("asyncio.sleep", new=AsyncMock())
 async def test_connection_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
@@ -76,6 +78,7 @@ async def test_connection_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 
+@patch("asyncio.sleep", new=AsyncMock())
 async def test_zeroconf_connection_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
@@ -92,6 +95,7 @@ async def test_zeroconf_connection_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
 
 
+@patch("asyncio.sleep", new=AsyncMock())
 async def test_zeroconf_confirm_connection_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
@@ -112,6 +116,7 @@ async def test_zeroconf_confirm_connection_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
 
 
+@patch("asyncio.sleep", new=AsyncMock())
 async def test_zeroconf_no_data(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the WLED config flow."""
 import aiohttp
+from wled import WLEDConnectionError
 
 from homeassistant import data_entry_flow
 from homeassistant.components.wled import config_flow
@@ -9,7 +10,7 @@ from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
-from tests.async_mock import AsyncMock, patch
+from tests.async_mock import MagicMock, patch
 from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -60,9 +61,9 @@ async def test_show_zerconf_form(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 
-@patch("asyncio.sleep", new=AsyncMock())
+@patch("homeassistant.components.wled.WLED.update", side_effect=WLEDConnectionError)
 async def test_connection_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    update_mock: MagicMock, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we show user form on WLED connection error."""
     aioclient_mock.get("http://example.com/json/", exc=aiohttp.ClientError)
@@ -78,9 +79,9 @@ async def test_connection_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 
-@patch("asyncio.sleep", new=AsyncMock())
+@patch("homeassistant.components.wled.WLED.update", side_effect=WLEDConnectionError)
 async def test_zeroconf_connection_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    update_mock: MagicMock, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort zeroconf flow on WLED connection error."""
     aioclient_mock.get("http://192.168.1.123/json/", exc=aiohttp.ClientError)
@@ -95,9 +96,9 @@ async def test_zeroconf_connection_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
 
 
-@patch("asyncio.sleep", new=AsyncMock())
+@patch("homeassistant.components.wled.WLED.update", side_effect=WLEDConnectionError)
 async def test_zeroconf_confirm_connection_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    update_mock: MagicMock, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort zeroconf flow on WLED connection error."""
     aioclient_mock.get("http://192.168.1.123:80/json/", exc=aiohttp.ClientError)
@@ -116,9 +117,9 @@ async def test_zeroconf_confirm_connection_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
 
 
-@patch("asyncio.sleep", new=AsyncMock())
+@patch("homeassistant.components.wled.WLED.update", side_effect=WLEDConnectionError)
 async def test_zeroconf_no_data(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    update_mock: MagicMock, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort if zeroconf provides no data."""
     flow = config_flow.WLEDFlowHandler()

--- a/tests/components/wled/test_init.py
+++ b/tests/components/wled/test_init.py
@@ -5,10 +5,12 @@ from homeassistant.components.wled.const import DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 from homeassistant.core import HomeAssistant
 
+from tests.async_mock import AsyncMock, patch
 from tests.components.wled import init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
+@patch("asyncio.sleep", new=AsyncMock())
 async def test_config_entry_not_ready(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:

--- a/tests/components/wled/test_init.py
+++ b/tests/components/wled/test_init.py
@@ -1,22 +1,20 @@
 """Tests for the WLED integration."""
-import aiohttp
+from wled import WLEDConnectionError
 
 from homeassistant.components.wled.const import DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 from homeassistant.core import HomeAssistant
 
-from tests.async_mock import AsyncMock, patch
+from tests.async_mock import MagicMock, patch
 from tests.components.wled import init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-@patch("asyncio.sleep", new=AsyncMock())
+@patch("homeassistant.components.wled.WLED.update", side_effect=WLEDConnectionError)
 async def test_config_entry_not_ready(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    mock_update: MagicMock, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the WLED configuration entry not ready."""
-    aioclient_mock.get("http://192.168.1.123:80/json/", exc=aiohttp.ClientError)
-
     entry = await init_integration(hass, aioclient_mock)
     assert entry.state == ENTRY_STATE_SETUP_RETRY
 

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from tests.async_mock import patch
+from tests.async_mock import AsyncMock, patch
 from tests.components.wled import init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -158,6 +158,7 @@ async def test_light_error(
         assert "Invalid response from API" in caplog.text
 
 
+@patch("asyncio.sleep", new=AsyncMock())
 async def test_light_connection_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -144,7 +144,7 @@ async def test_light_error(
     aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
     await init_integration(hass, aioclient_mock)
 
-    with patch("homeassistant.components.wled.WLEDDataUpdateCoordinator.async_refresh"):
+    with patch("homeassistant.components.wled.WLED.update"):
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_OFF,
@@ -164,9 +164,7 @@ async def test_light_connection_error(
     """Test error handling of the WLED switches."""
     await init_integration(hass, aioclient_mock)
 
-    with patch(
-        "homeassistant.components.wled.WLEDDataUpdateCoordinator.async_refresh"
-    ), patch(
+    with patch("homeassistant.components.wled.WLED.update"), patch(
         "homeassistant.components.wled.WLED.light", side_effect=WLEDConnectionError
     ):
         await hass.services.async_call(
@@ -345,7 +343,7 @@ async def test_effect_service_error(
     aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
     await init_integration(hass, aioclient_mock)
 
-    with patch("homeassistant.components.wled.WLEDDataUpdateCoordinator.async_refresh"):
+    with patch("homeassistant.components.wled.WLED.update"):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,

--- a/tests/components/wled/test_switch.py
+++ b/tests/components/wled/test_switch.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from tests.async_mock import patch
+from tests.async_mock import AsyncMock, patch
 from tests.components.wled import init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -156,6 +156,7 @@ async def test_switch_error(
         assert "Invalid response from API" in caplog.text
 
 
+@patch("asyncio.sleep", new=AsyncMock())
 async def test_switch_connection_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:

--- a/tests/components/wled/test_switch.py
+++ b/tests/components/wled/test_switch.py
@@ -142,7 +142,7 @@ async def test_switch_error(
     aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
     await init_integration(hass, aioclient_mock)
 
-    with patch("homeassistant.components.wled.WLEDDataUpdateCoordinator.async_refresh"):
+    with patch("homeassistant.components.wled.WLED.update"):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -162,9 +162,7 @@ async def test_switch_connection_error(
     """Test error handling of the WLED switches."""
     await init_integration(hass, aioclient_mock)
 
-    with patch(
-        "homeassistant.components.wled.WLEDDataUpdateCoordinator.async_refresh"
-    ), patch(
+    with patch("homeassistant.components.wled.WLED.update"), patch(
         "homeassistant.components.wled.WLED.nightlight", side_effect=WLEDConnectionError
     ):
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Release notes 0.4.0: <https://github.com/frenck/python-wled/releases/tag/v0.4.0>
Release notes 0.4.1: <https://github.com/frenck/python-wled/releases/tag/v0.4.1>

Changelog 0.3.0...0.4.1: <https://github.com/frenck/python-wled/compare/v0.3.0...v0.4.1>

- Improves the stability of the integration by handling flaky responses from the device API in the library (and retry).
- Reduces API calls with 50% if the firmware >= 0.10.0, by leveraging new, more efficient API endpoint.
- Implements brightness and on/off control on segments of the lights trip, instead of the strip as a whole if firmware >= 0.10.0.

The above is instantly active on updating the dependency, no change on the HA side needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
  - <https://github.com/home-assistant/core/issues/33921>
  - <https://github.com/Aircoookie/WLED/issues/843>
  - <https://github.com/Aircoookie/WLED/issues/875>
  - <https://github.com/Aircoookie/WLED/issues/289>
  - <https://github.com/Aircoookie/WLED/issues/290>
  - <https://community.home-assistant.io/t/wled-full-support-for-segments/198585>
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
