### PR TITLE
Add webostv payload option to command service

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -7,9 +7,9 @@ import voluptuous as vol
 from websockets.exceptions import ConnectionClosed
 
 from homeassistant.components.webostv.const import (
-    ATTR_ARGUMENT,
     ATTR_BUTTON,
     ATTR_COMMAND,
+    ATTR_PAYLOAD,
     CONF_ON_ACTION,
     CONF_SOURCES,
     DEFAULT_NAME,
@@ -61,7 +61,7 @@ CALL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids})
 BUTTON_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_BUTTON): cv.string})
 
 COMMAND_SCHEMA = CALL_SCHEMA.extend(
-    {vol.Required(ATTR_COMMAND): cv.string, vol.Optional(ATTR_ARGUMENT): cv.string}
+    {vol.Required(ATTR_COMMAND): cv.string, vol.Optional(ATTR_PAYLOAD): dict}
 )
 
 SOUND_OUTPUT_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_SOUND_OUTPUT): cv.string})

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -61,7 +61,7 @@ CALL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids})
 BUTTON_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_BUTTON): cv.string})
 
 COMMAND_SCHEMA = CALL_SCHEMA.extend(
-    {vol.Required(ATTR_COMMAND): cv.string, vol.Optional(ATTR_ARGUMENT): cv.string,}
+    {vol.Required(ATTR_COMMAND): cv.string, vol.Optional(ATTR_ARGUMENT): cv.string}
 )
 
 SOUND_OUTPUT_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_SOUND_OUTPUT): cv.string})

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -7,9 +7,9 @@ import voluptuous as vol
 from websockets.exceptions import ConnectionClosed
 
 from homeassistant.components.webostv.const import (
+    ATTR_ARGUMENT,
     ATTR_BUTTON,
     ATTR_COMMAND,
-    ATTR_ARGUMENT,
     CONF_ON_ACTION,
     CONF_SOURCES,
     DEFAULT_NAME,

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -9,6 +9,7 @@ from websockets.exceptions import ConnectionClosed
 from homeassistant.components.webostv.const import (
     ATTR_BUTTON,
     ATTR_COMMAND,
+    ATTR_ARGUMENT,
     CONF_ON_ACTION,
     CONF_SOURCES,
     DEFAULT_NAME,
@@ -59,7 +60,9 @@ CALL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids})
 
 BUTTON_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_BUTTON): cv.string})
 
-COMMAND_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_COMMAND): cv.string})
+COMMAND_SCHEMA = CALL_SCHEMA.extend(
+    {vol.Required(ATTR_COMMAND): cv.string, vol.Optional(ATTR_ARGUMENT): cv.string,}
+)
 
 SOUND_OUTPUT_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_SOUND_OUTPUT): cv.string})
 

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -5,6 +5,7 @@ DEFAULT_NAME = "LG webOS Smart TV"
 
 ATTR_BUTTON = "button"
 ATTR_COMMAND = "command"
+ATTR_ARGUMENT = "argument"
 ATTR_SOUND_OUTPUT = "sound_output"
 
 CONF_ON_ACTION = "turn_on_action"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -3,9 +3,9 @@ DOMAIN = "webostv"
 
 DEFAULT_NAME = "LG webOS Smart TV"
 
-ATTR_ARGUMENT = "argument"
 ATTR_BUTTON = "button"
 ATTR_COMMAND = "command"
+ATTR_PAYLOAD = "payload"
 ATTR_SOUND_OUTPUT = "sound_output"
 
 CONF_ON_ACTION = "turn_on_action"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -3,9 +3,9 @@ DOMAIN = "webostv"
 
 DEFAULT_NAME = "LG webOS Smart TV"
 
+ATTR_ARGUMENT = "argument"
 ATTR_BUTTON = "button"
 ATTR_COMMAND = "command"
-ATTR_ARGUMENT = "argument"
 ATTR_SOUND_OUTPUT = "sound_output"
 
 CONF_ON_ACTION = "turn_on_action"

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -24,6 +24,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.components.webostv.const import (
+    ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
     CONF_ON_ACTION,
     CONF_SOURCES,
@@ -452,4 +453,4 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @cmd
     async def async_command(self, command, **kwargs):
         """Send a command."""
-        await self._client.request(command, payload=kwargs.get("payload"))
+        await self._client.request(command, payload=kwargs.get(ATTR_PAYLOAD))

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import timedelta
 from functools import wraps
 import logging
+import json
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException, WebOsClient
 from websockets.exceptions import ConnectionClosed
@@ -450,6 +451,6 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         await self._client.button(button)
 
     @cmd
-    async def async_command(self, command):
+    async def async_command(self, command, **kwargs):
         """Send a command."""
-        await self._client.request(command)
+        await self._client.request(command, payload=json.loads(kwargs.get("argument"))

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -453,4 +453,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @cmd
     async def async_command(self, command, **kwargs):
         """Send a command."""
-        await self._client.request(command, payload=json.loads(kwargs.get("argument"))
+        argument = kwargs.get("argument")
+        if argument is not None:
+            argument = json.loads(argument)
+        await self._client.request(command, payload=argument)

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -2,8 +2,8 @@
 import asyncio
 from datetime import timedelta
 from functools import wraps
-import logging
 import json
+import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException, WebOsClient
 from websockets.exceptions import ConnectionClosed

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -2,7 +2,6 @@
 import asyncio
 from datetime import timedelta
 from functools import wraps
-import json
 import logging
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException, WebOsClient
@@ -453,7 +452,4 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @cmd
     async def async_command(self, command, **kwargs):
         """Send a command."""
-        argument = kwargs.get("argument")
-        if argument is not None:
-            argument = json.loads(argument)
-        await self._client.request(command, payload=argument)
+        await self._client.request(command, payload=kwargs.get("payload"))

--- a/homeassistant/components/webostv/services.yaml
+++ b/homeassistant/components/webostv/services.yaml
@@ -25,12 +25,11 @@ command:
         Endpoint of the command. Known valid endpoints are listed in
         https://github.com/TheRealLink/pylgtv/blob/master/pylgtv/endpoints.py
       example: "system.launcher/open"
-    argument:
+    payload:
       description: >-
-        An optional argument to provide to the endpoint in the format of a json string.
-        Note clicking full example will not work as the curly braces and quotes will be filtered, please manually enter/paste in the json string.
+        An optional payload to provide to the endpoint in the format of key value pair(s).
       example: >-
-        {"target": "https://www.google.com"}
+        target: https://www.google.com
 
 select_sound_output:
   description: "Send the TV the command to change sound output."

--- a/homeassistant/components/webostv/services.yaml
+++ b/homeassistant/components/webostv/services.yaml
@@ -26,8 +26,11 @@ command:
         https://github.com/TheRealLink/pylgtv/blob/master/pylgtv/endpoints.py
       example: "system.launcher/open"
     argument:
-      description: An optional argument to provide to the endpoint in the format of a json string.
-      example: '{"target": "https://www.google.com"}'
+      description: >-
+        An optional argument to provide to the endpoint in the format of a json string.
+        Note clicking full example will not work as the curly braces and quotes will be filtered, please manually enter/paste in the json string.
+      example: >-
+        {"target": "https://www.google.com"}
 
 select_sound_output:
   description: "Send the TV the command to change sound output."

--- a/homeassistant/components/webostv/services.yaml
+++ b/homeassistant/components/webostv/services.yaml
@@ -24,7 +24,10 @@ command:
       description: >-
         Endpoint of the command. Known valid endpoints are listed in
         https://github.com/TheRealLink/pylgtv/blob/master/pylgtv/endpoints.py
-      example: "media.controls/rewind"
+      example: "system.launcher/open"
+    argument:
+      description: An optional argument to provide to the endpoint in the format of a json string.
+      example: '{"target": "https://www.google.com"}'
 
 select_sound_output:
   description: "Send the TV the command to change sound output."

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -113,7 +113,7 @@ async def test_command(hass, client):
     await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
     await hass.async_block_till_done()
 
-    client.request.assert_called_with("test")
+    client.request.assert_called_with("test", payload=None)
 
 
 async def test_command_with_optional_arg(hass, client):
@@ -128,4 +128,6 @@ async def test_command_with_optional_arg(hass, client):
     await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
     await hass.async_block_till_done()
 
-    client.request.assert_called_with("test")
+    client.request.assert_called_with(
+        "test", payload={"target": "https://www.google.com"}
+    )

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -10,9 +10,9 @@ from homeassistant.components.media_player.const import (
     SERVICE_SELECT_SOURCE,
 )
 from homeassistant.components.webostv.const import (
-    ATTR_ARGUMENT,
     ATTR_BUTTON,
     ATTR_COMMAND,
+    ATTR_PAYLOAD,
     DOMAIN,
     SERVICE_BUTTON,
     SERVICE_COMMAND,
@@ -113,6 +113,8 @@ async def test_command(hass, client):
     await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
     await hass.async_block_till_done()
 
+    client.request.assert_called_with("test")
+
 
 async def test_command_with_optional_arg(hass, client):
     """Test generic command functionality."""
@@ -121,7 +123,9 @@ async def test_command_with_optional_arg(hass, client):
     data = {
         ATTR_ENTITY_ID: ENTITY_ID,
         ATTR_COMMAND: "test",
-        ATTR_ARGUMENT: {"target": "https://www.google.com"},
+        ATTR_PAYLOAD: {"target": "https://www.google.com"},
     }
     await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
     await hass.async_block_till_done()
+
+    client.request.assert_called_with("test")

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -121,7 +121,7 @@ async def test_command_with_optional_arg(hass, client):
     data = {
         ATTR_ENTITY_ID: ENTITY_ID,
         ATTR_COMMAND: "test",
-        ATTR_ARGUMENT: '{"target": "https://www.google.com"}',
+        ATTR_ARGUMENT: {"target": "https://www.google.com"},
     }
     await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
     await hass.async_block_till_done()

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -12,6 +12,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.components.webostv.const import (
     ATTR_BUTTON,
     ATTR_COMMAND,
+    ATTR_ARGUMENT,
     DOMAIN,
     SERVICE_BUTTON,
     SERVICE_COMMAND,
@@ -102,8 +103,7 @@ async def test_button(hass, client):
 
 
 async def test_command(hass, client):
-    """Test generic button functionality."""
-
+    """Test generic command functionality."""
     await setup_webostv(hass)
 
     data = {
@@ -113,4 +113,15 @@ async def test_command(hass, client):
     await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
     await hass.async_block_till_done()
 
-    client.request.assert_called_with("test")
+
+async def test_command_with_optional_arg(hass, client):
+    """Test generic command functionality."""
+    await setup_webostv(hass)
+
+    data = {
+        ATTR_ENTITY_ID: ENTITY_ID,
+        ATTR_COMMAND: "test",
+        ATTR_ARGUMENT: '{"target": "https://www.google.com"}',
+    }
+    await hass.services.async_call(DOMAIN, SERVICE_COMMAND, data)
+    await hass.async_block_till_done()

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -10,9 +10,9 @@ from homeassistant.components.media_player.const import (
     SERVICE_SELECT_SOURCE,
 )
 from homeassistant.components.webostv.const import (
+    ATTR_ARGUMENT,
     ATTR_BUTTON,
     ATTR_COMMAND,
-    ATTR_ARGUMENT,
     DOMAIN,
     SERVICE_BUTTON,
     SERVICE_COMMAND,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I was trying to use the command service with `system.launcher/open` as the endpoint which takes an argument of target, however currently supplying an argument to the command service is not supported. This PR adds a new feature that allows the command service to take an optional argument to resolve that issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
webostv:
    host: 192.168.1.153
    name: LG TV
    customize:
      sources:
        - Netflix
        - HDMI1
        - YouTube
        - LiveTV
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13596

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
