### PR TITLE
Periodically log when integrations are taking a while to setup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -32,7 +32,7 @@ ERROR_LOG_FILENAME = "home-assistant.log"
 # hass.data key for logging information.
 DATA_LOGGING = "logging"
 
-LOG_SLOW_STARTUP_INTERVAL = 30
+LOG_SLOW_STARTUP_INTERVAL = 60
 
 DEBUGGER_INTEGRATIONS = {"ptvsd"}
 CORE_INTEGRATIONS = ("homeassistant", "persistent_notification")

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -325,7 +325,7 @@ async def _async_set_up_integrations(
 ) -> None:
     """Set up all the integrations."""
 
-    hass.data[DATA_SETUP_STARTED] = {}
+    setup_started = hass.data[DATA_SETUP_STARTED] = {}
 
     async def async_setup_multi_components(domains: Set[str]) -> None:
         """Set up multiple domains. Log on failure."""
@@ -334,12 +334,8 @@ async def _async_set_up_integrations(
             """Periodic log of setups that are pending for longer than LOG_SLOW_STARTUP_INTERVAL."""
             while True:
                 await asyncio.sleep(LOG_SLOW_STARTUP_INTERVAL)
-                remaining = [
-                    domain
-                    for domain in domains
-                    if domain not in hass.config.components
-                    and domain in hass.data[DATA_SETUP_STARTED]
-                ]
+                remaining = [domain for domain in domains if domain in setup_started]
+
                 if remaining:
                     _LOGGER.info(
                         "Waiting on integrations to complete setup: %s",


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When one or more integrations are taking a while to setup
it is hard to determine which one is the cause.  We can
help narrow this down for the user with a periodic log
message about which domains are still waiting to be setup
every 30s.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

# Example logging
```
2020-05-27 23:25:54 INFO (MainThread) [homeassistant.setup] Setting up nut
2020-05-27 23:25:54 INFO (MainThread) [homeassistant.setup] Setting up nws
2020-05-27 23:25:54 INFO (MainThread) [homeassistant.setup] Setup of domain nut took 0.3 seconds.
2020-05-27 23:26:04 WARNING (MainThread) [homeassistant.setup] Setup of nws is taking over 10 seconds.
2020-05-27 23:26:24 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:26:54 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:27:24 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:27:54 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:28:24 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:28:54 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:29:24 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:29:54 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:30:24 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:30:54 INFO (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: sensor, nut, climate, nws
2020-05-27 23:30:56 INFO (MainThread) [homeassistant.components.sensor] Setting up sensor.nut
2020-05-27 23:30:56 INFO (MainThread) [homeassistant.components.sensor] Setting up sensor.nut
2020-05-27 23:30:59 INFO (MainThread) [homeassistant.setup] Setup of domain nws took 305.1 seconds.
2020-05-27 23:31:02 INFO (MainThread) [homeassistant.components.weather] Setting up weather.nws
2020-05-27 23:31:03 INFO (MainThread) [homeassistant.bootstrap] Home Assistant initialized in 310.82s
```

Maybe something like this


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35924
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
