### PR TITLE
Implement play_media in volumio component

### DIFF
--- a/homeassistant/components/volumio/manifest.json
+++ b/homeassistant/components/volumio/manifest.json
@@ -2,5 +2,6 @@
   "domain": "volumio",
   "name": "Volumio",
   "documentation": "https://www.home-assistant.io/integrations/volumio",
+  "requirements": ["python-socketio[asyncio_client]==4.6.0"],
   "codeowners": []
 }

--- a/homeassistant/components/volumio/manifest.json
+++ b/homeassistant/components/volumio/manifest.json
@@ -2,6 +2,6 @@
   "domain": "volumio",
   "name": "Volumio",
   "documentation": "https://www.home-assistant.io/integrations/volumio",
-  "requirements": ["volumio-websocket==1.0.3"],
+  "requirements": ["volumio-websocket==1.0.3", "python-mpd2==1.0.0"],
   "codeowners": []
 }

--- a/homeassistant/components/volumio/manifest.json
+++ b/homeassistant/components/volumio/manifest.json
@@ -2,6 +2,6 @@
   "domain": "volumio",
   "name": "Volumio",
   "documentation": "https://www.home-assistant.io/integrations/volumio",
-  "requirements": ["volumio-websocket==1.0.3", "python-mpd2==1.0.0"],
+  "requirements": ["volumio-websocket==1.0.4", "python-mpd2==1.0.0"],
   "codeowners": []
 }

--- a/homeassistant/components/volumio/manifest.json
+++ b/homeassistant/components/volumio/manifest.json
@@ -2,6 +2,6 @@
   "domain": "volumio",
   "name": "Volumio",
   "documentation": "https://www.home-assistant.io/integrations/volumio",
-  "requirements": ["volumio-websocket==1.0.4", "python-mpd2==1.0.0"],
+  "requirements": ["volumio-websocket==1.0.15", "python-mpd2==1.0.0"],
   "codeowners": []
 }

--- a/homeassistant/components/volumio/manifest.json
+++ b/homeassistant/components/volumio/manifest.json
@@ -2,6 +2,6 @@
   "domain": "volumio",
   "name": "Volumio",
   "documentation": "https://www.home-assistant.io/integrations/volumio",
-  "requirements": ["python-socketio[asyncio_client]==4.6.0"],
+  "requirements": ["volumio-websocket==1.0.3"],
   "codeowners": []
 }

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -185,6 +185,9 @@ class Volumio(MediaPlayerEntity):
                 else:
                     params = params["cmd"]
                     
+            if method == params:
+                params = None
+                    
             return method, params
         
         method, params = api2websocket(method, params)

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -321,8 +321,7 @@ class Volumio(MediaPlayerEntity):
             self._client.play()
             import time
             
-            while self._client.status()["state"] == "play":
-                time.sleep(0.1)
+            time.sleep(self._client.status().get("duration", 0)
             await self.send_volumio_msg("play")
             
             return

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -13,6 +13,8 @@ import time
 import aiohttp
 import voluptuous as vol
 
+import mpd
+
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
@@ -123,6 +125,14 @@ class Volumio(MediaPlayerEntity):
         self._lastvol = self._state.get("volume", 0)
         self._playlists = []
         self._currentplaylist = None
+                
+        self._client = mpd.MPDClient()
+        self._client.timeout = 30
+        self._client.idletimeout = None
+                
+        self._client.connect(self.server, "6600)
+        if self.password is not None:
+            self._client.password(self.password)
         
         # taken from https://github.com/volumio/Volumio2/blob/master/app/plugins/user_interface/websocket/index.js
         self._methods = {
@@ -296,9 +306,12 @@ class Volumio(MediaPlayerEntity):
                 
             await self.send_volumio_msg("playPlaylist", media_id)
         else:
-            await self.send_volumio_msg("clearQueue")
-            await self.send_volumio_msg("addToQueue", media_id)
-            await self.send_volumio_msg("play")
+            #await self.send_volumio_msg("clearQueue")
+            #await self.send_volumio_msg("addToQueue", media_id)
+            #await self.send_volumio_msg("play")
+            self._client.clear()
+            self._client.add(media_id)
+            self._client.play()
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -316,7 +316,8 @@ class Volumio(MediaPlayerEntity):
             self._client.clear()
             self._client.add(media_id)
         
-        waittimer = self._client.status().get("duration", 0)
+        waittimer = self._client.status().get("duration", None)
+        # TODO: There is no duration for TTS files. How can i get this information?
         self._client.play()
         await asyncio.sleep(waittimer + 1)
     
@@ -325,7 +326,7 @@ class Volumio(MediaPlayerEntity):
         
         if isPlaying:
             await self.send_volumio_msg("pause")
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.2) # small delay, otherwise pause and play confuse volumio.
             
         await self.mpd_play_media(media_type, media_id, **kwargs)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -314,20 +314,15 @@ class Volumio(MediaPlayerEntity):
     async def async_play_media(self, media_type, media_id, **kwargs):
         svc = self._state.get("service", None)
         
-        await self.send_volumio_msg("pause")
         if svc == "spop":
-            self._client.clear()
-            self._client.add(media_id)
-            self._client.play()
+            await self.send_volumio_msg("pause")
             
-            import time
-            time.sleep(self._client.status().get("duration", 1))
-            
-            await self.send_volumio_msg("play")
-            
-            return
-        
         self.mpd_play_media(media_type, media_id, kwargs)
+        
+        if svc == "spop":
+            import time
+            asyncio.sleep(self._client.status().get("duration", 2))
+            await self.send_volumio_msg("play")        
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -343,11 +343,6 @@ class Volumio(MediaPlayerEntity):
         self._client.stop()
         if isPlaying:
             await self.send_volumio_msg("play")
-        else:
-            await self.send_volumio_msg("stop")
-            await asyncio.sleep(0.2)
-            await self.send_volumio_msg("stop")
-            self._client.stop()
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -310,18 +310,20 @@ class Volumio(MediaPlayerEntity):
             self._client.clear()
             self._client.add(media_id)
             self._client.play()
+            
+            asyncio.sleep(self._client.status().get("duration", 2))
     
     async def async_play_media(self, media_type, media_id, **kwargs):
         svc = self._state.get("service", None)
         
-        if svc == "spop":
+        isPlaying = self.state == STATE_PLAYING
+        
+        if isPlaying and svc == "spop":
             await self.send_volumio_msg("pause")
             
         self.mpd_play_media(media_type, media_id, **kwargs)
         
-        if svc == "spop":
-            import time
-            asyncio.sleep(self._client.status().get("duration", 2))
+        if isPlaying and svc == "spop":
             await self.send_volumio_msg("play")        
 
     @property

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -326,7 +326,7 @@ class Volumio(MediaPlayerEntity):
         
         if isPlaying:
             await self.send_volumio_msg("pause")
-            await asyncio.sleep(0.2) # small delay, otherwise pause and play confuse volumio.
+            await asyncio.sleep(0.4) # small delay, otherwise pause and play confuse volumio.
             
         await self.mpd_play_media(media_type, media_id, **kwargs)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -160,7 +160,7 @@ class Volumio(MediaPlayerEntity):
     def init_websocket(self):
         """Initialize websocket, which handles all informations from / to volumio."""
         websession = async_get_clientsession(self.hass)
-        url = f"ws://{self.host}:{self.port}/socket.io"
+        url = f"ws://{self.host}:{self.port}"
         return websession.ws_connect(url)
         
     async def send_volumio_msg(self, method, params=None):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -332,7 +332,7 @@ class Volumio(MediaPlayerEntity):
         
         wait_seconds = 10
         split_number = 5
-        split = wait_seconds % split_number
+        split = wait_seconds / split_number
         
         counter = 0
         while self._client.status().get("state") == "play" or counter < wait_seconds:

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -199,12 +199,13 @@ class Volumio(MediaPlayerEntity):
         import json
         
         try:
-            async for msg in self._ws:
-                _LOGGER.debug("get, METHOD: %s, received DATA: %s", method, data)
-                
-                data = json.loads(msg.data)
-                if data[0] == method:
-                    return data[1]
+            async with self._ws as ws:
+                async for msg in ws:
+                    _LOGGER.debug("get, METHOD: %s, received DATA: %s", method, data)
+
+                    data = json.loads(msg.data)
+                    if data[0] == method:
+                        return data[1]
                 
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:
             _LOGGER.error(
@@ -224,7 +225,8 @@ class Volumio(MediaPlayerEntity):
             if params is not None:
                 request_data.append(params)
                 
-            data = await self._ws.send_json(request_data)
+            async with self._ws as ws:
+                data = await ws.send_json(request_data)
             
             _LOGGER.debug("send METHOD: %s, received DATA: %s", method, data)
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -158,15 +158,12 @@ class Volumio(MediaPlayerEntity):
             
             #TODO: There are lots more, continue at L673
         }
-        
-        self.init_websocket()
                 
     async def init_websocket(self):
         """Initialize websocket, which handles all informations from / to volumio."""
         #websession = async_get_clientsession(self.hass)
         url = f"http://{self.host}:{self.port}"
         sio = socketio.AsyncClient()
-        self._sio = sio
         await sio.connect(url)
         return sio
         
@@ -196,8 +193,10 @@ class Volumio(MediaPlayerEntity):
         def callback(sid, data):
             lock = False
             content = data
+            
+        sio = await self.init_websocket()
         
-        self.send(self._sio, method, params, callback)
+        self.send(sio, method, params, callback)
         
         while lock:
             _LOGGER.debug("wait")

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -321,7 +321,7 @@ class Volumio(MediaPlayerEntity):
             self._client.play()
             import time
             
-            time.sleep(self._client.status().get("duration", 0)
+            time.sleep(self._client.status().get("duration", 0))
             await self.send_volumio_msg("play")
             
             return

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -316,9 +316,9 @@ class Volumio(MediaPlayerEntity):
             self._client.clear()
             self._client.add(media_id)
         
-        waittimer = self._client.status().get("duration", 2)
+        waittimer = self._client.status().get("duration", 0)
         self._client.play()
-        await asyncio.sleep(waittimer)
+        await asyncio.sleep(waittimer + 1)
     
     async def async_play_media(self, media_type, media_id, **kwargs):
         isPlaying = self.state == STATE_PLAYING

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -161,8 +161,10 @@ class Volumio(MediaPlayerEntity):
     async def send_volumio_msg(self, method, params=None):
         """Handles volumio calls"""
         
-        state_name = await self.send(method, params)   
-        return getattr(self, state_name)
+        state_name = await self.send(method, params) 
+        if state_name is not None:
+            return getattr(self, state_name)
+        return None
 
     async def send(self, method, params=None):
         """Send message."""

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -16,6 +16,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
+    MEDIA_TYPE_PLAYLIST,
     SUPPORT_CLEAR_PLAYLIST,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -194,9 +194,9 @@ class Volumio(MediaPlayerEntity):
         """Send seek command."""
         self.send_volumio_msg("Seek", position)
 
-    def play_media(self, *args, **kwargs):
+    def play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
-        self.async_play_media(args, kwargs)
+        self.async_play_media(media_type, media_id, **kwargs)
 
     async def async_mpd_play_media(self, media_type, media_id, **kwargs):
         """Send the media player the command for playing a playlist."""

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -304,16 +304,15 @@ class Volumio(MediaPlayerEntity):
             # Cleanly disconnect in case connection is not in valid state
             self._client.connect(self.host, "6600")
         
+        self._client.clear()
         if media_type == MEDIA_TYPE_PLAYLIST:
             if media_id in self._playlists:
                 self._currentplaylist = media_id
             else:
                 self._currentplaylist = None
                 _LOGGER.warning("Unknown playlist name %s", media_id)
-            self._client.clear()
             self._client.load(media_id)
         else:
-            self._client.clear()
             self._client.add(media_id)
         
         waittimer = self._client.status().get("duration", 1)
@@ -345,9 +344,10 @@ class Volumio(MediaPlayerEntity):
         if isPlaying:
             await self.send_volumio_msg("play")
         else:
-            await asyncio.sleep(0.2)
-            self._client.stop()
             await self.send_volumio_msg("stop")
+            await asyncio.sleep(0.2)
+            await self.send_volumio_msg("stop")
+            self._client.stop()
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -317,7 +317,7 @@ class Volumio(MediaPlayerEntity):
         if svc == "spop":
             await self.send_volumio_msg("pause")
             
-        self.mpd_play_media(media_type, media_id, kwargs)
+        self.mpd_play_media(media_type, media_id, **kwargs)
         
         if svc == "spop":
             import time

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -190,12 +190,15 @@ class Volumio(MediaPlayerEntity):
         sio = socketio.AsyncClient()
         await sio.connect(url)
         
-        state_name = self._methods[method]
-        
-        @sio.on(state_name)
-        def func(data):
-            nonlocal state_name, self
-            setattr(self, state_name, data)
+        if method in self._methods:
+            state_name = self._methods[method]
+
+            @sio.on(state_name)
+            def func(data):
+                nonlocal state_name, self
+                setattr(self, state_name, data)
+        else:
+            state_name = None
         
         try:
             await sio.emit(method, params)

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -194,7 +194,7 @@ class Volumio(MediaPlayerEntity):
         
         @sio.on(state_name)
         def func(data):
-            nonlocal name, self
+            nonlocal state_name, self
             setattr(self, state_name, data)
         
         try:

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -216,7 +216,7 @@ class Volumio(MediaPlayerEntity):
             )
             return False
 
-        await sio.sleep(1)
+        await sio.sleep(0.1)
         await sio.disconnect()
         
         return state_name

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -26,6 +26,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
+    SUPPORT_PLAY_MEDIA
 )
 from homeassistant.const import (
     CONF_HOST,

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -194,7 +194,8 @@ class Volumio(MediaPlayerEntity):
         
         @sio.on(state_name)
         def func(data):
-            setattr(self, name, data)
+            nonlocal name, self
+            setattr(self, state_name, data)
         
         try:
             await sio.emit(method, params)

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -130,7 +130,7 @@ class Volumio(MediaPlayerEntity):
         self._client.timeout = 30
         self._client.idletimeout = None
                 
-        self._client.connect(self.server, "6600)
+        self._client.connect(self.server, "6600")
         if self.password is not None:
             self._client.password(self.password)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -129,14 +129,15 @@ class Volumio(MediaPlayerEntity):
 
     async def send_volumio_msg(self, method, params=None):
         """Handle volumio calls."""
-
-        return volumio_api_request(self.host, "6600", method, params)
+        _LOGGER.debug("Request: method %s, params %s", method, params)
+        return await volumio_api_request(self.host, self.port, method, params)
 
     async def async_update(self):
         """Update state."""
         resp = await self.send_volumio_msg("getState")
+        _LOGGER.debug("Got response: %s", resp)
         await self._async_update_playlists()
-        if resp is False:
+        if resp is None:
             return
         self._state = resp.copy()
 

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -159,7 +159,7 @@ class Volumio(MediaPlayerEntity):
         
         self.init_websocket()
         
-    async def init_websocket(self):
+    def init_websocket(self):
         """Initialize websocket, which handles all informations from / to volumio."""
         websession = async_get_clientsession(self.hass)
         url = f"http://{self.host}:{self.port}/socket.io"

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -330,12 +330,12 @@ class Volumio(MediaPlayerEntity):
             
         await self.mpd_play_media(media_type, media_id, **kwargs)
         
-        wait_seconds = 10
-        split_number = 5
+        wait_seconds = 5
+        split_number = 10
         split = wait_seconds / split_number
         
         counter = 0
-        while self._client.status().get("state") == "play" or counter < wait_seconds:
+        while counter < wait_seconds or self._client.status().get("state") == "play":
             await asyncio.sleep(split)
             counter += split
             

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -325,7 +325,7 @@ class Volumio(MediaPlayerEntity):
         
         if isPlaying:
             await self.send_volumio_msg("pause")
-            asyncio.sleep(1)
+            asyncio.sleep(10)
             
         self.mpd_play_media(media_type, media_id, **kwargs)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -160,7 +160,7 @@ class Volumio(MediaPlayerEntity):
     def init_websocket(self):
         """Initialize websocket, which handles all informations from / to volumio."""
         websession = async_get_clientsession(self.hass)
-        url = f"http://{self.host}:{self.port}/socket.io"
+        url = f"ws://{self.host}:{self.port}/socket.io"
         return websession.ws_connect(url)
         
     async def send_volumio_msg(self, method, params=None):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -194,7 +194,7 @@ class Volumio(MediaPlayerEntity):
         
         @sio.on(state_name)
         def func(data):
-            settattr(self, name, data)
+            setattr(self, name, data)
         
         try:
             await sio.emit(method, params)

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -306,10 +306,13 @@ class Volumio(MediaPlayerEntity):
         else:
             #await self.send_volumio_msg("clearQueue")
             #await self.send_volumio_msg("addToQueue", media_id)
-            #await self.send_volumio_msg("play")
+            await self.send_volumio_msg("pause")
             self._client.clear()
             self._client.add(media_id)
             self._client.play()
+            import time
+            time.sleep(2)
+            await self.send_volumio_msg("play")
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -318,14 +318,14 @@ class Volumio(MediaPlayerEntity):
         
         waittimer = self._client.status().get("duration", 2)
         self._client.play()
-        asyncio.sleep(waittimer)
+        await asyncio.sleep(waittimer)
     
     async def async_play_media(self, media_type, media_id, **kwargs):
         isPlaying = self.state == STATE_PLAYING
         
         if isPlaying:
             await self.send_volumio_msg("pause")
-            asyncio.sleep(10)
+            await asyncio.sleep(0.5)
             
         self.mpd_play_media(media_type, media_id, **kwargs)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -187,10 +187,11 @@ class Volumio(MediaPlayerEntity):
         lock = True
         content = None
         def callback(sid, data):
+            nonlocal lock
             lock = False
             content = data
                 
-        self.send(sio, method, params, callback)
+        await self.send(sio, method, params, callback)
         
         while lock:
             _LOGGER.debug("wait")

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -325,7 +325,7 @@ class Volumio(MediaPlayerEntity):
         
         if isPlaying:
             await self.send_volumio_msg("pause")
-            asyncio.sleep(0.1)
+            asyncio.sleep(0.5)
             
         self.mpd_play_media(media_type, media_id, **kwargs)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -316,10 +316,10 @@ class Volumio(MediaPlayerEntity):
             self._client.clear()
             self._client.add(media_id)
         
-        waittimer = self._client.status().get("duration", None)
+        waittimer = self._client.status().get("duration", 1)
         # TODO: There is no duration for TTS files. How can i get this information?
         self._client.play()
-        await asyncio.sleep(waittimer + 1)
+        await asyncio.sleep(waittimer)
     
     async def async_play_media(self, media_type, media_id, **kwargs):
         isPlaying = self.state == STATE_PLAYING

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -338,11 +338,12 @@ class Volumio(MediaPlayerEntity):
         while counter < wait_seconds or self._client.status().get("state") == "play":
             await asyncio.sleep(split)
             counter += split
-            
-        self._client.stop()
-        
+                    
         if isPlaying:
+            self._client.stop()
             await self.send_volumio_msg("play")
+        else:
+            await self.send_volumio_msg("pause")
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -321,7 +321,7 @@ class Volumio(MediaPlayerEntity):
             self._client.play()
             import time
             
-            while self._client.status()["state"] != "stop":
+            while self._client.status()["state"] == "play":
                 time.sleep(0.1)
             await self.send_volumio_msg("play")
             

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -312,19 +312,20 @@ class Volumio(MediaPlayerEntity):
                 _LOGGER.warning("Unknown playlist name %s", media_id)
             self._client.clear()
             self._client.load(media_id)
-            self._client.play()
         else:
             self._client.clear()
             self._client.add(media_id)
-            self._client.play()
-            
-            asyncio.sleep(self._client.status().get("duration", 2))
+        
+        waittimer = self._client.status().get("duration", 2)
+        self._client.play()
+        asyncio.sleep(waittimer)
     
     async def async_play_media(self, media_type, media_id, **kwargs):
         isPlaying = self.state == STATE_PLAYING
         
         if isPlaying:
             await self.send_volumio_msg("pause")
+            asyncio.sleep(0.1)
             
         self.mpd_play_media(media_type, media_id, **kwargs)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -186,7 +186,7 @@ class Volumio(MediaPlayerEntity):
         method, params = api2websocket(method, params)
         
         self.send(method, params)        
-        await data = self.get_volumio_msg(self._methods[method])
+        data = await self.get_volumio_msg(self._methods[method])
         
         _LOGGER.debug("received DATA: %s", data)
         return data

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -338,12 +338,13 @@ class Volumio(MediaPlayerEntity):
         while counter < wait_seconds or self._client.status().get("state") == "play":
             await asyncio.sleep(split)
             counter += split
-                    
+        
+        self._client.stop()
         if isPlaying:
-            self._client.stop()
             await self.send_volumio_msg("play")
         else:
             await asyncio.sleep(0.2)
+            self._client.stop()
             await self.send_volumio_msg("stop")
 
     @property

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -198,7 +198,7 @@ class Volumio(MediaPlayerEntity):
         """Play a piece of media."""
         self.async_play_media(args, kwargs)
 
-    async def mpd_play_media(self, media_type, media_id, **kwargs):
+    async def async_mpd_play_media(self, media_type, media_id, **kwargs):
         """Send the media player the command for playing a playlist."""
         _LOGGER.debug("Playing playlist: %s", media_id)
 
@@ -235,7 +235,7 @@ class Volumio(MediaPlayerEntity):
                 0.4
             )  # small delay, otherwise pause and play confuse volumio.
 
-        await self.mpd_play_media(media_type, media_id, **kwargs)
+        await self.async_mpd_play_media(media_type, media_id, **kwargs)
 
         wait_seconds = 5
         split_number = 10

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -187,16 +187,12 @@ class Volumio(MediaPlayerEntity):
         lock = True
         content = None
         def callback(sid, data):
-            nonlocal lock
+            nonlocal lock, content
             lock = False
             content = data
                 
         await self.send(sio, method, params, callback)
-        
-        while lock:
-            _LOGGER.debug("wait")
-            time.sleep(0.05)
-        
+               
         return content
 
     async def send(self, sio, method, params=None, callback=None):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -343,7 +343,7 @@ class Volumio(MediaPlayerEntity):
             self._client.stop()
             await self.send_volumio_msg("play")
         else:
-            await self.send_volumio_msg("pause")
+            await self.send_volumio_msg("stop")
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -184,12 +184,14 @@ class Volumio(MediaPlayerEntity):
         
         method, params = api2websocket(method, params)
         
-        async with init_websocket() as ws:
+        async with self.init_websocket() as ws:
             self.send(ws, method, params)
-            data = await self.get(ws, self._methods[method])
-        
-        _LOGGER.debug("received DATA: %s", data)
-        return data
+            if method in self._methods:
+                data = await self.get(ws, self._methods[method])
+                _LOGGER.debug("received DATA: %s", data)
+                
+                return data
+        return None
             
     async def get(self, ws, method):
         """Handles responses from websocket."""
@@ -292,7 +294,7 @@ class Volumio(MediaPlayerEntity):
     
     def media_seek(self, position):
         """Send seek command."""
-        self.send("Seek", position)
+        self.send_volumio_msg("Seek", position)
         
     def play_media(self, *args, **kwargs):
         """Play a piece of media."""
@@ -306,11 +308,11 @@ class Volumio(MediaPlayerEntity):
                 self._currentplaylist = None
                 _LOGGER.warning("Unknown playlist name %s", media_id)
                 
-            await self.send("playPlaylist", media_id)
+            await self.send_volumio_msg("playPlaylist", media_id)
         else:
-            await self.send("clearQueue")
-            await self.send("addToQueue", media_id)
-            await self.send("play")
+            await self.send_volumio_msg("clearQueue")
+            await self.send_volumio_msg("addToQueue", media_id)
+            await self.send_volumio_msg("play")
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -314,14 +314,15 @@ class Volumio(MediaPlayerEntity):
     async def async_play_media(self, media_type, media_id, **kwargs):
         svc = self._state.get("service", None)
         
-        if svc == "spop" or svc is None:
-            await self.send_volumio_msg("pause")
+        await self.send_volumio_msg("pause")
+        if svc == "spop":
             self._client.clear()
             self._client.add(media_id)
             self._client.play()
-            import time
             
-            time.sleep(self._client.status().get("duration", 0))
+            import time
+            time.sleep(self._client.status().get("duration", 1))
+            
             await self.send_volumio_msg("play")
             
             return

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -130,9 +130,7 @@ class Volumio(MediaPlayerEntity):
         self._client.timeout = 30
         self._client.idletimeout = None
                 
-        self._client.connect(self.server, "6600")
-        if self.password is not None:
-            self._client.password(self.password)
+        self._client.connect(self.host, "6600")
         
         # taken from https://github.com/volumio/Volumio2/blob/master/app/plugins/user_interface/websocket/index.js
         self._methods = {

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -229,19 +229,18 @@ class Volumio(MediaPlayerEntity):
     async def send(self, sio, method, params=None, callback=None):
         """Send message."""
         _LOGGER.debug("Send, method: %s params: %s", method, params)
-
-        data = None
         
         try:
-            data = await sio.emit(method, params, callback=callback)
+            await sio.emit(method, params, callback=callback)
             
             _LOGGER.debug("send METHOD: %s, received DATA: %s", method, data)
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:
             _LOGGER.error(
                 "Failed communicating with Volumio '%s': %s", self._name, type(error)
             )
+            return False
 
-        return data
+        return True
 
     async def async_update(self):
         """Update state."""

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -343,6 +343,7 @@ class Volumio(MediaPlayerEntity):
             self._client.stop()
             await self.send_volumio_msg("play")
         else:
+            await asyncio.sleep(0.2)
             await self.send_volumio_msg("stop")
 
     @property

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -327,20 +327,7 @@ class Volumio(MediaPlayerEntity):
             
             return
         
-        if media_type == MEDIA_TYPE_PLAYLIST:
-            if media_id in self._playlists:
-                self._currentplaylist = media_id
-            else:
-                self._currentplaylist = None
-                _LOGGER.warning("Unknown playlist name %s", media_id)
-            self._client.clear()
-            self._client.load(media_id)
-            self._client.play()
-        else:
-            self._client.clear()
-            self._client.add(media_id)
-            self._client.play()
-           
+        self.mpd_play_media(media_type, media_id, kwargs)
 
     @property
     def media_duration(self):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -186,8 +186,8 @@ class Volumio(MediaPlayerEntity):
         
         method, params = api2websocket(method, params)
         
-        self.send(method, params)        
-        data = await self.get_volumio_msg(self._methods[method])
+        self.send(method, params)
+        data = await self.get(self._methods[method])
         
         _LOGGER.debug("received DATA: %s", data)
         return data

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -173,7 +173,7 @@ class Volumio(MediaPlayerEntity):
         state_name = await self.send(method, params) 
         if state_name is not None:
             return getattr(self, state_name)
-        return None
+        return state_name
 
     async def send(self, method, params=None):
         """Send message."""
@@ -325,7 +325,7 @@ class Volumio(MediaPlayerEntity):
         
         if isPlaying:
             await self.send_volumio_msg("pause")
-            asyncio.sleep(0.5)
+            asyncio.sleep(1)
             
         self.mpd_play_media(media_type, media_id, **kwargs)
         

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -294,7 +294,7 @@ class Volumio(MediaPlayerEntity):
         """Play a piece of media."""
         self.async_play_media(args, kwargs)
         
-    def mpd_play_media(self, media_type, media_id, **kwargs):
+    async def mpd_play_media(self, media_type, media_id, **kwargs):
         """Send the media player the command for playing a playlist."""
         _LOGGER.debug("Playing playlist: %s", media_id)
 
@@ -327,7 +327,7 @@ class Volumio(MediaPlayerEntity):
             await self.send_volumio_msg("pause")
             await asyncio.sleep(0.5)
             
-        self.mpd_play_media(media_type, media_id, **kwargs)
+        await self.mpd_play_media(media_type, media_id, **kwargs)
         
         if isPlaying:
             await self.send_volumio_msg("play")

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -322,7 +322,9 @@ class Volumio(MediaPlayerEntity):
         await asyncio.sleep(waittimer)
     
     async def async_play_media(self, media_type, media_id, **kwargs):
-        isPlaying = self.state == STATE_PLAYING
+        isPlaying = False
+        if self.state == STATE_PLAYING:
+            isPlaying = True
         
         if isPlaying:
             await self.send_volumio_msg("pause")

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -220,7 +220,6 @@ class Volumio(MediaPlayerEntity):
             self._client.add(media_id)
 
         waittimer = self._client.status().get("duration", 1)
-        # TODO: There is no duration for TTS files. How can i get this information?
         self._client.play()
         await asyncio.sleep(waittimer)
 

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -330,6 +330,17 @@ class Volumio(MediaPlayerEntity):
             
         await self.mpd_play_media(media_type, media_id, **kwargs)
         
+        wait_seconds = 10
+        split_number = 5
+        split = wait_seconds % split_number
+        
+        counter = 0
+        while self._client.status().get("state") == "play" or counter < wait_seconds:
+            await asyncio.sleep(split)
+            counter += split
+            
+        self._client.stop()
+        
         if isPlaying:
             await self.send_volumio_msg("play")
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2154,7 +2154,7 @@ vilfo-api-client==0.3.2
 volkszaehler==0.1.2
 
 # homeassistant.components.volumio
-volumio-websocket==1.0.4
+volumio-websocket==1.0.15
 
 # homeassistant.components.volvooncall
 volvooncall==0.8.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1699,6 +1699,7 @@ python-juicenet==1.0.1
 python-miio==0.5.0.1
 
 # homeassistant.components.mpd
+# homeassistant.components.volumio
 python-mpd2==1.0.0
 
 # homeassistant.components.mystrom

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2154,7 +2154,7 @@ vilfo-api-client==0.3.2
 volkszaehler==0.1.2
 
 # homeassistant.components.volumio
-volumio-websocket==1.0.3
+volumio-websocket==1.0.4
 
 # homeassistant.components.volvooncall
 volvooncall==0.8.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1722,9 +1722,6 @@ python-ripple-api==0.0.3
 # homeassistant.components.sochain
 python-sochain-api==0.0.2
 
-# homeassistant.components.volumio
-python-socketio[asyncio_client]==4.6.0
-
 # homeassistant.components.songpal
 python-songpal==0.12
 
@@ -2154,6 +2151,9 @@ vilfo-api-client==0.3.2
 
 # homeassistant.components.volkszaehler
 volkszaehler==0.1.2
+
+# homeassistant.components.volumio
+volumio-websocket==1.0.3
 
 # homeassistant.components.volvooncall
 volvooncall==0.8.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1722,6 +1722,9 @@ python-ripple-api==0.0.3
 # homeassistant.components.sochain
 python-sochain-api==0.0.2
 
+# homeassistant.components.volumio
+python-socketio[asyncio_client]==4.6.0
+
 # homeassistant.components.songpal
 python-songpal==0.12
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR implements the play_media method, which was removed in PR #29969, because i want to use it with TTS. I added a new dependency, because i removed the HTTP API connection and implements a websocket (socket.io) connection to volumio. This was a sideeffect, because my first approach was to play media through volumio (in my case the tts media file). 

But i do not know enough about HASS to get all informations for the temporary tts files (or the media_id at all) to implement it with websockets, so i implement a workaround with a mpd client. This would be nice to remove (maybe we can do it together?), but at this stage it works for me very well.

Currently it plays one file or playlist for a maximum of 5 seconds (because of deadlock), because i cannot know, how long the duration of the file or playlist is. So this feature is only applicable for TTS apps or small media files.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
