### PR TITLE
Make the frontend available sooner (Part 1 of 2)

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -36,7 +36,7 @@ ERROR_LOG_FILENAME = "home-assistant.log"
 # This should be long enough for recorder to migrate schema
 # and mqtt_eventstream to setup fully.
 #
-TIMEOUT_EVENT_BOOTSTRAP = 1800
+TIMEOUT_EVENT_BOOTSTRAP = 14400
 
 # hass.data key for logging information.
 DATA_LOGGING = "logging"

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -29,15 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ERROR_LOG_FILENAME = "home-assistant.log"
 
-#
-# This timeout is a failsafe in case some integration starts a long
-# running task and blocks bootstrap from wrapping up.
-#
-# This should be long enough for recorder to migrate schema
-# and mqtt_eventstream to setup fully.
-#
-TIMEOUT_EVENT_BOOTSTRAP = 14400
-
 # hass.data key for logging information.
 DATA_LOGGING = "logging"
 
@@ -460,11 +451,4 @@ async def _async_set_up_integrations(
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
-    try:
-        async with timeout(TIMEOUT_EVENT_BOOTSTRAP):
-            await hass.async_block_till_done()
-    except asyncio.TimeoutError:
-        _LOGGER.warning(
-            "Something is blocking Home Assistant from wrapping up the "
-            "bootstrap phase. We're going to continue anyway."
-        )
+    await hass.async_block_till_done()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -29,8 +29,14 @@ _LOGGER = logging.getLogger(__name__)
 
 ERROR_LOG_FILENAME = "home-assistant.log"
 
-# How long to wait until things that run on bootstrap have to finish.
-TIMEOUT_EVENT_BOOTSTRAP = 15
+#
+# This timeout is a failsafe in case some integration starts a long
+# running task and blocks bootstrap from wrapping up.
+#
+# This should be long enough for recorder to migrate schema
+# and mqtt_eventstream to setup fully.
+#
+TIMEOUT_EVENT_BOOTSTRAP = 1800
 
 # hass.data key for logging information.
 DATA_LOGGING = "logging"

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -4,7 +4,7 @@ import logging
 import os
 import ssl
 from traceback import extract_stack
-from typing import Optional, cast
+from typing import Dict, Optional, cast
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPMovedPermanently
@@ -15,7 +15,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     SERVER_PORT,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import storage
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import bind_hass
@@ -216,29 +216,25 @@ async def async_setup(hass, config):
         ssl_profile=ssl_profile,
     )
 
-    async def stop_server(event):
+    startup_listeners = []
+
+    async def stop_server(event: Event) -> None:
         """Stop the server."""
         await server.stop()
 
-    async def start_server(event):
+    async def start_server(event: Event) -> None:
         """Start the server."""
+
+        for listener in startup_listeners:
+            listener()
+
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_server)
-        await server.start()
 
-        # If we are set up successful, we store the HTTP settings for safe mode.
-        store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        await start_http_server_and_save_config(hass, dict(conf), server)
 
-        if CONF_TRUSTED_PROXIES in conf:
-            conf_to_save = dict(conf)
-            conf_to_save[CONF_TRUSTED_PROXIES] = [
-                str(ip.network_address) for ip in conf_to_save[CONF_TRUSTED_PROXIES]
-            ]
-        else:
-            conf_to_save = conf
-
-        await store.async_save(conf_to_save)
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, start_server)
+    startup_listeners.append(
+        hass.bus.async_listen(EVENT_HOMEASSISTANT_START, start_server)
+    )
 
     hass.http = server
 
@@ -418,3 +414,20 @@ class HomeAssistantHTTP:
         """Stop the aiohttp server."""
         await self.site.stop()
         await self.runner.cleanup()
+
+
+async def start_http_server_and_save_config(
+    hass: HomeAssistant, conf: Dict, server: HomeAssistantHTTP
+) -> None:
+    """Startup the http server and save the config."""
+    await server.start()  # type: ignore
+
+    # If we are set up successful, we store the HTTP settings for safe mode.
+    store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
+
+    if CONF_TRUSTED_PROXIES in conf:
+        conf[CONF_TRUSTED_PROXIES] = [
+            str(ip.network_address) for ip in conf[CONF_TRUSTED_PROXIES]
+        ]
+
+    await store.async_save(conf)

--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -14,7 +14,7 @@ from aiohttp.web_exceptions import (
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.const import CONTENT_TYPE_JSON, HTTP_OK
+from homeassistant.const import CONTENT_TYPE_JSON, HTTP_OK, HTTP_SERVICE_UNAVAILABLE
 from homeassistant.core import Context, is_callback
 from homeassistant.helpers.json import JSONEncoder
 
@@ -107,8 +107,8 @@ def request_handler_factory(view: HomeAssistantView, handler: Callable) -> Calla
 
     async def handle(request: web.Request) -> web.StreamResponse:
         """Handle incoming request."""
-        if not request.app[KEY_HASS].is_running:
-            return web.Response(status=503)
+        if request.app[KEY_HASS].is_stopping:
+            return web.Response(status=HTTP_SERVICE_UNAVAILABLE)
 
         authenticated = request.get(KEY_AUTHENTICATED, False)
 

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -31,7 +31,9 @@ def async_response(
     @wraps(func)
     def schedule_handler(hass, connection, msg):
         """Schedule the handler."""
-        hass.async_create_task(_handle_async_response(func, hass, connection, msg))
+        # As the webserver is now started before the start
+        # event we do not want to block for websocket responders
+        hass.loop.create_task(_handle_async_response(func, hass, connection, msg))
 
     return schedule_handler
 

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -1,4 +1,5 @@
 """Decorators for the Websocket API."""
+import asyncio
 from functools import wraps
 import logging
 from typing import Awaitable, Callable
@@ -33,7 +34,7 @@ def async_response(
         """Schedule the handler."""
         # As the webserver is now started before the start
         # event we do not want to block for websocket responders
-        hass.loop.create_task(_handle_async_response(func, hass, connection, msg))
+        asyncio.create_task(_handle_async_response(func, hass, connection, msg))
 
     return schedule_handler
 

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -165,7 +165,9 @@ class WebSocketHandler:
             EVENT_HOMEASSISTANT_STOP, handle_hass_stop
         )
 
-        self._writer_task = self.hass.async_create_task(self._writer())
+        # As the webserver is now started before the start
+        # event we do not want to block for websocket responses
+        self._writer_task = self.hass.loop.create_task(self._writer())
 
         auth = AuthPhase(self._logger, self.hass, self._send_message, request)
         connection = None

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -167,7 +167,7 @@ class WebSocketHandler:
 
         # As the webserver is now started before the start
         # event we do not want to block for websocket responses
-        self._writer_task = self.hass.loop.create_task(self._writer())
+        self._writer_task = asyncio.create_task(self._writer())
 
         auth = AuthPhase(self._logger, self.hass, self._send_message, request)
         connection = None

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -209,6 +209,11 @@ class HomeAssistant:
         """Return if Home Assistant is running."""
         return self.state in (CoreState.starting, CoreState.running)
 
+    @property
+    def is_stopping(self) -> bool:
+        """Return if Home Assistant is stopping."""
+        return self.state in (CoreState.stopping, CoreState.final_write)
+
     def start(self) -> int:
         """Start Home Assistant.
 
@@ -260,6 +265,7 @@ class HomeAssistant:
 
         setattr(self.loop, "_thread_ident", threading.get_ident())
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        self.bus.async_fire(EVENT_CORE_CONFIG_UPDATE)
 
         try:
             # Only block for EVENT_HOMEASSISTANT_START listener
@@ -1391,6 +1397,7 @@ class Config:
             "version": __version__,
             "config_source": self.config_source,
             "safe_mode": self.safe_mode,
+            "state": self.hass.state.value,
             "external_url": self.external_url,
             "internal_url": self.internal_url,
         }

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -60,6 +60,9 @@ async def test_hassio_discovery_startup(hass, aioclient_mock, hassio_client):
 
 async def test_hassio_discovery_startup_done(hass, aioclient_mock, hassio_client):
     """Test startup and discovery with hass discovery."""
+    aioclient_mock.post(
+        "http://127.0.0.1/supervisor/options", json={"result": "ok", "data": {}},
+    )
     aioclient_mock.get(
         "http://127.0.0.1/discovery",
         json={
@@ -101,7 +104,7 @@ async def test_hassio_discovery_startup_done(hass, aioclient_mock, hassio_client
         await async_setup_component(hass, "hassio", {})
         await hass.async_block_till_done()
 
-        assert aioclient_mock.call_count == 2
+        assert aioclient_mock.call_count == 3
         assert mock_mqtt.called
         mock_mqtt.assert_called_with(
             {

--- a/tests/components/http/test_data_validator.py
+++ b/tests/components/http/test_data_validator.py
@@ -11,7 +11,7 @@ from tests.async_mock import Mock
 async def get_client(aiohttp_client, validator):
     """Generate a client that hits a view decorated with validator."""
     app = web.Application()
-    app["hass"] = Mock(is_running=True)
+    app["hass"] = Mock(is_stopping=False)
 
     class TestView(HomeAssistantView):
         url = "/"

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -43,7 +43,8 @@ class TestComponentLogbook(unittest.TestCase):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
         init_recorder_component(self.hass)  # Force an in memory DB
-        assert setup_component(self.hass, logbook.DOMAIN, self.EMPTY_CONFIG)
+        with patch("homeassistant.components.http.start_http_server_and_save_config"):
+            assert setup_component(self.hass, logbook.DOMAIN, self.EMPTY_CONFIG)
 
     def tearDown(self):
         """Stop everything that was started."""

--- a/tests/components/panel_iframe/test_init.py
+++ b/tests/components/panel_iframe/test_init.py
@@ -4,6 +4,7 @@ import unittest
 from homeassistant import setup
 from homeassistant.components import frontend
 
+from tests.async_mock import patch
 from tests.common import get_test_home_assistant
 
 
@@ -26,38 +27,42 @@ class TestPanelIframe(unittest.TestCase):
         ]
 
         for conf in to_try:
-            assert not setup.setup_component(
-                self.hass, "panel_iframe", {"panel_iframe": conf}
-            )
+            with patch(
+                "homeassistant.components.http.start_http_server_and_save_config"
+            ):
+                assert not setup.setup_component(
+                    self.hass, "panel_iframe", {"panel_iframe": conf}
+                )
 
     def test_correct_config(self):
         """Test correct config."""
-        assert setup.setup_component(
-            self.hass,
-            "panel_iframe",
-            {
-                "panel_iframe": {
-                    "router": {
-                        "icon": "mdi:network-wireless",
-                        "title": "Router",
-                        "url": "http://192.168.1.1",
-                        "require_admin": True,
-                    },
-                    "weather": {
-                        "icon": "mdi:weather",
-                        "title": "Weather",
-                        "url": "https://www.wunderground.com/us/ca/san-diego",
-                        "require_admin": True,
-                    },
-                    "api": {"icon": "mdi:weather", "title": "Api", "url": "/api"},
-                    "ftp": {
-                        "icon": "mdi:weather",
-                        "title": "FTP",
-                        "url": "ftp://some/ftp",
-                    },
-                }
-            },
-        )
+        with patch("homeassistant.components.http.start_http_server_and_save_config"):
+            assert setup.setup_component(
+                self.hass,
+                "panel_iframe",
+                {
+                    "panel_iframe": {
+                        "router": {
+                            "icon": "mdi:network-wireless",
+                            "title": "Router",
+                            "url": "http://192.168.1.1",
+                            "require_admin": True,
+                        },
+                        "weather": {
+                            "icon": "mdi:weather",
+                            "title": "Weather",
+                            "url": "https://www.wunderground.com/us/ca/san-diego",
+                            "require_admin": True,
+                        },
+                        "api": {"icon": "mdi:weather", "title": "Api", "url": "/api"},
+                        "ftp": {
+                            "icon": "mdi:weather",
+                            "title": "FTP",
+                            "url": "ftp://some/ftp",
+                        },
+                    }
+                },
+            )
 
         panels = self.hass.data[frontend.DATA_PANELS]
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -201,6 +201,43 @@ async def test_setup_after_deps_not_present(hass, caplog):
     assert order == ["root", "second_dep"]
 
 
+async def test_setup_continues_if_blocked(hass, caplog):
+    """Test we continue after timeout if blocked."""
+    caplog.set_level(logging.DEBUG)
+    order = []
+
+    def gen_domain_setup(domain):
+        async def async_setup(hass, config):
+            order.append(domain)
+            return True
+
+        return async_setup
+
+    mock_integration(
+        hass, MockModule(domain="root", async_setup=gen_domain_setup("root"))
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            domain="second_dep",
+            async_setup=gen_domain_setup("second_dep"),
+            partial_manifest={"after_dependencies": ["first_dep"]},
+        ),
+    )
+
+    with patch.object(bootstrap, "TIMEOUT_EVENT_BOOTSTRAP", 0):
+        hass.async_create_task(asyncio.sleep(2))
+        await bootstrap._async_set_up_integrations(
+            hass, {"root": {}, "first_dep": {}, "second_dep": {}}
+        )
+
+    assert "root" in hass.config.components
+    assert "first_dep" not in hass.config.components
+    assert "second_dep" in hass.config.components
+    assert order == ["root", "second_dep"]
+    assert "blocking Home Assistant from wrapping up" in caplog.text
+
+
 @pytest.fixture
 def mock_is_virtual_env():
     """Mock enable logging."""
@@ -261,7 +298,9 @@ async def test_setup_hass(
     with patch(
         "homeassistant.config.async_hass_config_yaml",
         return_value={"browser": {}, "frontend": {}},
-    ), patch.object(bootstrap, "LOG_SLOW_STARTUP_INTERVAL", 5000):
+    ), patch.object(bootstrap, "LOG_SLOW_STARTUP_INTERVAL", 5000), patch(
+        "homeassistant.components.http.start_http_server_and_save_config"
+    ):
         hass = await bootstrap.async_setup_hass(
             config_dir=get_test_config_dir(),
             verbose=verbose,
@@ -338,7 +377,7 @@ async def test_setup_hass_invalid_yaml(
     """Test it works."""
     with patch(
         "homeassistant.config.async_hass_config_yaml", side_effect=HomeAssistantError
-    ):
+    ), patch("homeassistant.components.http.start_http_server_and_save_config"):
         hass = await bootstrap.async_setup_hass(
             config_dir=get_test_config_dir(),
             verbose=False,
@@ -391,7 +430,9 @@ async def test_setup_hass_safe_mode(
     hass.config_entries._async_schedule_save()
     await flush_store(hass.config_entries._store)
 
-    with patch("homeassistant.components.browser.setup") as browser_setup:
+    with patch("homeassistant.components.browser.setup") as browser_setup, patch(
+        "homeassistant.components.http.start_http_server_and_save_config"
+    ):
         hass = await bootstrap.async_setup_hass(
             config_dir=get_test_config_dir(),
             verbose=False,
@@ -421,7 +462,7 @@ async def test_setup_hass_invalid_core_config(
     with patch(
         "homeassistant.config.async_hass_config_yaml",
         return_value={"homeassistant": {"non-existing": 1}},
-    ):
+    ), patch("homeassistant.components.http.start_http_server_and_save_config"):
         hass = await bootstrap.async_setup_hass(
             config_dir=get_test_config_dir(),
             verbose=False,
@@ -451,7 +492,7 @@ async def test_setup_safe_mode_if_no_frontend(
     with patch(
         "homeassistant.config.async_hass_config_yaml",
         return_value={"map": {}, "person": {"invalid": True}},
-    ):
+    ), patch("homeassistant.components.http.start_http_server_and_save_config"):
         hass = await bootstrap.async_setup_hass(
             config_dir=get_test_config_dir(),
             verbose=verbose,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -201,43 +201,6 @@ async def test_setup_after_deps_not_present(hass, caplog):
     assert order == ["root", "second_dep"]
 
 
-async def test_setup_continues_if_blocked(hass, caplog):
-    """Test we continue after timeout if blocked."""
-    caplog.set_level(logging.DEBUG)
-    order = []
-
-    def gen_domain_setup(domain):
-        async def async_setup(hass, config):
-            order.append(domain)
-            return True
-
-        return async_setup
-
-    mock_integration(
-        hass, MockModule(domain="root", async_setup=gen_domain_setup("root"))
-    )
-    mock_integration(
-        hass,
-        MockModule(
-            domain="second_dep",
-            async_setup=gen_domain_setup("second_dep"),
-            partial_manifest={"after_dependencies": ["first_dep"]},
-        ),
-    )
-
-    with patch.object(bootstrap, "TIMEOUT_EVENT_BOOTSTRAP", 0):
-        hass.async_create_task(asyncio.sleep(2))
-        await bootstrap._async_set_up_integrations(
-            hass, {"root": {}, "first_dep": {}, "second_dep": {}}
-        )
-
-    assert "root" in hass.config.components
-    assert "first_dep" not in hass.config.components
-    assert "second_dep" in hass.config.components
-    assert order == ["root", "second_dep"]
-    assert "blocking Home Assistant from wrapping up" in caplog.text
-
-
 @pytest.fixture
 def mock_is_virtual_env():
     """Mock enable logging."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,7 +35,7 @@ from homeassistant.exceptions import InvalidEntityFormatError, InvalidStateError
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from tests.async_mock import MagicMock, Mock, patch
+from tests.async_mock import MagicMock, Mock, PropertyMock, patch
 from tests.common import async_mock_service, get_test_home_assistant
 
 PST = pytz.timezone("America/Los_Angeles")
@@ -901,6 +901,8 @@ class TestConfig(unittest.TestCase):
     def test_as_dict(self):
         """Test as dict."""
         self.config.config_dir = "/test/ha-config"
+        self.config.hass = MagicMock()
+        type(self.config.hass.state).value = PropertyMock(return_value="RUNNING")
         expected = {
             "latitude": 0,
             "longitude": 0,
@@ -914,6 +916,7 @@ class TestConfig(unittest.TestCase):
             "version": __version__,
             "config_source": "default",
             "safe_mode": False,
+            "state": "RUNNING",
             "external_url": None,
             "internal_url": None,
         }


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Part 1 of 2 (no breaking changes in part 1, see part 2: https://github.com/home-assistant/core/pull/36264).
    
When integrations configured via the UI block startup or fail to start,
the webserver can remain offline which make it is impossible
to recover without manually changing files in
.storage since the UI is not available.

This change is the foundation that part 2 will build on
and enable a listener to start the webserver when the frontend
is finished loading.

Frontend Changes (home-assistant/frontend#6068)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35924
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
