### PR TITLE
Do async_setup_platform in background

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -34,6 +34,7 @@ from homeassistant.components.stream.const import (
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_FILENAME,
+    EVENT_HOMEASSISTANT_START,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
@@ -48,7 +49,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.network import get_url
 from homeassistant.loader import bind_hass
-from homeassistant.setup import async_when_setup
 
 from .const import DATA_CAMERA_PREFS, DOMAIN
 from .prefs import CameraPreferences
@@ -259,7 +259,7 @@ async def async_setup(hass, config):
 
     await component.async_setup(config)
 
-    async def preload_stream(hass, _):
+    async def preload_stream(_):
         for camera in component.entities:
             camera_prefs = prefs.get(camera.entity_id)
             if not camera_prefs.preload_stream:
@@ -273,7 +273,7 @@ async def async_setup(hass, config):
 
             request_stream(hass, source, keepalive=True, options=camera.stream_options)
 
-    async_when_setup(hass, DOMAIN_STREAM, preload_stream)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, preload_stream)
 
     @callback
     def update_tokens(time):

--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -74,9 +74,10 @@ async def async_setup(hass, config):
 
     if hass.is_running:
         await activate_on_start(None)
-        return True
+    else:
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, activate_on_start)
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, activate_on_start)
+    return True
 
 
 async def activate_automation(

--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_START,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_HOME,
@@ -59,17 +60,34 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the triggers to control lights based on device presence."""
+    conf = config[DOMAIN]
+    disable_turn_off = conf[CONF_DISABLE_TURN_OFF]
+    light_group = conf.get(CONF_LIGHT_GROUP)
+    light_profile = conf[CONF_LIGHT_PROFILE]
+    device_group = conf.get(CONF_DEVICE_GROUP)
+
+    async def activate_on_start(_):
+        """Activate automation."""
+        await activate_automation(
+            hass, device_group, light_group, light_profile, disable_turn_off
+        )
+
+    if hass.is_running:
+        await activate_on_start(None)
+        return True
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, activate_on_start)
+
+
+async def activate_automation(
+    hass, device_group, light_group, light_profile, disable_turn_off
+):
+    """Activate the automation."""
     logger = logging.getLogger(__name__)
     device_tracker = hass.components.device_tracker
     group = hass.components.group
     light = hass.components.light
     person = hass.components.person
-    conf = config[DOMAIN]
-    disable_turn_off = conf[CONF_DISABLE_TURN_OFF]
-    light_group = conf.get(CONF_LIGHT_GROUP)
-    light_profile = conf[CONF_LIGHT_PROFILE]
-
-    device_group = conf.get(CONF_DEVICE_GROUP)
 
     if device_group is None:
         device_entity_ids = hass.states.async_entity_ids(device_tracker.DOMAIN)
@@ -79,7 +97,7 @@ async def async_setup(hass, config):
 
     if not device_entity_ids:
         logger.error("No devices found to track")
-        return False
+        return
 
     # Get the light IDs from the specified group
     if light_group is None:
@@ -89,7 +107,7 @@ async def async_setup(hass, config):
 
     if not light_ids:
         logger.error("No lights found to turn on")
-        return False
+        return
 
     @callback
     def anyone_home():
@@ -219,7 +237,7 @@ async def async_setup(hass, config):
     )
 
     if disable_turn_off:
-        return True
+        return
 
     @callback
     def turn_off_lights_when_all_leave(entity, old_state, new_state):
@@ -247,4 +265,4 @@ async def async_setup(hass, config):
         STATE_NOT_HOME,
     )
 
-    return True
+    return

--- a/homeassistant/components/websocket_api/sensor.py
+++ b/homeassistant/components/websocket_api/sensor.py
@@ -24,7 +24,7 @@ class APICount(Entity):
 
     def __init__(self):
         """Initialize the API count."""
-        self.count = None
+        self.count = 0
 
     async def async_added_to_hass(self):
         """Added to hass."""
@@ -38,7 +38,6 @@ class APICount(Entity):
                 SIGNAL_WEBSOCKET_DISCONNECTED, self._update_count
             )
         )
-        self._update_count()
 
     @property
     def name(self):

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -291,7 +291,7 @@ class MiroboVacuum(StateVacuumEntity):
     @property
     def fan_speed_list(self):
         """Get the list of available fan speed steps of the vacuum cleaner."""
-        return list(self._fan_speeds)
+        return list(self._fan_speeds) if self._fan_speeds else []
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -123,15 +123,11 @@ class EntityComponent:
         self.config = config
 
         # Look in config for Domain, Domain 2, Domain 3 etc and load them
-        tasks = []
         for p_type, p_config in config_per_platform(config, self.domain):
-            tasks.append(self.async_setup_platform(p_type, p_config))
-
-        if tasks:
-            await asyncio.gather(*tasks)
+            self.hass.async_create_task(self.async_setup_platform(p_type, p_config))
 
         # Generic discovery listener for loading platform dynamically
-        # Refer to: homeassistant.components.discovery.load_platform()
+        # Refer to: homeassistant.helpers.discovery.async_load_platform()
         async def component_platform_discovered(
             platform: str, info: Optional[Dict[str, Any]]
         ) -> None:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -4,7 +4,7 @@ from contextvars import ContextVar
 from datetime import datetime, timedelta
 from logging import Logger
 from types import ModuleType
-from typing import TYPE_CHECKING, Dict, Iterable, Optional
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.core import CALLBACK_TYPE, callback, split_entity_id, valid_entity_id
@@ -51,6 +51,7 @@ class EntityPlatform:
         self.entity_namespace = entity_namespace
         self.config_entry = None
         self.entities: Dict[str, Entity] = {}  # pylint: disable=used-before-assignment
+        self._tasks: List[asyncio.Future] = []
         # Method to cancel the state change listener
         self._async_unsub_polling: Optional[CALLBACK_TYPE] = None
         # Method to cancel the retry of setup
@@ -176,6 +177,14 @@ class EntityPlatform:
 
             await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)
 
+            # Block till all entities are done
+            if self._tasks:
+                pending = [task for task in self._tasks if not task.done()]
+                self._tasks.clear()
+
+                if pending:
+                    await asyncio.gather(*pending)
+
             hass.config.components.add(full_name)
             return True
         except PlatformNotReady:
@@ -230,8 +239,12 @@ class EntityPlatform:
         self, new_entities: Iterable["Entity"], update_before_add: bool = False
     ) -> None:
         """Schedule adding entities for a single platform async."""
-        self.hass.async_create_task(
-            self.async_add_entities(new_entities, update_before_add=update_before_add),
+        self._tasks.append(
+            self.hass.async_create_task(
+                self.async_add_entities(
+                    new_entities, update_before_add=update_before_add
+                ),
+            )
         )
 
     def add_entities(

--- a/tests/components/air_quality/test_air_quality.py
+++ b/tests/components/air_quality/test_air_quality.py
@@ -17,6 +17,7 @@ async def test_state(hass):
     config = {"air_quality": {"platform": "demo"}}
 
     assert await async_setup_component(hass, "air_quality", config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("air_quality.demo_air_quality_home")
     assert state is not None
@@ -29,6 +30,7 @@ async def test_attributes(hass):
     config = {"air_quality": {"platform": "demo"}}
 
     assert await async_setup_component(hass, "air_quality", config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("air_quality.demo_air_quality_office")
     assert state is not None

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -111,8 +111,11 @@ async def test_migration(hass):
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
-    with patch("pyairvisual.api.API.nearest_city"):
+    with patch("pyairvisual.api.API.nearest_city"), patch.object(
+        hass.config_entries, "async_forward_entry_setup"
+    ):
         assert await async_setup_component(hass, DOMAIN, {DOMAIN: conf})
+        await hass.async_block_till_done()
 
     config_entries = hass.config_entries.async_entries(DOMAIN)
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -55,19 +55,19 @@ def events(hass):
 
 
 @pytest.fixture
-def mock_camera(hass):
+async def mock_camera(hass):
     """Initialize a demo camera platform."""
-    assert hass.loop.run_until_complete(
-        async_setup_component(hass, "camera", {camera.DOMAIN: {"platform": "demo"}})
+    assert await async_setup_component(
+        hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
 
 @pytest.fixture
-def mock_stream(hass):
+async def mock_stream(hass):
     """Initialize a demo camera platform with streaming."""
-    assert hass.loop.run_until_complete(
-        async_setup_component(hass, "stream", {"stream": {}})
-    )
+    assert await async_setup_component(hass, "stream", {"stream": {}})
+    await hass.async_block_till_done()
 
 
 def test_create_api_message_defaults(hass):

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -116,6 +116,7 @@ async def _test_reconnect(hass, caplog, config):
         patch_key
     ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -187,6 +188,7 @@ async def _test_adb_shell_returns_none(hass, config):
         patch_key
     ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -295,6 +297,7 @@ async def test_setup_with_adbkey(hass):
         patch_key
     ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER, patchers.PATCH_ISFILE, patchers.PATCH_ACCESS:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -315,6 +318,7 @@ async def _test_sources(hass, config0):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -395,6 +399,7 @@ async def _test_exclude_sources(hass, config0, expected_sources):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -463,6 +468,7 @@ async def _test_select_source(hass, config0, source, expected_arg, method_patch)
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -666,6 +672,7 @@ async def _test_setup_fail(hass, config):
         patch_key
     ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is None
@@ -698,6 +705,7 @@ async def test_setup_two_devices(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
         for entity_id in ["media_player.android_tv", "media_player.fire_tv"]:
             await hass.helpers.entity_component.async_update_entity(entity_id)
@@ -714,6 +722,7 @@ async def test_setup_same_device_twice(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
         state = hass.states.get(entity_id)
         assert state is not None
 
@@ -723,6 +732,7 @@ async def test_setup_same_device_twice(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
 
 async def test_adb_command(hass):
@@ -735,6 +745,7 @@ async def test_adb_command(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patch(
         "androidtv.basetv.BaseTV.adb_shell", return_value=response
@@ -762,6 +773,7 @@ async def test_adb_command_unicode_decode_error(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patch(
         "androidtv.basetv.BaseTV.adb_shell",
@@ -791,6 +803,7 @@ async def test_adb_command_key(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patch(
         "androidtv.basetv.BaseTV.adb_shell", return_value=response
@@ -819,6 +832,7 @@ async def test_adb_command_get_properties(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patch(
         "androidtv.androidtv.AndroidTV.get_properties_dict", return_value=response
@@ -844,6 +858,7 @@ async def test_update_lock_not_acquired(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patchers.patch_shell("")[patch_key]:
         await hass.helpers.entity_component.async_update_entity(entity_id)
@@ -877,6 +892,7 @@ async def test_download(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     # Failed download because path is not whitelisted
     with patch("androidtv.basetv.BaseTV.adb_pull") as patch_pull:
@@ -919,6 +935,7 @@ async def test_upload(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     # Failed upload because path is not whitelisted
     with patch("androidtv.basetv.BaseTV.adb_push") as patch_push:
@@ -959,6 +976,7 @@ async def test_androidtv_volume_set(hass):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patch(
         "androidtv.basetv.BaseTV.set_volume_level", return_value=0.5
@@ -984,6 +1002,7 @@ async def test_get_image(hass, hass_ws_client):
         patch_key
     ], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_ADB_SERVER)
+        await hass.async_block_till_done()
 
     with patchers.patch_shell("11")[patch_key]:
         await hass.helpers.entity_component.async_update_entity(entity_id)

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -45,6 +45,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.block_till_done()
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
         assert state.attributes.get("observations")[0]["prob_given_true"] == 0.8
@@ -75,6 +76,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         self.hass.block_till_done()
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test_binary")
         assert state.attributes.get("observations") == []
@@ -107,6 +109,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_monitored", 4)
         self.hass.block_till_done()
@@ -173,6 +176,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_monitored", "on")
 
@@ -227,6 +231,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_monitored", "on")
 
@@ -281,6 +286,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_monitored", "on")
         self.hass.block_till_done()
@@ -318,6 +324,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_monitored", "off")
 
@@ -401,6 +408,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_monitored", "on")
         self.hass.block_till_done()
@@ -452,6 +460,7 @@ class TestBayesianBinarySensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_monitored", "on")
         self.hass.block_till_done()

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -104,6 +104,7 @@ async def test_if_state(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -180,6 +181,7 @@ async def test_if_fires_on_for_condition(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -103,6 +103,7 @@ async def test_if_fires_on_state_change(hass, calls):
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -187,6 +188,7 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 

--- a/tests/components/bom/test_sensor.py
+++ b/tests/components/bom/test_sensor.py
@@ -70,6 +70,7 @@ class TestBOMWeatherSensor(unittest.TestCase):
         """Test the setup with custom settings."""
         with assert_setup_component(1, sensor.DOMAIN):
             assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
+            self.hass.block_till_done()
 
         fake_entities = [
             "bom_fake_feels_like_c",
@@ -85,6 +86,7 @@ class TestBOMWeatherSensor(unittest.TestCase):
     def test_sensor_values(self, mock_get):
         """Test retrieval of sensor values."""
         assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
+        self.hass.block_till_done()
 
         weather = self.hass.states.get("sensor.bom_fake_weather").state
         assert "Fine" == weather

--- a/tests/components/buienradar/test_sensor.py
+++ b/tests/components/buienradar/test_sensor.py
@@ -19,6 +19,7 @@ BASE_CONFIG = {
 async def test_smoke_test_setup_component(hass):
     """Smoke test for successfully set-up with default config."""
     assert await async_setup_component(hass, sensor.DOMAIN, BASE_CONFIG)
+    await hass.async_block_till_done()
 
     for cond in CONDITIONS:
         state = hass.states.get(f"sensor.volkel_{cond}")

--- a/tests/components/buienradar/test_weather.py
+++ b/tests/components/buienradar/test_weather.py
@@ -19,6 +19,7 @@ BASE_CONFIG = {
 async def test_smoke_test_setup_component(hass):
     """Smoke test for successfully set-up with default config."""
     assert await async_setup_component(hass, weather.DOMAIN, BASE_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get("weather.volkel")
     assert state.state == "unknown"

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -8,6 +8,7 @@ import homeassistant.util.dt as dt_util
 async def test_events_http_api(hass, hass_client):
     """Test the calendar demo view."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
     client = await hass_client()
     response = await client.get("/api/calendars/calendar.calendar_2")
     assert response.status == 400
@@ -27,6 +28,7 @@ async def test_events_http_api(hass, hass_client):
 async def test_calendars_http_api(hass, hass_client):
     """Test the calendar demo view."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
     client = await hass_client()
     response = await client.get("/api/calendars")
     assert response.status == 200

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -19,11 +19,12 @@ from tests.components.camera import common
 
 
 @pytest.fixture(name="mock_camera")
-def mock_camera_fixture(hass):
+async def mock_camera_fixture(hass):
     """Initialize a demo camera platform."""
-    assert hass.loop.run_until_complete(
-        async_setup_component(hass, "camera", {camera.DOMAIN: {"platform": "demo"}})
+    assert await async_setup_component(
+        hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     with patch(
         "homeassistant.components.demo.camera.Path.read_bytes", return_value=b"Test",
@@ -51,6 +52,7 @@ async def image_mock_url_fixture(hass):
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
 
 async def test_get_image_from_camera(hass, image_mock_url):
@@ -311,7 +313,10 @@ async def test_preload_stream(hass, mock_stream):
         "homeassistant.components.demo.camera.DemoCamera.stream_source",
         return_value="http://example.com",
     ):
-        await async_setup_component(hass, "camera", {DOMAIN: {"platform": "demo"}})
+        assert await async_setup_component(
+            hass, "camera", {DOMAIN: {"platform": "demo"}}
+        )
+        await hass.async_block_till_done()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
         assert mock_request_stream.called

--- a/tests/components/coinmarketcap/test_sensor.py
+++ b/tests/components/coinmarketcap/test_sensor.py
@@ -36,6 +36,7 @@ class TestCoinMarketCapSensor(unittest.TestCase):
         """Test the setup with custom settings."""
         with assert_setup_component(1, sensor.DOMAIN):
             assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
+            self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.ethereum")
         assert state is not None

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -68,6 +68,7 @@ async def test_state_value(hass):
             )
             is True
         )
+        await hass.async_block_till_done()
 
         assert "unknown" == hass.states.get("cover.test").state
 

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -43,6 +43,7 @@ class TestCommandSwitch(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
 
             state = self.hass.states.get("switch.test")
             assert STATE_OFF == state.state
@@ -79,6 +80,7 @@ class TestCommandSwitch(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
 
             state = self.hass.states.get("switch.test")
             assert STATE_OFF == state.state
@@ -117,6 +119,7 @@ class TestCommandSwitch(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
 
             state = self.hass.states.get("switch.test")
             assert STATE_OFF == state.state
@@ -152,7 +155,7 @@ class TestCommandSwitch(unittest.TestCase):
                     }
                 },
             )
-
+            self.hass.block_till_done()
             state = self.hass.states.get("switch.test")
             assert STATE_OFF == state.state
 

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -454,6 +454,7 @@ async def test_if_position(hass, calls):
     platform.init()
     ent = platform.ENTITIES[1]
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     assert await async_setup_component(
         hass,
@@ -557,6 +558,7 @@ async def test_if_tilt_position(hass, calls):
     platform.init()
     ent = platform.ENTITIES[2]
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     assert await async_setup_component(
         hass,

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -464,6 +464,7 @@ async def test_if_fires_on_position(hass, calls):
     platform.init()
     ent = platform.ENTITIES[1]
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     assert await async_setup_component(
         hass,
@@ -586,6 +587,7 @@ async def test_if_fires_on_tilt_position(hass, calls):
     platform.init()
     ent = platform.ENTITIES[1]
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     assert await async_setup_component(
         hass,

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -117,6 +117,7 @@ class TestDarkSkySetup(unittest.TestCase):
     def test_setup_with_config(self):
         """Test the platform setup with configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_MINIMAL)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.dark_sky_summary")
         assert state is not None
@@ -124,6 +125,7 @@ class TestDarkSkySetup(unittest.TestCase):
     def test_setup_with_invalid_config(self):
         """Test the platform setup with invalid configuration."""
         setup_component(self.hass, "sensor", INVALID_CONFIG_MINIMAL)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.dark_sky_summary")
         assert state is None
@@ -135,6 +137,7 @@ class TestDarkSkySetup(unittest.TestCase):
     def test_setup_with_language_config(self):
         """Test the platform setup with language configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_LANG_DE)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.dark_sky_summary")
         assert state is not None
@@ -142,6 +145,7 @@ class TestDarkSkySetup(unittest.TestCase):
     def test_setup_with_invalid_language_config(self):
         """Test the platform setup with language configuration."""
         setup_component(self.hass, "sensor", INVALID_CONFIG_LANG)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.dark_sky_summary")
         assert state is None
@@ -169,6 +173,7 @@ class TestDarkSkySetup(unittest.TestCase):
     def test_setup_with_alerts_config(self):
         """Test the platform setup with alert configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG_ALERTS)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.dark_sky_alerts")
         assert state.state == "0"
@@ -184,6 +189,7 @@ class TestDarkSkySetup(unittest.TestCase):
         mock_req.get(re.compile(uri), text=load_fixture("darksky.json"))
 
         assert setup_component(self.hass, "sensor", VALID_CONFIG_MINIMAL)
+        self.hass.block_till_done()
 
         assert mock_get_forecast.called
         assert mock_get_forecast.call_count == 1

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -43,6 +43,7 @@ class TestDarkSky(unittest.TestCase):
             weather.DOMAIN,
             {"weather": {"name": "test", "platform": "darksky", "api_key": "foo"}},
         )
+        self.hass.block_till_done()
 
         assert mock_get_forecast.called
         assert mock_get_forecast.call_count == 1
@@ -59,6 +60,7 @@ class TestDarkSky(unittest.TestCase):
             weather.DOMAIN,
             {"weather": {"name": "test", "platform": "darksky", "api_key": "foo"}},
         )
+        self.hass.block_till_done()
 
         state = self.hass.states.get("weather.test")
         assert state.state == "unavailable"

--- a/tests/components/demo/test_camera.py
+++ b/tests/components/demo/test_camera.py
@@ -22,13 +22,12 @@ ENTITY_CAMERA = "camera.demo_camera"
 
 
 @pytest.fixture(autouse=True)
-def demo_camera(hass):
+async def demo_camera(hass):
     """Initialize a demo camera platform."""
-    hass.loop.run_until_complete(
-        async_setup_component(
-            hass, CAMERA_DOMAIN, {CAMERA_DOMAIN: {"platform": DOMAIN}}
-        )
+    assert await async_setup_component(
+        hass, CAMERA_DOMAIN, {CAMERA_DOMAIN: {"platform": DOMAIN}}
     )
+    await hass.async_block_till_done()
 
 
 async def test_init_state_is_streaming(hass):

--- a/tests/components/demo/test_climate.py
+++ b/tests/components/demo/test_climate.py
@@ -43,6 +43,7 @@ async def setup_demo_climate(hass):
     """Initialize setup demo climate."""
     hass.config.units = METRIC_SYSTEM
     assert await async_setup_component(hass, DOMAIN, {"climate": {"platform": "demo"}})
+    await hass.async_block_till_done()
 
 
 def test_setup_params(hass):

--- a/tests/components/demo/test_cover.py
+++ b/tests/components/demo/test_cover.py
@@ -42,6 +42,7 @@ async def setup_comp(hass):
     """Set up demo cover component."""
     with assert_setup_component(1, DOMAIN):
         await async_setup_component(hass, DOMAIN, CONFIG)
+        await hass.async_block_till_done()
 
 
 async def test_supported_features(hass, setup_comp):

--- a/tests/components/demo/test_fan.py
+++ b/tests/components/demo/test_fan.py
@@ -16,11 +16,10 @@ def get_entity(hass):
 
 
 @pytest.fixture(autouse=True)
-def setup_comp(hass):
+async def setup_comp(hass):
     """Initialize components."""
-    hass.loop.run_until_complete(
-        async_setup_component(hass, fan.DOMAIN, {"fan": {"platform": "demo"}})
-    )
+    assert await async_setup_component(hass, fan.DOMAIN, {"fan": {"platform": "demo"}})
+    await hass.async_block_till_done()
 
 
 async def test_turn_on(hass):

--- a/tests/components/demo/test_light.py
+++ b/tests/components/demo/test_light.py
@@ -24,11 +24,12 @@ ENTITY_LIGHT = "light.bed_light"
 
 
 @pytest.fixture(autouse=True)
-def setup_comp(hass):
+async def setup_comp(hass):
     """Set up demo component."""
-    hass.loop.run_until_complete(
-        async_setup_component(hass, LIGHT_DOMAIN, {LIGHT_DOMAIN: {"platform": DOMAIN}})
+    assert await async_setup_component(
+        hass, LIGHT_DOMAIN, {LIGHT_DOMAIN: {"platform": DOMAIN}}
     )
+    await hass.async_block_till_done()
 
 
 async def test_state_attributes(hass):

--- a/tests/components/demo/test_lock.py
+++ b/tests/components/demo/test_lock.py
@@ -21,11 +21,12 @@ OPENABLE_LOCK = "lock.openable_lock"
 
 
 @pytest.fixture(autouse=True)
-def setup_comp(hass):
+async def setup_comp(hass):
     """Set up demo component."""
-    hass.loop.run_until_complete(
-        async_setup_component(hass, LOCK_DOMAIN, {LOCK_DOMAIN: {"platform": DOMAIN}})
+    assert await async_setup_component(
+        hass, LOCK_DOMAIN, {LOCK_DOMAIN: {"platform": DOMAIN}}
     )
+    await hass.async_block_till_done()
 
 
 async def test_locking(hass):

--- a/tests/components/demo/test_media_player.py
+++ b/tests/components/demo/test_media_player.py
@@ -29,6 +29,7 @@ async def test_source_select(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     state = hass.states.get(entity_id)
     assert state.attributes.get("source") == "dvd"
 
@@ -47,6 +48,7 @@ async def test_clear_playlist(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     assert hass.states.is_state(TEST_ENTITY_ID, "playing")
 
     await common.async_clear_playlist(hass, TEST_ENTITY_ID)
@@ -58,6 +60,7 @@ async def test_volume_services(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     state = hass.states.get(TEST_ENTITY_ID)
     assert state.attributes.get("volume_level") == 1.0
 
@@ -95,6 +98,7 @@ async def test_turning_off_and_on(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     assert hass.states.is_state(TEST_ENTITY_ID, "playing")
 
     await common.async_turn_off(hass, TEST_ENTITY_ID)
@@ -114,6 +118,7 @@ async def test_playing_pausing(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     assert hass.states.is_state(TEST_ENTITY_ID, "playing")
 
     await common.async_media_pause(hass, TEST_ENTITY_ID)
@@ -134,6 +139,7 @@ async def test_prev_next_track(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     state = hass.states.get(TEST_ENTITY_ID)
     assert state.attributes.get("media_track") == 1
 
@@ -152,6 +158,7 @@ async def test_prev_next_track(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     ent_id = "media_player.lounge_room"
     state = hass.states.get(ent_id)
     assert state.attributes.get("media_episode") == 1
@@ -170,6 +177,7 @@ async def test_play_media(hass):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     ent_id = "media_player.living_room"
     state = hass.states.get(ent_id)
     assert mp.SUPPORT_PLAY_MEDIA & state.attributes.get("supported_features") > 0
@@ -192,6 +200,7 @@ async def test_seek(hass, mock_media_seek):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     ent_id = "media_player.living_room"
     state = hass.states.get(ent_id)
     assert state.attributes["supported_features"] & mp.SUPPORT_SEEK
@@ -209,6 +218,7 @@ async def test_media_image_proxy(hass, hass_client):
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     fake_picture_data = "test.test"
 

--- a/tests/components/demo/test_remote.py
+++ b/tests/components/demo/test_remote.py
@@ -22,6 +22,7 @@ class TestDemoRemote(unittest.TestCase):
         assert setup_component(
             self.hass, remote.DOMAIN, {"remote": {"platform": "demo"}}
         )
+        self.hass.block_till_done()
 
     # pylint: disable=invalid-name
     def tearDown(self):

--- a/tests/components/demo/test_stt.py
+++ b/tests/components/demo/test_stt.py
@@ -6,11 +6,10 @@ from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(autouse=True)
-def setup_comp(hass):
+async def setup_comp(hass):
     """Set up demo component."""
-    hass.loop.run_until_complete(
-        async_setup_component(hass, stt.DOMAIN, {"stt": {"platform": "demo"}})
-    )
+    assert await async_setup_component(hass, stt.DOMAIN, {"stt": {"platform": "demo"}})
+    await hass.async_block_till_done()
 
 
 async def test_demo_settings(hass_client):

--- a/tests/components/demo/test_vacuum.py
+++ b/tests/components/demo/test_vacuum.py
@@ -51,6 +51,7 @@ ENTITY_VACUUM_STATE = f"{DOMAIN}.{DEMO_VACUUM_STATE}".lower()
 async def setup_demo_vacuum(hass):
     """Initialize setup demo vacuum."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "demo"}})
+    await hass.async_block_till_done()
 
 
 async def test_supported_features(hass):

--- a/tests/components/demo/test_water_heater.py
+++ b/tests/components/demo/test_water_heater.py
@@ -13,14 +13,13 @@ ENTITY_WATER_HEATER_CELSIUS = "water_heater.demo_water_heater_celsius"
 
 
 @pytest.fixture(autouse=True)
-def setup_comp(hass):
+async def setup_comp(hass):
     """Set up demo component."""
     hass.config.units = IMPERIAL_SYSTEM
-    hass.loop.run_until_complete(
-        async_setup_component(
-            hass, water_heater.DOMAIN, {"water_heater": {"platform": "demo"}}
-        )
+    assert await async_setup_component(
+        hass, water_heater.DOMAIN, {"water_heater": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
 
 async def test_setup_params(hass):

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -621,7 +621,7 @@ async def test_automation_with_sub_condition(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-
+    await hass.async_block_till_done()
     ent1, ent2, ent3 = platform.ENTITIES
 
     assert await async_setup_component(

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -75,6 +75,7 @@ async def test_default_setup(hass, mock_connection_factory):
 
     with assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -171,6 +172,7 @@ async def test_v4_meter(hass, mock_connection_factory):
 
     with assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -215,6 +217,7 @@ async def test_v5_meter(hass, mock_connection_factory):
 
     with assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -259,6 +262,7 @@ async def test_belgian_meter(hass, mock_connection_factory):
 
     with assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -292,6 +296,7 @@ async def test_belgian_meter_low(hass, mock_connection_factory):
 
     with assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -315,6 +320,7 @@ async def test_tcp(hass, mock_connection_factory):
 
     with assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     assert connection_factory.call_args_list[0][0][0] == "localhost"
     assert connection_factory.call_args_list[0][0][1] == "1234"

--- a/tests/components/dte_energy_bridge/test_sensor.py
+++ b/tests/components/dte_energy_bridge/test_sensor.py
@@ -38,6 +38,7 @@ class TestDteEnergyBridgeSetup(unittest.TestCase):
         assert setup_component(
             self.hass, "sensor", {"sensor": DTE_ENERGY_BRIDGE_CONFIG}
         )
+        self.hass.block_till_done()
         assert "0.411" == self.hass.states.get("sensor.current_energy_usage").state
 
     @requests_mock.Mocker()
@@ -50,6 +51,7 @@ class TestDteEnergyBridgeSetup(unittest.TestCase):
         assert setup_component(
             self.hass, "sensor", {"sensor": DTE_ENERGY_BRIDGE_CONFIG}
         )
+        self.hass.block_till_done()
         assert "0.411" == self.hass.states.get("sensor.current_energy_usage").state
 
     @requests_mock.Mocker()
@@ -62,4 +64,5 @@ class TestDteEnergyBridgeSetup(unittest.TestCase):
         assert setup_component(
             self.hass, "sensor", {"sensor": DTE_ENERGY_BRIDGE_CONFIG}
         )
+        self.hass.block_till_done()
         assert "unknown" == self.hass.states.get("sensor.current_energy_usage").state

--- a/tests/components/efergy/test_sensor.py
+++ b/tests/components/efergy/test_sensor.py
@@ -85,6 +85,7 @@ class TestEfergySensor(unittest.TestCase):
         """Test for successfully setting up the Efergy platform."""
         mock_responses(mock)
         assert setup_component(self.hass, "sensor", {"sensor": ONE_SENSOR_CONFIG})
+        self.hass.block_till_done()
 
         assert "38.21" == self.hass.states.get("sensor.energy_consumed").state
         assert "1580" == self.hass.states.get("sensor.energy_usage").state
@@ -97,6 +98,7 @@ class TestEfergySensor(unittest.TestCase):
         """Test for multiple sensors in one household."""
         mock_responses(mock)
         assert setup_component(self.hass, "sensor", {"sensor": MULTI_SENSOR_CONFIG})
+        self.hass.block_till_done()
 
         assert "218" == self.hass.states.get("sensor.efergy_728386").state
         assert "1808" == self.hass.states.get("sensor.efergy_0").state

--- a/tests/components/facebox/test_image_processing.py
+++ b/tests/components/facebox/test_image_processing.py
@@ -156,6 +156,7 @@ def test_valid_file_path():
 async def test_setup_platform(hass, mock_healthybox):
     """Set up platform with one entity."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
 
@@ -166,12 +167,14 @@ async def test_setup_platform_with_auth(hass, mock_healthybox):
     valid_config_auth[ip.DOMAIN][CONF_PASSWORD] = MOCK_PASSWORD
 
     await async_setup_component(hass, ip.DOMAIN, valid_config_auth)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
 
 async def test_process_image(hass, mock_healthybox, mock_image):
     """Test successful processing of an image."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     face_events = []
@@ -215,6 +218,7 @@ async def test_process_image(hass, mock_healthybox, mock_image):
 async def test_process_image_errors(hass, mock_healthybox, mock_image, caplog):
     """Test process_image errors."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     # Test connection error.
@@ -246,6 +250,7 @@ async def test_teach_service(
 ):
     """Test teaching of facebox."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     # Patch out 'is_allowed_path' as the mock files aren't allowed
@@ -319,6 +324,7 @@ async def test_setup_platform_with_name(hass, mock_healthybox):
     valid_config_named[ip.DOMAIN][ip.CONF_SOURCE][ip.CONF_NAME] = MOCK_NAME
 
     await async_setup_component(hass, ip.DOMAIN, valid_config_named)
+    await hass.async_block_till_done()
     assert hass.states.get(named_entity_id)
     state = hass.states.get(named_entity_id)
     assert state.attributes.get(CONF_FRIENDLY_NAME) == MOCK_NAME

--- a/tests/components/fido/test_sensor.py
+++ b/tests/components/fido/test_sensor.py
@@ -76,6 +76,7 @@ async def test_fido_sensor(loop, hass):
         }
         with assert_setup_component(1):
             await async_setup_component(hass, "sensor", config)
+            await hass.async_block_till_done()
         state = hass.states.get("sensor.fido_1112223344_balance")
         assert state.state == "160.12"
         assert state.attributes.get("number") == "1112223344"

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -42,6 +42,7 @@ class TestFileSensor(unittest.TestCase):
         create_file(TEST_FILE)
         config = {"sensor": {"platform": "filesize", CONF_FILE_PATHS: [TEST_FILE]}}
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
         assert len(self.hass.states.entity_ids()) == 1
         state = self.hass.states.get("sensor.mock_file_test_filesize_txt")
         assert state.state == "0.0"

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -59,6 +59,7 @@ class TestFilterSensor(unittest.TestCase):
         }
         with assert_setup_component(0):
             assert setup_component(self.hass, "sensor", config)
+            self.hass.block_till_done()
 
     def test_chain(self):
         """Test if filter chaining works."""
@@ -77,6 +78,7 @@ class TestFilterSensor(unittest.TestCase):
 
         with assert_setup_component(1, "sensor"):
             assert setup_component(self.hass, "sensor", config)
+            self.hass.block_till_done()
 
             for value in self.values:
                 self.hass.states.set(config["sensor"]["entity_id"], value.state)
@@ -128,6 +130,7 @@ class TestFilterSensor(unittest.TestCase):
             ):
                 with assert_setup_component(1, "sensor"):
                     assert setup_component(self.hass, "sensor", config)
+                    self.hass.block_till_done()
 
                 for value in self.values:
                     self.hass.states.set(config["sensor"]["entity_id"], value.state)
@@ -176,6 +179,7 @@ class TestFilterSensor(unittest.TestCase):
             ):
                 with assert_setup_component(1, "sensor"):
                     assert setup_component(self.hass, "sensor", config)
+                    self.hass.block_till_done()
 
                 self.hass.block_till_done()
                 state = self.hass.states.get("sensor.test")

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -36,7 +36,7 @@ async def test_valid_config(hass):
             }
         },
     )
-
+    await hass.async_block_till_done()
     state = hass.states.get("switch.flux")
     assert state
     assert state.state == "off"
@@ -57,6 +57,7 @@ async def test_restore_state_last_on(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("switch.flux")
     assert state
@@ -78,6 +79,7 @@ async def test_restore_state_last_off(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("switch.flux")
     assert state
@@ -129,6 +131,7 @@ async def test_flux_when_switch_is_off(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -178,6 +181,7 @@ async def test_flux_before_sunrise(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -231,6 +235,7 @@ async def test_flux_before_sunrise_known_location(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -284,6 +289,7 @@ async def test_flux_after_sunrise_before_sunset(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -337,6 +343,7 @@ async def test_flux_after_sunset_before_stop(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -391,6 +398,7 @@ async def test_flux_after_stop_before_sunrise(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -444,6 +452,7 @@ async def test_flux_with_custom_start_stop_times(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -501,6 +510,7 @@ async def test_flux_before_sunrise_stop_next_day(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -559,6 +569,7 @@ async def test_flux_after_sunrise_before_sunset_stop_next_day(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -617,6 +628,7 @@ async def test_flux_after_sunset_before_midnight_stop_next_day(hass, x):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -674,6 +686,7 @@ async def test_flux_after_sunset_after_midnight_stop_next_day(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -731,6 +744,7 @@ async def test_flux_after_stop_before_sunrise_stop_next_day(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -785,6 +799,7 @@ async def test_flux_with_custom_colortemps(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -841,6 +856,7 @@ async def test_flux_with_custom_brightness(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -895,6 +911,7 @@ async def test_flux_with_multiple_lights(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 
@@ -972,6 +989,7 @@ async def test_flux_with_mired(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 
@@ -1023,6 +1041,7 @@ async def test_flux_with_rgb(hass):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
+    await hass.async_block_till_done()
 
     ent1 = platform.ENTITIES[0]
 

--- a/tests/components/folder/test_sensor.py
+++ b/tests/components/folder/test_sensor.py
@@ -48,6 +48,7 @@ class TestFolderSensor(unittest.TestCase):
         create_file(TEST_FILE)
         config = {"sensor": {"platform": "folder", CONF_FOLDER_PATHS: TEST_DIR}}
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
         assert len(self.hass.states.entity_ids()) == 1
         state = self.hass.states.get("sensor.test_folder")
         assert state.state == "0.0"

--- a/tests/components/foobot/test_sensor.py
+++ b/tests/components/foobot/test_sensor.py
@@ -39,6 +39,7 @@ async def test_default_setup(hass, aioclient_mock):
         re.compile("api.foobot.io/v2/device/.*"), text=load_fixture("foobot_data.json")
     )
     assert await async_setup_component(hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
+    await hass.async_block_till_done()
 
     metrics = {
         "co2": ["1232.0", CONCENTRATION_PARTS_PER_MILLION],

--- a/tests/components/gdacs/test_geo_location.py
+++ b/tests/components/gdacs/test_geo_location.py
@@ -91,6 +91,7 @@ async def test_setup(hass):
     ) as mock_feed_update:
         mock_feed_update.return_value = "OK", [mock_entry_1, mock_entry_2, mock_entry_3]
         assert await async_setup_component(hass, gdacs.DOMAIN, CONFIG)
+        await hass.async_block_till_done()
         # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -213,6 +214,7 @@ async def test_setup_imperial(hass):
     ):
         mock_feed_update.return_value = "OK", [mock_entry_1]
         assert await async_setup_component(hass, gdacs.DOMAIN, CONFIG)
+        await hass.async_block_till_done()
         # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -76,12 +76,11 @@ async def test_valid_conf(hass):
 
 
 @pytest.fixture
-def setup_comp_1(hass):
+async def setup_comp_1(hass):
     """Initialize components."""
     hass.config.units = METRIC_SYSTEM
-    assert hass.loop.run_until_complete(
-        async_setup_component(hass, "homeassistant", {})
-    )
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
 
 
 async def test_heater_input_boolean(hass, setup_comp_1):
@@ -104,6 +103,7 @@ async def test_heater_input_boolean(hass, setup_comp_1):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert STATE_OFF == hass.states.get(heater_switch).state
 
@@ -122,6 +122,7 @@ async def test_heater_switch(hass, setup_comp_1):
     assert await async_setup_component(
         hass, switch.DOMAIN, {"switch": {"platform": "test"}}
     )
+    await hass.async_block_till_done()
     heater_switch = switch_1.entity_id
 
     assert await async_setup_component(
@@ -154,27 +155,26 @@ def _setup_sensor(hass, temp):
 
 
 @pytest.fixture
-def setup_comp_2(hass):
+async def setup_comp_2(hass):
     """Initialize components."""
     hass.config.units = METRIC_SYSTEM
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 2,
-                    "hot_tolerance": 4,
-                    "heater": ENT_SWITCH,
-                    "target_sensor": ENT_SENSOR,
-                    "away_temp": 16,
-                    "initial_hvac_mode": HVAC_MODE_HEAT,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "away_temp": 16,
+                "initial_hvac_mode": HVAC_MODE_HEAT,
+            }
+        },
     )
+    await hass.async_block_till_done()
 
 
 async def test_setup_defaults_to_unknown(hass):
@@ -195,6 +195,7 @@ async def test_setup_defaults_to_unknown(hass):
             }
         },
     )
+    await hass.async_block_till_done()
     assert HVAC_MODE_OFF == hass.states.get(ENTITY).state
 
 
@@ -288,6 +289,7 @@ async def test_sensor_unknown(hass):
             }
         },
     )
+    await hass.async_block_till_done()
     state = hass.states.get("climate.unknown")
     assert state.attributes.get("current_temperature") is None
 
@@ -307,6 +309,7 @@ async def test_sensor_unavailable(hass):
             }
         },
     )
+    await hass.async_block_till_done()
     state = hass.states.get("climate.unavailable")
     assert state.attributes.get("current_temperature") is None
 
@@ -438,28 +441,27 @@ def _setup_switch(hass, is_on):
 
 
 @pytest.fixture
-def setup_comp_3(hass):
+async def setup_comp_3(hass):
     """Initialize components."""
     hass.config.temperature_unit = TEMP_CELSIUS
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 2,
-                    "hot_tolerance": 4,
-                    "away_temp": 30,
-                    "heater": ENT_SWITCH,
-                    "target_sensor": ENT_SENSOR,
-                    "ac_mode": True,
-                    "initial_hvac_mode": HVAC_MODE_COOL,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 2,
+                "hot_tolerance": 4,
+                "away_temp": 30,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "ac_mode": True,
+                "initial_hvac_mode": HVAC_MODE_COOL,
+            }
+        },
     )
+    await hass.async_block_till_done()
 
 
 async def test_set_target_temp_ac_off(hass, setup_comp_3):
@@ -584,28 +586,27 @@ async def test_no_state_change_when_operation_mode_off_2(hass, setup_comp_3):
 
 
 @pytest.fixture
-def setup_comp_4(hass):
+async def setup_comp_4(hass):
     """Initialize components."""
     hass.config.temperature_unit = TEMP_CELSIUS
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 0.3,
-                    "hot_tolerance": 0.3,
-                    "heater": ENT_SWITCH,
-                    "target_sensor": ENT_SENSOR,
-                    "ac_mode": True,
-                    "min_cycle_duration": datetime.timedelta(minutes=10),
-                    "initial_hvac_mode": HVAC_MODE_COOL,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.3,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "ac_mode": True,
+                "min_cycle_duration": datetime.timedelta(minutes=10),
+                "initial_hvac_mode": HVAC_MODE_COOL,
+            }
+        },
     )
+    await hass.async_block_till_done()
 
 
 async def test_temp_change_ac_trigger_on_not_long_enough(hass, setup_comp_4):
@@ -695,28 +696,27 @@ async def test_mode_change_ac_trigger_on_not_long_enough(hass, setup_comp_4):
 
 
 @pytest.fixture
-def setup_comp_5(hass):
+async def setup_comp_5(hass):
     """Initialize components."""
     hass.config.temperature_unit = TEMP_CELSIUS
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 0.3,
-                    "hot_tolerance": 0.3,
-                    "heater": ENT_SWITCH,
-                    "target_sensor": ENT_SENSOR,
-                    "ac_mode": True,
-                    "min_cycle_duration": datetime.timedelta(minutes=10),
-                    "initial_hvac_mode": HVAC_MODE_COOL,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.3,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "ac_mode": True,
+                "min_cycle_duration": datetime.timedelta(minutes=10),
+                "initial_hvac_mode": HVAC_MODE_COOL,
+            }
+        },
     )
+    await hass.async_block_till_done()
 
 
 async def test_temp_change_ac_trigger_on_not_long_enough_2(hass, setup_comp_5):
@@ -806,27 +806,26 @@ async def test_mode_change_ac_trigger_on_not_long_enough_2(hass, setup_comp_5):
 
 
 @pytest.fixture
-def setup_comp_6(hass):
+async def setup_comp_6(hass):
     """Initialize components."""
     hass.config.temperature_unit = TEMP_CELSIUS
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 0.3,
-                    "hot_tolerance": 0.3,
-                    "heater": ENT_SWITCH,
-                    "target_sensor": ENT_SENSOR,
-                    "min_cycle_duration": datetime.timedelta(minutes=10),
-                    "initial_hvac_mode": HVAC_MODE_HEAT,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.3,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "min_cycle_duration": datetime.timedelta(minutes=10),
+                "initial_hvac_mode": HVAC_MODE_HEAT,
+            }
+        },
     )
+    await hass.async_block_till_done()
 
 
 async def test_temp_change_heater_trigger_off_not_long_enough(hass, setup_comp_6):
@@ -916,30 +915,30 @@ async def test_mode_change_heater_trigger_on_not_long_enough(hass, setup_comp_6)
 
 
 @pytest.fixture
-def setup_comp_7(hass):
+async def setup_comp_7(hass):
     """Initialize components."""
     hass.config.temperature_unit = TEMP_CELSIUS
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 0.3,
-                    "hot_tolerance": 0.3,
-                    "heater": ENT_SWITCH,
-                    "target_temp": 25,
-                    "target_sensor": ENT_SENSOR,
-                    "ac_mode": True,
-                    "min_cycle_duration": datetime.timedelta(minutes=15),
-                    "keep_alive": datetime.timedelta(minutes=10),
-                    "initial_hvac_mode": HVAC_MODE_COOL,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.3,
+                "heater": ENT_SWITCH,
+                "target_temp": 25,
+                "target_sensor": ENT_SENSOR,
+                "ac_mode": True,
+                "min_cycle_duration": datetime.timedelta(minutes=15),
+                "keep_alive": datetime.timedelta(minutes=10),
+                "initial_hvac_mode": HVAC_MODE_COOL,
+            }
+        },
     )
+
+    await hass.async_block_till_done()
 
 
 async def test_temp_change_ac_trigger_on_long_enough_3(hass, setup_comp_7):
@@ -994,29 +993,28 @@ def _send_time_changed(hass, now):
 
 
 @pytest.fixture
-def setup_comp_8(hass):
+async def setup_comp_8(hass):
     """Initialize components."""
     hass.config.temperature_unit = TEMP_CELSIUS
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 0.3,
-                    "hot_tolerance": 0.3,
-                    "target_temp": 25,
-                    "heater": ENT_SWITCH,
-                    "target_sensor": ENT_SENSOR,
-                    "min_cycle_duration": datetime.timedelta(minutes=15),
-                    "keep_alive": datetime.timedelta(minutes=10),
-                    "initial_hvac_mode": HVAC_MODE_HEAT,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.3,
+                "target_temp": 25,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "min_cycle_duration": datetime.timedelta(minutes=15),
+                "keep_alive": datetime.timedelta(minutes=10),
+                "initial_hvac_mode": HVAC_MODE_HEAT,
+            }
+        },
     )
+    await hass.async_block_till_done()
 
 
 async def test_temp_change_heater_trigger_on_long_enough_2(hass, setup_comp_8):
@@ -1066,29 +1064,28 @@ async def test_temp_change_heater_trigger_off_long_enough_2(hass, setup_comp_8):
 
 
 @pytest.fixture
-def setup_comp_9(hass):
+async def setup_comp_9(hass):
     """Initialize components."""
     hass.config.temperature_unit = TEMP_FAHRENHEIT
-    assert hass.loop.run_until_complete(
-        async_setup_component(
-            hass,
-            DOMAIN,
-            {
-                "climate": {
-                    "platform": "generic_thermostat",
-                    "name": "test",
-                    "cold_tolerance": 0.3,
-                    "hot_tolerance": 0.3,
-                    "target_temp": 25,
-                    "heater": ENT_SWITCH,
-                    "target_sensor": ENT_SENSOR,
-                    "min_cycle_duration": datetime.timedelta(minutes=15),
-                    "keep_alive": datetime.timedelta(minutes=10),
-                    "precision": 0.1,
-                }
-            },
-        )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test",
+                "cold_tolerance": 0.3,
+                "hot_tolerance": 0.3,
+                "target_temp": 25,
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "min_cycle_duration": datetime.timedelta(minutes=15),
+                "keep_alive": datetime.timedelta(minutes=10),
+                "precision": 0.1,
+            }
+        },
     )
+    await hass.async_block_till_done()
 
 
 async def test_precision(hass, setup_comp_9):
@@ -1116,6 +1113,7 @@ async def test_custom_setup_params(hass):
         },
     )
     assert result
+    await hass.async_block_till_done()
     state = hass.states.get(ENTITY)
     assert state.attributes.get("min_temp") == MIN_TEMP
     assert state.attributes.get("max_temp") == MAX_TEMP
@@ -1150,7 +1148,7 @@ async def test_restore_state(hass):
             }
         },
     )
-
+    await hass.async_block_till_done()
     state = hass.states.get("climate.test_thermostat")
     assert state.attributes[ATTR_TEMPERATURE] == 20
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_AWAY
@@ -1188,7 +1186,7 @@ async def test_no_restore_state(hass):
             }
         },
     )
-
+    await hass.async_block_till_done()
     state = hass.states.get("climate.test_thermostat")
     assert state.attributes[ATTR_TEMPERATURE] == 22
     assert state.state == HVAC_MODE_OFF

--- a/tests/components/geo_json_events/test_geo_location.py
+++ b/tests/components/geo_json_events/test_geo_location.py
@@ -73,6 +73,7 @@ async def test_setup(hass):
         )
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(hass, geo_location.DOMAIN, CONFIG)
+            await hass.async_block_till_done()
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
             # Collect events.
@@ -162,6 +163,7 @@ async def test_setup_with_custom_location(hass):
             assert await async_setup_component(
                 hass, geo_location.DOMAIN, CONFIG_WITH_CUSTOM_LOCATION
             )
+            await hass.async_block_till_done()
 
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -198,6 +200,7 @@ async def test_setup_race_condition(hass):
     ) as mock_feed:
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(hass, geo_location.DOMAIN, CONFIG)
+            await hass.async_block_till_done()
 
             mock_feed.return_value.update.return_value = "OK", [mock_entry_1]
 

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -67,6 +67,7 @@ async def test_setup(hass):
     ) as mock_feed_update:
         mock_feed_update.return_value = "OK", [mock_entry_1, mock_entry_2, mock_entry_3]
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
+        await hass.async_block_till_done()
         # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -172,6 +173,7 @@ async def test_setup_imperial(hass):
     ):
         mock_feed_update.return_value = "OK", [mock_entry_1]
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
+        await hass.async_block_till_done()
         # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -289,6 +289,7 @@ async def test_query_message(hass):
 async def test_execute(hass):
     """Test an execute command."""
     await async_setup_component(hass, "light", {"light": {"platform": "demo"}})
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         "light", "turn_off", {"entity_id": "light.ceiling_lights"}, blocking=True

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -57,6 +57,7 @@ async def setup_comp(hass):
     """Set up group cover component."""
     with assert_setup_component(2, DOMAIN):
         await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
 
 
 async def test_attributes(hass):
@@ -70,6 +71,7 @@ async def test_attributes(hass):
 
     with assert_setup_component(1, DOMAIN):
         await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_CLOSED

--- a/tests/components/hddtemp/test_sensor.py
+++ b/tests/components/hddtemp/test_sensor.py
@@ -96,6 +96,7 @@ class TestHDDTempSensor(unittest.TestCase):
     def test_hddtemp_min_config(self):
         """Test minimal hddtemp configuration."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG_MINIMAL)
+        self.hass.block_till_done()
 
         entity = self.hass.states.all()[0].entity_id
         state = self.hass.states.get(entity)
@@ -118,6 +119,7 @@ class TestHDDTempSensor(unittest.TestCase):
     def test_hddtemp_rename_config(self):
         """Test hddtemp configuration with different name."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG_NAME)
+        self.hass.block_till_done()
 
         entity = self.hass.states.all()[0].entity_id
         state = self.hass.states.get(entity)
@@ -130,6 +132,7 @@ class TestHDDTempSensor(unittest.TestCase):
     def test_hddtemp_one_disk(self):
         """Test hddtemp one disk configuration."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG_ONE_DISK)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.hd_temperature_dev_sdd1")
 
@@ -151,6 +154,7 @@ class TestHDDTempSensor(unittest.TestCase):
     def test_hddtemp_wrong_disk(self):
         """Test hddtemp wrong disk configuration."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG_WRONG_DISK)
+        self.hass.block_till_done()
 
         assert len(self.hass.states.all()) == 1
         state = self.hass.states.get("sensor.hd_temperature_dev_sdx1")
@@ -160,6 +164,7 @@ class TestHDDTempSensor(unittest.TestCase):
     def test_hddtemp_multiple_disks(self):
         """Test hddtemp multiple disk configuration."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG_MULTIPLE_DISKS)
+        self.hass.block_till_done()
 
         for sensor in [
             "sensor.hd_temperature_dev_sda1",
@@ -187,10 +192,12 @@ class TestHDDTempSensor(unittest.TestCase):
     def test_hddtemp_host_refused(self):
         """Test hddtemp if host unreachable."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG_HOST)
+        self.hass.block_till_done()
         assert len(self.hass.states.all()) == 0
 
     @patch("telnetlib.Telnet", new=TelnetMock)
     def test_hddtemp_host_unreachable(self):
         """Test hddtemp if host unreachable."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG_HOST_UNREACHABLE)
+        self.hass.block_till_done()
         assert len(self.hass.states.all()) == 0

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -175,6 +175,7 @@ async def test_car(hass, requests_mock_car_disabled_response):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -236,6 +237,7 @@ async def test_traffic_mode_enabled(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -262,6 +264,7 @@ async def test_imperial(hass, requests_mock_car_disabled_response):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -293,6 +296,7 @@ async def test_route_mode_shortest(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -324,6 +328,7 @@ async def test_route_mode_fastest(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -347,6 +352,7 @@ async def test_truck(hass, requests_mock_truck_response):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -378,6 +384,7 @@ async def test_public_transport(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -428,6 +435,7 @@ async def test_public_transport_time_table(hass, requests_mock_credentials_check
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -478,6 +486,7 @@ async def test_pedestrian(hass, requests_mock_credentials_check):
     }
 
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -529,6 +538,7 @@ async def test_bicycle(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -592,6 +602,7 @@ async def test_location_zone(hass, requests_mock_truck_response):
         }
         assert await async_setup_component(hass, "zone", zone_config)
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -631,6 +642,7 @@ async def test_location_sensor(hass, requests_mock_truck_response):
             }
         }
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -679,6 +691,7 @@ async def test_location_person(hass, requests_mock_truck_response):
             }
         }
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -727,6 +740,7 @@ async def test_location_device_tracker(hass, requests_mock_truck_response):
             }
         }
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -761,6 +775,7 @@ async def test_location_device_tracker_added_after_update(
             }
         }
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -829,6 +844,7 @@ async def test_location_device_tracker_in_zone(
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -862,6 +878,7 @@ async def test_route_not_found(hass, requests_mock_credentials_check, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -885,7 +902,8 @@ async def test_pattern_origin(hass, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
-    assert len(caplog.records) == 1
+    await hass.async_block_till_done()
+    assert len(caplog.records) == 2
     assert "invalid latitude" in caplog.text
 
 
@@ -904,7 +922,8 @@ async def test_pattern_destination(hass, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
-    assert len(caplog.records) == 1
+    await hass.async_block_till_done()
+    assert len(caplog.records) == 2
     assert "invalid latitude" in caplog.text
 
 
@@ -935,6 +954,7 @@ async def test_invalid_credentials(hass, requests_mock, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
     assert len(caplog.records) == 1
     assert "Invalid credentials" in caplog.text
 
@@ -964,6 +984,7 @@ async def test_attribution(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -992,6 +1013,7 @@ async def test_pattern_entity_state(hass, requests_mock_truck_response, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -1018,6 +1040,7 @@ async def test_pattern_entity_state_with_space(hass, requests_mock_truck_respons
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
 
 async def test_delayed_update(hass, requests_mock_truck_response, caplog):
@@ -1044,6 +1067,7 @@ async def test_delayed_update(hass, requests_mock_truck_response, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
     assert await async_setup_component(hass, "sensor", sensor_config)
     hass.states.async_set(
         "sensor.origin", ",".join([TRUCK_ORIGIN_LATITUDE, TRUCK_ORIGIN_LONGITUDE])
@@ -1084,6 +1108,7 @@ async def test_arrival(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -1121,6 +1146,7 @@ async def test_departure(hass, requests_mock_credentials_check):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -1147,7 +1173,8 @@ async def test_arrival_only_allowed_for_timetable(hass, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
-    assert len(caplog.records) == 1
+    await hass.async_block_till_done()
+    assert len(caplog.records) == 2
     assert "[arrival] is an invalid option" in caplog.text
 
 
@@ -1171,5 +1198,6 @@ async def test_exclusive_arrival_and_departure(hass, caplog):
         }
     }
     assert await async_setup_component(hass, DOMAIN, config)
-    assert len(caplog.records) == 1
+    await hass.async_block_till_done()
+    assert len(caplog.records) == 2
     assert "two or more values in the same group of exclusion" in caplog.text

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -45,6 +45,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.test")
         assert state.state == STATE_UNKNOWN

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -39,6 +39,7 @@ async def test_apply_service(hass):
     """Test the apply service."""
     assert await async_setup_component(hass, "scene", {})
     assert await async_setup_component(hass, "light", {"light": {"platform": "demo"}})
+    await hass.async_block_till_done()
 
     assert await hass.services.async_call(
         "scene", "apply", {"entities": {"light.bed_light": "off"}}, blocking=True

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -84,6 +84,7 @@ async def test_create_service(hass, caplog):
         "scene",
         {"scene": {"name": "hallo_2", "entities": {"light.kitchen": "on"}}},
     )
+    await hass.async_block_till_done()
     assert hass.states.get("scene.hallo") is None
     assert hass.states.get("scene.hallo_2") is not None
 
@@ -156,6 +157,7 @@ async def test_create_service(hass, caplog):
 async def test_snapshot_service(hass, caplog):
     """Test the snapshot option."""
     assert await async_setup_component(hass, "scene", {"scene": {}})
+    await hass.async_block_till_done()
     hass.states.async_set("light.my_light", "on", {"hs_color": (345, 75)})
     assert hass.states.get("scene.hallo") is None
 
@@ -213,6 +215,7 @@ async def test_snapshot_service(hass, caplog):
 async def test_ensure_no_intersection(hass):
     """Test that entities and snapshot_entities do not overlap."""
     assert await async_setup_component(hass, "scene", {"scene": {}})
+    await hass.async_block_till_done()
 
     with pytest.raises(vol.MultipleInvalid) as ex:
         assert await hass.services.async_call(
@@ -246,6 +249,7 @@ async def test_scenes_with_entity(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     assert sorted(ha_scene.scenes_with_entity(hass, "light.kitchen")) == [
         "scene.scene_1",
@@ -269,6 +273,7 @@ async def test_entities_in_scene(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     for scene_id, entities in (
         ("scene.scene_1", ["light.kitchen"]),
@@ -298,6 +303,7 @@ async def test_config(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     icon = hass.states.get("scene.scene_icon")
     assert icon is not None

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -123,6 +123,7 @@ async def test_camera_stream_source_configured(hass, run_driver, events):
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     entity_id = "camera.demo_camera"
 
@@ -227,6 +228,7 @@ async def test_camera_stream_source_configured_with_failing_ffmpeg(
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     entity_id = "camera.demo_camera"
 
@@ -271,6 +273,7 @@ async def test_camera_stream_source_found(hass, run_driver, events):
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     entity_id = "camera.demo_camera"
 
@@ -313,6 +316,7 @@ async def test_camera_stream_source_fails(hass, run_driver, events):
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     entity_id = "camera.demo_camera"
 
@@ -368,6 +372,7 @@ async def test_camera_stream_source_configured_and_copy_codec(hass, run_driver, 
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     entity_id = "camera.demo_camera"
 
@@ -436,6 +441,7 @@ async def test_camera_streaming_fails_after_starting_ffmpeg(hass, run_driver, ev
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     entity_id = "camera.demo_camera"
 
@@ -505,6 +511,7 @@ async def test_camera_with_linked_motion_sensor(hass, run_driver, events):
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     motion_entity_id = "binary_sensor.motion"
 
     hass.states.async_set(
@@ -564,6 +571,7 @@ async def test_camera_with_a_missing_linked_motion_sensor(hass, run_driver, even
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
     motion_entity_id = "binary_sensor.motion"
     entity_id = "camera.demo_camera"
     hass.states.async_set(entity_id, None)

--- a/tests/components/ign_sismologia/test_geo_location.py
+++ b/tests/components/ign_sismologia/test_geo_location.py
@@ -103,6 +103,7 @@ async def test_setup(hass):
         )
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(hass, geo_location.DOMAIN, CONFIG)
+            await hass.async_block_till_done()
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
             # Collect events.
@@ -207,6 +208,7 @@ async def test_setup_with_custom_location(hass):
             assert await async_setup_component(
                 hass, geo_location.DOMAIN, CONFIG_WITH_CUSTOM_LOCATION
             )
+            await hass.async_block_till_done()
 
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -59,6 +59,7 @@ class TestImageProcessing:
         config = {ip.DOMAIN: {"platform": "test"}, "camera": {"platform": "demo"}}
 
         setup_component(self.hass, ip.DOMAIN, config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("camera.demo_camera")
         self.url = f"{self.hass.config.api.base_url}{state.attributes.get(ATTR_ENTITY_PICTURE)}"
@@ -113,6 +114,7 @@ class TestImageProcessingAlpr:
             new_callable=PropertyMock(return_value=False),
         ):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         state = self.hass.states.get("camera.demo_camera")
         self.url = f"{self.hass.config.api.base_url}{state.attributes.get(ATTR_ENTITY_PICTURE)}"
@@ -218,6 +220,7 @@ class TestImageProcessingFace:
             new_callable=PropertyMock(return_value=False),
         ):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         state = self.hass.states.get("camera.demo_camera")
         self.url = f"{self.hass.config.api.base_url}{state.attributes.get(ATTR_ENTITY_PICTURE)}"

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -135,7 +135,7 @@ async def test_setup_configuration(hass):
             weather.DOMAIN,
             {"weather": {"name": "HomeTown", "platform": "ipma", "mode": "hourly"}},
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     state = hass.states.get("weather.hometown")
     assert state.state == "rainy"
@@ -182,7 +182,7 @@ async def test_daily_forecast(hass):
             weather.DOMAIN,
             {"weather": {"name": "HomeTown", "platform": "ipma", "mode": "daily"}},
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     state = hass.states.get("weather.hometown")
     assert state.state == "rainy"
@@ -208,7 +208,7 @@ async def test_hourly_forecast(hass):
             weather.DOMAIN,
             {"weather": {"name": "HomeTown", "platform": "ipma", "mode": "hourly"}},
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     state = hass.states.get("weather.hometown")
     assert state.state == "rainy"

--- a/tests/components/lastfm/test_sensor.py
+++ b/tests/components/lastfm/test_sensor.py
@@ -54,6 +54,7 @@ async def test_update_not_playing(hass, lastfm_network):
         sensor.DOMAIN,
         {"sensor": {"platform": "lastfm", "api_key": "secret-key", "users": ["test"]}},
     )
+    await hass.async_block_till_done()
 
     entity_id = "sensor.test"
 
@@ -74,6 +75,7 @@ async def test_update_playing(hass, lastfm_network):
         sensor.DOMAIN,
         {"sensor": {"platform": "lastfm", "api_key": "secret-key", "users": ["test"]}},
     )
+    await hass.async_block_till_done()
 
     entity_id = "sensor.test"
 

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -203,6 +203,7 @@ async def test_action(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -96,6 +96,7 @@ async def test_if_state(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 
@@ -173,6 +174,7 @@ async def test_if_fires_on_for_condition(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -96,6 +96,7 @@ async def test_if_fires_on_state_change(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 
@@ -180,6 +181,7 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -123,6 +123,7 @@ class TestLight(unittest.TestCase):
         assert setup_component(
             self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
         )
+        self.hass.block_till_done()
 
         ent1, ent2, ent3 = platform.ENTITIES
 
@@ -335,6 +336,7 @@ class TestLight(unittest.TestCase):
         assert setup_component(
             self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
         )
+        self.hass.block_till_done()
 
         ent1, _, _ = platform.ENTITIES
 
@@ -376,12 +378,13 @@ class TestLight(unittest.TestCase):
             return real_open(path, *args, **kwargs)
 
         profile_data = "id,x,y,brightness\ngroup.all_lights.default,.4,.6,99\n"
-        with mock.patch("os.path.isfile", side_effect=_mock_isfile):
-            with mock.patch("builtins.open", side_effect=_mock_open):
-                with mock_storage():
-                    assert setup_component(
-                        self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
-                    )
+        with mock.patch("os.path.isfile", side_effect=_mock_isfile), mock.patch(
+            "builtins.open", side_effect=_mock_open
+        ), mock_storage():
+            assert setup_component(
+                self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
+            )
+            self.hass.block_till_done()
 
         ent, _, _ = platform.ENTITIES
         common.turn_on(self.hass, ent.entity_id)
@@ -413,12 +416,13 @@ class TestLight(unittest.TestCase):
             + "group.all_lights.default,.3,.5,200\n"
             + "light.ceiling_2.default,.6,.6,100\n"
         )
-        with mock.patch("os.path.isfile", side_effect=_mock_isfile):
-            with mock.patch("builtins.open", side_effect=_mock_open):
-                with mock_storage():
-                    assert setup_component(
-                        self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
-                    )
+        with mock.patch("os.path.isfile", side_effect=_mock_isfile), mock.patch(
+            "builtins.open", side_effect=_mock_open
+        ), mock_storage():
+            assert setup_component(
+                self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
+            )
+            self.hass.block_till_done()
 
         dev = next(
             filter(lambda x: x.entity_id == "light.ceiling_2", platform.ENTITIES)
@@ -434,6 +438,7 @@ async def test_light_context(hass, hass_admin_user):
     platform = getattr(hass.components, "test.light")
     platform.init()
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.ceiling")
     assert state is not None
@@ -457,6 +462,7 @@ async def test_light_turn_on_auth(hass, hass_admin_user):
     platform = getattr(hass.components, "test.light")
     platform.init()
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.ceiling")
     assert state is not None
@@ -481,6 +487,7 @@ async def test_light_brightness_step(hass):
     entity.supported_features = light.SUPPORT_BRIGHTNESS
     entity.brightness = 100
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
     assert state is not None
@@ -515,6 +522,7 @@ async def test_light_brightness_pct_conversion(hass):
     entity.supported_features = light.SUPPORT_BRIGHTNESS
     entity.brightness = 100
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
     assert state is not None

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -93,6 +93,7 @@ async def test_camera_content_type(hass, hass_client):
         "camera",
         {"camera": [cam_config_jpg, cam_config_png, cam_config_svg, cam_config_noext]},
     )
+    await hass.async_block_till_done()
 
     client = await hass_client()
 

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -25,6 +25,7 @@ async def test_loading_file(hass, hass_client):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     client = await hass_client()
 
@@ -57,6 +58,7 @@ async def test_file_not_readable(hass, caplog):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     assert "Could not read" in caplog.text
     assert "config_test" in caplog.text

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -143,6 +143,7 @@ async def test_update_file_path(hass):
             "file_path": "mock/path_2.jpg",
         }
         await async_setup_component(hass, "camera", {"camera": [camera_1, camera_2]})
+        await hass.async_block_till_done()
 
         # Fetch state and check motion detection attribute
         state = hass.states.get("camera.local_file")

--- a/tests/components/london_air/test_sensor.py
+++ b/tests/components/london_air/test_sensor.py
@@ -28,6 +28,7 @@ class TestLondonAirSensor(unittest.TestCase):
         """Test for operational tube_state sensor with proper attributes."""
         mock_req.get(URL, text=load_fixture("london_air.json"))
         assert setup_component(self.hass, "sensor", {"sensor": self.config})
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.merton")
         assert state.state == "Low"

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -47,6 +47,7 @@ async def test_arm_home_no_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -73,6 +74,7 @@ async def test_arm_home_no_pending_when_code_not_req(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -98,6 +100,7 @@ async def test_arm_home_with_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -137,6 +140,7 @@ async def test_arm_home_with_invalid_code(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -162,6 +166,7 @@ async def test_arm_away_no_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -188,6 +193,7 @@ async def test_arm_away_no_pending_when_code_not_req(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -213,6 +219,7 @@ async def test_arm_home_with_template_code(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -239,6 +246,7 @@ async def test_arm_away_with_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -278,6 +286,7 @@ async def test_arm_away_with_invalid_code(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -303,6 +312,7 @@ async def test_arm_night_no_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -329,6 +339,7 @@ async def test_arm_night_no_pending_when_code_not_req(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -354,6 +365,7 @@ async def test_arm_night_with_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -398,6 +410,7 @@ async def test_arm_night_with_invalid_code(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -422,6 +435,7 @@ async def test_trigger_no_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -458,6 +472,7 @@ async def test_trigger_with_delay(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -500,6 +515,7 @@ async def test_trigger_zero_trigger_time(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -525,6 +541,7 @@ async def test_trigger_zero_trigger_time_with_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -550,6 +567,7 @@ async def test_trigger_with_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -602,6 +620,7 @@ async def test_trigger_with_unused_specific_delay(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -646,6 +665,7 @@ async def test_trigger_with_specific_delay(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -689,6 +709,7 @@ async def test_trigger_with_pending_and_delay(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -745,6 +766,7 @@ async def test_trigger_with_pending_and_specific_delay(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -798,6 +820,7 @@ async def test_armed_home_with_specific_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -830,6 +853,7 @@ async def test_armed_away_with_specific_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -862,6 +886,7 @@ async def test_armed_night_with_specific_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -896,6 +921,7 @@ async def test_trigger_with_specific_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -939,6 +965,7 @@ async def test_trigger_with_disarm_after_trigger(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -975,6 +1002,7 @@ async def test_trigger_with_zero_specific_trigger_time(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1001,6 +1029,7 @@ async def test_trigger_with_unused_zero_specific_trigger_time(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1036,6 +1065,7 @@ async def test_trigger_with_specific_trigger_time(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1072,6 +1102,7 @@ async def test_trigger_with_no_disarm_after_trigger(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1112,6 +1143,7 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1164,6 +1196,7 @@ async def test_disarm_while_pending_trigger(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1203,6 +1236,7 @@ async def test_disarm_during_trigger_with_invalid_code(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1242,6 +1276,7 @@ async def test_disarm_with_template_code(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1278,6 +1313,7 @@ async def test_arm_custom_bypass_no_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1304,6 +1340,7 @@ async def test_arm_custom_bypass_no_pending_when_code_not_req(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1329,6 +1366,7 @@ async def test_arm_custom_bypass_with_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1368,6 +1406,7 @@ async def test_arm_custom_bypass_with_invalid_code(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1392,6 +1431,7 @@ async def test_armed_custom_bypass_with_specific_pending(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1428,6 +1468,7 @@ async def test_arm_away_after_disabled_disarmed(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -1499,6 +1540,7 @@ async def test_restore_armed_state(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("alarm_control_panel.test")
     assert state
@@ -1525,6 +1567,7 @@ async def test_restore_disarmed_state(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("alarm_control_panel.test")
     assert state

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -86,6 +86,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -114,6 +115,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -141,6 +143,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -184,6 +187,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -211,6 +215,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -239,6 +244,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -266,6 +272,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -294,6 +301,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -337,6 +345,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -364,6 +373,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -392,6 +402,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -419,6 +430,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -468,6 +480,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -494,6 +507,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -535,6 +549,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -583,6 +598,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -610,6 +626,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -637,6 +654,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -693,6 +711,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -734,6 +753,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -762,6 +782,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -802,6 +823,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -842,6 +864,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -904,6 +927,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -949,6 +973,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -996,6 +1021,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1046,6 +1072,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1096,6 +1123,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1162,6 +1190,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1224,6 +1253,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1261,6 +1291,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1298,6 +1329,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1337,6 +1369,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1391,6 +1424,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1465,6 +1499,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1504,6 +1539,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1544,6 +1580,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1584,6 +1621,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1624,6 +1662,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         entity_id = "alarm_control_panel.test"
 
@@ -1656,6 +1695,7 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         # Component should send disarmed alarm state on startup
         self.hass.block_till_done()

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -45,6 +45,7 @@ async def test_get_image_http(hass, aiohttp_client):
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("media_player.bedroom")
     assert "entity_picture_local" not in state.attributes
@@ -72,6 +73,7 @@ async def test_get_image_http_remote(hass, aiohttp_client):
         await async_setup_component(
             hass, "media_player", {"media_player": {"platform": "demo"}}
         )
+        await hass.async_block_till_done()
 
         state = hass.states.get("media_player.bedroom")
         assert "entity_picture_local" in state.attributes

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -27,6 +27,17 @@ def mock_controller_client_1():
         yield service_mock
 
 
+@pytest.fixture(autouse=True)
+def mock_setup():
+    """Prevent setup."""
+    with patch(
+        "homeassistant.components.meteo_france.async_setup", return_value=True,
+    ), patch(
+        "homeassistant.components.meteo_france.async_setup_entry", return_value=True,
+    ):
+        yield
+
+
 @pytest.fixture(name="client_2")
 def mock_controller_client_2():
     """Mock a successful client."""

--- a/tests/components/mfi/test_sensor.py
+++ b/tests/components/mfi/test_sensor.py
@@ -64,6 +64,7 @@ class TestMfiSensorSetup(unittest.TestCase):
         config = dict(self.GOOD_CONFIG)
         del config[self.THING]["port"]
         assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
+        self.hass.block_till_done()
         assert mock_client.call_count == 1
         assert mock_client.call_args == mock.call(
             "foo", "user", "pass", port=6443, use_tls=True, verify=True
@@ -75,6 +76,7 @@ class TestMfiSensorSetup(unittest.TestCase):
         config = dict(self.GOOD_CONFIG)
         config[self.THING]["port"] = 6123
         assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
+        self.hass.block_till_done()
         assert mock_client.call_count == 1
         assert mock_client.call_args == mock.call(
             "foo", "user", "pass", port=6123, use_tls=True, verify=True
@@ -88,6 +90,7 @@ class TestMfiSensorSetup(unittest.TestCase):
         config[self.THING]["ssl"] = False
         config[self.THING]["verify_ssl"] = False
         assert setup_component(self.hass, self.COMPONENT.DOMAIN, config)
+        self.hass.block_till_done()
         assert mock_client.call_count == 1
         assert mock_client.call_args == mock.call(
             "foo", "user", "pass", port=6080, use_tls=False, verify=False
@@ -105,6 +108,7 @@ class TestMfiSensorSetup(unittest.TestCase):
             mock.MagicMock(ports=ports)
         ]
         assert setup_component(self.hass, sensor.DOMAIN, self.GOOD_CONFIG)
+        self.hass.block_till_done()
         for ident, port in ports.items():
             if ident != "bad":
                 mock_sensor.assert_any_call(port, self.hass)

--- a/tests/components/mfi/test_switch.py
+++ b/tests/components/mfi/test_switch.py
@@ -48,6 +48,7 @@ class TestMfiSwitchSetup(unittest.TestCase):
             mock.MagicMock(ports=ports)
         ]
         assert setup_component(self.hass, switch.DOMAIN, self.GOOD_CONFIG)
+        self.hass.block_till_done()
         for ident, port in ports.items():
             if ident != "bad":
                 mock_switch.assert_any_call(port)

--- a/tests/components/microsoft_face_detect/test_image_processing.py
+++ b/tests/components/microsoft_face_detect/test_image_processing.py
@@ -45,6 +45,7 @@ class TestMicrosoftFaceDetectSetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.microsoftface_demo_camera")
 
@@ -65,6 +66,7 @@ class TestMicrosoftFaceDetectSetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.test_local")
 
@@ -113,6 +115,7 @@ class TestMicrosoftFaceDetect:
         )
 
         setup_component(self.hass, ip.DOMAIN, self.config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("camera.demo_camera")
         url = f"{self.hass.config.api.base_url}{state.attributes.get(ATTR_ENTITY_PICTURE)}"

--- a/tests/components/microsoft_face_identify/test_image_processing.py
+++ b/tests/components/microsoft_face_identify/test_image_processing.py
@@ -45,6 +45,7 @@ class TestMicrosoftFaceIdentifySetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.microsoftface_demo_camera")
 
@@ -66,6 +67,7 @@ class TestMicrosoftFaceIdentifySetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.test_local")
 
@@ -114,6 +116,7 @@ class TestMicrosoftFaceIdentify:
         )
 
         setup_component(self.hass, ip.DOMAIN, self.config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("camera.demo_camera")
         url = f"{self.hass.config.api.base_url}{state.attributes.get(ATTR_ENTITY_PICTURE)}"

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -97,6 +97,7 @@ async def test_restoring_location(hass, create_registrations, webhook_client):
     # mobile app doesn't support unloading, so we just reload device tracker
     await hass.config_entries.async_forward_entry_unload(config_entry, "device_tracker")
     await hass.config_entries.async_forward_entry_setup(config_entry, "device_tracker")
+    await hass.async_block_till_done()
 
     state_2 = hass.states.get("device_tracker.test_1_2")
     assert state_2 is not None

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -69,6 +69,7 @@ async def run_test(
     now = dt_util.utcnow()
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         assert await async_setup_component(hass, entity_domain, config)
+        await hass.async_block_till_done()
 
     # Trigger update call with time_changed event
     now += timedelta(seconds=scan_interval + 1)

--- a/tests/components/mold_indicator/test_sensor.py
+++ b/tests/components/mold_indicator/test_sensor.py
@@ -52,7 +52,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
                 }
             },
         )
-
+        self.hass.block_till_done()
         moldind = self.hass.states.get("sensor.mold_indicator")
         assert moldind
         assert UNIT_PERCENTAGE == moldind.attributes.get("unit_of_measurement")
@@ -82,6 +82,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
         moldind = self.hass.states.get("sensor.mold_indicator")
@@ -116,6 +117,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
         moldind = self.hass.states.get("sensor.mold_indicator")
@@ -159,6 +161,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
         moldind = self.hass.states.get("sensor.mold_indicator")
@@ -196,6 +199,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
 
         self.hass.states.set(
@@ -268,6 +272,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
 
         self.hass.states.set(

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -29,6 +29,7 @@ class TestMoonSensor(unittest.TestCase):
         config = {"sensor": {"platform": "moon", "name": "moon_day1"}}
 
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.moon_day1")
         assert state.state == "waxing_crescent"
@@ -39,6 +40,7 @@ class TestMoonSensor(unittest.TestCase):
         config = {"sensor": {"platform": "moon", "name": "moon_day2"}}
 
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.moon_day2")
         assert state.state == "waning_gibbous"

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -107,6 +107,7 @@ async def test_update_state_via_state_topic(hass, mqtt_mock):
     assert await async_setup_component(
         hass, alarm_control_panel.DOMAIN, DEFAULT_CONFIG,
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -132,6 +133,7 @@ async def test_ignore_update_state_if_unknown_via_state_topic(hass, mqtt_mock):
     assert await async_setup_component(
         hass, alarm_control_panel.DOMAIN, DEFAULT_CONFIG,
     )
+    await hass.async_block_till_done()
 
     entity_id = "alarm_control_panel.test"
 
@@ -146,6 +148,7 @@ async def test_arm_home_publishes_mqtt(hass, mqtt_mock):
     assert await async_setup_component(
         hass, alarm_control_panel.DOMAIN, DEFAULT_CONFIG,
     )
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_home(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -175,6 +178,7 @@ async def test_arm_home_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG_CODE)
     config[alarm_control_panel.DOMAIN]["code_arm_required"] = False
     assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config,)
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_home(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -187,6 +191,7 @@ async def test_arm_away_publishes_mqtt(hass, mqtt_mock):
     assert await async_setup_component(
         hass, alarm_control_panel.DOMAIN, DEFAULT_CONFIG,
     )
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_away(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -216,6 +221,7 @@ async def test_arm_away_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG_CODE)
     config[alarm_control_panel.DOMAIN]["code_arm_required"] = False
     assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config,)
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_away(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -228,6 +234,7 @@ async def test_arm_night_publishes_mqtt(hass, mqtt_mock):
     assert await async_setup_component(
         hass, alarm_control_panel.DOMAIN, DEFAULT_CONFIG,
     )
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_night(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -257,6 +264,7 @@ async def test_arm_night_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG_CODE)
     config[alarm_control_panel.DOMAIN]["code_arm_required"] = False
     assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config,)
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_night(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -278,6 +286,7 @@ async def test_arm_custom_bypass_publishes_mqtt(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_custom_bypass(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -306,6 +315,7 @@ async def test_arm_custom_bypass_not_publishes_mqtt_with_invalid_code_when_req(
             }
         },
     )
+    await hass.async_block_till_done()
 
     call_count = mqtt_mock.async_publish.call_count
     await common.async_alarm_arm_custom_bypass(hass, "abcd")
@@ -331,6 +341,7 @@ async def test_arm_custom_bypass_publishes_mqtt_when_code_not_req(hass, mqtt_moc
             }
         },
     )
+    await hass.async_block_till_done()
 
     await common.async_alarm_arm_custom_bypass(hass)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -343,6 +354,7 @@ async def test_disarm_publishes_mqtt(hass, mqtt_mock):
     assert await async_setup_component(
         hass, alarm_control_panel.DOMAIN, DEFAULT_CONFIG,
     )
+    await hass.async_block_till_done()
 
     await common.async_alarm_disarm(hass)
     mqtt_mock.async_publish.assert_called_once_with("alarm/command", "DISARM", 0, False)
@@ -359,6 +371,7 @@ async def test_disarm_publishes_mqtt_with_template(hass, mqtt_mock):
         '{"action":"{{ action }}",' '"code":"{{ code }}"}'
     )
     assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config,)
+    await hass.async_block_till_done()
 
     await common.async_alarm_disarm(hass, 1234)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -375,6 +388,7 @@ async def test_disarm_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
     config[alarm_control_panel.DOMAIN]["code"] = "1234"
     config[alarm_control_panel.DOMAIN]["code_disarm_required"] = False
     assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config,)
+    await hass.async_block_till_done()
 
     await common.async_alarm_disarm(hass)
     mqtt_mock.async_publish.assert_called_once_with("alarm/command", "DISARM", 0, False)
@@ -414,6 +428,7 @@ async def test_update_state_via_state_topic_template(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("alarm_control_panel.test")
     assert state.state == STATE_UNKNOWN
@@ -430,6 +445,7 @@ async def test_attributes_code_number(hass, mqtt_mock):
     config[alarm_control_panel.DOMAIN]["code"] = CODE_NUMBER
 
     assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("alarm_control_panel.test")
     assert (
@@ -444,6 +460,7 @@ async def test_attributes_code_text(hass, mqtt_mock):
     config[alarm_control_panel.DOMAIN]["code"] = CODE_TEXT
 
     assert await async_setup_component(hass, alarm_control_panel.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("alarm_control_panel.test")
     assert (

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -71,6 +71,7 @@ async def test_setting_sensor_value_expires_availability_topic(hass, mqtt_mock, 
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
     assert state.state == STATE_UNAVAILABLE
@@ -99,6 +100,7 @@ async def test_setting_sensor_value_expires(hass, mqtt_mock, caplog):
             }
         },
     )
+    await hass.async_block_till_done()
 
     # State should be unavailable since expire_after is defined and > 0
     state = hass.states.get("binary_sensor.test")
@@ -172,6 +174,7 @@ async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
 
@@ -201,6 +204,7 @@ async def test_invalid_sensor_value_via_mqtt_message(hass, mqtt_mock, caplog):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
 
@@ -240,6 +244,7 @@ async def test_setting_sensor_value_via_mqtt_message_and_template(hass, mqtt_moc
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
     assert state.state == STATE_OFF
@@ -267,6 +272,7 @@ async def test_valid_device_class(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
     assert state.attributes.get("device_class") == "motion"
@@ -286,6 +292,7 @@ async def test_invalid_device_class(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
     assert state is None
@@ -327,6 +334,7 @@ async def test_force_update_disabled(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     events = []
 
@@ -362,6 +370,7 @@ async def test_force_update_enabled(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     events = []
 
@@ -398,6 +407,7 @@ async def test_off_delay(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     events = []
 

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -49,6 +49,7 @@ async def test_run_camera_setup(hass, aiohttp_client):
         "camera",
         {"camera": {"platform": "mqtt", "topic": topic, "name": "Test Camera"}},
     )
+    await hass.async_block_till_done()
 
     url = hass.states.get("camera.test_camera").attributes["entity_picture"]
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -72,6 +72,7 @@ DEFAULT_CONFIG = {
 async def test_setup_params(hass, mqtt_mock):
     """Test the initial parameters."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("temperature") == 21
@@ -85,6 +86,7 @@ async def test_setup_params(hass, mqtt_mock):
 async def test_supported_features(hass, mqtt_mock):
     """Test the supported_features."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     support = (
@@ -102,6 +104,7 @@ async def test_supported_features(hass, mqtt_mock):
 async def test_get_hvac_modes(hass, mqtt_mock):
     """Test that the operation list returns the correct modes."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     modes = state.attributes.get("hvac_modes")
@@ -121,6 +124,7 @@ async def test_set_operation_bad_attr_and_state(hass, mqtt_mock, caplog):
     Also check the state.
     """
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "off"
@@ -136,6 +140,7 @@ async def test_set_operation_bad_attr_and_state(hass, mqtt_mock, caplog):
 async def test_set_operation(hass, mqtt_mock):
     """Test setting of new operation mode."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "off"
@@ -151,6 +156,7 @@ async def test_set_operation_pessimistic(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["mode_state_topic"] = "mode-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "unknown"
@@ -173,6 +179,7 @@ async def test_set_operation_with_power_command(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["power_command_topic"] = "power-command"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "off"
@@ -196,6 +203,7 @@ async def test_set_operation_with_power_command(hass, mqtt_mock):
 async def test_set_fan_mode_bad_attr(hass, mqtt_mock, caplog):
     """Test setting fan mode without required attribute."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("fan_mode") == "low"
@@ -213,6 +221,7 @@ async def test_set_fan_mode_pessimistic(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["fan_mode_state_topic"] = "fan-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("fan_mode") is None
@@ -233,6 +242,7 @@ async def test_set_fan_mode_pessimistic(hass, mqtt_mock):
 async def test_set_fan_mode(hass, mqtt_mock):
     """Test setting of new fan mode."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("fan_mode") == "low"
@@ -245,6 +255,7 @@ async def test_set_fan_mode(hass, mqtt_mock):
 async def test_set_swing_mode_bad_attr(hass, mqtt_mock, caplog):
     """Test setting swing mode without required attribute."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("swing_mode") == "off"
@@ -262,6 +273,7 @@ async def test_set_swing_pessimistic(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["swing_mode_state_topic"] = "swing-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("swing_mode") is None
@@ -282,6 +294,7 @@ async def test_set_swing_pessimistic(hass, mqtt_mock):
 async def test_set_swing(hass, mqtt_mock):
     """Test setting of new swing mode."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("swing_mode") == "off"
@@ -294,6 +307,7 @@ async def test_set_swing(hass, mqtt_mock):
 async def test_set_target_temperature(hass, mqtt_mock):
     """Test setting the target temperature."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("temperature") == 21
@@ -326,6 +340,7 @@ async def test_set_target_temperature_pessimistic(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["temperature_state_topic"] = "temperature-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("temperature") is None
@@ -346,6 +361,7 @@ async def test_set_target_temperature_pessimistic(hass, mqtt_mock):
 async def test_set_target_temperature_low_high(hass, mqtt_mock):
     """Test setting the low/high target temperature."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     await common.async_set_temperature(
         hass, target_temp_low=20, target_temp_high=23, entity_id=ENTITY_CLIMATE
@@ -363,6 +379,7 @@ async def test_set_target_temperature_low_highpessimistic(hass, mqtt_mock):
     config["climate"]["temperature_low_state_topic"] = "temperature-low-state"
     config["climate"]["temperature_high_state_topic"] = "temperature-high-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("target_temp_low") is None
@@ -398,6 +415,7 @@ async def test_receive_mqtt_temperature(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["current_temperature_topic"] = "current_temperature"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "current_temperature", "47")
     state = hass.states.get(ENTITY_CLIMATE)
@@ -409,6 +427,7 @@ async def test_set_away_mode_pessimistic(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["away_mode_state_topic"] = "away-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") is None
@@ -437,6 +456,7 @@ async def test_set_away_mode(hass, mqtt_mock):
     config["climate"]["payload_off"] = "AUS"
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") is None
@@ -467,6 +487,7 @@ async def test_set_hvac_action(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["action_topic"] = "action"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("hvac_action") is None
@@ -481,6 +502,7 @@ async def test_set_hold_pessimistic(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["hold_state_topic"] = "hold-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("hold_mode") is None
@@ -501,6 +523,7 @@ async def test_set_hold_pessimistic(hass, mqtt_mock):
 async def test_set_hold(hass, mqtt_mock):
     """Test setting the hold mode."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") is None
@@ -525,6 +548,7 @@ async def test_set_hold(hass, mqtt_mock):
 async def test_set_preset_mode_twice(hass, mqtt_mock):
     """Test setting of the same mode twice only publishes once."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") is None
@@ -543,6 +567,7 @@ async def test_set_aux_pessimistic(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["aux_state_topic"] = "aux-state"
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("aux_heat") == "off"
@@ -567,6 +592,7 @@ async def test_set_aux_pessimistic(hass, mqtt_mock):
 async def test_set_aux(hass, mqtt_mock):
     """Test setting of the aux heating."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("aux_heat") == "off"
@@ -612,6 +638,7 @@ async def test_set_target_temperature_low_high_with_templates(hass, mqtt_mock, c
     config["climate"]["temperature_high_state_template"] = "{{ value_json.temp_high }}"
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
 
@@ -658,6 +685,7 @@ async def test_set_with_templates(hass, mqtt_mock, caplog):
     config["climate"]["current_temperature_topic"] = "current-temperature"
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     # Operation Mode
     state = hass.states.get(ENTITY_CLIMATE)
@@ -745,6 +773,7 @@ async def test_min_temp_custom(hass, mqtt_mock):
     config["climate"]["min_temp"] = 26
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     min_temp = state.attributes.get("min_temp")
@@ -759,6 +788,7 @@ async def test_max_temp_custom(hass, mqtt_mock):
     config["climate"]["max_temp"] = 60
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     max_temp = state.attributes.get("max_temp")
@@ -773,6 +803,7 @@ async def test_temp_step_custom(hass, mqtt_mock):
     config["climate"]["temp_step"] = 0.01
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
     temp_step = state.attributes.get("target_temp_step")
@@ -788,6 +819,7 @@ async def test_temperature_unit(hass, mqtt_mock):
     config["climate"]["current_temperature_topic"] = "current_temperature"
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "current_temperature", "77")
 
@@ -945,6 +977,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock):
 async def test_precision_default(hass, mqtt_mock):
     """Test that setting precision to tenths works as intended."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+    await hass.async_block_till_done()
 
     await common.async_set_temperature(
         hass, temperature=23.67, entity_id=ENTITY_CLIMATE
@@ -959,6 +992,7 @@ async def test_precision_halves(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["precision"] = 0.5
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     await common.async_set_temperature(
         hass, temperature=23.67, entity_id=ENTITY_CLIMATE
@@ -973,6 +1007,7 @@ async def test_precision_whole(hass, mqtt_mock):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["precision"] = 1.0
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
 
     await common.async_set_temperature(
         hass, temperature=23.67, entity_id=ENTITY_CLIMATE

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -39,6 +39,7 @@ async def help_test_availability_without_topic(hass, mqtt_mock, domain, config):
     """Test availability without defined availability topic."""
     assert "availability_topic" not in config[domain]
     assert await async_setup_component(hass, domain, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get(f"{domain}.test")
     assert state.state != STATE_UNAVAILABLE
@@ -61,6 +62,7 @@ async def help_test_default_availability_payload(
     config = copy.deepcopy(config)
     config[domain]["availability_topic"] = "availability-topic"
     assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
 
     state = hass.states.get(f"{domain}.test")
     assert state.state == STATE_UNAVAILABLE
@@ -108,6 +110,7 @@ async def help_test_custom_availability_payload(
     config[domain]["payload_available"] = "good"
     config[domain]["payload_not_available"] = "nogood"
     assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
 
     state = hass.states.get(f"{domain}.test")
     assert state.state == STATE_UNAVAILABLE
@@ -147,6 +150,7 @@ async def help_test_setting_attribute_via_mqtt_json_message(
     config = copy.deepcopy(config)
     config[domain]["json_attributes_topic"] = "attr-topic"
     assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "attr-topic", '{ "val": "100" }')
     state = hass.states.get(f"{domain}.test")
@@ -164,6 +168,7 @@ async def help_test_setting_attribute_with_template(hass, mqtt_mock, domain, con
     config[domain]["json_attributes_topic"] = "attr-topic"
     config[domain]["json_attributes_template"] = "{{ value_json['Timer1'] | tojson }}"
     assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(
         hass, "attr-topic", json.dumps({"Timer1": {"Arm": 0, "Time": "22:18"}})
@@ -185,6 +190,7 @@ async def help_test_update_with_json_attrs_not_dict(
     config = copy.deepcopy(config)
     config[domain]["json_attributes_topic"] = "attr-topic"
     assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "attr-topic", '[ "list", "of", "things"]')
     state = hass.states.get(f"{domain}.test")
@@ -204,6 +210,7 @@ async def help_test_update_with_json_attrs_bad_JSON(
     config = copy.deepcopy(config)
     config[domain]["json_attributes_topic"] = "attr-topic"
     assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "attr-topic", "This is not JSON")
 
@@ -251,7 +258,8 @@ async def help_test_discovery_update_attr(hass, mqtt_mock, caplog, domain, confi
 async def help_test_unique_id(hass, domain, config):
     """Test unique id option only creates one entity per unique_id."""
     await async_mock_mqtt_component(hass)
-    assert await async_setup_component(hass, domain, config,)
+    assert await async_setup_component(hass, domain, config)
+    await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(domain)) == 1
 
 
@@ -459,6 +467,7 @@ async def help_test_entity_id_update_subscriptions(
     registry = mock_registry(hass, {})
     mock_mqtt = await async_mock_mqtt_component(hass)
     assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
 
     state = hass.states.get(f"{domain}.test")
     assert state is not None

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -76,6 +76,7 @@ async def test_state_via_state_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -112,6 +113,7 @@ async def test_opening_and_closing_state_via_custom_state_payload(hass, mqtt_moc
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -152,6 +154,7 @@ async def test_open_closed_state_from_position_optimistic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -199,6 +202,7 @@ async def test_position_via_position_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -236,6 +240,7 @@ async def test_state_via_template(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -267,6 +272,7 @@ async def test_position_via_template(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -301,6 +307,7 @@ async def test_optimistic_state_change(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -358,6 +365,7 @@ async def test_optimistic_state_change_with_position(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -419,6 +427,7 @@ async def test_send_open_cover_command(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -447,6 +456,7 @@ async def test_send_close_cover_command(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -475,6 +485,7 @@ async def test_send_stop__cover_command(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
@@ -507,6 +518,7 @@ async def test_current_cover_position(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state_attributes_dict = hass.states.get("cover.test").attributes
     assert not (ATTR_CURRENT_POSITION in state_attributes_dict)
@@ -557,6 +569,7 @@ async def test_current_cover_position_inverted(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state_attributes_dict = hass.states.get("cover.test").attributes
     assert not (ATTR_CURRENT_POSITION in state_attributes_dict)
@@ -613,6 +626,7 @@ async def test_optimistic_position(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state is None
@@ -638,6 +652,7 @@ async def test_position_update(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state_attributes_dict = hass.states.get("cover.test").attributes
     assert not (ATTR_CURRENT_POSITION in state_attributes_dict)
@@ -675,6 +690,7 @@ async def test_set_position_templated(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -706,6 +722,7 @@ async def test_set_position_untemplated(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -737,6 +754,7 @@ async def test_set_position_untemplated_custom_percentage_range(hass, mqtt_mock)
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -766,6 +784,7 @@ async def test_no_command_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert hass.states.get("cover.test").attributes["supported_features"] == 240
 
@@ -787,6 +806,7 @@ async def test_no_payload_stop(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert hass.states.get("cover.test").attributes["supported_features"] == 3
 
@@ -810,6 +830,7 @@ async def test_with_command_topic_and_tilt(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert hass.states.get("cover.test").attributes["supported_features"] == 251
 
@@ -834,6 +855,7 @@ async def test_tilt_defaults(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state_attributes_dict = hass.states.get("cover.test").attributes
     assert ATTR_CURRENT_TILT_POSITION in state_attributes_dict
@@ -864,6 +886,7 @@ async def test_tilt_via_invocation_defaults(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -943,6 +966,7 @@ async def test_tilt_given_value(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -1023,6 +1047,7 @@ async def test_tilt_given_value_optimistic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -1079,6 +1104,7 @@ async def test_tilt_given_value_altered_range(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -1145,6 +1171,7 @@ async def test_tilt_via_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tilt-status-topic", "0")
 
@@ -1184,6 +1211,7 @@ async def test_tilt_via_topic_template(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tilt-status-topic", "99")
 
@@ -1222,6 +1250,7 @@ async def test_tilt_via_topic_altered_range(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tilt-status-topic", "0")
 
@@ -1270,6 +1299,7 @@ async def test_tilt_via_topic_template_altered_range(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tilt-status-topic", "99")
 
@@ -1313,6 +1343,7 @@ async def test_tilt_position(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -1348,6 +1379,7 @@ async def test_tilt_position_altered_range(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         cover.DOMAIN,
@@ -1738,6 +1770,7 @@ async def test_valid_device_class(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state.attributes.get("device_class") == "garage"
@@ -1757,6 +1790,7 @@ async def test_invalid_device_class(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("cover.test")
     assert state is None

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -50,6 +50,7 @@ async def test_fail_setup_if_no_command_topic(hass, mqtt_mock):
     assert await async_setup_component(
         hass, fan.DOMAIN, {fan.DOMAIN: {"platform": "mqtt", "name": "test"}}
     )
+    await hass.async_block_till_done()
     assert hass.states.get("fan.test") is None
 
 
@@ -79,6 +80,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test")
     assert state.state is STATE_OFF
@@ -141,6 +143,7 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test")
     assert state.state is STATE_OFF
@@ -207,6 +210,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test")
     assert state.state is STATE_OFF
@@ -300,6 +304,7 @@ async def test_on_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test")
     assert state.state is STATE_OFF
@@ -352,6 +357,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test")
     assert state.state is STATE_OFF
@@ -450,6 +456,7 @@ async def test_attributes(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test")
     assert state.state is STATE_OFF
@@ -537,6 +544,7 @@ async def test_custom_speed_list(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test")
     assert state.state is STATE_OFF
@@ -577,6 +585,7 @@ async def test_supported_features(hass, mqtt_mock):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("fan.test1")
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 0

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -76,6 +76,7 @@ async def test_default_supported_features(hass, mqtt_mock):
     assert await async_setup_component(
         hass, vacuum.DOMAIN, {vacuum.DOMAIN: DEFAULT_CONFIG}
     )
+    await hass.async_block_till_done()
     entity = hass.states.get("vacuum.mqtttest")
     entity_features = entity.attributes.get(mqttvacuum.CONF_SUPPORTED_FEATURES, 0)
     assert sorted(services_to_strings(entity_features, SERVICE_TO_STRING)) == sorted(
@@ -99,6 +100,7 @@ async def test_all_commands(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     await common.async_turn_on(hass, "vacuum.mqtttest")
     mqtt_mock.async_publish.assert_called_once_with(
@@ -178,6 +180,7 @@ async def test_commands_without_supported_features(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     await common.async_turn_on(hass, "vacuum.mqtttest")
     mqtt_mock.async_publish.assert_not_called()
@@ -225,6 +228,7 @@ async def test_attributes_without_supported_features(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "battery_level": 54,
@@ -250,6 +254,7 @@ async def test_status(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "battery_level": 54,
@@ -289,6 +294,7 @@ async def test_status_battery(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "battery_level": 54
@@ -306,6 +312,7 @@ async def test_status_cleaning(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "cleaning": true
@@ -323,6 +330,7 @@ async def test_status_docked(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "docked": true
@@ -340,6 +348,7 @@ async def test_status_charging(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "charging": true
@@ -357,6 +366,7 @@ async def test_status_fan_speed(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "fan_speed": "max"
@@ -374,6 +384,7 @@ async def test_status_fan_speed_list(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == ["min", "medium", "high", "max"]
@@ -391,6 +402,7 @@ async def test_status_no_fan_speed_list(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) is None
@@ -404,6 +416,7 @@ async def test_status_error(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "error": "Error1"
@@ -434,6 +447,7 @@ async def test_battery_template(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "retroroomba/battery_level", "54")
     state = hass.states.get("vacuum.mqtttest")
@@ -449,6 +463,7 @@ async def test_status_invalid_json(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "vacuum/state", '{"asdfasas false}')
     state = hass.states.get("vacuum.mqtttest")
@@ -462,6 +477,7 @@ async def test_missing_battery_template(hass, mqtt_mock):
     config.pop(mqttvacuum.CONF_BATTERY_LEVEL_TEMPLATE)
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state is None
@@ -473,6 +489,7 @@ async def test_missing_charging_template(hass, mqtt_mock):
     config.pop(mqttvacuum.CONF_CHARGING_TEMPLATE)
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state is None
@@ -484,6 +501,7 @@ async def test_missing_cleaning_template(hass, mqtt_mock):
     config.pop(mqttvacuum.CONF_CLEANING_TEMPLATE)
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state is None
@@ -495,6 +513,7 @@ async def test_missing_docked_template(hass, mqtt_mock):
     config.pop(mqttvacuum.CONF_DOCKED_TEMPLATE)
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state is None
@@ -506,6 +525,7 @@ async def test_missing_error_template(hass, mqtt_mock):
     config.pop(mqttvacuum.CONF_ERROR_TEMPLATE)
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state is None
@@ -517,6 +537,7 @@ async def test_missing_fan_speed_template(hass, mqtt_mock):
     config.pop(mqttvacuum.CONF_FAN_SPEED_TEMPLATE)
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.mqtttest")
     assert state is None

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -201,6 +201,7 @@ async def test_fail_setup_if_no_command_topic(hass, mqtt_mock):
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {"platform": "mqtt", "name": "test"}}
     )
+    await hass.async_block_till_done()
     assert hass.states.get("light.test") is None
 
 
@@ -218,6 +219,7 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(hass, mqt
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -269,6 +271,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -365,6 +368,7 @@ async def test_invalid_state_via_topic(hass, mqtt_mock, caplog):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -456,6 +460,7 @@ async def test_brightness_controlling_scale(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -501,6 +506,7 @@ async def test_brightness_from_rgb_controlling_scale(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -540,6 +546,7 @@ async def test_white_value_controlling_scale(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -599,6 +606,7 @@ async def test_controlling_state_via_topic_with_templates(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -676,6 +684,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     ):
         with assert_setup_component(1, light.DOMAIN):
             assert await async_setup_component(hass, light.DOMAIN, config)
+            await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
@@ -751,6 +760,7 @@ async def test_sending_mqtt_rgb_command_with_template(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -786,6 +796,7 @@ async def test_sending_mqtt_color_temp_command_with_template(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -818,6 +829,7 @@ async def test_show_brightness_if_only_command_topic(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -843,6 +855,7 @@ async def test_show_color_temp_only_if_command_topic(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -868,6 +881,7 @@ async def test_show_effect_only_if_command_topic(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -893,6 +907,7 @@ async def test_show_hs_if_only_command_topic(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -918,6 +933,7 @@ async def test_show_white_value_if_only_command_topic(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -943,6 +959,7 @@ async def test_show_xy_if_only_command_topic(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -968,6 +985,7 @@ async def test_on_command_first(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1002,6 +1020,7 @@ async def test_on_command_last(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1038,6 +1057,7 @@ async def test_on_command_brightness(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1091,6 +1111,7 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1153,6 +1174,7 @@ async def test_on_command_rgb(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1243,6 +1265,7 @@ async def test_on_command_rgb_template(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1279,6 +1302,7 @@ async def test_effect(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1498,6 +1522,7 @@ async def test_max_mireds(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.attributes.get("min_mireds") == 153

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -156,6 +156,7 @@ async def test_fail_setup_if_no_command_topic(hass, mqtt_mock):
         light.DOMAIN,
         {light.DOMAIN: {"platform": "mqtt", "schema": "json", "name": "test"}},
     )
+    await hass.async_block_till_done()
     assert hass.states.get("light.test") is None
 
 
@@ -174,6 +175,7 @@ async def test_no_color_brightness_color_temp_white_val_if_no_topics(hass, mqtt_
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -222,6 +224,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -346,6 +349,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
@@ -457,6 +461,7 @@ async def test_sending_hs_color(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -519,6 +524,7 @@ async def test_sending_rgb_color_no_brightness(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -572,6 +578,7 @@ async def test_sending_rgb_color_with_brightness(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -641,6 +648,7 @@ async def test_sending_rgb_color_with_scaled_brightness(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -709,6 +717,7 @@ async def test_sending_xy_color(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -771,6 +780,7 @@ async def test_effect(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -830,6 +840,7 @@ async def test_flash_short_and_long(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -869,6 +880,7 @@ async def test_transition(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -916,6 +928,7 @@ async def test_brightness_scale(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -959,6 +972,7 @@ async def test_invalid_values(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -1235,6 +1249,7 @@ async def test_max_mireds(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.attributes.get("min_mireds") == 153

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -84,6 +84,7 @@ async def test_setup_fails(hass, mqtt_mock):
             light.DOMAIN,
             {light.DOMAIN: {"platform": "mqtt", "schema": "template", "name": "test"}},
         )
+        await hass.async_block_till_done()
     assert hass.states.get("light.test") is None
 
     with assert_setup_component(0, light.DOMAIN):
@@ -99,6 +100,7 @@ async def test_setup_fails(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
     assert hass.states.get("light.test") is None
 
     with assert_setup_component(0, light.DOMAIN):
@@ -115,6 +117,7 @@ async def test_setup_fails(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
     assert hass.states.get("light.test") is None
 
     with assert_setup_component(0, light.DOMAIN):
@@ -131,6 +134,7 @@ async def test_setup_fails(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
     assert hass.states.get("light.test") is None
 
 
@@ -159,6 +163,7 @@ async def test_state_change_via_topic(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -214,6 +219,7 @@ async def test_state_brightness_color_effect_temp_white_change_via_topic(
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -313,6 +319,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
                     }
                 },
             )
+            await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
@@ -454,6 +461,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -567,6 +575,7 @@ async def test_effect(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -617,6 +626,7 @@ async def test_flash(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -664,6 +674,7 @@ async def test_transition(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -719,6 +730,7 @@ async def test_invalid_values(hass, mqtt_mock):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
@@ -994,6 +1006,7 @@ async def test_max_mireds(hass, mqtt_mock):
     }
 
     assert await async_setup_component(hass, light.DOMAIN, config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
     assert state.attributes.get("min_mireds") == 153

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -58,6 +58,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
@@ -92,6 +93,7 @@ async def test_controlling_non_default_state_via_topic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
@@ -127,6 +129,7 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
@@ -163,6 +166,7 @@ async def test_controlling_non_default_state_via_topic_and_json_message(
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
@@ -195,6 +199,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED
@@ -240,6 +245,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("lock.test")
     assert state.state is STATE_UNLOCKED

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -64,6 +64,7 @@ async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "test-topic", "100")
     state = hass.states.get("sensor.test")
@@ -88,6 +89,7 @@ async def test_setting_sensor_value_expires(hass, mqtt_mock, caplog):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test")
     assert state.state == "unknown"
@@ -155,6 +157,7 @@ async def test_setting_sensor_value_via_mqtt_json_message(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "test-topic", '{ "val": "100" }')
     state = hass.states.get("sensor.test")
@@ -176,6 +179,7 @@ async def test_force_update_disabled(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     events = []
 
@@ -209,6 +213,7 @@ async def test_force_update_enabled(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     events = []
 
@@ -262,6 +267,7 @@ async def test_invalid_device_class(hass, mqtt_mock):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test")
     assert state is None

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -82,6 +82,7 @@ async def test_default_supported_features(hass, mqtt_mock):
     assert await async_setup_component(
         hass, vacuum.DOMAIN, {vacuum.DOMAIN: DEFAULT_CONFIG}
     )
+    await hass.async_block_till_done()
     entity = hass.states.get("vacuum.mqtttest")
     entity_features = entity.attributes.get(mqttvacuum.CONF_SUPPORTED_FEATURES, 0)
     assert sorted(services_to_strings(entity_features, SERVICE_TO_STRING)) == sorted(
@@ -97,6 +98,7 @@ async def test_all_commands(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_START, {"entity_id": ENTITY_MATCH_ALL}, blocking=True
@@ -168,6 +170,7 @@ async def test_commands_without_supported_features(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_START, {"entity_id": ENTITY_MATCH_ALL}, blocking=True
@@ -223,6 +226,7 @@ async def test_status(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "battery_level": 54,
@@ -260,6 +264,7 @@ async def test_no_fan_vacuum(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     message = """{
         "battery_level": 54,
@@ -309,6 +314,7 @@ async def test_status_invalid_json(hass, mqtt_mock):
     )
 
     assert await async_setup_component(hass, vacuum.DOMAIN, {vacuum.DOMAIN: config})
+    await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "vacuum/state", '{"asdfasas false}')
     state = hass.states.get("vacuum.mqtttest")

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -59,6 +59,7 @@ async def test_controlling_state_via_topic(hass, mock_publish):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
     assert state.state == STATE_OFF
@@ -97,6 +98,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mock_publish):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
     assert state.state == STATE_ON
@@ -137,6 +139,7 @@ async def test_controlling_state_via_topic_and_json_message(hass, mock_publish):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
     assert state.state == STATE_OFF
@@ -213,6 +216,7 @@ async def test_custom_state_payload(hass, mock_publish):
             }
         },
     )
+    await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
     assert state.state == STATE_OFF

--- a/tests/components/mqtt_room/test_sensor.py
+++ b/tests/components/mqtt_room/test_sensor.py
@@ -68,6 +68,7 @@ async def test_room_update(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     await send_message(hass, BEDROOM_TOPIC, FAR_MESSAGE)
     await assert_state(hass, BEDROOM)

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -49,6 +49,7 @@ async def assert_setup_sensor(hass, config, count=1):
     """Set up the sensor and assert it's been created."""
     with assert_setup_component(count):
         assert await async_setup_component(hass, sensor.DOMAIN, config)
+        await hass.async_block_till_done()
 
 
 @pytest.fixture

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -92,6 +92,7 @@ class TestNSWFuelStation(unittest.TestCase):
         """Test the setup with custom settings."""
         with assert_setup_component(1, sensor.DOMAIN):
             assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
+            self.hass.block_till_done()
 
         fake_entities = ["my_fake_station_p95", "my_fake_station_e10"]
 
@@ -106,6 +107,7 @@ class TestNSWFuelStation(unittest.TestCase):
     def test_sensor_values(self):
         """Test retrieval of sensor values."""
         assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
+        self.hass.block_till_done()
 
         assert "140.0" == self.hass.states.get("sensor.my_fake_station_e10").state
         assert "150.0" == self.hass.states.get("sensor.my_fake_station_p95").state

--- a/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
+++ b/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
@@ -126,6 +126,7 @@ async def test_setup(hass):
         )
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(hass, geo_location.DOMAIN, CONFIG)
+            await hass.async_block_till_done()
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
             # Collect events.
@@ -242,6 +243,7 @@ async def test_setup_with_custom_location(hass):
             assert await async_setup_component(
                 hass, geo_location.DOMAIN, CONFIG_WITH_CUSTOM_LOCATION
             )
+            await hass.async_block_till_done()
 
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/openalpr_cloud/test_image_processing.py
+++ b/tests/components/openalpr_cloud/test_image_processing.py
@@ -36,6 +36,7 @@ class TestOpenAlprCloudSetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.openalpr_demo_camera")
 
@@ -53,6 +54,7 @@ class TestOpenAlprCloudSetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.test_local")
 
@@ -108,6 +110,7 @@ class TestOpenAlprCloud:
             new_callable=PropertyMock(return_value=False),
         ):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         self.alpr_events = []
 

--- a/tests/components/openalpr_local/test_image_processing.py
+++ b/tests/components/openalpr_local/test_image_processing.py
@@ -46,6 +46,7 @@ class TestOpenAlprLocalSetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.openalpr_demo_camera")
 
@@ -62,6 +63,7 @@ class TestOpenAlprLocalSetup:
 
         with assert_setup_component(1, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         assert self.hass.states.get("image_processing.test_local")
 
@@ -77,6 +79,7 @@ class TestOpenAlprLocalSetup:
 
         with assert_setup_component(0, ip.DOMAIN):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
 
 class TestOpenAlprLocal:
@@ -101,6 +104,7 @@ class TestOpenAlprLocal:
             new_callable=PropertyMock(return_value=False),
         ):
             setup_component(self.hass, ip.DOMAIN, config)
+            self.hass.block_till_done()
 
         state = self.hass.states.get("camera.demo_camera")
         self.url = f"{self.hass.config.api.base_url}{state.attributes.get(ATTR_ENTITY_PICTURE)}"

--- a/tests/components/openhardwaremonitor/test_sensor.py
+++ b/tests/components/openhardwaremonitor/test_sensor.py
@@ -35,6 +35,7 @@ class TestOpenHardwareMonitorSetup(unittest.TestCase):
         )
 
         assert setup_component(self.hass, "sensor", self.config)
+        self.hass.block_till_done()
         entities = self.hass.states.async_entity_ids("sensor")
         assert len(entities) == 38
 

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -1,5 +1,6 @@
 """Define tests for the OpenUV config flow."""
 from pyopenuv.errors import InvalidApiKeyError
+import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.openuv import DOMAIN
@@ -13,6 +14,17 @@ from homeassistant.const import (
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def mock_setup():
+    """Prevent setup."""
+    with patch(
+        "homeassistant.components.openuv.async_setup", return_value=True,
+    ), patch(
+        "homeassistant.components.openuv.async_setup_entry", return_value=True,
+    ):
+        yield
 
 
 async def test_duplicate_error(hass):

--- a/tests/components/pilight/test_sensor.py
+++ b/tests/components/pilight/test_sensor.py
@@ -48,6 +48,7 @@ def test_sensor_value_from_code():
                 }
             },
         )
+        HASS.block_till_done()
 
         state = HASS.states.get("sensor.test")
         assert state.state == "unknown"

--- a/tests/components/pilight/test_sensor.py
+++ b/tests/components/pilight/test_sensor.py
@@ -78,6 +78,7 @@ def test_disregard_wrong_payload():
                 }
             },
         )
+        HASS.block_till_done()
 
         # Try set value from data with incorrect payload
         fire_pilight_message(
@@ -121,6 +122,7 @@ def test_variable_missing(caplog):
                 }
             },
         )
+        HASS.block_till_done()
 
         # Create code without sensor variable
         fire_pilight_message(

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -26,6 +26,7 @@ async def prometheus_client(loop, hass, hass_client):
     await setup.async_setup_component(
         hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
     )
+    await hass.async_block_till_done()
 
     sensor1 = DemoSensor(
         None, "Television Energy", 74, None, ENERGY_KILO_WATT_HOUR, None

--- a/tests/components/qld_bushfire/test_geo_location.py
+++ b/tests/components/qld_bushfire/test_geo_location.py
@@ -98,6 +98,7 @@ async def test_setup(hass):
         )
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(hass, geo_location.DOMAIN, CONFIG)
+            await hass.async_block_till_done()
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
             # Collect events.
@@ -201,6 +202,7 @@ async def test_setup_with_custom_location(hass):
             assert await async_setup_component(
                 hass, geo_location.DOMAIN, CONFIG_WITH_CUSTOM_LOCATION
             )
+            await hass.async_block_till_done()
 
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/random/test_binary_sensor.py
+++ b/tests/components/random/test_binary_sensor.py
@@ -24,6 +24,7 @@ class TestRandomSensor(unittest.TestCase):
         config = {"binary_sensor": {"platform": "random", "name": "test"}}
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test")
 
@@ -37,6 +38,7 @@ class TestRandomSensor(unittest.TestCase):
         config = {"binary_sensor": {"platform": "random", "name": "test"}}
 
         assert setup_component(self.hass, "binary_sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("binary_sensor.test")
 

--- a/tests/components/random/test_sensor.py
+++ b/tests/components/random/test_sensor.py
@@ -29,6 +29,7 @@ class TestRandomSensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.test")
 

--- a/tests/components/reddit/test_sensor.py
+++ b/tests/components/reddit/test_sensor.py
@@ -160,6 +160,7 @@ class TestRedditSetup(unittest.TestCase):
     def test_setup_with_valid_config(self):
         """Test the platform setup with Reddit configuration."""
         setup_component(self.hass, "sensor", VALID_CONFIG)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.reddit_worldnews")
         assert int(state.state) == MOCK_RESULTS_LENGTH

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -88,6 +88,7 @@ class TestRestBinarySensorSetup(unittest.TestCase):
                 "binary_sensor",
                 {"binary_sensor": {"platform": "rest", "resource": "http://localhost"}},
             )
+            self.hass.block_till_done()
         assert 1 == mock_req.call_count
 
     @requests_mock.Mocker()
@@ -113,6 +114,7 @@ class TestRestBinarySensorSetup(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
         assert 1 == mock_req.call_count
 
     @requests_mock.Mocker()
@@ -139,6 +141,7 @@ class TestRestBinarySensorSetup(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
         assert 1 == mock_req.call_count
 
 

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -76,6 +76,7 @@ class TestRestSensorSetup(unittest.TestCase):
                 "sensor",
                 {"sensor": {"platform": "rest", "resource": "http://localhost"}},
             )
+            self.hass.block_till_done()
         assert 2 == mock_req.call_count
 
     @requests_mock.Mocker()
@@ -93,6 +94,7 @@ class TestRestSensorSetup(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
         assert mock_req.call_count == 2
 
     @requests_mock.Mocker()
@@ -111,6 +113,7 @@ class TestRestSensorSetup(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
 
     @requests_mock.Mocker()
     def test_setup_get(self, mock_req):
@@ -137,6 +140,7 @@ class TestRestSensorSetup(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
         assert 2 == mock_req.call_count
 
     @requests_mock.Mocker()
@@ -165,6 +169,7 @@ class TestRestSensorSetup(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
         assert 2 == mock_req.call_count
 
     @requests_mock.Mocker()
@@ -192,6 +197,7 @@ class TestRestSensorSetup(unittest.TestCase):
                     }
                 },
             )
+            self.hass.block_till_done()
         assert 2 == mock_req.call_count
 
 

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -165,6 +165,7 @@ async def test_rmvtransport_min_config(hass):
         "RMVtransport.RMVtransport.get_departures", return_value=get_departures_mock(),
     ):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL) is True
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert state.state == "7"
@@ -184,6 +185,7 @@ async def test_rmvtransport_name_config(hass):
         "RMVtransport.RMVtransport.get_departures", return_value=get_departures_mock(),
     ):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_NAME)
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.my_station")
     assert state.attributes["friendly_name"] == "My Station"
@@ -195,6 +197,7 @@ async def test_rmvtransport_misc_config(hass):
         "RMVtransport.RMVtransport.get_departures", return_value=get_departures_mock(),
     ):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_MISC)
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
@@ -207,6 +210,7 @@ async def test_rmvtransport_dest_config(hass):
         "RMVtransport.RMVtransport.get_departures", return_value=get_departures_mock(),
     ):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_DEST)
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert state.state == "11"
@@ -225,6 +229,7 @@ async def test_rmvtransport_no_departures(hass):
         return_value=get_no_departures_mock(),
     ):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert not state

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -23,6 +23,7 @@ class TestScene(unittest.TestCase):
         assert setup_component(
             self.hass, light.DOMAIN, {light.DOMAIN: {"platform": "test"}}
         )
+        self.hass.block_till_done()
 
         self.light_1, self.light_2 = test_light.ENTITIES[0:2]
 
@@ -72,6 +73,7 @@ class TestScene(unittest.TestCase):
                 ]
             },
         )
+        self.hass.block_till_done()
 
         common.activate(self.hass, "scene.test")
         self.hass.block_till_done()
@@ -121,6 +123,7 @@ class TestScene(unittest.TestCase):
                 ]
             },
         )
+        self.hass.block_till_done()
 
         common.activate(self.hass, "scene.test")
         self.hass.block_till_done()

--- a/tests/components/season/test_sensor.py
+++ b/tests/components/season/test_sensor.py
@@ -207,6 +207,7 @@ class TestSeason(unittest.TestCase):
         """Test platform setup of northern hemisphere."""
         self.hass.config.latitude = HEMISPHERE_NORTHERN["homeassistant"]["latitude"]
         assert setup_component(self.hass, "sensor", HEMISPHERE_NORTHERN)
+        self.hass.block_till_done()
         assert (
             self.hass.config.as_dict()["latitude"]
             == HEMISPHERE_NORTHERN["homeassistant"]["latitude"]
@@ -218,6 +219,7 @@ class TestSeason(unittest.TestCase):
         """Test platform setup of southern hemisphere."""
         self.hass.config.latitude = HEMISPHERE_SOUTHERN["homeassistant"]["latitude"]
         assert setup_component(self.hass, "sensor", HEMISPHERE_SOUTHERN)
+        self.hass.block_till_done()
         assert (
             self.hass.config.as_dict()["latitude"]
             == HEMISPHERE_SOUTHERN["homeassistant"]["latitude"]
@@ -229,6 +231,7 @@ class TestSeason(unittest.TestCase):
         """Test platform setup of equator."""
         self.hass.config.latitude = HEMISPHERE_EQUATOR["homeassistant"]["latitude"]
         assert setup_component(self.hass, "sensor", HEMISPHERE_EQUATOR)
+        self.hass.block_till_done()
         assert (
             self.hass.config.as_dict()["latitude"]
             == HEMISPHERE_EQUATOR["homeassistant"]["latitude"]
@@ -240,4 +243,5 @@ class TestSeason(unittest.TestCase):
         """Test platform setup of missing latlong."""
         self.hass.config.latitude = None
         assert setup_component(self.hass, "sensor", HEMISPHERE_EMPTY)
+        self.hass.block_till_done()
         assert self.hass.config.as_dict()["latitude"] is None

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -57,6 +57,7 @@ async def test_get_conditions(hass, device_reg, entity_reg):
         )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_conditions = [
         {
@@ -93,6 +94,7 @@ async def test_get_condition_capabilities(hass, device_reg, entity_reg):
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_capabilities = {
         "extra_fields": [
@@ -128,6 +130,7 @@ async def test_get_condition_capabilities_none(hass, device_reg, entity_reg):
     config_entry.add_to_hass(hass)
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     conditions = [
         {
@@ -160,6 +163,7 @@ async def test_if_state_not_above_below(hass, calls, caplog):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -193,6 +197,7 @@ async def test_if_state_above(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -250,6 +255,7 @@ async def test_if_state_below(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -307,6 +313,7 @@ async def test_if_state_between(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -61,6 +61,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_triggers = [
         {
@@ -98,6 +99,7 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_capabilities = {
         "extra_fields": [
@@ -134,6 +136,7 @@ async def test_get_trigger_capabilities_none(hass, device_reg, entity_reg):
     config_entry.add_to_hass(hass)
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     triggers = [
         {
@@ -165,6 +168,7 @@ async def test_if_fires_not_on_above_below(hass, calls, caplog):
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -194,6 +198,7 @@ async def test_if_fires_on_state_above(hass, calls):
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -251,6 +256,7 @@ async def test_if_fires_on_state_below(hass, calls):
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -308,6 +314,7 @@ async def test_if_fires_on_state_between(hass, calls):
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 
@@ -378,6 +385,7 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     sensor1 = platform.ENTITIES["battery"]
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -130,6 +130,7 @@ async def _setup_seventeentrack(hass, config=None, summary_data=None):
 
     ProfileMock.summary_data = summary_data
     assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
 
 
 async def _goto_future(hass, future=None):
@@ -144,13 +145,14 @@ async def _goto_future(hass, future=None):
 async def test_full_valid_config(hass):
     """Ensure everything starts correctly."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_FULL)
+    await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids()) == len(ProfileMock.summary_data.keys())
 
 
 async def test_valid_config(hass):
     """Ensure everything starts correctly."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
-
+    await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids()) == len(ProfileMock.summary_data.keys())
 
 

--- a/tests/components/sigfox/test_sensor.py
+++ b/tests/components/sigfox/test_sensor.py
@@ -50,6 +50,7 @@ class TestSigfoxSensor(unittest.TestCase):
             url = re.compile(API_URL + "devicetypes")
             mock_req.get(url, text="{}", status_code=401)
             assert setup_component(self.hass, "sensor", VALID_CONFIG)
+            self.hass.block_till_done()
         assert len(self.hass.states.entity_ids()) == 0
 
     def test_valid_credentials(self):
@@ -65,6 +66,7 @@ class TestSigfoxSensor(unittest.TestCase):
             mock_req.get(url3, text=VALID_MESSAGE)
 
             assert setup_component(self.hass, "sensor", VALID_CONFIG)
+            self.hass.block_till_done()
 
             assert len(self.hass.states.entity_ids()) == 1
             state = self.hass.states.get("sensor.sigfox_fake_id")

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -88,6 +88,7 @@ async def test_bad_api_key(hass, caplog):
         "simplehound.core.cloud.detect", side_effect=hound.SimplehoundException
     ):
         await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+        await hass.async_block_till_done()
         assert "Sighthound error" in caplog.text
         assert not hass.states.get(VALID_ENTITY_ID)
 
@@ -95,12 +96,14 @@ async def test_bad_api_key(hass, caplog):
 async def test_setup_platform(hass, mock_detections):
     """Set up platform with one entity."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
 
 async def test_process_image(hass, mock_image, mock_detections):
     """Process an image."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     person_events = []
@@ -128,6 +131,7 @@ async def test_catch_bad_image(
     valid_config_save_file = deepcopy(VALID_CONFIG)
     valid_config_save_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
     await async_setup_component(hass, ip.DOMAIN, valid_config_save_file)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
@@ -141,6 +145,7 @@ async def test_save_image(hass, mock_image, mock_detections):
     valid_config_save_file = deepcopy(VALID_CONFIG)
     valid_config_save_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
     await async_setup_component(hass, ip.DOMAIN, valid_config_save_file)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     with mock.patch(
@@ -166,6 +171,7 @@ async def test_save_timestamped_image(hass, mock_image, mock_detections, mock_no
     valid_config_save_ts_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
     valid_config_save_ts_file[ip.DOMAIN].update({sh.CONF_SAVE_TIMESTAMPTED_FILE: True})
     await async_setup_component(hass, ip.DOMAIN, valid_config_save_ts_file)
+    await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     with mock.patch(

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -24,6 +24,7 @@ async def test_sma_config(hass):
         assert await async_setup_component(
             hass, DOMAIN, {DOMAIN: dict(BASE_CFG, sensors=sensors)}
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.current_consumption")
     assert state

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -48,6 +48,7 @@ async def test_setup_hass(hass: HomeAssistant, aioclient_mock) -> None:
     entry = MockConfigEntry(domain="smhi", data=TEST_CONFIG)
 
     await hass.config_entries.async_forward_entry_setup(entry, WEATHER_DOMAIN)
+    await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
 
     #  Testing the actual entity state for

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -39,6 +39,7 @@ class TestSQLSensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.count_tables")
         assert state.state == "5"
@@ -64,6 +65,7 @@ class TestSQLSensor(unittest.TestCase):
         }
 
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
 
         state = self.hass.states.get("sensor.count_tables")
         assert state.state == STATE_UNKNOWN

--- a/tests/components/startca/test_sensor.py
+++ b/tests/components/startca/test_sensor.py
@@ -146,6 +146,7 @@ async def test_unlimited_setup(hass, aioclient_mock):
     )
 
     await async_setup_component(hass, "sensor", {"sensor": config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.start_ca_usage_ratio")
     assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE

--- a/tests/components/startca/test_sensor.py
+++ b/tests/components/startca/test_sensor.py
@@ -50,6 +50,7 @@ async def test_capped_setup(hass, aioclient_mock):
     )
 
     await async_setup_component(hass, "sensor", {"sensor": config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.start_ca_usage_ratio")
     assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -57,6 +57,7 @@ class TestStatisticsSensor(unittest.TestCase):
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -82,6 +83,7 @@ class TestStatisticsSensor(unittest.TestCase):
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -121,6 +123,7 @@ class TestStatisticsSensor(unittest.TestCase):
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -150,6 +153,7 @@ class TestStatisticsSensor(unittest.TestCase):
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -197,6 +201,7 @@ class TestStatisticsSensor(unittest.TestCase):
                 },
             )
 
+            self.hass.block_till_done()
             self.hass.start()
             self.hass.block_till_done()
 
@@ -238,6 +243,7 @@ class TestStatisticsSensor(unittest.TestCase):
                 },
             )
 
+            self.hass.block_till_done()
             self.hass.start()
             self.hass.block_till_done()
 
@@ -291,6 +297,7 @@ class TestStatisticsSensor(unittest.TestCase):
                 },
             )
 
+            self.hass.block_till_done()
             self.hass.start()
             self.hass.block_till_done()
 
@@ -342,6 +349,7 @@ class TestStatisticsSensor(unittest.TestCase):
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -407,6 +415,7 @@ class TestStatisticsSensor(unittest.TestCase):
             )
             self.hass.block_till_done()
 
+            self.hass.block_till_done()
             self.hass.start()
             self.hass.block_till_done()
 

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -75,6 +75,7 @@ async def test_action(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -96,6 +96,7 @@ async def test_if_state(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 
@@ -173,6 +174,7 @@ async def test_if_fires_on_for_condition(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -96,6 +96,7 @@ async def test_if_fires_on_state_change(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 
@@ -180,6 +181,7 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     ent1, ent2, ent3 = platform.ENTITIES
 

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -33,6 +33,7 @@ class TestSwitch(unittest.TestCase):
         assert setup_component(
             self.hass, switch.DOMAIN, {switch.DOMAIN: {CONF_PLATFORM: "test"}}
         )
+        self.hass.block_till_done()
         assert switch.is_on(self.hass, self.switch_1.entity_id)
         assert not switch.is_on(self.hass, self.switch_2.entity_id)
         assert not switch.is_on(self.hass, self.switch_3.entity_id)

--- a/tests/components/teksavvy/test_sensor.py
+++ b/tests/components/teksavvy/test_sensor.py
@@ -44,6 +44,7 @@ async def test_capped_setup(hass, aioclient_mock):
     )
 
     await async_setup_component(hass, "sensor", {"sensor": config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.teksavvy_data_limit")
     assert state.attributes.get("unit_of_measurement") == DATA_GIGABYTES
@@ -125,6 +126,7 @@ async def test_unlimited_setup(hass, aioclient_mock):
     )
 
     await async_setup_component(hass, "sensor", {"sensor": config})
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.teksavvy_data_limit")
     assert state.attributes.get("unit_of_measurement") == DATA_GIGABYTES

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -54,6 +54,7 @@ async def test_template_state_text(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -136,6 +137,7 @@ async def test_optimistic_states(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -189,6 +191,7 @@ async def test_no_action_scripts(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -261,6 +264,7 @@ async def test_template_syntax_error(hass, caplog):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -305,6 +309,7 @@ async def test_invalid_name_does_not_create(hass, caplog):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -325,6 +330,7 @@ async def test_invalid_panel_does_not_create(hass, caplog):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -338,6 +344,7 @@ async def test_no_panels_does_not_create(hass, caplog):
         hass, "alarm_control_panel", {"alarm_control_panel": {"platform": "template"}},
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -383,6 +390,7 @@ async def test_name(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -425,6 +433,7 @@ async def test_arm_home_action(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -471,6 +480,7 @@ async def test_arm_away_action(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -517,6 +527,7 @@ async def test_arm_night_action(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -563,6 +574,7 @@ async def test_disarm_action(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -127,6 +127,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -161,6 +162,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -193,6 +195,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -224,6 +227,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
         init_calls = len(_async_render.mock_calls)
@@ -280,6 +284,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         with assert_setup_component(1):
             assert setup.setup_component(self.hass, "binary_sensor", config)
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -335,6 +340,7 @@ async def test_template_delay_on(hass):
         }
     }
     await setup.async_setup_component(hass, "binary_sensor", config)
+    await hass.async_block_till_done()
     await hass.async_start()
 
     hass.states.async_set("sensor.test_state", "on")
@@ -394,6 +400,7 @@ async def test_template_delay_off(hass):
     }
     hass.states.async_set("sensor.test_state", "on")
     await setup.async_setup_component(hass, "binary_sensor", config)
+    await hass.async_block_till_done()
     await hass.async_start()
 
     hass.states.async_set("sensor.test_state", "off")
@@ -452,6 +459,7 @@ async def test_available_without_availability_template(hass):
         }
     }
     await setup.async_setup_component(hass, "binary_sensor", config)
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -475,6 +483,7 @@ async def test_availability_template(hass):
         }
     }
     await setup.async_setup_component(hass, "binary_sensor", config)
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -537,7 +546,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
             }
         },
     )
-
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -62,6 +62,7 @@ async def test_template_state_text(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -104,6 +105,7 @@ async def test_template_state_boolean(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -137,6 +139,7 @@ async def test_template_position(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -192,6 +195,7 @@ async def test_template_tilt(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -226,6 +230,7 @@ async def test_template_out_of_bounds(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -264,6 +269,7 @@ async def test_template_mutex(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -310,6 +316,7 @@ async def test_template_open_and_close(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -347,6 +354,7 @@ async def test_template_non_numeric(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -378,6 +386,7 @@ async def test_open_action(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -416,6 +425,7 @@ async def test_close_stop_action(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -463,6 +473,7 @@ async def test_set_position(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -537,6 +548,7 @@ async def test_set_tilt_position(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -578,6 +590,7 @@ async def test_open_tilt_action(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -616,6 +629,7 @@ async def test_close_tilt_action(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -644,6 +658,7 @@ async def test_set_position_optimistic(hass, calls):
                 }
             },
         )
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -708,6 +723,7 @@ async def test_set_tilt_position_optimistic(hass, calls):
                 }
             },
         )
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -782,6 +798,7 @@ async def test_icon_template(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -825,6 +842,7 @@ async def test_entity_picture_template(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -866,6 +884,7 @@ async def test_availability_template(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -905,6 +924,7 @@ async def test_availability_without_availability_template(hass, calls):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -938,6 +958,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -972,6 +993,7 @@ async def test_device_class(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -1006,6 +1028,7 @@ async def test_invalid_device_class(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -63,6 +63,7 @@ async def test_missing_optional_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -88,6 +89,7 @@ async def test_missing_value_template_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -113,6 +115,7 @@ async def test_missing_turn_on_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -138,6 +141,7 @@ async def test_missing_turn_off_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -161,6 +165,7 @@ async def test_invalid_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -202,6 +207,7 @@ async def test_templates_with_entities(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -241,6 +247,7 @@ async def test_availability_template_with_entities(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -282,6 +289,7 @@ async def test_templates_with_valid_values(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -311,6 +319,7 @@ async def test_templates_invalid_values(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -342,6 +351,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -687,5 +697,6 @@ async def _register_components(hass, speed_list=None):
             {"fan": {"platform": "template", "fans": {"test_fan": test_fan_config}}},
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -78,6 +78,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -117,6 +118,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -169,6 +171,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -208,6 +211,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -246,6 +250,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -265,6 +270,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -277,6 +283,7 @@ class TestTemplateLight:
                 self.hass, "light", {"light": {"platform": "template"}}
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -316,6 +323,7 @@ class TestTemplateLight:
         del light["light"]["lights"]["light_one"][missing_key]
         with assert_setup_component(count, "light"):
             assert setup.setup_component(self.hass, "light", light)
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -353,6 +361,7 @@ class TestTemplateLight:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -395,6 +404,7 @@ class TestTemplateLight:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -440,6 +450,7 @@ class TestTemplateLight:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -482,6 +493,7 @@ class TestTemplateLight:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -526,6 +538,7 @@ class TestTemplateLight:
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -587,6 +600,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -625,6 +639,7 @@ class TestTemplateLight:
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -685,6 +700,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -737,6 +753,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -775,6 +792,7 @@ class TestTemplateLight:
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -825,6 +843,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -870,6 +889,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -920,6 +940,7 @@ class TestTemplateLight:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -975,6 +996,7 @@ class TestTemplateLight:
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -1046,6 +1068,7 @@ class TestTemplateLight:
                     }
                 },
             )
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
         state = self.hass.states.get("light.test_template_light")
@@ -1084,6 +1107,7 @@ async def test_available_template_with_entities(hass):
             }
         },
     )
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -1134,6 +1158,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -57,6 +57,7 @@ class TestTemplateLock:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -94,6 +95,7 @@ class TestTemplateLock:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -122,6 +124,7 @@ class TestTemplateLock:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -150,6 +153,7 @@ class TestTemplateLock:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -178,6 +182,7 @@ class TestTemplateLock:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -192,6 +197,7 @@ class TestTemplateLock:
                 {"lock": {"platform": "template", "value_template": "Invalid"}},
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -219,6 +225,7 @@ class TestTemplateLock:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -246,6 +253,7 @@ class TestTemplateLock:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -281,6 +289,7 @@ class TestTemplateLock:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -315,6 +324,7 @@ class TestTemplateLock:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -352,6 +362,7 @@ async def test_available_template_with_entities(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -389,6 +400,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -42,6 +42,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -75,6 +76,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -108,6 +110,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -138,6 +141,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -168,6 +172,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -200,6 +205,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -229,6 +235,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
         assert self.hass.states.all() == []
@@ -252,6 +259,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -276,6 +284,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -295,6 +304,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
 
         assert self.hass.states.all() == []
@@ -306,6 +316,7 @@ class TestTemplateSensor:
                 self.hass, "sensor", {"sensor": {"platform": "template"}}
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -329,6 +340,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -401,6 +413,7 @@ class TestTemplateSensor:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -445,6 +458,7 @@ async def test_available_template_with_entities(hass):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -510,6 +524,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -549,6 +564,7 @@ async def test_no_template_match_all(hass, caplog):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert hass.states.get("sensor.invalid_state").state == "unknown"
     assert hass.states.get("sensor.invalid_icon").state == "unknown"

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -56,6 +56,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -97,6 +98,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -129,6 +131,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -164,6 +167,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -205,6 +209,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -243,6 +248,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -274,6 +280,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -293,6 +300,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -305,6 +313,7 @@ class TestTemplateSwitch:
                 self.hass, "switch", {"switch": {"platform": "template"}}
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -336,6 +345,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -367,6 +377,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -398,6 +409,7 @@ class TestTemplateSwitch:
                 },
             )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -425,6 +437,7 @@ class TestTemplateSwitch:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -461,6 +474,7 @@ class TestTemplateSwitch:
             },
         )
 
+        self.hass.block_till_done()
         self.hass.start()
         self.hass.block_till_done()
 
@@ -502,6 +516,7 @@ async def test_available_template_with_entities(hass):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -542,6 +557,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -50,6 +50,7 @@ async def test_missing_optional_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -70,6 +71,7 @@ async def test_missing_start_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -90,6 +92,7 @@ async def test_invalid_config(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -120,6 +123,7 @@ async def test_templates_with_entities(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -152,6 +156,7 @@ async def test_templates_with_valid_values(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -178,6 +183,7 @@ async def test_templates_invalid_values(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -205,6 +211,7 @@ async def test_invalid_templates(hass, calls):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -230,6 +237,7 @@ async def test_available_template_with_entities(hass, calls):
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -266,6 +274,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
         },
     )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -446,6 +455,7 @@ async def _register_basic_vacuum(hass):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 
@@ -532,5 +542,6 @@ async def _register_components(hass):
             },
         )
 
+    await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -79,8 +79,8 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=test_time,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
-        self.hass.block_till_done()
         state = self.hass.states.get("binary_sensor.evening")
         assert state.state == STATE_ON
 
@@ -97,8 +97,8 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=test_time,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
-        self.hass.block_till_done()
         state = self.hass.states.get("binary_sensor.night")
         assert state.state == STATE_ON
 
@@ -117,6 +117,7 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=test_time,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
             state = self.hass.states.get("binary_sensor.night")
             assert state.state == STATE_OFF
@@ -151,8 +152,8 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=test_time,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
-        self.hass.block_till_done()
         state = self.hass.states.get("binary_sensor.night")
         assert state.state == STATE_OFF
 
@@ -172,8 +173,8 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=test_time,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
-        self.hass.block_till_done()
         state = self.hass.states.get("binary_sensor.night")
         assert state.state == STATE_OFF
 
@@ -232,6 +233,7 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
             self.hass.block_till_done()
             state = self.hass.states.get(entity_id)
@@ -328,6 +330,7 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
             self.hass.block_till_done()
             state = self.hass.states.get(entity_id)
@@ -424,8 +427,8 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
-        self.hass.block_till_done()
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_OFF
 
@@ -497,8 +500,8 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
-        self.hass.block_till_done()
         state = self.hass.states.get(entity_id)
         assert state.state == STATE_OFF
 
@@ -544,6 +547,7 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
             self.hass.block_till_done()
             state = self.hass.states.get(entity_id)
@@ -659,6 +663,7 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
             self.hass.block_till_done()
             state = self.hass.states.get(entity_id)
@@ -774,6 +779,7 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
             self.hass.block_till_done()
             state = self.hass.states.get(entity_id)
@@ -883,6 +889,7 @@ class TestBinarySensorTod(unittest.TestCase):
             return_value=testtime,
         ):
             setup_component(self.hass, "binary_sensor", config)
+            self.hass.block_till_done()
 
             self.hass.block_till_done()
             state = self.hass.states.get(entity_id)

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -149,6 +149,7 @@ async def setup_gateway(hass, mock_gateway, mock_api):
     hass.data[tradfri.KEY_GATEWAY] = {entry.entry_id: mock_gateway}
     hass.data[tradfri.KEY_API] = {entry.entry_id: mock_api}
     await hass.config_entries.async_forward_entry_setup(entry, "light")
+    await hass.async_block_till_done()
 
 
 def mock_light(test_features={}, test_state={}, n=0):

--- a/tests/components/transport_nsw/test_sensor.py
+++ b/tests/components/transport_nsw/test_sensor.py
@@ -46,6 +46,7 @@ class TestRMVtransportSensor(unittest.TestCase):
     def test_transportnsw_config(self, mock_get_departures):
         """Test minimal TransportNSW configuration."""
         assert setup_component(self.hass, "sensor", VALID_CONFIG)
+        self.hass.block_till_done()
         state = self.hass.states.get("sensor.next_bus")
         assert state.state == "16"
         assert state.attributes["stop_id"] == "209516"

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -35,6 +35,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_state", "1")
         self.hass.block_till_done()
@@ -62,6 +63,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         now = dt_util.utcnow()
         for val in [10, 0, 20, 30]:
@@ -103,6 +105,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         now = dt_util.utcnow()
         for val in [30, 20, 30, 10]:
@@ -137,6 +140,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_state", "2")
         self.hass.block_till_done()
@@ -162,6 +166,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_state", "1")
         self.hass.block_till_done()
@@ -187,6 +192,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_state", "2")
         self.hass.block_till_done()
@@ -212,6 +218,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
         self.hass.states.set("sensor.test_state", "State", {"attr": "1"})
         self.hass.block_till_done()
         self.hass.states.set("sensor.test_state", "State", {"attr": "2"})
@@ -236,6 +243,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_state", "State", {"attr": "2"})
         self.hass.block_till_done()
@@ -262,6 +270,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         for val in [0, 1, 2, 3, 2, 1]:
             self.hass.states.set("sensor.test_state", val)
@@ -285,6 +294,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_state", "Non")
         self.hass.block_till_done()
@@ -310,6 +320,7 @@ class TestTrendBinarySensor:
                 }
             },
         )
+        self.hass.block_till_done()
 
         self.hass.states.set("sensor.test_state", "State", {"attr": "2"})
         self.hass.block_till_done()

--- a/tests/components/twitch/test_twitch.py
+++ b/tests/components/twitch/test_twitch.py
@@ -54,6 +54,7 @@ async def test_init(hass):
         "homeassistant.components.twitch.sensor.TwitchClient", return_value=twitch_mock
     ):
         assert await async_setup_component(hass, sensor.DOMAIN, CONFIG) is True
+        await hass.async_block_till_done()
 
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.state == "offline"
@@ -76,6 +77,7 @@ async def test_offline(hass):
         "homeassistant.components.twitch.sensor.TwitchClient", return_value=twitch_mock,
     ):
         assert await async_setup_component(hass, sensor.DOMAIN, CONFIG) is True
+        await hass.async_block_till_done()
 
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.state == "offline"
@@ -94,6 +96,7 @@ async def test_streaming(hass):
         "homeassistant.components.twitch.sensor.TwitchClient", return_value=twitch_mock,
     ):
         assert await async_setup_component(hass, sensor.DOMAIN, CONFIG) is True
+        await hass.async_block_till_done()
 
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.state == "streaming"
@@ -116,9 +119,8 @@ async def test_oauth_without_sub_and_follow(hass):
     with patch(
         "homeassistant.components.twitch.sensor.TwitchClient", return_value=twitch_mock,
     ):
-        assert (
-            await async_setup_component(hass, sensor.DOMAIN, CONFIG_WITH_OAUTH) is True
-        )
+        assert await async_setup_component(hass, sensor.DOMAIN, CONFIG_WITH_OAUTH)
+        await hass.async_block_till_done()
 
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.attributes["subscribed"] is False
@@ -139,9 +141,8 @@ async def test_oauth_with_sub(hass):
     with patch(
         "homeassistant.components.twitch.sensor.TwitchClient", return_value=twitch_mock,
     ):
-        assert (
-            await async_setup_component(hass, sensor.DOMAIN, CONFIG_WITH_OAUTH) is True
-        )
+        assert await async_setup_component(hass, sensor.DOMAIN, CONFIG_WITH_OAUTH)
+        await hass.async_block_till_done()
 
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.attributes["subscribed"] is True
@@ -164,9 +165,8 @@ async def test_oauth_with_follow(hass):
     with patch(
         "homeassistant.components.twitch.sensor.TwitchClient", return_value=twitch_mock,
     ):
-        assert (
-            await async_setup_component(hass, sensor.DOMAIN, CONFIG_WITH_OAUTH) is True
-        )
+        assert await async_setup_component(hass, sensor.DOMAIN, CONFIG_WITH_OAUTH)
+        await hass.async_block_till_done()
 
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.attributes["subscribed"] is False

--- a/tests/components/uk_transport/test_sensor.py
+++ b/tests/components/uk_transport/test_sensor.py
@@ -61,6 +61,7 @@ class TestUkTransportSensor(unittest.TestCase):
             uri = re.compile(UkTransportSensor.TRANSPORT_API_URL_BASE + "*")
             mock_req.get(uri, text=load_fixture("uk_transport_bus.json"))
             assert setup_component(self.hass, "sensor", {"sensor": self.config})
+            self.hass.block_till_done()
 
         bus_state = self.hass.states.get("sensor.next_bus_to_wantage")
 
@@ -85,6 +86,7 @@ class TestUkTransportSensor(unittest.TestCase):
             uri = re.compile(UkTransportSensor.TRANSPORT_API_URL_BASE + "*")
             mock_req.get(uri, text=load_fixture("uk_transport_train.json"))
             assert setup_component(self.hass, "sensor", {"sensor": self.config})
+            self.hass.block_till_done()
 
         train_state = self.hass.states.get("sensor.next_train_to_WAT")
 

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -121,6 +121,7 @@ async def test_setup(hass):
         )
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(hass, geo_location.DOMAIN, CONFIG)
+            await hass.async_block_till_done()
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
             # Collect events.
@@ -228,6 +229,7 @@ async def test_setup_with_custom_location(hass):
             assert await async_setup_component(
                 hass, geo_location.DOMAIN, CONFIG_WITH_CUSTOM_LOCATION
             )
+            await hass.async_block_till_done()
 
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -57,6 +57,7 @@ class TestWolSwitch(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         state = self.hass.states.get("switch.wake_on_lan")
         assert STATE_OFF == state.state
@@ -93,6 +94,7 @@ class TestWolSwitch(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         state = self.hass.states.get("switch.wake_on_lan")
         assert STATE_OFF == state.state
@@ -130,6 +132,7 @@ class TestWolSwitch(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         state = self.hass.states.get("switch.wake_on_lan")
         assert STATE_OFF == state.state
@@ -155,6 +158,7 @@ class TestWolSwitch(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
         calls = mock_service(self.hass, "shell_command", "turn_off_target")
 
         state = self.hass.states.get("switch.wake_on_lan")
@@ -196,6 +200,7 @@ class TestWolSwitch(unittest.TestCase):
                 }
             },
         )
+        self.hass.block_till_done()
 
         state = self.hass.states.get("switch.wake_on_lan")
         assert STATE_OFF == state.state

--- a/tests/components/weather/test_weather.py
+++ b/tests/components/weather/test_weather.py
@@ -32,6 +32,7 @@ class TestWeather(unittest.TestCase):
         assert setup_component(
             self.hass, weather.DOMAIN, {"weather": {"platform": "demo"}}
         )
+        self.hass.block_till_done()
 
     def tearDown(self):
         """Stop down everything that was started."""

--- a/tests/components/websocket_api/conftest.py
+++ b/tests/components/websocket_api/conftest.py
@@ -24,6 +24,7 @@ async def no_auth_websocket_client(hass, aiohttp_client):
     auth_ok = await ws.receive_json()
     assert auth_ok["type"] == TYPE_AUTH_REQUIRED
 
+    ws.client = client
     yield ws
 
     if not ws.closed:

--- a/tests/components/websocket_api/conftest.py
+++ b/tests/components/websocket_api/conftest.py
@@ -16,6 +16,7 @@ async def websocket_client(hass, hass_ws_client):
 async def no_auth_websocket_client(hass, aiohttp_client):
     """Websocket connection that requires authentication."""
     assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
 
     client = await aiohttp_client(hass.http.app)
     ws = await client.ws_connect(URL)

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -1,6 +1,8 @@
 """Test auth of websocket API."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
     TYPE_AUTH_INVALID,
@@ -12,34 +14,52 @@ from homeassistant.components.websocket_api.const import (
     SIGNAL_WEBSOCKET_DISCONNECTED,
     URL,
 )
+from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro
 
 
-async def test_auth_events(
-    hass, no_auth_websocket_client, legacy_auth, hass_access_token
-):
-    """Test authenticating."""
+@pytest.fixture
+def track_connected(hass):
+    """Track connected and disconnected events."""
     connected_evt = []
+
+    @callback
+    def track_connected():
+        connected_evt.append(1)
+
     hass.helpers.dispatcher.async_dispatcher_connect(
-        SIGNAL_WEBSOCKET_CONNECTED, lambda: connected_evt.append(1)
+        SIGNAL_WEBSOCKET_CONNECTED, track_connected
     )
     disconnected_evt = []
+
+    @callback
+    def track_disconnected():
+        disconnected_evt.append(1)
+
     hass.helpers.dispatcher.async_dispatcher_connect(
-        SIGNAL_WEBSOCKET_DISCONNECTED, lambda: disconnected_evt.append(1)
+        SIGNAL_WEBSOCKET_DISCONNECTED, track_disconnected
     )
+
+    return {"connected": connected_evt, "disconnected": disconnected_evt}
+
+
+async def test_auth_events(
+    hass, no_auth_websocket_client, legacy_auth, hass_access_token, track_connected
+):
+    """Test authenticating."""
 
     await test_auth_active_with_token(hass, no_auth_websocket_client, hass_access_token)
     await hass.async_block_till_done()
 
-    assert len(connected_evt) == 1
-    assert not disconnected_evt
+    assert len(track_connected["connected"]) == 1
+    assert not track_connected["disconnected"]
 
     await no_auth_websocket_client.close()
     await hass.async_block_till_done()
 
-    assert len(disconnected_evt) == 1
+    assert len(track_connected["disconnected"]) == 1
 
 
 async def test_auth_via_msg_incorrect_pass(no_auth_websocket_client):
@@ -59,27 +79,21 @@ async def test_auth_via_msg_incorrect_pass(no_auth_websocket_client):
     assert msg["message"] == "Invalid access token or password"
 
 
-async def test_auth_events_incorrect_pass(hass, no_auth_websocket_client):
+async def test_auth_events_incorrect_pass(
+    hass, no_auth_websocket_client, track_connected
+):
     """Test authenticating."""
-    connected_evt = []
-    hass.helpers.dispatcher.async_dispatcher_connect(
-        SIGNAL_WEBSOCKET_CONNECTED, lambda: connected_evt.append(1)
-    )
-    disconnected_evt = []
-    hass.helpers.dispatcher.async_dispatcher_connect(
-        SIGNAL_WEBSOCKET_DISCONNECTED, lambda: disconnected_evt.append(1)
-    )
 
     await test_auth_via_msg_incorrect_pass(no_auth_websocket_client)
 
-    assert not connected_evt
-    assert not disconnected_evt
+    assert not track_connected["connected"]
+    assert not track_connected["disconnected"]
 
     await no_auth_websocket_client.close()
     await hass.async_block_till_done()
 
-    assert not connected_evt
-    assert not disconnected_evt
+    assert not track_connected["connected"]
+    assert not track_connected["disconnected"]
 
 
 async def test_pre_auth_only_auth_allowed(no_auth_websocket_client):

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -103,6 +103,7 @@ async def test_auth_active_with_token(
 ):
     """Test authenticating with a token."""
     assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
 
     await no_auth_websocket_client.send_json(
         {"type": TYPE_AUTH, "access_token": hass_access_token}

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -51,7 +51,6 @@ async def test_auth_events(
     """Test authenticating."""
 
     await test_auth_active_with_token(hass, no_auth_websocket_client, hass_access_token)
-    await hass.async_block_till_done()
 
     assert len(track_connected["connected"]) == 1
     assert not track_connected["disconnected"]
@@ -79,9 +78,7 @@ async def test_auth_via_msg_incorrect_pass(no_auth_websocket_client):
     assert msg["message"] == "Invalid access token or password"
 
 
-async def test_auth_events_incorrect_pass(
-    hass, no_auth_websocket_client, track_connected
-):
+async def test_auth_events_incorrect_pass(no_auth_websocket_client, track_connected):
     """Test authenticating."""
 
     await test_auth_via_msg_incorrect_pass(no_auth_websocket_client)
@@ -90,7 +87,6 @@ async def test_auth_events_incorrect_pass(
     assert not track_connected["disconnected"]
 
     await no_auth_websocket_client.close()
-    await hass.async_block_till_done()
 
     assert not track_connected["connected"]
     assert not track_connected["disconnected"]
@@ -117,14 +113,11 @@ async def test_auth_active_with_token(
     hass, no_auth_websocket_client, hass_access_token
 ):
     """Test authenticating with a token."""
-    assert await async_setup_component(hass, "websocket_api", {})
-    await hass.async_block_till_done()
-
     await no_auth_websocket_client.send_json(
         {"type": TYPE_AUTH, "access_token": hass_access_token}
     )
-
     auth_msg = await no_auth_websocket_client.receive_json()
+
     assert auth_msg["type"] == TYPE_AUTH_OK
 
 
@@ -133,6 +126,7 @@ async def test_auth_active_user_inactive(hass, aiohttp_client, hass_access_token
     refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
     refresh_token.user.is_active = False
     assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
 
     client = await aiohttp_client(hass.http.app)
 
@@ -149,6 +143,7 @@ async def test_auth_active_user_inactive(hass, aiohttp_client, hass_access_token
 async def test_auth_active_with_password_not_allow(hass, aiohttp_client):
     """Test authenticating with a token."""
     assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
 
     client = await aiohttp_client(hass.http.app)
 
@@ -165,6 +160,7 @@ async def test_auth_active_with_password_not_allow(hass, aiohttp_client):
 async def test_auth_legacy_support_with_password(hass, aiohttp_client, legacy_auth):
     """Test authenticating with a token."""
     assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
 
     client = await aiohttp_client(hass.http.app)
 
@@ -181,6 +177,7 @@ async def test_auth_legacy_support_with_password(hass, aiohttp_client, legacy_au
 async def test_auth_with_invalid_token(hass, aiohttp_client):
     """Test authenticating with a token."""
     assert await async_setup_component(hass, "websocket_api", {})
+    await hass.async_block_till_done()
 
     client = await aiohttp_client(hass.http.app)
 

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -31,6 +31,7 @@ async def test_auth_events(
     )
 
     await test_auth_active_with_token(hass, no_auth_websocket_client, hass_access_token)
+    await hass.async_block_till_done()
 
     assert len(connected_evt) == 1
     assert not disconnected_evt

--- a/tests/components/websocket_api/test_sensor.py
+++ b/tests/components/websocket_api/test_sensor.py
@@ -15,6 +15,7 @@ async def test_websocket_api(
         await async_setup_component(
             hass, "sensor", {"sensor": {"platform": "websocket_api"}}
         )
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.connected_clients")
     assert state.state == "0"

--- a/tests/components/websocket_api/test_sensor.py
+++ b/tests/components/websocket_api/test_sensor.py
@@ -1,31 +1,37 @@
 """Test cases for the API stream sensor."""
 
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.components.websocket_api.auth import TYPE_AUTH_REQUIRED
+from homeassistant.components.websocket_api.http import URL
 
 from .test_auth import test_auth_active_with_token
 
-from tests.common import assert_setup_component
 
-
-async def test_websocket_api(
-    hass, no_auth_websocket_client, hass_access_token, legacy_auth
-):
+async def test_websocket_api(hass, aiohttp_client, hass_access_token, legacy_auth):
     """Test API streams."""
-    with assert_setup_component(1):
-        await async_setup_component(
-            hass, "sensor", {"sensor": {"platform": "websocket_api"}}
-        )
-        await hass.async_block_till_done()
+    await async_setup_component(
+        hass, "sensor", {"sensor": {"platform": "websocket_api"}}
+    )
+    await hass.async_block_till_done()
+
+    client = await aiohttp_client(hass.http.app)
+    ws = await client.ws_connect(URL)
+
+    auth_ok = await ws.receive_json()
+
+    assert auth_ok["type"] == TYPE_AUTH_REQUIRED
+
+    ws.client = client
 
     state = hass.states.get("sensor.connected_clients")
     assert state.state == "0"
 
-    await test_auth_active_with_token(hass, no_auth_websocket_client, hass_access_token)
+    await test_auth_active_with_token(hass, ws, hass_access_token)
 
     state = hass.states.get("sensor.connected_clients")
     assert state.state == "1"
 
-    await no_auth_websocket_client.close()
+    await ws.close()
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.connected_clients")

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -109,6 +109,7 @@ class TestWorkdaySetup:
         """Set up workday component."""
         with assert_setup_component(1, "binary_sensor"):
             setup_component(self.hass, "binary_sensor", self.config_province)
+            self.hass.block_till_done()
 
         entity = self.hass.states.get("binary_sensor.workday_sensor")
         assert entity is not None
@@ -119,6 +120,7 @@ class TestWorkdaySetup:
         """Test if workdays are reported correctly."""
         with assert_setup_component(1, "binary_sensor"):
             setup_component(self.hass, "binary_sensor", self.config_province)
+            self.hass.block_till_done()
 
         self.hass.start()
 
@@ -131,6 +133,7 @@ class TestWorkdaySetup:
         """Test if weekends are reported correctly."""
         with assert_setup_component(1, "binary_sensor"):
             setup_component(self.hass, "binary_sensor", self.config_province)
+            self.hass.block_till_done()
 
         self.hass.start()
 
@@ -143,6 +146,7 @@ class TestWorkdaySetup:
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, "binary_sensor"):
             setup_component(self.hass, "binary_sensor", self.config_province)
+            self.hass.block_till_done()
 
         self.hass.start()
 
@@ -153,6 +157,7 @@ class TestWorkdaySetup:
         """Set up workday component."""
         with assert_setup_component(1, "binary_sensor"):
             setup_component(self.hass, "binary_sensor", self.config_noprovince)
+            self.hass.block_till_done()
 
         entity = self.hass.states.get("binary_sensor.workday_sensor")
         assert entity is not None
@@ -163,6 +168,7 @@ class TestWorkdaySetup:
         """Test if public holidays are reported correctly."""
         with assert_setup_component(1, "binary_sensor"):
             setup_component(self.hass, "binary_sensor", self.config_noprovince)
+            self.hass.block_till_done()
 
         self.hass.start()
 

--- a/tests/components/worldclock/test_sensor.py
+++ b/tests/components/worldclock/test_sensor.py
@@ -18,6 +18,7 @@ class TestWorldClockSensor(unittest.TestCase):
         config = {"sensor": {"platform": "worldclock", "time_zone": "America/New_York"}}
 
         assert setup_component(self.hass, "sensor", config)
+        self.hass.block_till_done()
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/wunderground/test_sensor.py
+++ b/tests/components/wunderground/test_sensor.py
@@ -61,6 +61,7 @@ async def test_setup(hass, aioclient_mock):
 
     with assert_setup_component(1, "sensor"):
         await async_setup_component(hass, "sensor", {"sensor": VALID_CONFIG})
+        await hass.async_block_till_done()
 
 
 async def test_setup_pws(hass, aioclient_mock):
@@ -84,6 +85,7 @@ async def test_sensor(hass, aioclient_mock):
     aioclient_mock.get(URL, text=load_fixture("wunderground-valid.json"))
 
     await async_setup_component(hass, "sensor", {"sensor": VALID_CONFIG})
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.pws_weather")
     assert state.state == "Clear"
@@ -136,6 +138,7 @@ async def test_invalid_data(hass, aioclient_mock):
     aioclient_mock.get(URL, text=load_fixture("wunderground-invalid.json"))
 
     await async_setup_component(hass, "sensor", {"sensor": VALID_CONFIG})
+    await hass.async_block_till_done()
 
     for condition in VALID_CONFIG["monitored_conditions"]:
         state = hass.states.get(f"sensor.pws_{condition}")

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -62,6 +62,7 @@ class TestYamahaMediaPlayer(unittest.TestCase):
         config = {"media_player": {"platform": "yamaha", "host": "127.0.0.1"}}
 
         assert setup_component(self.hass, mp.DOMAIN, config)
+        self.hass.block_till_done()
 
     @patch("rxv.RXV")
     def test_enable_output(self, mock_rxv):

--- a/tests/components/yandex_transport/test_yandex_transport_sensor.py
+++ b/tests/components/yandex_transport/test_yandex_transport_sensor.py
@@ -50,6 +50,7 @@ async def assert_setup_sensor(hass, config, count=1):
     """Set up the sensor and assert it's been created."""
     with assert_setup_component(count):
         assert await async_setup_component(hass, sensor.DOMAIN, config)
+        await hass.async_block_till_done()
 
 
 async def test_setup_platform_valid_config(hass, mock_requester):

--- a/tests/components/yr/test_sensor.py
+++ b/tests/components/yr/test_sensor.py
@@ -23,6 +23,7 @@ async def test_default_setup(hass, aioclient_mock):
         "homeassistant.components.yr.sensor.dt_util.utcnow", return_value=NOW
     ), assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.yr_symbol")
 
@@ -53,6 +54,7 @@ async def test_custom_setup(hass, aioclient_mock):
         "homeassistant.components.yr.sensor.dt_util.utcnow", return_value=NOW
     ), assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.yr_pressure")
     assert state.attributes.get("unit_of_measurement") == "hPa"
@@ -99,6 +101,7 @@ async def test_forecast_setup(hass, aioclient_mock):
         "homeassistant.components.yr.sensor.dt_util.utcnow", return_value=NOW
     ), assert_setup_component(1):
         await async_setup_component(hass, "sensor", {"sensor": config})
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.yr_pressure")
     assert state.attributes.get("unit_of_measurement") == "hPa"

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -180,7 +180,7 @@ async def test_platform_not_ready(hass):
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     await component.async_setup({DOMAIN: {"platform": "mod1"}})
-
+    await hass.async_block_till_done()
     assert len(platform1_setup.mock_calls) == 1
     assert "test_domain.mod1" not in hass.config.components
 
@@ -280,7 +280,7 @@ async def test_setup_dependencies_platform(hass):
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     await component.async_setup({DOMAIN: {"platform": "test_component"}})
-
+    await hass.async_block_till_done()
     assert "test_component" in hass.config.components
     assert "test_component2" in hass.config.components
     assert "test_domain.test_component" in hass.config.components

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -184,6 +184,7 @@ async def test_platform_warn_slow_setup(hass):
 
     with patch.object(hass.loop, "call_later") as mock_call:
         await component.async_setup({DOMAIN: {"platform": "platform"}})
+        await hass.async_block_till_done()
         assert mock_call.called
 
         # mock_calls[0] is the warning message for component setup
@@ -209,6 +210,7 @@ async def test_platform_error_slow_setup(hass, caplog):
         component = EntityComponent(_LOGGER, DOMAIN, hass)
         mock_entity_platform(hass, "test_domain.test_platform", platform)
         await component.async_setup({DOMAIN: {"platform": "test_platform"}})
+        await hass.async_block_till_done()
         assert len(called) == 1
         assert "test_domain.test_platform" not in hass.config.components
         assert "test_platform is taking longer than 0 seconds" in caplog.text
@@ -242,6 +244,7 @@ async def test_parallel_updates_async_platform(hass):
     component._platforms = {}
 
     await component.async_setup({DOMAIN: {"platform": "platform"}})
+    await hass.async_block_till_done()
 
     handle = list(component._platforms.values())[-1]
     assert handle.parallel_updates is None
@@ -268,6 +271,7 @@ async def test_parallel_updates_async_platform_with_constant(hass):
     component._platforms = {}
 
     await component.async_setup({DOMAIN: {"platform": "platform"}})
+    await hass.async_block_till_done()
 
     handle = list(component._platforms.values())[-1]
 
@@ -293,6 +297,7 @@ async def test_parallel_updates_sync_platform(hass):
     component._platforms = {}
 
     await component.async_setup({DOMAIN: {"platform": "platform"}})
+    await hass.async_block_till_done()
 
     handle = list(component._platforms.values())[-1]
 
@@ -319,6 +324,7 @@ async def test_parallel_updates_sync_platform_with_constant(hass):
     component._platforms = {}
 
     await component.async_setup({DOMAIN: {"platform": "platform"}})
+    await hass.async_block_till_done()
 
     handle = list(component._platforms.values())[-1]
 

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -113,6 +113,7 @@ async def test_get_translations(hass, mock_config_flows):
     assert translations == {}
 
     assert await async_setup_component(hass, "switch", {"switch": {"platform": "test"}})
+    await hass.async_block_till_done()
 
     translations = await translation.async_get_translations(hass, "en", "state")
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -358,6 +358,7 @@ class TestSetup:
             "switch",
             {"comp_a": {"valid": True}, "switch": {"platform": "platform_a"}},
         )
+        self.hass.block_till_done()
         assert "comp_a" in self.hass.config.components
 
     def test_platform_specific_config_validation(self):
@@ -380,6 +381,7 @@ class TestSetup:
                 "switch",
                 {"switch": {"platform": "platform_a", "invalid": True}},
             )
+            self.hass.block_till_done()
             assert mock_setup.call_count == 0
 
         self.hass.data.pop(setup.DATA_SETUP)
@@ -397,6 +399,7 @@ class TestSetup:
                     }
                 },
             )
+            self.hass.block_till_done()
             assert mock_setup.call_count == 0
 
         self.hass.data.pop(setup.DATA_SETUP)
@@ -408,6 +411,7 @@ class TestSetup:
                 "switch",
                 {"switch": {"platform": "platform_a", "valid": True}},
             )
+            self.hass.block_till_done()
             assert mock_setup.call_count == 1
 
     def test_disable_component_if_invalid_return(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make `EntityComponent.async_setup(…)` no longer wait until `platform.async_setup_platform(…)` is done.

This makes sense for various reasons:
 - Setting up a platform involves setting up the integration and then the entities. There is no reason for the entity component (ie `light`) to wait for this
 - We were waiting for `async_setup_platform` to finish, but `async_add_entities` was not part of what was awaited for.
 - We use `hass.async_create_task` so we still make sure they are finished before we finish startup.

I expect an even faster startup time now :)

It could happen previously that an integration was forwarding their config entry or making a discovery for `sensor` integration and then had to wait for `sensor` to set up all its platforms first (for no good reason).

CC @bdraco

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
