### PR TITLE
Make the frontend available sooner (Part 2 of 2)

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -36,7 +36,7 @@ ERROR_LOG_FILENAME = "home-assistant.log"
 # This should be long enough for recorder to migrate schema
 # and mqtt_eventstream to setup fully.
 #
-TIMEOUT_EVENT_BOOTSTRAP = 1800
+TIMEOUT_EVENT_BOOTSTRAP = 14400
 
 # hass.data key for logging information.
 DATA_LOGGING = "logging"

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -29,15 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ERROR_LOG_FILENAME = "home-assistant.log"
 
-#
-# This timeout is a failsafe in case some integration starts a long
-# running task and blocks bootstrap from wrapping up.
-#
-# This should be long enough for recorder to migrate schema
-# and mqtt_eventstream to setup fully.
-#
-TIMEOUT_EVENT_BOOTSTRAP = 14400
-
 # hass.data key for logging information.
 DATA_LOGGING = "logging"
 
@@ -460,11 +451,4 @@ async def _async_set_up_integrations(
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
-    try:
-        async with timeout(TIMEOUT_EVENT_BOOTSTRAP):
-            await hass.async_block_till_done()
-    except asyncio.TimeoutError:
-        _LOGGER.warning(
-            "Something is blocking Home Assistant from wrapping up the "
-            "bootstrap phase. We're going to continue anyway."
-        )
+    await hass.async_block_till_done()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -29,6 +29,9 @@ _LOGGER = logging.getLogger(__name__)
 
 ERROR_LOG_FILENAME = "home-assistant.log"
 
+# How long to wait until things that run on bootstrap have to finish.
+TIMEOUT_EVENT_BOOTSTRAP = 15
+
 # hass.data key for logging information.
 DATA_LOGGING = "logging"
 
@@ -451,4 +454,11 @@ async def _async_set_up_integrations(
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
-    await hass.async_block_till_done()
+    try:
+        async with timeout(TIMEOUT_EVENT_BOOTSTRAP):
+            await hass.async_block_till_done()
+    except asyncio.TimeoutError:
+        _LOGGER.warning(
+            "Something is blocking Home Assistant from wrapping up the "
+            "bootstrap phase. We're going to continue anyway."
+        )

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -29,8 +29,14 @@ _LOGGER = logging.getLogger(__name__)
 
 ERROR_LOG_FILENAME = "home-assistant.log"
 
-# How long to wait until things that run on bootstrap have to finish.
-TIMEOUT_EVENT_BOOTSTRAP = 15
+#
+# This timeout is a failsafe in case some integration starts a long
+# running task and blocks bootstrap from wrapping up.
+#
+# This should be long enough for recorder to migrate schema
+# and mqtt_eventstream to setup fully.
+#
+TIMEOUT_EVENT_BOOTSTRAP = 1800
 
 # hass.data key for logging information.
 DATA_LOGGING = "logging"

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import storage
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import bind_hass
+from homeassistant.setup import ATTR_COMPONENT, EVENT_COMPONENT_LOADED
 import homeassistant.util as hass_util
 from homeassistant.util import ssl as ssl_util
 
@@ -232,6 +233,17 @@ async def async_setup(hass, config):
 
         await start_http_server_and_save_config(hass, dict(conf), server)
 
+    async def async_wait_frontend_load(event: Event) -> None:
+        """Wait for the frontend to load."""
+
+        if event.data[ATTR_COMPONENT] != "frontend":
+            return
+
+        await start_server(event)
+
+    startup_listeners.append(
+        hass.bus.async_listen(EVENT_COMPONENT_LOADED, async_wait_frontend_load)
+    )
     startup_listeners.append(
         hass.bus.async_listen(EVENT_HOMEASSISTANT_START, start_server)
     )

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -434,6 +434,8 @@ async def start_http_server_and_save_config(
     """Startup the http server and save the config."""
     await server.start()  # type: ignore
 
+    assert 0
+
     # If we are set up successful, we store the HTTP settings for safe mode.
     store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -434,8 +434,6 @@ async def start_http_server_and_save_config(
     """Startup the http server and save the config."""
     await server.start()  # type: ignore
 
-    assert 0
-
     # If we are set up successful, we store the HTTP settings for safe mode.
     store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -316,6 +316,8 @@ async def test_setup_hass_takes_longer_than_log_slow_startup(
     ), patch.object(bootstrap, "LOG_SLOW_STARTUP_INTERVAL", 0.3), patch(
         "homeassistant.components.frontend.async_setup",
         side_effect=_async_setup_that_blocks_startup,
+    ), patch(
+        "homeassistant.components.http.start_http_server_and_save_config"
     ):
         await bootstrap.async_setup_hass(
             config_dir=get_test_config_dir(),

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -201,43 +201,6 @@ async def test_setup_after_deps_not_present(hass, caplog):
     assert order == ["root", "second_dep"]
 
 
-async def test_setup_continues_if_blocked(hass, caplog):
-    """Test we continue after timeout if blocked."""
-    caplog.set_level(logging.DEBUG)
-    order = []
-
-    def gen_domain_setup(domain):
-        async def async_setup(hass, config):
-            order.append(domain)
-            return True
-
-        return async_setup
-
-    mock_integration(
-        hass, MockModule(domain="root", async_setup=gen_domain_setup("root"))
-    )
-    mock_integration(
-        hass,
-        MockModule(
-            domain="second_dep",
-            async_setup=gen_domain_setup("second_dep"),
-            partial_manifest={"after_dependencies": ["first_dep"]},
-        ),
-    )
-
-    with patch.object(bootstrap, "TIMEOUT_EVENT_BOOTSTRAP", 0):
-        hass.async_create_task(asyncio.sleep(2))
-        await bootstrap._async_set_up_integrations(
-            hass, {"root": {}, "first_dep": {}, "second_dep": {}}
-        )
-
-    assert "root" in hass.config.components
-    assert "first_dep" not in hass.config.components
-    assert "second_dep" in hass.config.components
-    assert order == ["root", "second_dep"]
-    assert "blocking Home Assistant from wrapping up" in caplog.text
-
-
 @pytest.fixture
 def mock_is_virtual_env():
     """Mock enable logging."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -201,6 +201,43 @@ async def test_setup_after_deps_not_present(hass, caplog):
     assert order == ["root", "second_dep"]
 
 
+async def test_setup_continues_if_blocked(hass, caplog):
+    """Test we continue after timeout if blocked."""
+    caplog.set_level(logging.DEBUG)
+    order = []
+
+    def gen_domain_setup(domain):
+        async def async_setup(hass, config):
+            order.append(domain)
+            return True
+
+        return async_setup
+
+    mock_integration(
+        hass, MockModule(domain="root", async_setup=gen_domain_setup("root"))
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            domain="second_dep",
+            async_setup=gen_domain_setup("second_dep"),
+            partial_manifest={"after_dependencies": ["first_dep"]},
+        ),
+    )
+
+    with patch.object(bootstrap, "TIMEOUT_EVENT_BOOTSTRAP", 0):
+        hass.async_create_task(asyncio.sleep(2))
+        await bootstrap._async_set_up_integrations(
+            hass, {"root": {}, "first_dep": {}, "second_dep": {}}
+        )
+
+    assert "root" in hass.config.components
+    assert "first_dep" not in hass.config.components
+    assert "second_dep" in hass.config.components
+    assert order == ["root", "second_dep"]
+    assert "blocking Home Assistant from wrapping up" in caplog.text
+
+
 @pytest.fixture
 def mock_is_virtual_env():
     """Mock enable logging."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The webserver is now started as soon as the frontend can be loaded.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Part 2 of 2 (Part #1 - https://github.com/home-assistant/core/pull/36263)

When integrations configured via the UI block startup or fail to start,
the webserver can remain offline which make it is impossible
to recover without manually changing files in
.storage since the UI is not available.

This change is the foundation that part 2 will build on
and enable a listener to start the webserver when the frontend
is finished loading.

Frontend Changes (home-assistant/frontend#6068)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35924
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
