### PR TITLE
Allow Guardian config flow to be ignored

### DIFF
--- a/homeassistant/components/guardian/config_flow.py
+++ b/homeassistant/components/guardian/config_flow.py
@@ -5,12 +5,27 @@ import voluptuous as vol
 
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
+from homeassistant.core import callback
 
 from .const import CONF_UID, DOMAIN, LOGGER  # pylint:disable=unused-import
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_IP_ADDRESS): str, vol.Required(CONF_PORT, default=7777): int}
 )
+
+UNIQUE_ID = "guardian_{0}"
+
+
+@callback
+def async_get_pin_from_discovery_hostname(hostname):
+    """Get the device's 4-digit PIN from its zeroconf-discovered hostname."""
+    return hostname.split(".")[0].split("-")[1]
+
+
+@callback
+def async_get_pin_from_uid(uid):
+    """Get the device's 4-digit PIN from its UID."""
+    return uid[-4:]
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -22,7 +37,6 @@ async def validate_input(hass: core.HomeAssistant, data):
         ping_data = await client.device.ping()
 
     return {
-        "title": f"Elexa Guardian ({data[CONF_IP_ADDRESS]})",
         CONF_UID: ping_data["data"]["uid"],
     }
 
@@ -37,15 +51,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self.discovery_info = {}
 
+    async def _async_set_unique_id(self, pin):
+        """Set the config entry's unique ID (based on the device's 4-digit PIN)."""
+        await self.async_set_unique_id(UNIQUE_ID.format(pin))
+        self._abort_if_unique_id_configured()
+
     async def async_step_user(self, user_input=None):
         """Handle configuration via the UI."""
         if user_input is None:
             return self.async_show_form(
                 step_id="user", data_schema=DATA_SCHEMA, errors={}
             )
-
-        await self.async_set_unique_id(user_input[CONF_IP_ADDRESS])
-        self._abort_if_unique_id_configured()
 
         try:
             info = await validate_input(self.hass, user_input)
@@ -57,8 +73,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors={CONF_IP_ADDRESS: "cannot_connect"},
             )
 
+        pin = async_get_pin_from_uid(info[CONF_UID])
+        await self._async_set_unique_id(pin)
+
         return self.async_create_entry(
-            title=info["title"], data={CONF_UID: info["uid"], **user_input}
+            title=info[CONF_UID], data={CONF_UID: info["uid"], **user_input}
         )
 
     async def async_step_zeroconf(self, discovery_info=None):
@@ -66,19 +85,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if discovery_info is None:
             return self.async_abort(reason="connection_error")
 
-        ip_address = discovery_info["host"]
+        pin = async_get_pin_from_discovery_hostname(discovery_info["hostname"])
+        await self._async_set_unique_id(pin)
 
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-        self.context[CONF_IP_ADDRESS] = ip_address
+        self.context[CONF_IP_ADDRESS] = discovery_info["host"]
 
         if any(
-            ip_address == flow["context"][CONF_IP_ADDRESS]
+            discovery_info["host"] == flow["context"][CONF_IP_ADDRESS]
             for flow in self._async_in_progress()
         ):
             return self.async_abort(reason="already_in_progress")
 
         self.discovery_info = {
-            CONF_IP_ADDRESS: ip_address,
+            CONF_IP_ADDRESS: discovery_info["host"],
             CONF_PORT: discovery_info["port"],
         }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability for Guardian config flows to be ignored. Note that this PR revises the unique ID originally set by https://github.com/home-assistant/core/pull/34627; this would normally be a breaking change, but since https://github.com/home-assistant/core/pull/34627 hasn't been included in a release yet (and I intend to merge this prior to the next release), there isn't anything to be concerned about.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
