### PR TITLE
Add support for simultaneous runs of Script helper - Part 3

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -393,58 +393,83 @@ class _ScriptRun(_ScriptRunBase):
         except KeyError:
             delay = None
         done = asyncio.Event()
+        tasks = [
+            self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
+        ]
         try:
             async with timeout(delay):
-                _, pending = await asyncio.wait(
-                    {self._stop.wait(), done.wait()},
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-            for pending_task in pending:
-                pending_task.cancel()
+                await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError:
             if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
                 self._log(_TIMEOUT_MSG)
                 raise _StopScript
         finally:
+            for task in tasks:
+                task.cancel()
             unsub()
 
     async def _async_call_service_step(self):
         """Call the service specified in the action."""
         domain, service, service_data = self._prep_call_service_step()
 
+        running_script = (
+            domain == "python_script"
+            or domain == "script"
+            and service != SERVICE_TURN_OFF
+        )
         # If this might start a script then disable the call timeout.
         # Otherwise use the normal service call limit.
-        if domain == "script" and service != SERVICE_TURN_OFF:
+        if running_script:
             limit = None
         else:
             limit = SERVICE_CALL_LIMIT
 
-        coro = self._hass.services.async_call(
-            domain,
-            service,
-            service_data,
-            blocking=True,
-            context=self._context,
-            limit=limit,
+        service_task = self._hass.async_create_task(
+            self._hass.services.async_call(
+                domain,
+                service,
+                service_data,
+                blocking=True,
+                context=self._context,
+                limit=limit,
+            )
         )
-
         if limit is not None:
             # There is a call limit, so just wait for it to finish.
-            await coro
+            await service_task
             return
 
-        # No call limit (i.e., potentially starting one or more fully blocking scripts)
-        # so watch for a stop request.
-        done, pending = await asyncio.wait(
-            {self._stop.wait(), coro}, return_when=asyncio.FIRST_COMPLETED,
-        )
-        # Note that cancelling the service call, if it has not yet returned, will also
-        # stop any non-background script runs that it may have started.
-        for pending_task in pending:
-            pending_task.cancel()
-        # Propagate any exceptions that might have happened.
-        for done_task in done:
-            done_task.result()
+        async def async_cancel_service_task():
+            # Stop service task and wait for it to finish.
+            service_task.cancel()
+            try:
+                await service_task
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        # No call limit so watch for a stop request.
+        stop_task = self._hass.async_create_task(self._stop.wait())
+        try:
+            await asyncio.wait(
+                {service_task, stop_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+        # If our task is cancelled, then cancel service task, too. Note that if service
+        # task is cancelled otherwise the CancelledError exception will not be raised to
+        # here due to the call to asyncio.wait(). Rather we'll check for that below.
+        except asyncio.CancelledError:
+            await async_cancel_service_task()
+            raise
+        finally:
+            stop_task.cancel()
+
+        if service_task.cancelled():
+            raise asyncio.CancelledError
+        if service_task.done():
+            # Propagate any exceptions that occurred.
+            service_task.result()
+        elif running_script:
+            # Stopped before service completed, so cancel service.
+            await async_cancel_service_task()
 
 
 class _QueuedScriptRun(_ScriptRun):
@@ -459,12 +484,18 @@ class _QueuedScriptRun(_ScriptRun):
         lock_task = self._hass.async_create_task(
             self._script._queue_lck.acquire()  # pylint: disable=protected-access
         )
-        done, pending = await asyncio.wait(
-            {self._stop.wait(), lock_task}, return_when=asyncio.FIRST_COMPLETED
-        )
-        for pending_task in pending:
-            pending_task.cancel()
-        self.lock_acquired = lock_task in done
+        stop_task = self._hass.async_create_task(self._stop.wait())
+        try:
+            await asyncio.wait(
+                {lock_task, stop_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+        except asyncio.CancelledError:
+            lock_task.cancel()
+            self._finish()
+            raise
+        finally:
+            stop_task.cancel()
+        self.lock_acquired = lock_task.done() and not lock_task.cancelled()
 
         # If we've been told to stop, then just finish up. Otherwise, we've acquired the
         # lock so we can go ahead and start the run.
@@ -785,6 +816,8 @@ class Script:
                 self._hass, self, variables, context, self._log_exceptions, shared
             )
         else:
+            # TODO: Enforce max # of runs to guard against run away recursive parallel
+            # blocking calls to self??? And, if so, will this replace queue_max???
             if self._script_mode != SCRIPT_MODE_QUEUE:
                 cls = _ScriptRun
             else:
@@ -807,6 +840,9 @@ class Script:
         """Stop running script."""
         if not self.is_running:
             return
+        # TODO: Should runs be stopped in reverse order in case there are recursive
+        # calls??? Or is it better this way, and runs further down the chain will just
+        # already be stopped by the time we try to stop them here???
         await asyncio.shield(asyncio.gather(*(run.async_stop() for run in self._runs)))
         if update_state:
             self._changed()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -818,8 +818,6 @@ class Script:
                 self._hass, self, variables, context, self._log_exceptions, shared
             )
         else:
-            # TODO: Enforce max # of runs to guard against run away recursive parallel
-            # blocking calls to self??? And, if so, will this replace queue_max???
             if self._script_mode != SCRIPT_MODE_QUEUE:
                 cls = _ScriptRun
             else:
@@ -842,9 +840,6 @@ class Script:
         """Stop running script."""
         if not self.is_running:
             return
-        # TODO: Should runs be stopped in reverse order in case there are recursive
-        # calls??? Or is it better this way, and runs further down the chain will just
-        # already be stopped by the time we try to stop them here???
         await asyncio.shield(asyncio.gather(*(run.async_stop() for run in self._runs)))
         if update_state:
             self._changed()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -413,7 +413,9 @@ class _ScriptRun(_ScriptRunBase):
         domain, service, service_data = self._prep_call_service_step()
 
         running_script = (
-            domain == "python_script"
+            domain == "automation"
+            and service == "trigger"
+            or domain == "python_script"
             or domain == "script"
             and service != SERVICE_TURN_OFF
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-on to #32442

- When canceling service call, wait for cancellation to complete.
- Pass tasks instead of coroutines to `asyncio.wait()` (since passing coroutines is deprecated, and this makes the overall code cleaner and more consistent.)
- Handle cancellation in `_QueuedScriptRun.async_run()`.
- Disable service call limit for `automation.trigger` service & `python_script`'s, too.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
