### PR TITLE
Fix group member extraction from templates during initialization

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -100,22 +100,22 @@ def extract_entities(
         elif result.group("entity_id"):
             if result.group("func") == "expand":
                 group_entity_id = result.group("entity_id")
+                group_entity = _get_state(hass, group_entity_id)
 
                 # pylint: disable=import-outside-toplevel
                 from homeassistant.components import group
 
-                if split_entity_id(group_entity_id)[0] == group.DOMAIN:
-                    """Expand group, but do not use `expand` template function
-                    here. Group entities may not have been initialized yet and
-                    could be thrown out.
-                    """
-                    group_entity = _get_state(hass, group_entity_id)
-                    if group_entity is not None:
-                        group_entities = group_entity.attributes.get(ATTR_ENTITY_ID)
+                if (
+                    split_entity_id(group_entity_id)[0] == group.DOMAIN
+                    and group_entity is not None
+                ):
+                    # Expand group, but do not use `expand` template function
+                    # here. Group entities may not have been initialized yet and
+                    # could be thrown out.
+                    group_entities = group_entity.attributes.get(ATTR_ENTITY_ID)
 
-                        if group_entities is not None:
-                            for entity_id in group_entities:
-                                extraction_final.append(entity_id)
+                    for entity_id in group_entities or []:
+                        extraction_final.append(entity_id)
 
             extraction_final.append(result.group("entity_id"))
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1764,9 +1764,19 @@ states.sensor.pick_humidity.state ~ „ %“
     )
 
     hass.states.async_set("test_domain.object", "exists")
-    await group.Group.async_create_group(hass, "expand group", ["test_domain.object"])
+    await group.Group.async_create_group(
+        hass,
+        "expand group",
+        ["test_domain.object", "test_domain.object_not_yet_loaded"],
+    )
 
-    assert sorted(["group.expand_group", "test_domain.object"]) == sorted(
+    assert sorted(
+        [
+            "group.expand_group",
+            "test_domain.object_not_yet_loaded",
+            "test_domain.object",
+        ]
+    ) == sorted(
         template.extract_entities(
             hass, "{{ expand('group.expand_group') | list | length }}"
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Correctly extract group members during initialization when using `expand` in a template sensor.

During initialization, group members may not yet have been registered with HA, so they would not be returned by the `expand` template function. Instead, we expand groups manually.

I am actually not sure why the original PR worked in the first place. It must have been because I reloaded groups while keeping HA running, or because the group was initialized after its members. Tests were OK, since only correctly initialized entities were tested. I've amended the tests accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35872.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
