### PR TITLE
Add config flow for Tile

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -790,6 +790,7 @@ omit =
     homeassistant/components/thomson/device_tracker.py
     homeassistant/components/tibber/*
     homeassistant/components/tikteck/light.py
+    homeassistant/components/tile/__init__.py
     homeassistant/components/tile/device_tracker.py
     homeassistant/components/time_date/sensor.py
     homeassistant/components/tmb/sensor.py

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -4,17 +4,10 @@ from datetime import timedelta
 
 from pytile import async_login
 from pytile.errors import TileError
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    CONF_MONITORED_VARIABLES,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-)
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -29,41 +22,10 @@ DEFAULT_UPDATE_INTERVAL = timedelta(minutes=2)
 
 CONF_SHOW_INACTIVE = "show_inactive"
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.deprecated(CONF_SHOW_INACTIVE, invalidation_version="0.114.0"),
-            cv.deprecated(CONF_MONITORED_VARIABLES, invalidation_version="0.114.0"),
-            vol.Schema(
-                {
-                    vol.Required(CONF_USERNAME): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string,
-                    vol.Optional(CONF_SHOW_INACTIVE, default=False): cv.boolean,
-                    vol.Optional(
-                        CONF_MONITORED_VARIABLES, default=DEVICE_TYPES
-                    ): vol.All(cv.ensure_list, [vol.In(DEVICE_TYPES)]),
-                }
-            ),
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
 
 async def async_setup(hass, config):
     """Set up the Tile component."""
     hass.data[DOMAIN] = {DATA_COORDINATOR: {}}
-
-    if DOMAIN not in config:
-        return True
-
-    conf = config[DOMAIN]
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-        )
-    )
 
     return True
 

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -1,1 +1,181 @@
-"""The tile component."""
+"""The Tile component."""
+import asyncio
+from datetime import timedelta
+
+from pytile import async_login
+from pytile.errors import TileError
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    CONF_MONITORED_VARIABLES,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DATA_COORDINATOR, DOMAIN, LOGGER
+
+PLATFORMS = ["device_tracker"]
+DEVICE_TYPES = ["PHONE", "TILE"]
+
+DEFAULT_ATTRIBUTION = "Data provided by Tile"
+DEFAULT_ICON = "mdi:view-grid"
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=2)
+
+CONF_SHOW_INACTIVE = "show_inactive"
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.All(
+            cv.deprecated(CONF_SHOW_INACTIVE, invalidation_version="0.114.0"),
+            cv.deprecated(CONF_MONITORED_VARIABLES, invalidation_version="0.114.0"),
+            vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME): cv.string,
+                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Optional(CONF_SHOW_INACTIVE, default=False): cv.boolean,
+                    vol.Optional(
+                        CONF_MONITORED_VARIABLES, default=DEVICE_TYPES
+                    ): vol.All(cv.ensure_list, [vol.In(DEVICE_TYPES)]),
+                }
+            ),
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """Set up the Tile component."""
+    hass.data[DOMAIN] = {DATA_COORDINATOR: {}}
+
+    if DOMAIN not in config:
+        return True
+
+    conf = config[DOMAIN]
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+        )
+    )
+
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set up Tile as config entry."""
+    websession = aiohttp_client.async_get_clientsession(hass)
+
+    client = await async_login(
+        config_entry.data[CONF_USERNAME],
+        config_entry.data[CONF_PASSWORD],
+        session=websession,
+    )
+
+    async def async_update_data():
+        """Get new data from the API."""
+        try:
+            return await client.tiles.all()
+        except TileError as err:
+            raise UpdateFailed(f"Error while retrieving data: {err}")
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        name=config_entry.title,
+        update_interval=DEFAULT_UPDATE_INTERVAL,
+        update_method=async_update_data,
+    )
+
+    await coordinator.async_refresh()
+    hass.data[DOMAIN][DATA_COORDINATOR][config_entry.entry_id] = coordinator
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload a Tile config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(config_entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN][DATA_COORDINATOR].pop(config_entry.entry_id)
+
+    return unload_ok
+
+
+class TileEntity(Entity):
+    """Define a generic Tile entity."""
+
+    def __init__(self, coordinator):
+        """Initialize."""
+        self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._name = None
+        self._unique_id = None
+        self.coordinator = coordinator
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return self._attrs
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return DEFAULT_ICON
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Disable polling."""
+        return False
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the entity."""
+        return self._unique_id
+
+    @callback
+    def _update_from_latest_data(self):
+        """Update the entity from the latest data."""
+        raise NotImplementedError
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+
+        @callback
+        def update():
+            """Update the state."""
+            self._update_from_latest_data()
+            self.async_write_ha_state()
+
+        self.async_on_remove(self.coordinator.async_add_listener(update))
+
+        self._update_from_latest_data()
+
+    async def async_update(self):
+        """Update the entity.
+
+        Only used by the generic entity update service.
+        """
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tile/config_flow.py
+++ b/homeassistant/components/tile/config_flow.py
@@ -1,0 +1,52 @@
+"""Config flow to configure the Tile integration."""
+from pytile import async_login
+from pytile.errors import TileError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import aiohttp_client
+
+from .const import DOMAIN  # pylint: disable=unused-import
+
+
+class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Tile config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize the config flow."""
+        self.data_schema = vol.Schema(
+            {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+        )
+
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
+        return self.async_show_form(
+            step_id="user", data_schema=self.data_schema, errors=errors or {}
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        if not user_input:
+            return await self._show_form()
+
+        await self.async_set_unique_id(user_input[CONF_USERNAME])
+        self._abort_if_unique_id_configured()
+
+        session = aiohttp_client.async_get_clientsession(self.hass)
+
+        try:
+            await async_login(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD], session=session
+            )
+        except TileError:
+            return await self._show_form({"base": "invalid_credentials"})
+
+        return self.async_create_entry(title=user_input[CONF_USERNAME], data=user_input)

--- a/homeassistant/components/tile/config_flow.py
+++ b/homeassistant/components/tile/config_flow.py
@@ -28,6 +28,10 @@ class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=self.data_schema, errors=errors or {}
         )
 
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
         if not user_input:

--- a/homeassistant/components/tile/config_flow.py
+++ b/homeassistant/components/tile/config_flow.py
@@ -28,10 +28,6 @@ class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=self.data_schema, errors=errors or {}
         )
 
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user(import_config)
-
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
         if not user_input:

--- a/homeassistant/components/tile/const.py
+++ b/homeassistant/components/tile/const.py
@@ -1,0 +1,8 @@
+"""Define Tile constants."""
+import logging
+
+DOMAIN = "tile"
+
+DATA_COORDINATOR = "coordinator"
+
+LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -1,9 +1,15 @@
 """Support for Tile device trackers."""
+import logging
+
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_GPS
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
 from . import DATA_COORDINATOR, DOMAIN, TileEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 ATTR_ALTITUDE = "altitude"
 ATTR_CONNECTION_STATE = "connection_state"
@@ -25,6 +31,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         ],
         True,
     )
+
+
+async def async_setup_scanner(hass, config, async_see, discovery_info=None):
+    """Detect a legacy configuration and import it."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_USERNAME: config[CONF_USERNAME],
+                CONF_PASSWORD: config[CONF_PASSWORD],
+            },
+        )
+    )
+
+    _LOGGER.info(
+        "Your Tile configuration has been imported into the UI; "
+        "please remove it from configuration.yaml"
+    )
+
+    return True
 
 
 class TileDeviceTracker(TileEntity, TrackerEntity):

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -1,21 +1,9 @@
-"""Support for Tile® Bluetooth trackers."""
-from datetime import timedelta
-import logging
+"""Support for Tile device trackers."""
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker.const import SOURCE_TYPE_GPS
+from homeassistant.core import callback
 
-from pytile import async_login
-from pytile.errors import SessionExpiredError, TileError
-import voluptuous as vol
-
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
-from homeassistant.const import CONF_MONITORED_VARIABLES, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import aiohttp_client, config_validation as cv
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util import slugify
-from homeassistant.util.json import load_json, save_json
-
-_LOGGER = logging.getLogger(__name__)
-CLIENT_UUID_CONFIG_FILE = ".tile.conf"
-DEVICE_TYPES = ["PHONE", "TILE"]
+from . import DATA_COORDINATOR, DOMAIN, TileEntity
 
 ATTR_ALTITUDE = "altitude"
 ATTR_CONNECTION_STATE = "connection_state"
@@ -23,118 +11,92 @@ ATTR_IS_DEAD = "is_dead"
 ATTR_IS_LOST = "is_lost"
 ATTR_RING_STATE = "ring_state"
 ATTR_VOIP_STATE = "voip_state"
-ATTR_TILE_ID = "tile_identifier"
 ATTR_TILE_NAME = "tile_name"
 
-CONF_SHOW_INACTIVE = "show_inactive"
 
-DEFAULT_ICON = "mdi:view-grid"
-DEFAULT_SCAN_INTERVAL = timedelta(minutes=2)
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Tile device trackers."""
+    coordinator = hass.data[DOMAIN][DATA_COORDINATOR][config_entry.entry_id]
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_SHOW_INACTIVE, default=False): cv.boolean,
-        vol.Optional(CONF_MONITORED_VARIABLES, default=DEVICE_TYPES): vol.All(
-            cv.ensure_list, [vol.In(DEVICE_TYPES)]
-        ),
-    }
-)
-
-
-async def async_setup_scanner(hass, config, async_see, discovery_info=None):
-    """Validate the configuration and return a Tile scanner."""
-    websession = aiohttp_client.async_get_clientsession(hass)
-
-    config_file = hass.config.path(
-        ".{}{}".format(slugify(config[CONF_USERNAME]), CLIENT_UUID_CONFIG_FILE)
+    async_add_entities(
+        [
+            TileDeviceTracker(coordinator, tile_uuid, tile)
+            for tile_uuid, tile in coordinator.data.items()
+        ],
+        True,
     )
-    config_data = await hass.async_add_job(load_json, config_file)
-    if config_data:
-        client = await async_login(
-            config[CONF_USERNAME],
-            config[CONF_PASSWORD],
-            websession,
-            client_uuid=config_data["client_uuid"],
-        )
-    else:
-        client = await async_login(
-            config[CONF_USERNAME], config[CONF_PASSWORD], websession
-        )
-
-        config_data = {"client_uuid": client.client_uuid}
-        await hass.async_add_job(save_json, config_file, config_data)
-
-    scanner = TileScanner(
-        client,
-        hass,
-        async_see,
-        config[CONF_MONITORED_VARIABLES],
-        config[CONF_SHOW_INACTIVE],
-    )
-    return await scanner.async_init()
 
 
-class TileScanner:
-    """Define an object to retrieve Tile data."""
+class TileDeviceTracker(TileEntity, TrackerEntity):
+    """Representation of a network infrastructure device."""
 
-    def __init__(self, client, hass, async_see, types, show_inactive):
+    def __init__(self, coordinator, tile_uuid, tile):
         """Initialize."""
-        self._async_see = async_see
-        self._client = client
-        self._hass = hass
-        self._show_inactive = show_inactive
-        self._types = types
+        super().__init__(coordinator)
+        self._name = tile["name"]
+        self._tile = tile
+        self._tile_uuid = tile_uuid
+        self._unique_id = f"tile_{tile_uuid}"
 
-    async def async_init(self):
-        """Further initialize connection to the Tile servers."""
-        try:
-            await self._client.async_init()
-        except TileError as err:
-            _LOGGER.error("Unable to set up Tile scanner: %s", err)
-            return False
+    @property
+    def available(self):
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and not self._tile["is_dead"]
 
-        await self._async_update()
+    @property
+    def battery_level(self):
+        """Return the battery level of the device.
 
-        async_track_time_interval(self._hass, self._async_update, DEFAULT_SCAN_INTERVAL)
+        Percentage from 0-100.
+        """
+        return None
 
-        return True
+    @property
+    def location_accuracy(self):
+        """Return the location accuracy of the device.
 
-    async def _async_update(self, now=None):
-        """Update info from Tile."""
-        try:
-            await self._client.async_init()
-            tiles = await self._client.tiles.all(
-                whitelist=self._types, show_inactive=self._show_inactive
+        Value in meters.
+        """
+        return round(
+            (
+                self._tile["last_tile_state"]["h_accuracy"]
+                + self._tile["last_tile_state"]["v_accuracy"]
             )
-        except SessionExpiredError:
-            _LOGGER.info("Session expired; trying again shortly")
-            return
-        except TileError as err:
-            _LOGGER.error("There was an error while updating: %s", err)
-            return
+            / 2
+        )
 
-        if not tiles:
-            _LOGGER.warning("No Tiles found")
-            return
+    @property
+    def latitude(self) -> float:
+        """Return latitude value of the device."""
+        return self._tile["last_tile_state"]["latitude"]
 
-        for tile in tiles:
-            await self._async_see(
-                dev_id="tile_{}".format(slugify(tile["tile_uuid"])),
-                gps=(
-                    tile["last_tile_state"]["latitude"],
-                    tile["last_tile_state"]["longitude"],
-                ),
-                attributes={
-                    ATTR_ALTITUDE: tile["last_tile_state"]["altitude"],
-                    ATTR_CONNECTION_STATE: tile["last_tile_state"]["connection_state"],
-                    ATTR_IS_DEAD: tile["is_dead"],
-                    ATTR_IS_LOST: tile["last_tile_state"]["is_lost"],
-                    ATTR_RING_STATE: tile["last_tile_state"]["ring_state"],
-                    ATTR_VOIP_STATE: tile["last_tile_state"]["voip_state"],
-                    ATTR_TILE_ID: tile["tile_uuid"],
-                    ATTR_TILE_NAME: tile["name"],
-                },
-                icon=DEFAULT_ICON,
-            )
+    @property
+    def longitude(self) -> float:
+        """Return longitude value of the device."""
+        return self._tile["last_tile_state"]["longitude"]
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return SOURCE_TYPE_GPS
+
+    @property
+    def state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        attr.update(
+            super().state_attributes,
+            **{
+                ATTR_ALTITUDE: self._tile["last_tile_state"]["altitude"],
+                ATTR_IS_LOST: self._tile["last_tile_state"]["is_lost"],
+                ATTR_RING_STATE: self._tile["last_tile_state"]["ring_state"],
+                ATTR_VOIP_STATE: self._tile["last_tile_state"]["voip_state"],
+            },
+        )
+
+        return attr
+
+    @callback
+    def _update_from_latest_data(self):
+        """Update the entity from the latest data."""
+        self._tile = self.coordinator.data[self._tile_uuid]

--- a/homeassistant/components/tile/manifest.json
+++ b/homeassistant/components/tile/manifest.json
@@ -1,7 +1,8 @@
 {
   "domain": "tile",
   "name": "Tile",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tile",
-  "requirements": ["pytile==3.0.1"],
+  "requirements": ["pytile==3.0.6"],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/tile/strings.json
+++ b/homeassistant/components/tile/strings.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configure Tile",
+        "data": {
+          "username": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "invalid_credentials": "Invalid Tile credentials provided."
+    },
+    "abort": {
+      "already_configured": "This Tile account is already registered."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure Tile",
+        "data": {
+          "show_inactive": "Show inactive Tiles"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/tile/translations/en.json
+++ b/homeassistant/components/tile/translations/en.json
@@ -1,0 +1,29 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "This Tile account is already registered."
+        },
+        "error": {
+            "invalid_credentials": "Invalid Tile credentials provided."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "username": "[%key:common::config_flow::data::email%]"
+                },
+                "title": "Configure Tile"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "show_inactive": "Show inactive Tiles"
+                },
+                "title": "Configure Tile"
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -143,6 +143,7 @@ FLOWS = [
     "tellduslive",
     "tesla",
     "tibber",
+    "tile",
     "toon",
     "totalconnect",
     "tplink",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1765,7 +1765,7 @@ python_opendata_transport==0.2.1
 pythonegardia==1.0.40
 
 # homeassistant.components.tile
-pytile==3.0.1
+pytile==3.0.6
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -731,6 +731,9 @@ python-velbus==2.0.43
 # homeassistant.components.awair
 python_awair==0.0.4
 
+# homeassistant.components.tile
+pytile==3.0.6
+
 # homeassistant.components.traccar
 pytraccar==0.9.0
 

--- a/tests/components/tile/__init__.py
+++ b/tests/components/tile/__init__.py
@@ -1,0 +1,1 @@
+"""Define tests for the Tile component."""

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -3,7 +3,7 @@ from pytile.errors import TileError
 
 from homeassistant import data_entry_flow
 from homeassistant.components.tile import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from tests.async_mock import patch
@@ -44,6 +44,28 @@ async def test_invalid_credentials(hass):
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {"base": "invalid_credentials"}
+
+
+async def test_step_import(hass):
+    """Test that the import step works."""
+    conf = {
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
+    }
+
+    with patch(
+        "homeassistant.components.tile.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.tile.config_flow.async_login"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+        )
+        print(result)
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "user@host.com"
+        assert result["data"] == {
+            CONF_USERNAME: "user@host.com",
+            CONF_PASSWORD: "123abc",
+        }
 
 
 async def test_step_user(hass):

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -1,268 +1,74 @@
 """Define tests for the Tile config flow."""
-from pyairvisual.errors import InvalidKeyError, NodeProError
+from pytile.errors import TileError
 
 from homeassistant import data_entry_flow
-from homeassistant.components.airvisual import (
-    CONF_GEOGRAPHIES,
-    CONF_INTEGRATION_TYPE,
-    DOMAIN,
-    INTEGRATION_TYPE_GEOGRAPHY,
-    INTEGRATION_TYPE_NODE_PRO,
-)
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_IP_ADDRESS,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_PASSWORD,
-    CONF_SHOW_ON_MAP,
-)
-from homeassistant.setup import async_setup_component
+from homeassistant.components.tile import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 
 async def test_duplicate_error(hass):
-    """Test that errors are shown when duplicate entries are added."""
-    geography_conf = {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
+    """Test that errors are shown when duplicates are added."""
+    conf = {
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
     }
-    node_pro_conf = {CONF_IP_ADDRESS: "192.168.1.100", CONF_PASSWORD: "12345"}
 
-    MockConfigEntry(
-        domain=DOMAIN, unique_id="51.528308, -0.3817765", data=geography_conf
-    ).add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data=geography_conf
+    MockConfigEntry(domain=DOMAIN, unique_id="user@host.com", data=conf).add_to_hass(
+        hass
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
-
-    MockConfigEntry(
-        domain=DOMAIN, unique_id="192.168.1.100", data=node_pro_conf
-    ).add_to_hass(hass)
-
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data={"type": "Tile Node/Pro"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=node_pro_conf
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_invalid_identifier(hass):
-    """Test that an invalid API key or Node/Pro ID throws an error."""
-    geography_conf = {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
-    }
-
-    with patch(
-        "pyairvisual.api.API.nearest_city", side_effect=InvalidKeyError,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=geography_conf
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
-
-
-async def test_node_pro_error(hass):
-    """Test that an invalid Node/Pro ID shows an error."""
-    node_pro_conf = {CONF_IP_ADDRESS: "192.168.1.100", CONF_PASSWORD: "my_password"}
-
-    with patch(
-        "pyairvisual.node.Node.from_samba", side_effect=NodeProError,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data={"type": "Tile Node/Pro"}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=node_pro_conf
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_IP_ADDRESS: "unable_to_connect"}
-
-
-async def test_migration(hass):
-    """Test migrating from version 1 to the current version."""
+async def test_invalid_credentials(hass):
+    """Test that invalid credentials key throws an error."""
     conf = {
-        CONF_API_KEY: "abcde12345",
-        CONF_GEOGRAPHIES: [
-            {CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765},
-            {CONF_LATITUDE: 35.48847, CONF_LONGITUDE: 137.5263065},
-        ],
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
     }
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, version=1, unique_id="abcde12345", data=conf
-    )
-    config_entry.add_to_hass(hass)
-
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-
-    with patch("pyairvisual.api.API.nearest_city"):
-        assert await async_setup_component(hass, DOMAIN, {DOMAIN: conf})
-
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-
-    assert len(config_entries) == 2
-
-    assert config_entries[0].unique_id == "51.528308, -0.3817765"
-    assert config_entries[0].title == "Cloud API (51.528308, -0.3817765)"
-    assert config_entries[0].data == {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
-        CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
-    }
-
-    assert config_entries[1].unique_id == "35.48847, 137.5263065"
-    assert config_entries[1].title == "Cloud API (35.48847, 137.5263065)"
-    assert config_entries[1].data == {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 35.48847,
-        CONF_LONGITUDE: 137.5263065,
-        CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
-    }
-
-
-async def test_options_flow(hass):
-    """Test config flow options."""
-    geography_conf = {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
-    }
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="51.528308, -0.3817765",
-        data=geography_conf,
-        options={CONF_SHOW_ON_MAP: True},
-    )
-    config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.airvisual.async_setup_entry", return_value=True
+        "homeassistant.components.tile.config_flow.async_login", side_effect=TileError,
     ):
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=conf
+        )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["step_id"] == "init"
-
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_SHOW_ON_MAP: False}
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert config_entry.options == {CONF_SHOW_ON_MAP: False}
-
-
-async def test_step_geography(hass):
-    """Test the geograph (cloud API) step."""
-    conf = {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
-    }
-
-    with patch(
-        "homeassistant.components.airvisual.async_setup_entry", return_value=True
-    ), patch("pyairvisual.api.API.nearest_city"):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Cloud API (51.528308, -0.3817765)"
-        assert result["data"] == {
-            CONF_API_KEY: "abcde12345",
-            CONF_LATITUDE: 51.528308,
-            CONF_LONGITUDE: -0.3817765,
-            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
-        }
-
-
-async def test_step_node_pro(hass):
-    """Test the Node/Pro step."""
-    conf = {CONF_IP_ADDRESS: "192.168.1.100", CONF_PASSWORD: "my_password"}
-
-    with patch(
-        "homeassistant.components.airvisual.async_setup_entry", return_value=True
-    ), patch("pyairvisual.node.Node.from_samba"):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data={"type": "Tile Node/Pro"}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=conf
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Node/Pro (192.168.1.100)"
-        assert result["data"] == {
-            CONF_IP_ADDRESS: "192.168.1.100",
-            CONF_PASSWORD: "my_password",
-            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_NODE_PRO,
-        }
-
-
-async def test_step_import(hass):
-    """Test the import step for both types of configuration."""
-    geography_conf = {
-        CONF_API_KEY: "abcde12345",
-        CONF_LATITUDE: 51.528308,
-        CONF_LONGITUDE: -0.3817765,
-    }
-
-    with patch(
-        "homeassistant.components.airvisual.async_setup_entry", return_value=True
-    ), patch("pyairvisual.api.API.nearest_city"):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=geography_conf
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Cloud API (51.528308, -0.3817765)"
-        assert result["data"] == {
-            CONF_API_KEY: "abcde12345",
-            CONF_LATITUDE: 51.528308,
-            CONF_LONGITUDE: -0.3817765,
-            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
-        }
+        assert result["errors"] == {"base": "invalid_credentials"}
 
 
 async def test_step_user(hass):
-    """Test the user ("pick the integration type") step."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    """Test that the user step works."""
+    conf = {
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
+    }
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
+    with patch(
+        "homeassistant.components.tile.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.tile.config_flow.async_login"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "user"
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={"type": INTEGRATION_TYPE_GEOGRAPHY},
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "geography"
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={"type": INTEGRATION_TYPE_NODE_PRO},
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "node_pro"
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=conf
+        )
+        print(result)
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "user@host.com"
+        assert result["data"] == {
+            CONF_USERNAME: "user@host.com",
+            CONF_PASSWORD: "123abc",
+        }

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -1,0 +1,268 @@
+"""Define tests for the Tile config flow."""
+from pyairvisual.errors import InvalidKeyError, NodeProError
+
+from homeassistant import data_entry_flow
+from homeassistant.components.airvisual import (
+    CONF_GEOGRAPHIES,
+    CONF_INTEGRATION_TYPE,
+    DOMAIN,
+    INTEGRATION_TYPE_GEOGRAPHY,
+    INTEGRATION_TYPE_NODE_PRO,
+)
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_IP_ADDRESS,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_PASSWORD,
+    CONF_SHOW_ON_MAP,
+)
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_duplicate_error(hass):
+    """Test that errors are shown when duplicate entries are added."""
+    geography_conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
+    node_pro_conf = {CONF_IP_ADDRESS: "192.168.1.100", CONF_PASSWORD: "12345"}
+
+    MockConfigEntry(
+        domain=DOMAIN, unique_id="51.528308, -0.3817765", data=geography_conf
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=geography_conf
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+    MockConfigEntry(
+        domain=DOMAIN, unique_id="192.168.1.100", data=node_pro_conf
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={"type": "Tile Node/Pro"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=node_pro_conf
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_invalid_identifier(hass):
+    """Test that an invalid API key or Node/Pro ID throws an error."""
+    geography_conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
+
+    with patch(
+        "pyairvisual.api.API.nearest_city", side_effect=InvalidKeyError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=geography_conf
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
+
+
+async def test_node_pro_error(hass):
+    """Test that an invalid Node/Pro ID shows an error."""
+    node_pro_conf = {CONF_IP_ADDRESS: "192.168.1.100", CONF_PASSWORD: "my_password"}
+
+    with patch(
+        "pyairvisual.node.Node.from_samba", side_effect=NodeProError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data={"type": "Tile Node/Pro"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=node_pro_conf
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {CONF_IP_ADDRESS: "unable_to_connect"}
+
+
+async def test_migration(hass):
+    """Test migrating from version 1 to the current version."""
+    conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_GEOGRAPHIES: [
+            {CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765},
+            {CONF_LATITUDE: 35.48847, CONF_LONGITUDE: 137.5263065},
+        ],
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, version=1, unique_id="abcde12345", data=conf
+    )
+    config_entry.add_to_hass(hass)
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+    with patch("pyairvisual.api.API.nearest_city"):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: conf})
+
+    config_entries = hass.config_entries.async_entries(DOMAIN)
+
+    assert len(config_entries) == 2
+
+    assert config_entries[0].unique_id == "51.528308, -0.3817765"
+    assert config_entries[0].title == "Cloud API (51.528308, -0.3817765)"
+    assert config_entries[0].data == {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+        CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
+    }
+
+    assert config_entries[1].unique_id == "35.48847, 137.5263065"
+    assert config_entries[1].title == "Cloud API (35.48847, 137.5263065)"
+    assert config_entries[1].data == {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 35.48847,
+        CONF_LONGITUDE: 137.5263065,
+        CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
+    }
+
+
+async def test_options_flow(hass):
+    """Test config flow options."""
+    geography_conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="51.528308, -0.3817765",
+        data=geography_conf,
+        options={CONF_SHOW_ON_MAP: True},
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.airvisual.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_SHOW_ON_MAP: False}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert config_entry.options == {CONF_SHOW_ON_MAP: False}
+
+
+async def test_step_geography(hass):
+    """Test the geograph (cloud API) step."""
+    conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
+
+    with patch(
+        "homeassistant.components.airvisual.async_setup_entry", return_value=True
+    ), patch("pyairvisual.api.API.nearest_city"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "Cloud API (51.528308, -0.3817765)"
+        assert result["data"] == {
+            CONF_API_KEY: "abcde12345",
+            CONF_LATITUDE: 51.528308,
+            CONF_LONGITUDE: -0.3817765,
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
+        }
+
+
+async def test_step_node_pro(hass):
+    """Test the Node/Pro step."""
+    conf = {CONF_IP_ADDRESS: "192.168.1.100", CONF_PASSWORD: "my_password"}
+
+    with patch(
+        "homeassistant.components.airvisual.async_setup_entry", return_value=True
+    ), patch("pyairvisual.node.Node.from_samba"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data={"type": "Tile Node/Pro"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=conf
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "Node/Pro (192.168.1.100)"
+        assert result["data"] == {
+            CONF_IP_ADDRESS: "192.168.1.100",
+            CONF_PASSWORD: "my_password",
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_NODE_PRO,
+        }
+
+
+async def test_step_import(hass):
+    """Test the import step for both types of configuration."""
+    geography_conf = {
+        CONF_API_KEY: "abcde12345",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
+
+    with patch(
+        "homeassistant.components.airvisual.async_setup_entry", return_value=True
+    ), patch("pyairvisual.api.API.nearest_city"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=geography_conf
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "Cloud API (51.528308, -0.3817765)"
+        assert result["data"] == {
+            CONF_API_KEY: "abcde12345",
+            CONF_LATITUDE: 51.528308,
+            CONF_LONGITUDE: -0.3817765,
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_GEOGRAPHY,
+        }
+
+
+async def test_step_user(hass):
+    """Test the user ("pick the integration type") step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={"type": INTEGRATION_TYPE_GEOGRAPHY},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "geography"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={"type": INTEGRATION_TYPE_NODE_PRO},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "node_pro"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The entity IDs for the Tile integration have changed to reflect the human-friendly name of the Tile (as defined in the Tile mobile app). Please update your automations/etc. accordingly.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a config flow for Tile. It also makes use of the more modern device tracker API under the hood.

I've tied this to `configuration.yaml` for now (except for a few deprecation notices) so that users can have a path to migrating to a config entry; I know ADR-0010 stipulates that we won't accept additions/alterations to YAML config in cases like this, but I believe this should be allowed so that there's a smoother transition.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/35896
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
