### PR TITLE
Add support for VeSync Fans

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -853,6 +853,7 @@ omit =
     homeassistant/components/vesync/__init__.py
     homeassistant/components/vesync/common.py
     homeassistant/components/vesync/const.py
+    homeassistant/components/vesync/fan.py
     homeassistant/components/vesync/switch.py
     homeassistant/components/viaggiatreno/sensor.py
     homeassistant/components/vicare/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -441,7 +441,7 @@ homeassistant/components/velux/* @Julius2342
 homeassistant/components/vera/* @vangorra
 homeassistant/components/versasense/* @flamm3blemuff1n
 homeassistant/components/version/* @fabaff
-homeassistant/components/vesync/* @markperdue @webdjoe
+homeassistant/components/vesync/* @markperdue @webdjoe @thegardenmonkey
 homeassistant/components/vicare/* @oischinger
 homeassistant/components/vilfo/* @ManneW
 homeassistant/components/vivotek/* @HarlemSquirrel

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -16,9 +16,9 @@ from .const import (
     SERVICE_UPDATE_DEVS,
     VS_DISCOVERY,
     VS_DISPATCHERS,
+    VS_FANS,
     VS_MANAGER,
     VS_SWITCHES,
-    VS_FANS,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     VS_DISPATCHERS,
     VS_MANAGER,
     VS_SWITCHES,
+    VS_FANS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,6 +81,7 @@ async def async_setup_entry(hass, config_entry):
     hass.data[DOMAIN][VS_MANAGER] = manager
 
     switches = hass.data[DOMAIN][VS_SWITCHES] = []
+    fans = hass.data[DOMAIN][VS_FANS] = []
 
     hass.data[DOMAIN][VS_DISPATCHERS] = []
 
@@ -87,13 +89,19 @@ async def async_setup_entry(hass, config_entry):
         switches.extend(device_dict[VS_SWITCHES])
         hass.async_create_task(forward_setup(config_entry, "switch"))
 
+    if device_dict[VS_FANS]:
+        fans.extend(device_dict[VS_FANS])
+        hass.async_create_task(forward_setup(config_entry, "fan"))
+
     async def async_new_device_discovery(service):
         """Discover if new devices should be added."""
         manager = hass.data[DOMAIN][VS_MANAGER]
         switches = hass.data[DOMAIN][VS_SWITCHES]
+        fans = hass.data[DOMAIN][VS_FANS]
 
         dev_dict = await async_process_devices(hass, manager)
         switch_devs = dev_dict.get(VS_SWITCHES, [])
+        fan_devs = dev_dict.get(VS_FANS, [])
 
         switch_set = set(switch_devs)
         new_switches = list(switch_set.difference(switches))
@@ -104,6 +112,16 @@ async def async_setup_entry(hass, config_entry):
         if new_switches and not switches:
             switches.extend(new_switches)
             hass.async_create_task(forward_setup(config_entry, "switch"))
+
+        fan_set = set(fan_devs)
+        new_fans = list(fan_set.difference(fans))
+        if new_fans and fans:
+            fans.extend(new_fans)
+            async_dispatcher_send(hass, VS_DISCOVERY.format(VS_FANS), new_fans)
+            return
+        if new_fans and not fans:
+            fans.extend(new_fans)
+            hass.async_create_task(forward_setup(config_entry, "fan"))
 
     hass.services.async_register(
         DOMAIN, SERVICE_UPDATE_DEVS, async_new_device_discovery
@@ -119,7 +137,11 @@ async def async_unload_entry(hass, entry):
     if hass.data[DOMAIN][VS_SWITCHES]:
         remove_switches = await forward_unload(entry, "switch")
 
-    if remove_switches:
+    remove_fans = False
+    if hass.data[DOMAIN][VS_FANS]:
+        remove_fans = await forward_unload(entry, "fan")
+
+    if remove_switches and remove_fans:
         hass.services.async_remove(DOMAIN, SERVICE_UPDATE_DEVS)
         del hass.data[DOMAIN]
         return True

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -1,4 +1,4 @@
-"""Etekcity VeSync integration."""
+"""VeSync integration."""
 import logging
 
 from pyvesync import VeSync

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -1,4 +1,5 @@
 """VeSync integration."""
+import asyncio
 import logging
 
 from pyvesync import VeSync

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.helpers.entity import ToggleEntity
 
-from .const import VS_SWITCHES
+from .const import VS_SWITCHES, VS_FANS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -12,8 +12,13 @@ async def async_process_devices(hass, manager):
     """Assign devices to proper component."""
     devices = {}
     devices[VS_SWITCHES] = []
+    devices[VS_FANS] = []
 
     await hass.async_add_executor_job(manager.update)
+
+    if manager.fans:
+        devices[VS_FANS].extend(manager.fans)
+        _LOGGER.info("%d VeSync fans found", len(manager.fans))
 
     if manager.outlets:
         devices[VS_SWITCHES].extend(manager.outlets)
@@ -49,7 +54,7 @@ class VeSyncDevice(ToggleEntity):
 
     @property
     def is_on(self):
-        """Return True if switch is on."""
+        """Return True if device is on."""
         return self.device.device_status == "on"
 
     @property

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -62,10 +62,6 @@ class VeSyncDevice(ToggleEntity):
         """Return True if device is available."""
         return self.device.connection_status == "online"
 
-    def turn_on(self, **kwargs):
-        """Turn the device on."""
-        self.device.turn_on()
-
     def turn_off(self, **kwargs):
         """Turn the device off."""
         self.device.turn_off()

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.helpers.entity import ToggleEntity
 
-from .const import VS_SWITCHES, VS_FANS
+from .const import VS_FANS, VS_SWITCHES
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -6,4 +6,5 @@ VS_DISCOVERY = "vesync_discovery_{}"
 SERVICE_UPDATE_DEVS = "update_devices"
 
 VS_SWITCHES = "switches"
+VS_FANS = "fans"
 VS_MANAGER = "manager"

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -1,7 +1,7 @@
 """Support for Etekcity VeSync fans."""
 import logging
 
-from homeassistant.components.fan import FanEntity, SUPPORT_SET_SPEED
+from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -61,11 +61,6 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         return SUPPORT_SET_SPEED
 
     @property
-    def is_on(self):
-        """Return True if device is on."""
-        return self.smartfan.device_status == "on"
-
-    @property
     def speed(self):
         """Return the current speed."""
         if self.smartfan.mode == "auto":
@@ -87,11 +82,6 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         return self.smartfan.uuid
 
     @property
-    def name(self):
-        """Return the name of the fan."""
-        return self.smartfan.device_name
-
-    @property
     def device_state_attributes(self):
         """Return the state attributes of the fan."""
         attr = {}
@@ -110,11 +100,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
             self.smartfan.manual_mode()
             self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))
 
-    def turn_on(self, speed, **kwargs):
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn the device on."""
         self.smartfan.turn_on()
-        if speed is None or speed == "auto":
-            self.smartfan.auto_mode()
-        else:
-            self.smartfan.manual_mode()
-            self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))
+        self.set_speed(speed)

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -1,4 +1,4 @@
-"""Support for Etekcity VeSync fans."""
+"""Support for VeSync fans."""
 import logging
 
 from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -1,0 +1,118 @@
+"""Support for Etekcity VeSync fans"""
+import logging
+
+from homeassistant.components.fan import FanEntity, SUPPORT_SET_SPEED
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .common import VeSyncDevice
+from .const import DOMAIN, VS_DISCOVERY, VS_DISPATCHERS, VS_FANS
+
+_LOGGER = logging.getLogger(__name__)
+
+DEV_TYPE_TO_HA = {
+    "LV-PUR131S": "fan",
+}
+
+FAN_SPEEDS = ["auto", "low", "medium", "high"]
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the VeSync fan platform."""
+
+    async def async_discover(devices):
+        """Add new devices to platform."""
+        _async_setup_entities(devices, async_add_entities)
+
+    disp = async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_FANS), async_discover)
+    hass.data[DOMAIN][VS_DISPATCHERS].append(disp)
+
+    _async_setup_entities(hass.data[DOMAIN][VS_FANS], async_add_entities)
+    return True
+
+
+@callback
+def _async_setup_entities(devices, async_add_entities):
+    """Check if device is online and add entity."""
+    dev_list = []
+    for dev in devices:
+        if DEV_TYPE_TO_HA.get(dev.device_type) == "fan":
+            dev_list.append(VeSyncFanHA(dev))
+        else:
+            _LOGGER.warning(
+                "%s - Unknown device type - %s", dev.device_name, dev.device_type
+            )
+            continue
+
+    async_add_entities(dev_list, update_before_add=True)
+
+
+class VeSyncFanHA(VeSyncDevice, FanEntity):
+    """Representation of a VeSync fan."""
+
+    def __init__(self, fan):
+        """Initialize the VeSync fan device."""
+        super().__init__(fan)
+        self.smartfan = fan
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_SET_SPEED
+
+    @property
+    def is_on(self):
+        """Return True if device is on"""
+        return self.smartfan.device_status == "on"
+
+    @property
+    def speed(self):
+        """Return the current speed."""
+        if self.smartfan.mode == "auto":
+            return "auto"
+        if self.smartfan.mode == "manual":
+            current_level = self.smartfan.fan_level
+            if current_level is not None:
+                return FAN_SPEEDS[current_level]
+        return None
+
+    @property
+    def speed_list(self):
+        """Get the list of available speeds"""
+        return FAN_SPEEDS
+
+    @property
+    def unique_info(self):
+        """Return the ID of this fan."""
+        return self.smartfan.uuid
+
+    @property
+    def name(self):
+        """Return the name of the fan."""
+        return self.smartfan.device_name
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the fan."""
+        attr = {}
+        attr["mode"] = self.smartfan.mode
+        attr["active_time"] = self.smartfan.active_time
+        attr["filter_life"] = self.smartfan.filter_life
+        attr["air_quality"] = self.smartfan.air_quality
+        attr["screen_status"] = self.smartfan.screen_status
+        return attr
+
+    def set_speed(self, speed):
+        if speed is None or speed == "auto":
+            self.smartfan.auto_mode()
+        else:
+            self.smartfan.manual_mode()
+            self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))
+
+    def turn_on(self, speed, **kwargs):
+        self.smartfan.turn_on()
+        if speed is None or speed == "auto":
+            self.smartfan.auto_mode()
+        else:
+            self.smartfan.manual_mode()
+            self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -103,7 +103,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         return attr
 
     def set_speed(self, speed):
-        """Sets the speed of the device."""
+        """Set the speed of the device."""
         if speed is None or speed == "auto":
             self.smartfan.auto_mode()
         else:

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -1,4 +1,4 @@
-"""Support for Etekcity VeSync fans"""
+"""Support for Etekcity VeSync fans."""
 import logging
 
 from homeassistant.components.fan import FanEntity, SUPPORT_SET_SPEED
@@ -62,7 +62,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
 
     @property
     def is_on(self):
-        """Return True if device is on"""
+        """Return True if device is on."""
         return self.smartfan.device_status == "on"
 
     @property
@@ -78,7 +78,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
 
     @property
     def speed_list(self):
-        """Get the list of available speeds"""
+        """Get the list of available speeds."""
         return FAN_SPEEDS
 
     @property
@@ -103,6 +103,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         return attr
 
     def set_speed(self, speed):
+        """Sets the speed of the device."""
         if speed is None or speed == "auto":
             self.smartfan.auto_mode()
         else:
@@ -110,6 +111,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
             self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))
 
     def turn_on(self, speed, **kwargs):
+        """Turn the device on."""
         self.smartfan.turn_on()
         if speed is None or speed == "auto":
             self.smartfan.auto_mode()

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -22,7 +22,7 @@ DEV_TYPE_TO_HA = {
 }
 
 SPEED_AUTO = "auto"
-FAN_SPEEDS = [SPEED_AUTO, SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -102,6 +102,9 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
 
     def set_speed(self, speed):
         """Set the speed of the device."""
+        if not self.smartfan.is_on:
+            self.smartfan.turn_on()
+
         if speed is None or speed == SPEED_AUTO:
             self.smartfan.auto_mode()
         else:

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -22,7 +22,7 @@ DEV_TYPE_TO_HA = {
 }
 
 SPEED_AUTO = "auto"
-FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+FAN_SPEEDS = [SPEED_AUTO, SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -14,7 +14,8 @@ DEV_TYPE_TO_HA = {
     "LV-PUR131S": "fan",
 }
 
-FAN_SPEEDS = ["auto", "low", "medium", "high"]
+SPEED_AUTO = "auto"
+FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -63,8 +64,8 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
     @property
     def speed(self):
         """Return the current speed."""
-        if self.smartfan.mode == "auto":
-            return "auto"
+        if self.smartfan.mode == SPEED_AUTO:
+            return SPEED_AUTO
         if self.smartfan.mode == "manual":
             current_level = self.smartfan.fan_level
             if current_level is not None:
@@ -85,16 +86,16 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
     def device_state_attributes(self):
         """Return the state attributes of the fan."""
         return {
-           "mode": self.smartfan.mode,
-           "active_time": self.smartfan.active_time,
-           "filter_life": self.smartfan.filter_life,
-           "air_quality": self.smartfan.air_quality,
-           "screen_status": self.smartfan.screen_status
+            "mode": self.smartfan.mode,
+            "active_time": self.smartfan.active_time,
+            "filter_life": self.smartfan.filter_life,
+            "air_quality": self.smartfan.air_quality,
+            "screen_status": self.smartfan.screen_status,
         }
 
     def set_speed(self, speed):
         """Set the speed of the device."""
-        if speed is None or speed == "auto":
+        if speed is None or speed == SPEED_AUTO:
             self.smartfan.auto_mode()
         else:
             self.smartfan.manual_mode()

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -84,13 +84,13 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the fan."""
-        attr = {}
-        attr["mode"] = self.smartfan.mode
-        attr["active_time"] = self.smartfan.active_time
-        attr["filter_life"] = self.smartfan.filter_life
-        attr["air_quality"] = self.smartfan.air_quality
-        attr["screen_status"] = self.smartfan.screen_status
-        return attr
+        return {
+           "mode": self.smartfan.mode,
+           "active_time": self.smartfan.active_time,
+           "filter_life": self.smartfan.filter_life,
+           "air_quality": self.smartfan.air_quality,
+           "screen_status": self.smartfan.screen_status
+        }
 
     def set_speed(self, speed):
         """Set the speed of the device."""

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -1,7 +1,14 @@
 """Support for VeSync fans."""
 import logging
 
-from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
+from homeassistant.components.fan import (
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SPEED_OFF,
+    SUPPORT_SET_SPEED,
+    FanEntity,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 

--- a/homeassistant/components/vesync/manifest.json
+++ b/homeassistant/components/vesync/manifest.json
@@ -1,8 +1,13 @@
 {
   "domain": "vesync",
-  "name": "Etekcity VeSync",
+  "name": "VeSync",
   "documentation": "https://www.home-assistant.io/integrations/vesync",
-  "codeowners": ["@markperdue", "@webdjoe"],
-  "requirements": ["pyvesync==1.1.0"],
+  "codeowners": [
+    "@markperdue",
+    "@webdjoe"
+  ],
+  "requirements": [
+    "pyvesync==1.1.0"
+  ],
   "config_flow": true
 }

--- a/homeassistant/components/vesync/manifest.json
+++ b/homeassistant/components/vesync/manifest.json
@@ -4,7 +4,8 @@
   "documentation": "https://www.home-assistant.io/integrations/vesync",
   "codeowners": [
     "@markperdue",
-    "@webdjoe"
+    "@webdjoe",
+    "@thegardenmonkey"
   ],
   "requirements": [
     "pyvesync==1.1.0"

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -89,6 +89,10 @@ class VeSyncSwitchHA(VeSyncDevice, SwitchEntity):
         self.smartplug.update()
         self.smartplug.update_energy()
 
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self.device.turn_on()
+
 
 class VeSyncLightSwitch(VeSyncDevice, SwitchEntity):
     """Handle representation of VeSync Light Switch."""
@@ -97,3 +101,7 @@ class VeSyncLightSwitch(VeSyncDevice, SwitchEntity):
         """Initialize Light Switch device class."""
         super().__init__(switch)
         self.switch = switch
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self.device.turn_on()

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -1,4 +1,4 @@
-"""Support for Etekcity VeSync switches."""
+"""Support for VeSync switches."""
 import logging
 
 from homeassistant.components.switch import SwitchEntity

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -55,7 +55,15 @@ def _async_setup_entities(devices, async_add_entities):
     async_add_entities(dev_list, update_before_add=True)
 
 
-class VeSyncSwitchHA(VeSyncDevice, SwitchEntity):
+class VeSyncBaseSwitch(VeSyncDevice, SwitchEntity):
+    """Base class for VeSync switch Device Representations."""
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self.device.turn_on()
+
+
+class VeSyncSwitchHA(VeSyncBaseSwitch, SwitchEntity):
     """Representation of a VeSync switch."""
 
     def __init__(self, plug):
@@ -89,19 +97,11 @@ class VeSyncSwitchHA(VeSyncDevice, SwitchEntity):
         self.smartplug.update()
         self.smartplug.update_energy()
 
-    def turn_on(self, **kwargs):
-        """Turn the device on."""
-        self.device.turn_on()
 
-
-class VeSyncLightSwitch(VeSyncDevice, SwitchEntity):
+class VeSyncLightSwitch(VeSyncBaseSwitch, SwitchEntity):
     """Handle representation of VeSync Light Switch."""
 
     def __init__(self, switch):
         """Initialize Light Switch device class."""
         super().__init__(switch)
         self.switch = switch
-
-    def turn_on(self, **kwargs):
-        """Turn the device on."""
-        self.device.turn_on()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support to the VeSync component to include "fans" that are supported by the VeSync App / eco-system. Currently this includes the Leviot Smart Air Purifier LV-PUR131S. The added code is essentially a duplication of what is done in the current switch component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ x ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
home-assistant/home-assistant.io#13590
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x ] The code change is tested and works locally.
- [ x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x ] There is no commented out code in this PR.
- [ x ] I have followed the [development checklist][dev-checklist]
- [ x ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ x ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
