### PR TITLE
Fix SP2-CL (0x7544) sensor update

### DIFF
--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -265,13 +265,18 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
         """Update the state of the device."""
         try:
             self._state = await self.device.async_request(self.device.api.check_power)
+        except BroadlinkException as err_msg:
+            _LOGGER.error("Failed to update state: %s", err_msg)
+            return
+
+        try:
             self._load_power = await self.device.async_request(
                 self.device.api.get_energy
             )
         except CommandNotSupportedError:
             return
         except BroadlinkException as err_msg:
-            _LOGGER.error("Failed to update state: %s", err_msg)
+            _LOGGER.error("Failed to update load power: %s", err_msg)
 
 
 class BroadlinkMP1Slot(BroadlinkRMSwitch):

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -4,7 +4,7 @@ from ipaddress import ip_address
 import logging
 
 import broadlink as blk
-from broadlink.exceptions import BroadlinkException
+from broadlink.exceptions import BroadlinkException, CommandNotSupportedError
 import voluptuous as vol
 
 from homeassistant.components.switch import DOMAIN, PLATFORM_SCHEMA, SwitchEntity
@@ -264,13 +264,12 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
     async def async_update(self):
         """Update the state of the device."""
         try:
-            state = await self.device.async_request(self.device.api.check_power)
-            load_power = await self.device.async_request(self.device.api.get_energy)
+            self._state = await self.device.async_request(self.device.api.check_power)
+            self._load_power = await self.device.async_request(self.device.api.get_energy)
+        except CommandNotSupportedError:
+            return
         except BroadlinkException as err_msg:
             _LOGGER.error("Failed to update state: %s", err_msg)
-            return
-        self._state = state
-        self._load_power = load_power
 
 
 class BroadlinkMP1Slot(BroadlinkRMSwitch):

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -265,7 +265,9 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
         """Update the state of the device."""
         try:
             self._state = await self.device.async_request(self.device.api.check_power)
-            self._load_power = await self.device.async_request(self.device.api.get_energy)
+            self._load_power = await self.device.async_request(
+                self.device.api.get_energy
+            )
         except CommandNotSupportedError:
             return
         except BroadlinkException as err_msg:


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SP2-CL (0x7544) does not support get_energy(). We need to ignore the CommandNotSupportedError in the update method.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
switch:
  - platform: broadlink
    host: 192.168.0.12
    mac: C8-F7-42-1B-4F-3D
    type: sp2
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/36180
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
