### PR TITLE
Check todoist due date is not None in async_get_events

### DIFF
--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -500,16 +500,17 @@ class TodoistProjectData:
 
         events = []
         for task in project_task_data:
-            due_date = _parse_due_date(task["due"])
-            if start_date < due_date < end_date:
-                event = {
-                    "uid": task["id"],
-                    "title": task["content"],
-                    "start": due_date.isoformat(),
-                    "end": due_date.isoformat(),
-                    "allDay": True,
-                }
-                events.append(event)
+            if task["due"] is not None:
+                due_date = _parse_due_date(task["due"])
+                if start_date < due_date < end_date:
+                    event = {
+                        "uid": task["id"],
+                        "title": task["content"],
+                        "start": due_date.isoformat(),
+                        "end": due_date.isoformat(),
+                        "allDay": True,
+                    }
+                    events.append(event)
         return events
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -500,17 +500,18 @@ class TodoistProjectData:
 
         events = []
         for task in project_task_data:
-            if task["due"] is not None:
-                due_date = _parse_due_date(task["due"])
-                if start_date < due_date < end_date:
-                    event = {
-                        "uid": task["id"],
-                        "title": task["content"],
-                        "start": due_date.isoformat(),
-                        "end": due_date.isoformat(),
-                        "allDay": True,
-                    }
-                    events.append(event)
+            if task["due"] is None:
+                continue
+            due_date = _parse_due_date(task["due"])
+            if start_date < due_date < end_date:
+                event = {
+                    "uid": task["id"],
+                    "title": task["content"],
+                    "start": due_date.isoformat(),
+                    "end": due_date.isoformat(),
+                    "allDay": True,
+                }
+                events.append(event)
         return events
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)


### PR DESCRIPTION
Check that due date is not None, prevents taks without due dates from breaking Calendar API

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Todoist integration throws an error in the **async_get_events** method if there is a task without a due date, preventing them for working correctly with the Calendar API. This PR adds a check that the due date is not None before checking if the due date is within the date range being requested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 35921
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
