### PR TITLE
Cover group considers opening and closing states

### DIFF
--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -28,7 +28,9 @@ from homeassistant.const import (
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
     STATE_CLOSED,
+    STATE_CLOSING,
     STATE_OPEN,
+    STATE_OPENING,
 )
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -41,7 +43,7 @@ DEMO_COVER_POS = "cover.hall_window"
 DEMO_COVER_TILT = "cover.living_room_window"
 DEMO_TILT = "cover.tilt_demo"
 
-CONFIG = {
+CONFIG_ALL = {
     DOMAIN: [
         {"platform": "demo"},
         {
@@ -51,28 +53,36 @@ CONFIG = {
     ]
 }
 
+CONFIG_POS = {
+    DOMAIN: [
+        {"platform": "demo"},
+        {
+            "platform": "group",
+            CONF_ENTITIES: [DEMO_COVER_POS, DEMO_COVER_TILT, DEMO_TILT],
+        },
+    ]
+}
+
+CONFIG_ATTRIBUTES = {
+    DOMAIN: {
+        "platform": "group",
+        CONF_ENTITIES: [DEMO_COVER, DEMO_COVER_POS, DEMO_COVER_TILT, DEMO_TILT],
+    }
+}
+
 
 @pytest.fixture
-async def setup_comp(hass):
+async def setup_comp(hass, config_count):
     """Set up group cover component."""
-    with assert_setup_component(2, DOMAIN):
-        await async_setup_component(hass, DOMAIN, CONFIG)
+    config, count = config_count
+    with assert_setup_component(count, DOMAIN):
+        await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
 
-async def test_attributes(hass):
+@pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
+async def test_attributes(hass, setup_comp):
     """Test handling of state attributes."""
-    config = {
-        DOMAIN: {
-            "platform": "group",
-            CONF_ENTITIES: [DEMO_COVER, DEMO_COVER_POS, DEMO_COVER_TILT, DEMO_TILT],
-        }
-    }
-
-    with assert_setup_component(1, DOMAIN):
-        await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
-
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_CLOSED
     assert state.attributes[ATTR_FRIENDLY_NAME] == DEFAULT_NAME
@@ -193,11 +203,13 @@ async def test_attributes(hass):
     assert state.attributes[ATTR_ASSUMED_STATE] is True
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_open_covers(hass, setup_comp):
     """Test open cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
     )
+
     for _ in range(10):
         future = dt_util.utcnow() + timedelta(seconds=1)
         async_fire_time_changed(hass, future)
@@ -212,11 +224,13 @@ async def test_open_covers(hass, setup_comp):
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 100
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_close_covers(hass, setup_comp):
     """Test close cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
     )
+
     for _ in range(10):
         future = dt_util.utcnow() + timedelta(seconds=1)
         async_fire_time_changed(hass, future)
@@ -231,6 +245,7 @@ async def test_close_covers(hass, setup_comp):
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 0
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_toggle_covers(hass, setup_comp):
     """Test toggle cover function."""
     # Start covers in open state
@@ -280,6 +295,7 @@ async def test_toggle_covers(hass, setup_comp):
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 100
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_stop_covers(hass, setup_comp):
     """Test stop cover function."""
     await hass.services.async_call(
@@ -305,6 +321,7 @@ async def test_stop_covers(hass, setup_comp):
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 80
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_set_cover_position(hass, setup_comp):
     """Test set cover position function."""
     await hass.services.async_call(
@@ -327,6 +344,7 @@ async def test_set_cover_position(hass, setup_comp):
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 50
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_open_tilts(hass, setup_comp):
     """Test open tilt function."""
     await hass.services.async_call(
@@ -346,6 +364,7 @@ async def test_open_tilts(hass, setup_comp):
     )
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_close_tilts(hass, setup_comp):
     """Test close tilt function."""
     await hass.services.async_call(
@@ -363,6 +382,7 @@ async def test_close_tilts(hass, setup_comp):
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_toggle_tilts(hass, setup_comp):
     """Test toggle tilt function."""
     # Start tilted open
@@ -415,6 +435,7 @@ async def test_toggle_tilts(hass, setup_comp):
     )
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_stop_tilts(hass, setup_comp):
     """Test stop tilts function."""
     await hass.services.async_call(
@@ -438,6 +459,7 @@ async def test_stop_tilts(hass, setup_comp):
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_TILT_POSITION] == 60
 
 
+@pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
 async def test_set_tilt_positions(hass, setup_comp):
     """Test set tilt position function."""
     await hass.services.async_call(
@@ -456,3 +478,27 @@ async def test_set_tilt_positions(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 80
 
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_TILT_POSITION] == 80
+
+
+@pytest.mark.parametrize("config_count", [(CONFIG_POS, 2)])
+async def test_is_opening(hass, setup_comp):
+    """Test is_opening property."""
+    await hass.services.async_call(
+        DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
+    )
+
+    assert hass.states.get(COVER_GROUP).state == STATE_OPENING
+    assert hass.states.get(DEMO_COVER_POS).state == STATE_OPENING
+    assert hass.states.get(DEMO_COVER_TILT).state == STATE_OPENING
+
+
+@pytest.mark.parametrize("config_count", [(CONFIG_POS, 2)])
+async def test_is_closing(hass, setup_comp):
+    """Test is_closing property."""
+    await hass.services.async_call(
+        DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
+    )
+
+    assert hass.states.get(COVER_GROUP).state == STATE_CLOSING
+    assert hass.states.get(DEMO_COVER_POS).state == STATE_CLOSING
+    assert hass.states.get(DEMO_COVER_TILT).state == STATE_CLOSING


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The `is_opening` and `is_closing` properties are not implemented for the cover platform of the group component. Therefore the group entity does not react to the opening and closing states of the grouped cover entities.
In the implementation I followed the behavior of the `is_closed` property which changes if only one of the grouped entities is in a closed state. If the grouped entities implement the `is_opening` and `is_closing` properties, the group entity will adopt the corresponding state if only one of the grouped entities changes.
The tests are not changed so this shouldn't be a breaking change in the behavior of the cover group.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
