### PR TITLE
Fix roku select source with app ids

### DIFF
--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -222,7 +222,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             await self.coordinator.roku.remote("home")
 
         appl = next(
-            (app for app in self.coordinator.data.apps if app.name == source), None
+            (app for app in self.coordinator.data.apps if app.name == source or app.app_id == source), None
         )
 
         if appl is not None:

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -225,7 +225,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             (
                 app
                 for app in self.coordinator.data.apps
-                if app.name == source or app.app_id == source
+                if source in (app.name, app.app_id)
             ),
             None,
         )

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -222,7 +222,12 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             await self.coordinator.roku.remote("home")
 
         appl = next(
-            (app for app in self.coordinator.data.apps if app.name == source or app.app_id == source), None
+            (
+                app
+                for app in self.coordinator.data.apps
+                if app.name == source or app.app_id == source
+            ),
+            None,
         )
 
         if appl is not None:

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -280,7 +280,7 @@ async def test_services(
             blocking=True,
         )
 
-        remote_mock.assert_called_once_with("pause")
+        remote_mock.assert_called_once_with("play")
 
     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -274,10 +274,13 @@ async def test_services(
 
     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(
-            MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: MAIN_ENTITY_ID}, blocking=True
+            MP_DOMAIN,
+            SERVICE_MEDIA_PAUSE,
+            {ATTR_ENTITY_ID: MAIN_ENTITY_ID},
+            blocking=True,
         )
 
-        remote_mock.assert_called_once_with("poweroff")
+        remote_mock.assert_called_once_with("pause")
 
     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -274,13 +274,10 @@ async def test_services(
 
     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(
-            MP_DOMAIN,
-            SERVICE_MEDIA_PAUSE,
-            {ATTR_ENTITY_ID: MAIN_ENTITY_ID},
-            blocking=True,
+            MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: MAIN_ENTITY_ID}, blocking=True
         )
 
-        remote_mock.assert_called_once_with("play")
+        remote_mock.assert_called_once_with("poweroff")
 
     with patch("homeassistant.components.roku.Roku.remote") as remote_mock:
         await hass.services.async_call(
@@ -332,7 +329,7 @@ async def test_services(
 
         remote_mock.assert_called_once_with("home")
 
-    with patch("homeassistant.components.roku.Roku.launch") as remote_mock:
+    with patch("homeassistant.components.roku.Roku.launch") as launch_mock:
         await hass.services.async_call(
             MP_DOMAIN,
             SERVICE_SELECT_SOURCE,
@@ -340,7 +337,17 @@ async def test_services(
             blocking=True,
         )
 
-        remote_mock.assert_called_once_with("12")
+        launch_mock.assert_called_once_with(12)
+
+    with patch("homeassistant.components.roku.Roku.launch") as launch_mock:
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_SELECT_SOURCE,
+            {ATTR_ENTITY_ID: MAIN_ENTITY_ID, ATTR_INPUT_SOURCE: 12},
+            blocking=True,
+        )
+
+        launch_mock.assert_called_once_with(12)
 
 
 async def test_tv_services(

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -340,7 +340,7 @@ async def test_services(
             blocking=True,
         )
 
-        launch_mock.assert_called_once_with(12)
+        launch_mock.assert_called_once_with("12")
 
     with patch("homeassistant.components.roku.Roku.launch") as launch_mock:
         await hass.services.async_call(
@@ -350,7 +350,7 @@ async def test_services(
             blocking=True,
         )
 
-        launch_mock.assert_called_once_with(12)
+        launch_mock.assert_called_once_with("12")
 
 
 async def test_tv_services(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

It was previously possible to pass an app id to select_source service due to the old library internal lookups.

This change restores that ability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36184
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
