### PR TITLE
Revert "Ensure frontend is available if integrations fail to start - Part 1 of 2"

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -29,9 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ERROR_LOG_FILENAME = "home-assistant.log"
 
-# How long to wait until things that run on bootstrap have to finish.
-TIMEOUT_EVENT_BOOTSTRAP = 15
-
 # hass.data key for logging information.
 DATA_LOGGING = "logging"
 
@@ -47,13 +44,6 @@ STAGE_1_INTEGRATIONS = {
     "mqtt_eventstream",
     # To provide account link implementations
     "cloud",
-    # Ensure supervisor is available
-    "hassio",
-    # Get the frontend up and running as soon
-    # as possible so problem integrations can
-    # be removed
-    "frontend",
-    "config",
 }
 
 
@@ -409,8 +399,6 @@ async def _async_set_up_integrations(
     )
 
     if stage_1_domains:
-        _LOGGER.info("Setting up %s", stage_1_domains)
-
         await async_setup_multi_components(stage_1_domains)
 
     # Load all integrations
@@ -454,11 +442,4 @@ async def _async_set_up_integrations(
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
-    try:
-        async with timeout(TIMEOUT_EVENT_BOOTSTRAP):
-            await hass.async_block_till_done()
-    except asyncio.TimeoutError:
-        _LOGGER.warning(
-            "Something is blocking Home Assistant from wrapping up the "
-            "bootstrap phase. We're going to continue anyway."
-        )
+    await hass.async_block_till_done()

--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -14,7 +14,7 @@ from aiohttp.web_exceptions import (
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.const import CONTENT_TYPE_JSON, HTTP_OK, HTTP_SERVICE_UNAVAILABLE
+from homeassistant.const import CONTENT_TYPE_JSON, HTTP_OK
 from homeassistant.core import Context, is_callback
 from homeassistant.helpers.json import JSONEncoder
 
@@ -107,8 +107,8 @@ def request_handler_factory(view: HomeAssistantView, handler: Callable) -> Calla
 
     async def handle(request: web.Request) -> web.StreamResponse:
         """Handle incoming request."""
-        if request.app[KEY_HASS].is_stopping:
-            return web.Response(status=HTTP_SERVICE_UNAVAILABLE)
+        if not request.app[KEY_HASS].is_running:
+            return web.Response(status=503)
 
         authenticated = request.get(KEY_AUTHENTICATED, False)
 

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -31,9 +31,7 @@ def async_response(
     @wraps(func)
     def schedule_handler(hass, connection, msg):
         """Schedule the handler."""
-        # As the webserver is now started before the start
-        # event we do not want to block for websocket responders
-        hass.loop.create_task(_handle_async_response(func, hass, connection, msg))
+        hass.async_create_task(_handle_async_response(func, hass, connection, msg))
 
     return schedule_handler
 

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -165,9 +165,7 @@ class WebSocketHandler:
             EVENT_HOMEASSISTANT_STOP, handle_hass_stop
         )
 
-        # As the webserver is now started before the start
-        # event we do not want to block for websocket responses
-        self._writer_task = self.hass.loop.create_task(self._writer())
+        self._writer_task = self.hass.async_create_task(self._writer())
 
         auth = AuthPhase(self._logger, self.hass, self._send_message, request)
         connection = None

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -209,11 +209,6 @@ class HomeAssistant:
         """Return if Home Assistant is running."""
         return self.state in (CoreState.starting, CoreState.running)
 
-    @property
-    def is_stopping(self) -> bool:
-        """Return if Home Assistant is stopping."""
-        return self.state in (CoreState.stopping, CoreState.final_write)
-
     def start(self) -> int:
         """Start Home Assistant.
 
@@ -265,7 +260,6 @@ class HomeAssistant:
 
         setattr(self.loop, "_thread_ident", threading.get_ident())
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        self.bus.async_fire(EVENT_CORE_CONFIG_UPDATE)
 
         try:
             # Only block for EVENT_HOMEASSISTANT_START listener
@@ -1397,7 +1391,6 @@ class Config:
             "version": __version__,
             "config_source": self.config_source,
             "safe_mode": self.safe_mode,
-            "state": self.hass.state.value,
             "external_url": self.external_url,
             "internal_url": self.internal_url,
         }

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -60,9 +60,6 @@ async def test_hassio_discovery_startup(hass, aioclient_mock, hassio_client):
 
 async def test_hassio_discovery_startup_done(hass, aioclient_mock, hassio_client):
     """Test startup and discovery with hass discovery."""
-    aioclient_mock.post(
-        "http://127.0.0.1/supervisor/options", json={"result": "ok", "data": {}},
-    )
     aioclient_mock.get(
         "http://127.0.0.1/discovery",
         json={
@@ -104,7 +101,7 @@ async def test_hassio_discovery_startup_done(hass, aioclient_mock, hassio_client
         await async_setup_component(hass, "hassio", {})
         await hass.async_block_till_done()
 
-        assert aioclient_mock.call_count == 3
+        assert aioclient_mock.call_count == 2
         assert mock_mqtt.called
         mock_mqtt.assert_called_with(
             {

--- a/tests/components/http/test_data_validator.py
+++ b/tests/components/http/test_data_validator.py
@@ -11,7 +11,7 @@ from tests.async_mock import Mock
 async def get_client(aiohttp_client, validator):
     """Generate a client that hits a view decorated with validator."""
     app = web.Application()
-    app["hass"] = Mock(is_stopping=False)
+    app["hass"] = Mock(is_running=True)
 
     class TestView(HomeAssistantView):
         url = "/"

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -19,13 +19,7 @@ from tests.async_mock import AsyncMock, Mock
 @pytest.fixture
 def mock_request():
     """Mock a request."""
-    return Mock(app={"hass": Mock(is_stopping=False)}, match_info={})
-
-
-@pytest.fixture
-def mock_request_with_stopping():
-    """Mock a request."""
-    return Mock(app={"hass": Mock(is_stopping=True)}, match_info={})
+    return Mock(app={"hass": Mock(is_running=True)}, match_info={})
 
 
 async def test_invalid_json(caplog):
@@ -61,11 +55,3 @@ async def test_handling_service_not_found(mock_request):
             Mock(requires_auth=False),
             AsyncMock(side_effect=ServiceNotFound("test", "test")),
         )(mock_request)
-
-
-async def test_not_running(mock_request_with_stopping):
-    """Test we get a 503 when not running."""
-    response = await request_handler_factory(
-        Mock(requires_auth=False), AsyncMock(side_effect=Unauthorized)
-    )(mock_request_with_stopping)
-    assert response.status == 503

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -43,8 +43,7 @@ class TestComponentLogbook(unittest.TestCase):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         init_recorder_component(self.hass)  # Force an in memory DB
-        with patch("homeassistant.components.http.start_http_server_and_save_config"):
-            assert setup_component(self.hass, logbook.DOMAIN, self.EMPTY_CONFIG)
+        assert setup_component(self.hass, logbook.DOMAIN, self.EMPTY_CONFIG)
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/panel_iframe/test_init.py
+++ b/tests/components/panel_iframe/test_init.py
@@ -4,7 +4,6 @@ import unittest
 from homeassistant import setup
 from homeassistant.components import frontend
 
-from tests.async_mock import patch
 from tests.common import get_test_home_assistant
 
 
@@ -27,42 +26,38 @@ class TestPanelIframe(unittest.TestCase):
         ]
 
         for conf in to_try:
-            with patch(
-                "homeassistant.components.http.start_http_server_and_save_config"
-            ):
-                assert not setup.setup_component(
-                    self.hass, "panel_iframe", {"panel_iframe": conf}
-                )
+            assert not setup.setup_component(
+                self.hass, "panel_iframe", {"panel_iframe": conf}
+            )
 
     def test_correct_config(self):
         """Test correct config."""
-        with patch("homeassistant.components.http.start_http_server_and_save_config"):
-            assert setup.setup_component(
-                self.hass,
-                "panel_iframe",
-                {
-                    "panel_iframe": {
-                        "router": {
-                            "icon": "mdi:network-wireless",
-                            "title": "Router",
-                            "url": "http://192.168.1.1",
-                            "require_admin": True,
-                        },
-                        "weather": {
-                            "icon": "mdi:weather",
-                            "title": "Weather",
-                            "url": "https://www.wunderground.com/us/ca/san-diego",
-                            "require_admin": True,
-                        },
-                        "api": {"icon": "mdi:weather", "title": "Api", "url": "/api"},
-                        "ftp": {
-                            "icon": "mdi:weather",
-                            "title": "FTP",
-                            "url": "ftp://some/ftp",
-                        },
-                    }
-                },
-            )
+        assert setup.setup_component(
+            self.hass,
+            "panel_iframe",
+            {
+                "panel_iframe": {
+                    "router": {
+                        "icon": "mdi:network-wireless",
+                        "title": "Router",
+                        "url": "http://192.168.1.1",
+                        "require_admin": True,
+                    },
+                    "weather": {
+                        "icon": "mdi:weather",
+                        "title": "Weather",
+                        "url": "https://www.wunderground.com/us/ca/san-diego",
+                        "require_admin": True,
+                    },
+                    "api": {"icon": "mdi:weather", "title": "Api", "url": "/api"},
+                    "ftp": {
+                        "icon": "mdi:weather",
+                        "title": "FTP",
+                        "url": "ftp://some/ftp",
+                    },
+                }
+            },
+        )
 
         panels = self.hass.data[frontend.DATA_PANELS]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,7 +35,7 @@ from homeassistant.exceptions import InvalidEntityFormatError, InvalidStateError
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from tests.async_mock import MagicMock, Mock, PropertyMock, patch
+from tests.async_mock import MagicMock, Mock, patch
 from tests.common import async_mock_service, get_test_home_assistant
 
 PST = pytz.timezone("America/Los_Angeles")
@@ -901,8 +901,6 @@ class TestConfig(unittest.TestCase):
     def test_as_dict(self):
         """Test as dict."""
         self.config.config_dir = "/test/ha-config"
-        self.config.hass = MagicMock()
-        type(self.config.hass.state).value = PropertyMock(return_value="RUNNING")
         expected = {
             "latitude": 0,
             "longitude": 0,
@@ -916,7 +914,6 @@ class TestConfig(unittest.TestCase):
             "version": __version__,
             "config_source": "default",
             "safe_mode": False,
-            "state": "RUNNING",
             "external_url": None,
             "internal_url": None,
         }


### PR DESCRIPTION
The problem is we monitor the port not the API on Supervisor.

What still would work, open a different port until all is ready and move over to the old port.

Reverts home-assistant/core#36093

EDIT:
Hover I think that would work if we modify the Supervisor to work in this direction. So it's not wrong but merged too early.