### PR TITLE
Bump zeroconf, pychromecast. Log if zeroconf.get_service_info fails.

### DIFF
--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==5.2.0"],
+  "requirements": ["pychromecast==5.3.0"],
   "after_dependencies": ["cloud","zeroconf"],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -192,6 +192,7 @@ def setup(hass, config):
         if not service_info:
             # Prevent the browser thread from collapsing as
             # service_info can be None
+            _LOGGER.debug("Failed to get info for device %s", name)
             return
 
         info = info_from_service(service_info)

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.26.2"],
+  "requirements": ["zeroconf==0.26.3"],
   "dependencies": ["api"],
   "codeowners": ["@robbiet480", "@Kane610"],
   "quality_scale": "internal"

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -25,7 +25,7 @@ ruamel.yaml==0.15.100
 sqlalchemy==1.3.17
 voluptuous-serialize==2.3.0
 voluptuous==0.11.7
-zeroconf==0.26.2
+zeroconf==0.26.3
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1248,7 +1248,7 @@ pycfdns==0.0.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==5.2.0
+pychromecast==5.3.0
 
 # homeassistant.components.cmus
 pycmus==0.1.1
@@ -2242,7 +2242,7 @@ youtube_dl==2020.05.08
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.26.2
+zeroconf==0.26.3
 
 # homeassistant.components.zha
 zha-quirks==0.0.39

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -533,7 +533,7 @@ pyblackbird==0.5
 pybotvac==0.0.17
 
 # homeassistant.components.cast
-pychromecast==5.2.0
+pychromecast==5.3.0
 
 # homeassistant.components.coolmaster
 pycoolmasternet==0.0.4
@@ -906,7 +906,7 @@ xmltodict==0.12.0
 ya_ma==0.3.8
 
 # homeassistant.components.zeroconf
-zeroconf==0.26.2
+zeroconf==0.26.3
 
 # homeassistant.components.zha
 zha-quirks==0.0.39


### PR DESCRIPTION
**Please see note about before cherry-picking to 0.110.4 https://github.com/home-assistant/core/pull/36185#issuecomment-635064191**

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump zeroconf, pychromecast. Log if zeroconf.get_service_info fails.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35922 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
