### PR TITLE
Ensure a deleted integration can be removed

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -268,7 +268,15 @@ class ConfigEntry:
             return True
 
         if integration is None:
-            integration = await loader.async_get_integration(hass, self.domain)
+            try:
+                integration = await loader.async_get_integration(hass, self.domain)
+            except loader.IntegrationNotFound:
+                # The integration was likely a custom_component
+                # that was uninstalled, or an integration
+                # that has been renamed without removing the config
+                # entry.
+                self.state = ENTRY_STATE_NOT_LOADED
+                return True
 
         component = integration.get_component()
 
@@ -316,7 +324,11 @@ class ConfigEntry:
         if self.source == SOURCE_IGNORE:
             return
 
-        integration = await loader.async_get_integration(hass, self.domain)
+        try:
+            integration = await loader.async_get_integration(hass, self.domain)
+        except loader.IntegrationNotFound:
+            return
+
         component = integration.get_component()
         if not hasattr(component, "async_remove_entry"):
             return

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -327,6 +327,10 @@ class ConfigEntry:
         try:
             integration = await loader.async_get_integration(hass, self.domain)
         except loader.IntegrationNotFound:
+            # The integration was likely a custom_component
+            # that was uninstalled, or an integration
+            # that has been renamed without removing the config
+            # entry.
             return
 
         component = integration.get_component()

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -365,6 +365,28 @@ async def test_remove_entry_if_not_loaded(hass, manager):
     assert len(mock_unload_entry.mock_calls) == 0
 
 
+async def test_remove_entry_if_integration_deleted(hass, manager):
+    """Test that we can remove an entry when the integration is deleted."""
+    mock_unload_entry = AsyncMock(return_value=True)
+
+    MockConfigEntry(domain="test", entry_id="test1").add_to_manager(manager)
+    MockConfigEntry(domain="comp", entry_id="test2").add_to_manager(manager)
+    MockConfigEntry(domain="test", entry_id="test3").add_to_manager(manager)
+
+    assert [item.entry_id for item in manager.async_entries()] == [
+        "test1",
+        "test2",
+        "test3",
+    ]
+
+    result = await manager.async_remove("test2")
+
+    assert result == {"require_restart": False}
+    assert [item.entry_id for item in manager.async_entries()] == ["test1", "test3"]
+
+    assert len(mock_unload_entry.mock_calls) == 0
+
+
 async def test_add_entry_calls_setup_entry(hass, manager):
     """Test we call setup_config_entry."""
     mock_setup_entry = AsyncMock(return_value=True)


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure a deleted integration can be removed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
