### PR TITLE
Add new Zehnder ComfoAir 350 integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -142,6 +142,7 @@ omit =
     homeassistant/components/co2signal/*
     homeassistant/components/coinbase/*
     homeassistant/components/comed_hourly_pricing/sensor.py
+    homeassistant/components/comfoair/*
     homeassistant/components/comfoconnect/*
     homeassistant/components/concord232/alarm_control_panel.py
     homeassistant/components/concord232/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,6 +76,7 @@ homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/cloud/* @home-assistant/cloud
 homeassistant/components/cloudflare/* @ludeeus
+homeassistant/components/comfoair/* @mtdcr
 homeassistant/components/comfoconnect/* @michaelarnauts
 homeassistant/components/config/* @home-assistant/core
 homeassistant/components/configurator/* @home-assistant/core

--- a/homeassistant/components/comfoair/__init__.py
+++ b/homeassistant/components/comfoair/__init__.py
@@ -1,0 +1,118 @@
+"""Support to control a Zehnder ComfoAir 350 ventilation unit."""
+
+import logging
+import voluptuous as vol
+
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import discovery
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+import homeassistant.helpers.config_validation as cv
+from comfoair.asyncio import ComfoAir
+
+DOMAIN = "comfoair"
+SIGNAL_COMFOAIR_UPDATE_RECEIVED = "comfoair_update_received"
+CONF_SERIAL_PORT = "serial_port"
+DEFAULT_NAME = "ComfoAir"
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_SERIAL_PORT): cv.string,
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+SERVICE_VIRTUALKEY = "virtualkey"
+ATTR_MASK = "mask"
+ATTR_TYPE = "type"
+CA_PRESS_EVENTS = ["PRESS_SHORT", "PRESS_LONG"]
+
+SCHEMA_SERVICE_VIRTUALKEY = vol.Schema(
+    {
+        vol.Required(ATTR_MASK): vol.In(range(1, 64)),
+        vol.Optional(ATTR_TYPE, default=CA_PRESS_EVENTS[0]): vol.In(CA_PRESS_EVENTS),
+    }
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Set up the ComfoAir component."""
+    hass.data[DOMAIN] = ComfoAirModule(hass, config)
+    await hass.data[DOMAIN].connect()
+
+    for com in ["fan", "sensor"]:
+        coro = discovery.async_load_platform(hass, com, DOMAIN, {}, config)
+        hass.async_create_task(coro)
+
+    async def _ca_service_virtualkey(service):
+        ev_mask = service.data.get(ATTR_MASK)
+        ev_type = service.data.get(ATTR_TYPE)
+        await hass.data[DOMAIN].keypress(ev_mask, ev_type)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_VIRTUALKEY,
+        _ca_service_virtualkey,
+        schema=SCHEMA_SERVICE_VIRTUALKEY,
+    )
+
+    return True
+
+
+class ComfoAirModule:
+    """Representation of a ComfoAir component."""
+
+    def __init__(self, hass: HomeAssistantType, config: ConfigType):
+        """Initialize the ComfoAir component."""
+        self._hass = hass
+        self._name = config[DOMAIN].get(CONF_NAME)
+        self._cache = {}
+
+        self._ca = ComfoAir(config[DOMAIN].get(CONF_SERIAL_PORT))
+        self._ca.add_listener(self._event)
+
+    async def _event(self, event):
+        cmd, data = event
+        if self._cache.get(cmd) == data:
+            return
+        self._cache[cmd] = data
+
+        async_dispatcher_send(self._hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, [cmd, data])
+
+    async def connect(self):
+        """Connect to a serial port or socket."""
+        await self._ca.connect(self._hass.loop)
+
+    async def stop(self):
+        """Close resources."""
+        self._ca.remove_listener(self._event)
+        self._ca.shutdown()
+
+    async def set_speed(self, speed: int):
+        """Set the speed of the fans."""
+        await self._ca.set_speed(speed)
+
+    def __getitem__(self, key: int) -> bytes:
+        """Access cached data."""
+        return self._cache.get(key)
+
+    @property
+    def name(self):
+        """Access configured name of ventilation unit."""
+        return self._name
+
+    async def keypress(self, ev_mask: int, ev_type: str):
+        """Simulate a keypress."""
+        if ev_type == "PRESS_LONG":
+            millis = 1000
+        else:
+            millis = 100
+
+        await self._ca.emulate_keypress(ev_mask, millis)

--- a/homeassistant/components/comfoair/__init__.py
+++ b/homeassistant/components/comfoair/__init__.py
@@ -107,7 +107,7 @@ class ComfoAirModule:
         self._name = name
         self._ca = ComfoAir(port)
         self._device_info = {
-            "identifiers": {port},
+            "identifiers": {(port,)},
             "name": name,
             "manufacturer": "Zehnder",
             "model": "ComfoAir 350",

--- a/homeassistant/components/comfoair/__init__.py
+++ b/homeassistant/components/comfoair/__init__.py
@@ -7,8 +7,8 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event
-from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 DOMAIN = "comfoair"
@@ -47,9 +47,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     hass.data[DOMAIN] = ComfoAirModule(hass, config)
     await hass.data[DOMAIN].connect()
 
-    for com in ["fan", "sensor"]:
-        coro = discovery.async_load_platform(hass, com, DOMAIN, {}, config)
-        hass.async_create_task(coro)
+    hass.async_create_task(async_load_platform(hass, "fan", DOMAIN, {}, config))
 
     async def ca_service_virtualkey(service):
         ev_mask = service.data[ATTR_MASK]

--- a/homeassistant/components/comfoair/__init__.py
+++ b/homeassistant/components/comfoair/__init__.py
@@ -147,3 +147,7 @@ class ComfoAirModule:
     def add_cooked_listener(self, attr, callback):
         """Register a callback for a sensor value."""
         return self._ca.add_cooked_listener(attr, callback)
+
+    def remove_cooked_listener(self, attr, callback):
+        """Unregister a callback for a sensor value."""
+        return self._ca.remove_cooked_listener(attr, callback)

--- a/homeassistant/components/comfoair/__init__.py
+++ b/homeassistant/components/comfoair/__init__.py
@@ -6,6 +6,7 @@ from comfoair.asyncio import ComfoAir
 import voluptuous as vol
 
 from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -93,10 +94,10 @@ class ComfoAirModule:
         """Connect to a serial port or socket."""
         await self._ca.connect(self._hass.loop)
 
-    async def stop(self):
+    async def stop(self, event: Event):
         """Close resources."""
         self._ca.remove_listener(self._event)
-        self._ca.shutdown()
+        await self._ca.shutdown()
 
     async def set_speed(self, speed: int):
         """Set the speed of the fans."""

--- a/homeassistant/components/comfoair/__init__.py
+++ b/homeassistant/components/comfoair/__init__.py
@@ -1,19 +1,21 @@
 """Support to control a Zehnder ComfoAir 350 ventilation unit."""
 
+import asyncio
 import logging
+from typing import Any, Dict, Optional
 
 from comfoair.asyncio import ComfoAir
 import voluptuous as vol
 
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-DOMAIN = "comfoair"
-CONF_SERIAL_PORT = "serial_port"
-DEFAULT_NAME = "ComfoAir"
+from .const import CONF_SERIAL_PORT, DEFAULT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +35,7 @@ SERVICE_VIRTUALKEY = "virtualkey"
 ATTR_MASK = "mask"
 ATTR_TYPE = "type"
 CA_PRESS_EVENTS = ["PRESS_SHORT", "PRESS_LONG"]
+PLATFORMS = [FAN_DOMAIN, SENSOR_DOMAIN]
 
 SCHEMA_SERVICE_VIRTUALKEY = vol.Schema(
     {
@@ -44,10 +47,23 @@ SCHEMA_SERVICE_VIRTUALKEY = vol.Schema(
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     """Set up the ComfoAir component."""
-    hass.data[DOMAIN] = ComfoAirModule(hass, config)
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Set up a ComfoAir entry."""
+    if DOMAIN in hass.data:
+        _LOGGER.error("Sorry, only one ComfoAir supported for now")
+        return False
+
+    conf = entry.data
+    hass.data[DOMAIN] = ComfoAirModule(hass, conf[CONF_NAME], conf[CONF_SERIAL_PORT])
     await hass.data[DOMAIN].connect()
 
-    hass.async_create_task(async_load_platform(hass, "fan", DOMAIN, {}, config))
+    for domain in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, domain)
+        )
 
     async def ca_service_virtualkey(service):
         ev_mask = service.data[ATTR_MASK]
@@ -66,14 +82,36 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     return True
 
 
+async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+
+    await hass.data[DOMAIN].stop()
+
+    return unload_ok
+
+
 class ComfoAirModule:
     """Representation of a ComfoAir component."""
 
-    def __init__(self, hass: HomeAssistantType, config: ConfigType):
+    def __init__(self, hass: HomeAssistantType, name: str, port: str):
         """Initialize the ComfoAir component."""
         self._hass = hass
-        self._name = config[DOMAIN][CONF_NAME]
-        self._ca = ComfoAir(config[DOMAIN][CONF_SERIAL_PORT])
+        self._name = name
+        self._ca = ComfoAir(port)
+        self._device_info = {
+            "identifiers": {port},
+            "name": name,
+            "manufacturer": "Zehnder",
+            "model": "ComfoAir 350",
+        }
 
     async def connect(self):
         """Connect to a serial port or socket."""
@@ -86,6 +124,11 @@ class ComfoAirModule:
     async def set_speed(self, speed: int):
         """Set the speed of the fans."""
         await self._ca.set_speed(speed)
+
+    @property
+    def device_info(self) -> Optional[Dict[str, Any]]:
+        """Return device specific attributes."""
+        return self._device_info
 
     @property
     def name(self):

--- a/homeassistant/components/comfoair/config_flow.py
+++ b/homeassistant/components/comfoair/config_flow.py
@@ -52,6 +52,8 @@ class ComfoAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             title = f"{port.description}, s/n: {port.serial_number or 'n/a'}"
             title += f" - {port.manufacturer}" if port.manufacturer else ""
 
+            await self.async_set_unique_id(user_input[CONF_SERIAL_PORT])
+
             return self.async_create_entry(title=title, data=user_input)
 
         schema = vol.Schema(

--- a/homeassistant/components/comfoair/config_flow.py
+++ b/homeassistant/components/comfoair/config_flow.py
@@ -8,7 +8,12 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 
-from .const import CONF_SERIAL_PORT, DEFAULT_NAME, DEFAULT_PORT, DOMAIN
+from .const import (  # pylint:disable=unused-import
+    CONF_SERIAL_PORT,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DOMAIN,
+)
 
 CONF_MANUAL_PATH = "Enter Manually"
 

--- a/homeassistant/components/comfoair/config_flow.py
+++ b/homeassistant/components/comfoair/config_flow.py
@@ -1,0 +1,95 @@
+"""Config Flow for ComfoAir."""
+import os
+from typing import Any, Dict, Optional
+
+import serial.tools.list_ports
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME
+
+from .const import CONF_SERIAL_PORT, DEFAULT_NAME, DEFAULT_PORT, DOMAIN
+
+CONF_MANUAL_PATH = "Enter Manually"
+
+
+class ComfoAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """ComfoAir config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Handle a flow initialized by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        list_of_ports = [
+            f"{p}, s/n: {p.serial_number or 'n/a'}"
+            + (f" - {p.manufacturer}" if p.manufacturer else "")
+            for p in ports
+        ]
+        list_of_ports.append(CONF_MANUAL_PATH)
+
+        if user_input is not None:
+            user_selection = user_input[CONF_SERIAL_PORT]
+            if user_selection == CONF_MANUAL_PATH:
+                return await self.async_step_port_config()
+
+            port = ports[list_of_ports.index(user_selection)]
+            user_input[CONF_SERIAL_PORT] = await self.hass.async_add_executor_job(
+                get_serial_by_id, port.device
+            )
+
+            title = f"{port.description}, s/n: {port.serial_number or 'n/a'}"
+            title += f" - {port.manufacturer}" if port.manufacturer else ""
+
+            return self.async_create_entry(title=title, data=user_input)
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+                vol.Required(CONF_SERIAL_PORT, default=list_of_ports[0]): vol.In(
+                    list_of_ports
+                ),
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=schema)
+
+    async def async_step_port_config(self, user_input=None):
+        """Enter port settings specific for this type of radio."""
+        if user_input is not None:
+            user_input[CONF_SERIAL_PORT] = await self.hass.async_add_executor_job(
+                get_serial_by_id, user_input[CONF_SERIAL_PORT]
+            )
+            return self.async_create_entry(
+                title=user_input[CONF_SERIAL_PORT], data=user_input,
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+                vol.Required(CONF_SERIAL_PORT, default=DEFAULT_PORT): str,
+            }
+        )
+        return self.async_show_form(step_id="port_config", data_schema=schema)
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        return await self.async_step_port_config(user_input)
+
+
+def get_serial_by_id(dev_path: str) -> str:
+    """Return a /dev/serial/by-id match for given device if available."""
+    by_id = "/dev/serial/by-id"
+    if not os.path.isdir(by_id):
+        return dev_path
+
+    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
+        if os.path.realpath(path) == dev_path:
+            return path
+
+    return dev_path

--- a/homeassistant/components/comfoair/const.py
+++ b/homeassistant/components/comfoair/const.py
@@ -1,0 +1,5 @@
+"""Constants shared by ComfoAir modules."""
+CONF_SERIAL_PORT = "serial_port"
+DEFAULT_NAME = "ComfoAir"
+DEFAULT_PORT = "/dev/ttyUSB0"
+DOMAIN = "comfoair"

--- a/homeassistant/components/comfoair/fan.py
+++ b/homeassistant/components/comfoair/fan.py
@@ -1,0 +1,116 @@
+"""Platform to control a Zehnder ComfoAir 350 ventilation unit."""
+import logging
+
+from homeassistant.components.fan import (
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SPEED_OFF,
+    SUPPORT_SET_SPEED,
+    FanEntity,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import DOMAIN, SIGNAL_COMFOAIR_UPDATE_RECEIVED, ComfoAirModule
+
+_LOGGER = logging.getLogger(__name__)
+
+SPEED_MAPPING = {1: SPEED_OFF, 2: SPEED_LOW, 3: SPEED_MEDIUM, 4: SPEED_HIGH}
+
+
+async def async_setup_platform(hass, conf, async_add_entities, discovery_info):
+    """Set up the ComfoAir fan platform."""
+    unit = hass.data[DOMAIN]
+
+    async_add_entities([ComfoAirFan(hass, ca=unit)], True)
+
+
+class ComfoAirFan(FanEntity):
+    """Representation of the ComfoAir fan platform."""
+
+    def __init__(self, hass, ca: ComfoAirModule) -> None:
+        """Initialize the ComfoAir fan."""
+        self._ca = ca
+        self._speed = 1
+        self._saved_speed = 2
+        self._sensor_id = 0xCE
+
+        def _update_state(cmd, data):
+            if cmd == self._sensor_id and len(data) >= 9:
+                speed = data[8]
+                if 1 <= speed <= 4:
+                    self._speed = speed
+
+        @callback
+        def async_handle_update(var):
+            cmd, data = var
+            if cmd == self._sensor_id:
+                _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
+                _update_state(cmd, data)
+                self.async_schedule_update_ha_state()
+
+        data = self._ca[self._sensor_id]
+        if data:
+            _update_state(self._sensor_id, data)
+
+        # Register for dispatcher updates
+        async_dispatcher_connect(
+            hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
+        )
+
+    @property
+    def should_poll(self) -> bool:
+        """Do not poll."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the fan."""
+        return self._ca.name
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return "mdi:air-conditioner"
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_SET_SPEED
+
+    @property
+    def speed(self):
+        """Return the current fan mode."""
+        return SPEED_MAPPING[self._speed]
+
+    @property
+    def speed_list(self):
+        """List of available fan modes."""
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+    def async_turn_on(self, speed: str = None, **kwargs):
+        """Turn on the fan."""
+        if speed is None:
+            return self.__ca_set_speed(self._saved_speed)
+
+        return self.async_set_speed(speed)
+
+    def async_turn_off(self, **kwargs):
+        """Turn off the fan (to away)."""
+        if self._speed > 1:
+            self._saved_speed = self._speed
+        return self.__ca_set_speed(1)
+
+    def async_set_speed(self, speed: str):
+        """Set fan speed."""
+        for key, value in SPEED_MAPPING.items():
+            if value == speed:
+                return self.__ca_set_speed(key)
+
+        # shouldn't happen
+        return self.async_turn_off()
+
+    def __ca_set_speed(self, speed):
+        _LOGGER.debug("Changing fan speed to %s", SPEED_MAPPING[speed])
+        return self._ca.set_speed(speed)

--- a/homeassistant/components/comfoair/fan.py
+++ b/homeassistant/components/comfoair/fan.py
@@ -17,46 +17,50 @@ from . import DOMAIN, SIGNAL_COMFOAIR_UPDATE_RECEIVED, ComfoAirModule
 _LOGGER = logging.getLogger(__name__)
 
 SPEED_MAPPING = {1: SPEED_OFF, 2: SPEED_LOW, 3: SPEED_MEDIUM, 4: SPEED_HIGH}
+SPEED_VALUES = list(SPEED_MAPPING.values())
 
 
 async def async_setup_platform(hass, conf, async_add_entities, discovery_info):
     """Set up the ComfoAir fan platform."""
     unit = hass.data[DOMAIN]
 
-    async_add_entities([ComfoAirFan(hass, ca=unit)], True)
+    async_add_entities([ComfoAirFan(ca=unit)], True)
 
 
 class ComfoAirFan(FanEntity):
     """Representation of the ComfoAir fan platform."""
 
-    def __init__(self, hass, ca: ComfoAirModule) -> None:
+    def __init__(self, ca: ComfoAirModule) -> None:
         """Initialize the ComfoAir fan."""
         self._ca = ca
         self._speed = 1
         self._saved_speed = 2
         self._sensor_id = 0xCE
 
-        def _update_state(cmd, data):
-            if cmd == self._sensor_id and len(data) >= 9:
-                speed = data[8]
-                if 1 <= speed <= 4:
-                    self._speed = speed
+        data = self._ca[self._sensor_id]
+        if data:
+            self._update_state(self._sensor_id, data)
+
+    def _update_state(self, cmd, data):
+        if cmd == self._sensor_id and len(data) >= 9:
+            speed = data[8]
+            if 1 <= speed <= 4:
+                self._speed = speed
+
+    async def async_added_to_hass(self):
+        """Register for sensor updates."""
 
         @callback
         def async_handle_update(var):
             cmd, data = var
             if cmd == self._sensor_id:
                 _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
-                _update_state(cmd, data)
+                self._update_state(cmd, data)
                 self.async_schedule_update_ha_state()
-
-        data = self._ca[self._sensor_id]
-        if data:
-            _update_state(self._sensor_id, data)
 
         # Register for dispatcher updates
         async_dispatcher_connect(
-            hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
+            self.hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
         )
 
     @property
@@ -87,12 +91,12 @@ class ComfoAirFan(FanEntity):
     @property
     def speed_list(self):
         """List of available fan modes."""
-        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+        return SPEED_VALUES
 
     def async_turn_on(self, speed: str = None, **kwargs):
         """Turn on the fan."""
         if speed is None:
-            return self.__ca_set_speed(self._saved_speed)
+            return self._ca_set_speed(self._saved_speed)
 
         return self.async_set_speed(speed)
 
@@ -100,17 +104,17 @@ class ComfoAirFan(FanEntity):
         """Turn off the fan (to away)."""
         if self._speed > 1:
             self._saved_speed = self._speed
-        return self.__ca_set_speed(1)
+        return self._ca_set_speed(1)
 
     def async_set_speed(self, speed: str):
         """Set fan speed."""
         for key, value in SPEED_MAPPING.items():
             if value == speed:
-                return self.__ca_set_speed(key)
+                return self._ca_set_speed(key)
 
         # shouldn't happen
         return self.async_turn_off()
 
-    def __ca_set_speed(self, speed):
+    def _ca_set_speed(self, speed):
         _LOGGER.debug("Changing fan speed to %s", SPEED_MAPPING[speed])
         return self._ca.set_speed(speed)

--- a/homeassistant/components/comfoair/fan.py
+++ b/homeassistant/components/comfoair/fan.py
@@ -1,5 +1,8 @@
 """Platform to control a Zehnder ComfoAir 350 ventilation unit."""
 import logging
+from typing import Optional
+
+from comfoair.asyncio import ComfoAir
 
 from homeassistant.components.fan import (
     SPEED_HIGH,
@@ -9,10 +12,8 @@ from homeassistant.components.fan import (
     SUPPORT_SET_SPEED,
     FanEntity,
 )
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import DOMAIN, SIGNAL_COMFOAIR_UPDATE_RECEIVED, ComfoAirModule
+from . import DOMAIN, ComfoAirModule
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,33 +36,18 @@ class ComfoAirFan(FanEntity):
         self._ca = ca
         self._speed = 1
         self._saved_speed = 2
-        self._sensor_id = 0xCE
-
-        data = self._ca[self._sensor_id]
-        if data:
-            self._update_state(self._sensor_id, data)
-
-    def _update_state(self, cmd, data):
-        if cmd == self._sensor_id and len(data) >= 9:
-            speed = data[8]
-            if 1 <= speed <= 4:
-                self._speed = speed
+        self._attr = ComfoAir.FAN_SPEED_MODE
 
     async def async_added_to_hass(self):
         """Register for sensor updates."""
 
-        @callback
-        def async_handle_update(var):
-            cmd, data = var
-            if cmd == self._sensor_id:
-                _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
-                self._update_state(cmd, data)
-                self.async_schedule_update_ha_state()
+        async def async_handle_update(attr, value):
+            _LOGGER.debug("Dispatcher update for %s: %s", attr, value)
+            assert attr == self._attr
+            self._speed = value
+            self.async_schedule_update_ha_state()
 
-        # Register for dispatcher updates
-        async_dispatcher_connect(
-            self.hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
-        )
+        self._ca.add_cooked_listener(self._attr, async_handle_update)
 
     @property
     def should_poll(self) -> bool:
@@ -93,7 +79,7 @@ class ComfoAirFan(FanEntity):
         """List of available fan modes."""
         return SPEED_VALUES
 
-    def async_turn_on(self, speed: str = None, **kwargs):
+    def async_turn_on(self, speed: Optional[str] = None, **kwargs):
         """Turn on the fan."""
         if speed is None:
             return self._ca_set_speed(self._saved_speed)

--- a/homeassistant/components/comfoair/fan.py
+++ b/homeassistant/components/comfoair/fan.py
@@ -12,6 +12,7 @@ from homeassistant.components.fan import (
     SUPPORT_SET_SPEED,
     FanEntity,
 )
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import DOMAIN, ComfoAirModule
 
@@ -21,7 +22,9 @@ SPEED_MAPPING = {1: SPEED_OFF, 2: SPEED_LOW, 3: SPEED_MEDIUM, 4: SPEED_HIGH}
 SPEED_VALUES = list(SPEED_MAPPING.values())
 
 
-async def async_setup_platform(hass, conf, async_add_entities, discovery_info):
+async def async_setup_platform(
+    hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
+) -> None:
     """Set up the ComfoAir fan platform."""
     unit = hass.data[DOMAIN]
 

--- a/homeassistant/components/comfoair/fan.py
+++ b/homeassistant/components/comfoair/fan.py
@@ -20,6 +20,8 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 SPEED_MAPPING = {1: SPEED_OFF, 2: SPEED_LOW, 3: SPEED_MEDIUM, 4: SPEED_HIGH}
 SPEED_VALUES = list(SPEED_MAPPING.values())
 

--- a/homeassistant/components/comfoair/manifest.json
+++ b/homeassistant/components/comfoair/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "comfoair",
+  "name": "ComfoAir",
+  "documentation": "https://www.home-assistant.io/components/comfoair",
+  "requirements": [
+    "bitstring==3.1.5",
+    "pycomfoair==0.0.1"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@mtdcr"
+  ]
+}

--- a/homeassistant/components/comfoair/manifest.json
+++ b/homeassistant/components/comfoair/manifest.json
@@ -1,10 +1,9 @@
 {
   "domain": "comfoair",
   "name": "ComfoAir",
-  "documentation": "https://www.home-assistant.io/components/comfoair",
+  "documentation": "https://www.home-assistant.io/integrations/comfoair",
   "requirements": [
-    "bitstring==3.1.5",
-    "pycomfoair==0.0.2"
+    "pycomfoair==0.0.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/comfoair/manifest.json
+++ b/homeassistant/components/comfoair/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "comfoair",
   "name": "ComfoAir",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/comfoair",
   "requirements": [
     "pycomfoair==0.0.3"

--- a/homeassistant/components/comfoair/manifest.json
+++ b/homeassistant/components/comfoair/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/components/comfoair",
   "requirements": [
     "bitstring==3.1.5",
-    "pycomfoair==0.0.1"
+    "pycomfoair==0.0.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/comfoair/sensor.py
+++ b/homeassistant/components/comfoair/sensor.py
@@ -1,0 +1,157 @@
+"""Platform to control a Zehnder ComfoAir 350 ventilation unit."""
+
+import logging
+
+from homeassistant.const import CONF_RESOURCES, TEMP_CELSIUS
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+from . import DOMAIN, ComfoAirModule, SIGNAL_COMFOAIR_UPDATE_RECEIVED
+from bitstring import BitArray
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_COMFORT_TEMPERATURE = "comfort_temperature"
+ATTR_OUTSIDE_TEMPERATURE = "outside_temperature"
+ATTR_SUPPLY_TEMPERATURE = "supply_temperature"
+ATTR_RETURN_TEMPERATURE = "return_temperature"
+ATTR_EXHAUST_TEMPERATURE = "exhaust_temperature"
+ATTR_AIR_FLOW_SUPPLY = "air_flow_supply"
+ATTR_AIR_FLOW_EXHAUST = "air_flow_exhaust"
+ATTR_FAN_SPEED_MODE = "speed_mode"
+
+SENSOR_TYPES = {
+    ATTR_COMFORT_TEMPERATURE: [
+        "Comfort Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        0 * 8,
+        8,
+    ],
+    ATTR_OUTSIDE_TEMPERATURE: [
+        "Outside Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        1 * 8,
+        8,
+    ],
+    ATTR_SUPPLY_TEMPERATURE: [
+        "Supply Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        2 * 8,
+        8,
+    ],
+    ATTR_RETURN_TEMPERATURE: [
+        "Return Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        3 * 8,
+        8,
+    ],
+    ATTR_EXHAUST_TEMPERATURE: [
+        "Exhaust Temperature",
+        TEMP_CELSIUS,
+        "mdi:thermometer",
+        0xD2,
+        4 * 8,
+        8,
+    ],
+    ATTR_AIR_FLOW_EXHAUST: ["Exhaust airflow", "%", "mdi:fan", 0xCE, 6 * 8, 8],
+    ATTR_AIR_FLOW_SUPPLY: ["Supply airflow", "%", "mdi:fan", 0xCE, 7 * 8, 8],
+    ATTR_FAN_SPEED_MODE: ["Speed mode", "", "mdi:fan", 0xCE, 8 * 8, 8],
+}
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the ComfoAir sensor platform."""
+    unit = hass.data[DOMAIN]
+
+    sensors = []
+    for resource in config.get(CONF_RESOURCES, []):
+        sensor_type = resource.lower()
+        _LOGGER.debug("Sensor type: %s", sensor_type)
+
+        if sensor_type not in SENSOR_TYPES:
+            _LOGGER.warning("Sensor type: %s is not a valid sensor", sensor_type)
+            continue
+
+        sensors.append(
+            ComfoAirSensor(
+                hass,
+                name="%s %s" % (unit.name, SENSOR_TYPES[sensor_type][0]),
+                ca=unit,
+                sensor_type=sensor_type,
+            )
+        )
+
+    async_add_entities(sensors, True)
+
+
+class ComfoAirSensor(Entity):
+    """Representation of a ComfoAir sensor."""
+
+    def __init__(self, hass, name, ca: ComfoAirModule, sensor_type) -> None:
+        """Initialize the ComfoAir sensor."""
+        self._ca = ca
+        self._sensor_type = sensor_type
+        self._unit = SENSOR_TYPES[self._sensor_type][1]
+        self._icon = SENSOR_TYPES[self._sensor_type][2]
+        self._sensor_id = SENSOR_TYPES[self._sensor_type][3]
+        self._offset = SENSOR_TYPES[self._sensor_type][4]
+        self._size = SENSOR_TYPES[self._sensor_type][5]
+        self._name = name
+        self._data = None
+
+        def _update_state(data):
+            bits = BitArray(data)
+            value = bits[self._offset : self._offset + self._size].uint
+            if self._unit == TEMP_CELSIUS:
+                value = (value / 2) - 20
+            self._data = value
+
+        @callback
+        def async_handle_update(var):
+            cmd, data = var
+            if cmd == self._sensor_id:
+                _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
+                _update_state(data)
+                self.async_schedule_update_ha_state()
+
+        data = self._ca[self._sensor_id]
+        if data:
+            _update_state(data)
+
+        # Register for dispatcher updates
+        async_dispatcher_connect(
+            hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
+        )
+
+    @property
+    def should_poll(self) -> bool:
+        """Do not poll."""
+        return False
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._data
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit

--- a/homeassistant/components/comfoair/sensor.py
+++ b/homeassistant/components/comfoair/sensor.py
@@ -24,6 +24,8 @@ ATTR_AIR_FLOW_SUPPLY = "air_flow_supply"
 ATTR_AIR_FLOW_EXHAUST = "air_flow_exhaust"
 ATTR_FAN_SPEED_MODE = "speed_mode"
 
+PARALLEL_UPDATES = 0
+
 SENSOR_TYPES = {
     ATTR_COMFORT_TEMPERATURE: [
         "Comfort Temperature",

--- a/homeassistant/components/comfoair/sensor.py
+++ b/homeassistant/components/comfoair/sensor.py
@@ -1,14 +1,17 @@
 """Platform to control a Zehnder ComfoAir 350 ventilation unit."""
 
 import logging
+from typing import Any, Dict, Optional
 
 from comfoair.asyncio import ComfoAir
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN, ComfoAirModule
+from . import ComfoAirModule
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,46 +30,58 @@ SENSOR_TYPES = {
         TEMP_CELSIUS,
         "mdi:thermometer",
         ComfoAir.TEMP_COMFORT,
+        DEVICE_CLASS_TEMPERATURE,
     ],
     ATTR_OUTSIDE_TEMPERATURE: [
         "Outside Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
         ComfoAir.TEMP_OUTSIDE,
+        DEVICE_CLASS_TEMPERATURE,
     ],
     ATTR_SUPPLY_TEMPERATURE: [
         "Supply Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
         ComfoAir.TEMP_SUPPLY,
+        DEVICE_CLASS_TEMPERATURE,
     ],
     ATTR_RETURN_TEMPERATURE: [
         "Return Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
         ComfoAir.TEMP_RETURN,
+        DEVICE_CLASS_TEMPERATURE,
     ],
     ATTR_EXHAUST_TEMPERATURE: [
         "Exhaust Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
         ComfoAir.TEMP_EXHAUST,
+        DEVICE_CLASS_TEMPERATURE,
     ],
     ATTR_AIR_FLOW_EXHAUST: [
         "Exhaust airflow",
         "%",
         "mdi:fan",
         ComfoAir.AIRFLOW_EXHAUST,
+        None,
     ],
-    ATTR_AIR_FLOW_SUPPLY: ["Supply airflow", "%", "mdi:fan", ComfoAir.AIRFLOW_SUPPLY],
-    ATTR_FAN_SPEED_MODE: ["Speed mode", "", "mdi:fan", ComfoAir.FAN_SPEED_MODE],
+    ATTR_AIR_FLOW_SUPPLY: [
+        "Supply airflow",
+        "%",
+        "mdi:fan",
+        ComfoAir.AIRFLOW_SUPPLY,
+        None,
+    ],
+    ATTR_FAN_SPEED_MODE: ["Speed mode", "", "mdi:fan", ComfoAir.FAN_SPEED_MODE, None],
 }
 
 
-async def async_setup_platform(
-    hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
-) -> None:
-    """Set up the ComfoAir sensor platform."""
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+) -> bool:
+    """Set up the ComfoAir sensor config entry."""
     unit = hass.data[DOMAIN]
 
     sensors = []
@@ -80,6 +95,7 @@ async def async_setup_platform(
         )
 
     async_add_entities(sensors, True)
+    return True
 
 
 class ComfoAirSensor(Entity):
@@ -92,19 +108,27 @@ class ComfoAirSensor(Entity):
         self._unit = SENSOR_TYPES[self._sensor_type][1]
         self._icon = SENSOR_TYPES[self._sensor_type][2]
         self._attr = SENSOR_TYPES[self._sensor_type][3]
+        self._class = SENSOR_TYPES[self._sensor_type][4]
         self._name = name
+        self._unique_id = name
         self._data = None
+        self._handler = None
 
     async def async_added_to_hass(self):
         """Register for sensor updates."""
 
-        async def async_handle_update(attr, value):
+        async def _async_handle_update(attr, value):
             _LOGGER.debug("Dispatcher update for %s: %s", attr, value)
             assert attr == self._attr
             self._data = value
             self.async_schedule_update_ha_state()
 
-        self._ca.add_cooked_listener(self._attr, async_handle_update)
+        self._handler = _async_handle_update
+        self._ca.add_cooked_listener(self._attr, self._handler)
+
+    async def async_will_remove_from_hass(self):
+        """Unregister sensor updates."""
+        self._ca.remove_cooked_listener(self._attr, self._handler)
 
     @property
     def should_poll(self) -> bool:
@@ -112,21 +136,36 @@ class ComfoAirSensor(Entity):
         return False
 
     @property
-    def state(self):
+    def state(self) -> Optional[str]:
         """Return the state of the entity."""
         return self._data
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
         return self._icon
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return the unit of measurement of this entity, if any."""
         return self._unit
+
+    @property
+    def device_info(self) -> Optional[Dict[str, Any]]:
+        """Return device specific attributes."""
+        return self._ca.device_info
+
+    @property
+    def device_class(self) -> str:
+        """Return the device_class."""
+        return self._class
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique id."""
+        return self._unique_id

--- a/homeassistant/components/comfoair/sensor.py
+++ b/homeassistant/components/comfoair/sensor.py
@@ -2,14 +2,12 @@
 
 import logging
 
-from bitstring import BitArray
+from comfoair.asyncio import ComfoAir
 
 from homeassistant.const import TEMP_CELSIUS
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from . import DOMAIN, SIGNAL_COMFOAIR_UPDATE_RECEIVED, ComfoAirModule
+from . import DOMAIN, ComfoAirModule
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,45 +25,40 @@ SENSOR_TYPES = {
         "Comfort Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
-        0xD2,
-        0 * 8,
-        8,
+        ComfoAir.TEMP_COMFORT,
     ],
     ATTR_OUTSIDE_TEMPERATURE: [
         "Outside Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
-        0xD2,
-        1 * 8,
-        8,
+        ComfoAir.TEMP_OUTSIDE,
     ],
     ATTR_SUPPLY_TEMPERATURE: [
         "Supply Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
-        0xD2,
-        2 * 8,
-        8,
+        ComfoAir.TEMP_SUPPLY,
     ],
     ATTR_RETURN_TEMPERATURE: [
         "Return Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
-        0xD2,
-        3 * 8,
-        8,
+        ComfoAir.TEMP_RETURN,
     ],
     ATTR_EXHAUST_TEMPERATURE: [
         "Exhaust Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
-        0xD2,
-        4 * 8,
-        8,
+        ComfoAir.TEMP_EXHAUST,
     ],
-    ATTR_AIR_FLOW_EXHAUST: ["Exhaust airflow", "%", "mdi:fan", 0xCE, 6 * 8, 8],
-    ATTR_AIR_FLOW_SUPPLY: ["Supply airflow", "%", "mdi:fan", 0xCE, 7 * 8, 8],
-    ATTR_FAN_SPEED_MODE: ["Speed mode", "", "mdi:fan", 0xCE, 8 * 8, 8],
+    ATTR_AIR_FLOW_EXHAUST: [
+        "Exhaust airflow",
+        "%",
+        "mdi:fan",
+        ComfoAir.AIRFLOW_EXHAUST,
+    ],
+    ATTR_AIR_FLOW_SUPPLY: ["Supply airflow", "%", "mdi:fan", ComfoAir.AIRFLOW_SUPPLY],
+    ATTR_FAN_SPEED_MODE: ["Speed mode", "", "mdi:fan", ComfoAir.FAN_SPEED_MODE],
 }
 
 
@@ -95,38 +88,20 @@ class ComfoAirSensor(Entity):
         self._sensor_type = sensor_type
         self._unit = SENSOR_TYPES[self._sensor_type][1]
         self._icon = SENSOR_TYPES[self._sensor_type][2]
-        self._sensor_id = SENSOR_TYPES[self._sensor_type][3]
-        self._offset = SENSOR_TYPES[self._sensor_type][4]
-        self._size = SENSOR_TYPES[self._sensor_type][5]
+        self._attr = SENSOR_TYPES[self._sensor_type][3]
         self._name = name
         self._data = None
-
-        data = self._ca[self._sensor_id]
-        if data:
-            self._update_state(data)
-
-    def _update_state(self, data):
-        bits = BitArray(data)
-        value = bits[self._offset : self._offset + self._size].uint
-        if self._unit == TEMP_CELSIUS:
-            value = (value / 2) - 20
-        self._data = value
 
     async def async_added_to_hass(self):
         """Register for sensor updates."""
 
-        @callback
-        def async_handle_update(var):
-            cmd, data = var
-            if cmd == self._sensor_id:
-                _LOGGER.debug("Dispatcher update for %#x: %s", cmd, data.hex())
-                self._update_state(data)
-                self.async_schedule_update_ha_state()
+        async def async_handle_update(attr, value):
+            _LOGGER.debug("Dispatcher update for %s: %s", attr, value)
+            assert attr == self._attr
+            self._data = value
+            self.async_schedule_update_ha_state()
 
-        # Register for dispatcher updates
-        async_dispatcher_connect(
-            self.hass, SIGNAL_COMFOAIR_UPDATE_RECEIVED, async_handle_update
-        )
+        self._ca.add_cooked_listener(self._attr, async_handle_update)
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/comfoair/sensor.py
+++ b/homeassistant/components/comfoair/sensor.py
@@ -6,6 +6,7 @@ from comfoair.asyncio import ComfoAir
 
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import DOMAIN, ComfoAirModule
 
@@ -62,7 +63,9 @@ SENSOR_TYPES = {
 }
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
+) -> None:
     """Set up the ComfoAir sensor platform."""
     unit = hass.data[DOMAIN]
 

--- a/homeassistant/components/comfoair/services.yaml
+++ b/homeassistant/components/comfoair/services.yaml
@@ -1,0 +1,9 @@
+virtualkey:
+  description: Press a virtual key from CC-Ease.
+  fields:
+    mask:
+      description: Mask of keys to press (1=fan, 2=mode, 4=clock, 8=temp, 16=plus, 32=minus)
+      example: 1
+    type:
+      description: Event to send i.e. PRESS_LONG, PRESS_SHORT.
+      example: PRESS_SHORT

--- a/homeassistant/components/comfoair/translations/de.json
+++ b/homeassistant/components/comfoair/translations/de.json
@@ -1,0 +1,28 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Es ist nur eine einzige Konfiguration von ComfoAir zul\u00e4ssig."
+        },
+        "error": {
+            "cannot_connect": "Kein Verbindung zu ComfoAir-Ger\u00e4t m\u00f6glich"
+        },
+        "step": {
+            "port_config": {
+                "data": {
+                    "name:": "Name",
+                    "serial_port": "Serieller Ger\u00e4tepfad"
+                },
+                "description": "Geben Sie die portspezifischen Einstellungen ein",
+                "title": "Einstellungen"
+            },
+            "user": {
+                "data": {
+                    "name:": "Name",
+                    "serial_port": "Serieller Ger\u00e4tepfad"
+                },
+                "description": "W\u00e4hlen Sie die serielle Schnittstelle aus",
+                "title": "ComfoAir"
+            }
+        }
+    }
+}

--- a/homeassistant/components/comfoair/translations/en.json
+++ b/homeassistant/components/comfoair/translations/en.json
@@ -1,0 +1,28 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Only a single configuration of ComfoAir is allowed."
+        },
+        "error": {
+            "cannot_connect": "Unable to connect to ComfoAir device."
+        },
+        "step": {
+            "port_config": {
+                "data": {
+                    "name": "Name",
+                    "serial_port": "Serial device path"
+                },
+                "description": "Enter port specific settings",
+                "title": "Settings"
+            },
+            "user": {
+                "data": {
+                    "name": "Name",
+                    "serial_port": "Serial device path"
+                },
+                "description": "Select serial port",
+                "title": "ComfoAir"
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -31,6 +31,7 @@ FLOWS = [
     "bsblan",
     "cast",
     "cert_expiry",
+    "comfoair",
     "control4",
     "coolmaster",
     "coronavirus",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -333,9 +333,6 @@ bellows==0.18.0
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.7.7
 
-# homeassistant.components.comfoair
-bitstring==3.1.5
-
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1
 
@@ -1262,7 +1259,7 @@ pychromecast==7.1.2
 pycmus==0.1.1
 
 # homeassistant.components.comfoair
-pycomfoair==0.0.1
+pycomfoair==0.0.3
 
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -333,6 +333,9 @@ bellows==0.18.0
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.7.7
 
+# homeassistant.components.comfoair
+bitstring==3.1.5
+
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1
 
@@ -1257,6 +1260,9 @@ pychromecast==7.1.2
 
 # homeassistant.components.cmus
 pycmus==0.1.1
+
+# homeassistant.components.comfoair
+pycomfoair==0.0.1
 
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -591,6 +591,9 @@ pybotvac==0.0.17
 # homeassistant.components.cast
 pychromecast==7.1.2
 
+# homeassistant.components.comfoair
+pycomfoair==0.0.3
+
 # homeassistant.components.coolmaster
 pycoolmasternet==0.0.4
 

--- a/tests/components/comfoair/__init__.py
+++ b/tests/components/comfoair/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ComfoAir component."""

--- a/tests/components/comfoair/test_config_flow.py
+++ b/tests/components/comfoair/test_config_flow.py
@@ -1,0 +1,138 @@
+"""Tests for ComfoAir config flow."""
+
+import asyncio
+import socket
+
+import serial.tools.list_ports
+
+from homeassistant import setup
+from homeassistant.components.comfoair import config_flow
+from homeassistant.components.comfoair.const import (
+    CONF_SERIAL_PORT,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_NAME, CONF_SOURCE
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+
+from tests.async_mock import MagicMock, patch
+from tests.common import MockConfigEntry
+
+
+class ComfoAirSim(asyncio.Protocol):
+    """Mock of a silent ComfoAir device."""
+
+
+def com_port(device):
+    """Mock of a serial port."""
+    port = serial.tools.list_ports_common.ListPortInfo()
+    port.serial_number = "1234"
+    port.manufacturer = "Virtual serial port"
+    port.device = device
+    port.description = "Some serial port"
+
+    return port
+
+
+def first_host_and_port(srv):
+    """Return first host and port of a server."""
+
+    for sock in srv.sockets:
+        if sock.family == socket.AF_INET:
+            return sock.getsockname()
+        if sock.family == socket.AF_INET6:
+            return sock.getsockname()[0:2]
+
+    raise ValueError("Invalid socket")
+
+
+async def simulator():
+    """Return server and URL."""
+    loop = asyncio.get_running_loop()
+    srv = await loop.create_server(ComfoAirSim, port=0)
+    host, port = first_host_and_port(srv)
+    return srv, f"socket://{host}:{port}"
+
+
+async def test_user_flow(hass):
+    """Test user flow."""
+    srv, url = await simulator()
+    async with srv:
+        with patch(
+            "serial.tools.list_ports.comports", MagicMock(return_value=[com_port(url)])
+        ):
+            port = com_port(url)
+            port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={CONF_SOURCE: SOURCE_USER},
+                data={CONF_NAME: DEFAULT_NAME, CONF_SERIAL_PORT: port_select},
+            )
+            assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+            assert result["title"].startswith(port.description)
+            assert result["data"] == {
+                CONF_NAME: DEFAULT_NAME,
+                CONF_SERIAL_PORT: port.device,
+            }
+
+
+async def test_user_flow_show_form(hass):
+    """Test user step form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_user_flow_manual(hass):
+    """Test user flow manual entry."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={CONF_SERIAL_PORT: config_flow.CONF_MANUAL_PATH},
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "port_config"
+
+
+async def test_user_flow_existing_config_entry(hass):
+    """Test if config entry already exists."""
+    MockConfigEntry(domain=DOMAIN, data={CONF_SERIAL_PORT: "/dev/ttyUSB1"}).add_to_hass(
+        hass
+    )
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}
+    )
+
+    assert result["type"] == "abort"
+
+
+async def test_user_port_config(hass):
+    """Test port config."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={CONF_NAME: DEFAULT_NAME, CONF_SERIAL_PORT: config_flow.CONF_MANUAL_PATH},
+    )
+
+    srv, url = await simulator()
+    async with srv:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_NAME: DEFAULT_NAME, CONF_SERIAL_PORT: url},
+        )
+
+        assert result["type"] == "create_entry"
+        assert result["title"].startswith(url)
+        assert result["data"] == {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_SERIAL_PORT: url,
+        }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This integrates support for Zehnder ComfoAir 350 ventilation units and compatibles. This is not to be confused with the comfoconnect component, which integrates the newer Q350 units.

It allows reading temperature sensors and setting fan speeds. Currently it expects a CC Ease controller to be present.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/10964

There was a previous attempt to get this merged from Oct 2019 to Jan 2020 (#27961). I've hopefully addressed the remaining issues by now by moving bit-fiddling parts into the underlying library.

The documentation pull request hasn't been changed since then. Do I need to make a new one?

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
