### PR TITLE
Use new elkm1-lib module's LD log data support to correctly identify user_ids

### DIFF
--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -160,7 +160,7 @@ class ElkArea(ElkAttachedEntity, AlarmControlPanelEntity, RestoreEntity):
         _LOGGER.warning("alarm_control_panel::watch_area: %s", changeset)
         self._changed_by_keypad = None
         self._changed_by_id = area.log_number + 1
-        self._change_by = username(self._elk, area.log_number)
+        self._changed_by = username(self._elk, area.log_number)
         self._changed_by_time = "%04d-%02d-%02dT%02d:%02d" % (
             area.log_year, area.log_month, area.log_day,
             area.log_hour, area.log_minute

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -157,7 +157,6 @@ class ElkArea(ElkAttachedEntity, AlarmControlPanelEntity, RestoreEntity):
     def _watch_area(self, area, changeset):
         if not changeset.get("log_event"):
             return
-        _LOGGER.warning("alarm_control_panel::watch_area: %s", changeset)
         self._changed_by_keypad = None
         self._changed_by_id = area.log_number
         self._changed_by = username(self._elk, area.log_number - 1)

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -161,8 +161,11 @@ class ElkArea(ElkAttachedEntity, AlarmControlPanelEntity, RestoreEntity):
         self._changed_by_id = area.log_number
         self._changed_by = username(self._elk, area.log_number - 1)
         self._changed_by_time = "%04d-%02d-%02dT%02d:%02d" % (
-            area.log_year, area.log_month, area.log_day,
-            area.log_hour, area.log_minute
+            area.log_year,
+            area.log_month,
+            area.log_day,
+            area.log_hour,
+            area.log_minute,
         )
         self.async_write_ha_state()
 

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -125,7 +125,7 @@ class ElkArea(ElkAttachedEntity, AlarmControlPanelEntity, RestoreEntity):
     async def async_added_to_hass(self):
         """Register callback for ElkM1 changes."""
         await super().async_added_to_hass()
-        if len(self._elk.areas) == 1:
+        if len(self._elk.areas.elements) == 1:
             for keypad in self._elk.keypads:
                 keypad.add_callback(self._watch_keypad)
         self._element.add_callback(self._watch_area)

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -159,8 +159,8 @@ class ElkArea(ElkAttachedEntity, AlarmControlPanelEntity, RestoreEntity):
             return
         _LOGGER.warning("alarm_control_panel::watch_area: %s", changeset)
         self._changed_by_keypad = None
-        self._changed_by_id = area.log_number + 1
-        self._changed_by = username(self._elk, area.log_number)
+        self._changed_by_id = area.log_number
+        self._changed_by = username(self._elk, area.log_number - 1)
         self._changed_by_time = "%04d-%02d-%02dT%02d:%02d" % (
             area.log_year, area.log_month, area.log_day,
             area.log_hour, area.log_minute

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -125,8 +125,10 @@ class ElkArea(ElkAttachedEntity, AlarmControlPanelEntity, RestoreEntity):
     async def async_added_to_hass(self):
         """Register callback for ElkM1 changes."""
         await super().async_added_to_hass()
-        for keypad in self._elk.keypads:
-            keypad.add_callback(self._watch_keypad)
+        if len(self._elk.areas) == 1:
+            for keypad in self._elk.keypads:
+                keypad.add_callback(self._watch_keypad)
+        self._element.add_callback(self._watch_area)
 
         # We do not get changed_by back from resync.
         last_state = await self.async_get_last_state()
@@ -151,6 +153,19 @@ class ElkArea(ElkAttachedEntity, AlarmControlPanelEntity, RestoreEntity):
             self._changed_by_id = keypad.last_user + 1
             self._changed_by = username(self._elk, keypad.last_user)
             self.async_write_ha_state()
+
+    def _watch_area(self, area, changeset):
+        if not changeset.get("log_event"):
+            return
+        _LOGGER.warning("alarm_control_panel::watch_area: %s", changeset)
+        self._changed_by_keypad = None
+        self._changed_by_id = area.log_number + 1
+        self._change_by = username(self._elk, area.log_number)
+        self._changed_by_time = "%04d-%02d-%02dT%02d:%02d" % (
+            area.log_year, area.log_month, area.log_day,
+            area.log_hour, area.log_minute
+        )
+        self.async_write_ha_state()
 
     @property
     def code_format(self):

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -2,7 +2,7 @@
   "domain": "elkm1",
   "name": "Elk-M1 Control",
   "documentation": "https://www.home-assistant.io/integrations/elkm1",
-  "requirements": ["elkm1-lib==0.7.17"],
+  "requirements": ["elkm1-lib==0.7.18"],
   "codeowners": ["@bdraco"],
   "config_flow": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -523,7 +523,7 @@ elgato==0.2.0
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==0.7.17
+elkm1-lib==0.7.18
 
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -230,7 +230,7 @@ eebrightbox==0.0.4
 elgato==0.2.0
 
 # homeassistant.components.elkm1
-elkm1-lib==0.7.17
+elkm1-lib==0.7.18
 
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes a bad bug in the behaviour of systems with multiple areas where the wrong user_id would be listed in the changed_by and changed_by_id attributes of a panel.  The old code is still used for and only for the case where there is exactly one area configured (since that works).  The new code requires ensuring the event log setting is turned on for serial interfaces.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

https://github.com/home-assistant/core/issues/35310

- Link to documentation pull request: 

https://github.com/home-assistant/home-assistant.io/pull/13613

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
