### PR TITLE
Bump pdunehd library to version 1.3.1

### DIFF
--- a/homeassistant/components/dunehd/manifest.json
+++ b/homeassistant/components/dunehd/manifest.json
@@ -2,6 +2,6 @@
   "domain": "dunehd",
   "name": "DuneHD",
   "documentation": "https://www.home-assistant.io/integrations/dunehd",
-  "requirements": ["pdunehd==1.3"],
+  "requirements": ["pdunehd==1.3.1"],
   "codeowners": []
 }

--- a/homeassistant/components/dunehd/media_player.py
+++ b/homeassistant/components/dunehd/media_player.py
@@ -78,11 +78,11 @@ class DuneHDPlayerEntity(MediaPlayerEntity):
         state = STATE_OFF
         if "playback_position" in self._state:
             state = STATE_PLAYING
-        if self._state["player_state"] in ("playing", "buffering"):
+        if self._state.get("player_state") in ("playing", "buffering"):
             state = STATE_PLAYING
         if int(self._state.get("playback_speed", 1234)) == 0:
             state = STATE_PAUSED
-        if self._state["player_state"] == "navigator":
+        if self._state.get("player_state") == "navigator":
             state = STATE_ON
         return state
 
@@ -153,7 +153,7 @@ class DuneHDPlayerEntity(MediaPlayerEntity):
         return self._state.get("playback_url", "Not playing")
 
     def __update_title(self):
-        if self._state["player_state"] == "bluray_playback":
+        if self._state.get("player_state") == "bluray_playback":
             self._media_title = "Blu-Ray"
         elif "playback_url" in self._state:
             sources = self._sources

--- a/homeassistant/components/dunehd/media_player.py
+++ b/homeassistant/components/dunehd/media_player.py
@@ -94,7 +94,7 @@ class DuneHDPlayerEntity(MediaPlayerEntity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return True if self._state else False
+        return bool(self._state)
 
     @property
     def volume_level(self):

--- a/homeassistant/components/dunehd/media_player.py
+++ b/homeassistant/components/dunehd/media_player.py
@@ -92,6 +92,11 @@ class DuneHDPlayerEntity(MediaPlayerEntity):
         return self._name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return True if self._state else False
+
+    @property
     def volume_level(self):
         """Return the volume level of the media player (0..1)."""
         return int(self._state.get("playback_volume", 0)) / 100

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1043,7 +1043,7 @@ panasonic_viera==0.3.5
 pcal9535a==0.7
 
 # homeassistant.components.dunehd
-pdunehd==1.3
+pdunehd==1.3.1
 
 # homeassistant.components.pencom
 pencompy==0.0.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `pdunehd` library to:
- better handling state updates and initialize integration when device is offline
- change entity state to `unavailable` when device is offline

This is my first step in working on this integration. The next step will be to add config_flow and update the integration to current standards.

Library changelog:
- https://github.com/valentinalexeev/pdunehd/commit/9502237c24b4a6291c33d8e46c7ff9877515b7e1
- https://github.com/valentinalexeev/pdunehd/commit/76730b38e916ae1d24b9f66a36fdafcea958cbeb

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
