### PR TITLE
Add Pi-Hole binary sensor, switch, and DataUpdateCoordinator

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -1,5 +1,8 @@
 """The pi_hole component."""
+import asyncio
+from datetime import timedelta
 import logging
+from typing import Any, Dict
 
 from hole import Hole
 from hole.exceptions import HoleError
@@ -8,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
@@ -16,20 +19,21 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_VERIFY_SSL,
 )
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     CONF_DISABLE_SECONDS,
     CONF_LOCATION,
+    DEFAULT_DISABLE_SECONDS,
     DEFAULT_LOCATION,
     DEFAULT_NAME,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
-    MIN_TIME_BETWEEN_UPDATES,
     SERVICE_DISABLE,
     SERVICE_DISABLE_ATTR_DURATION,
     SERVICE_DISABLE_ATTR_NAME,
@@ -45,7 +49,9 @@ PI_HOLE_SCHEMA = vol.Schema(
             vol.Required(CONF_HOST): cv.string,
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
             vol.Optional(CONF_API_KEY): cv.string,
-            vol.Optional(CONF_DISABLE_SECONDS): cv.positive_int,
+            vol.Optional(
+                CONF_DISABLE_SECONDS, default=DEFAULT_DISABLE_SECONDS
+            ): cv.positive_int,
             vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
             vol.Optional(CONF_LOCATION, default=DEFAULT_LOCATION): cv.string,
             vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
@@ -58,24 +64,28 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+SERVICE_DISABLE_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            vol.Required(SERVICE_DISABLE_ATTR_DURATION): vol.All(
+                cv.time_period_str, cv.positive_timedelta
+            ),
+            vol.Optional(SERVICE_DISABLE_ATTR_NAME): str,
+        },
+    )
+)
 
-async def async_setup(hass, config):
+SERVICE_ENABLE_SCHEMA = vol.Schema({vol.Optional(SERVICE_ENABLE_ATTR_NAME): str})
+
+
+PLATFORM_DOMAINS = [SENSOR_DOMAIN, BINARY_SENSOR_DOMAIN, SWITCH_DOMAIN]
+SCAN_INTERVAL = timedelta(seconds=20)
+
+
+async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
     """Set up the pi_hole integration."""
 
-    service_disable_schema = vol.Schema(
-        vol.All(
-            {
-                vol.Required(SERVICE_DISABLE_ATTR_DURATION): vol.All(
-                    cv.time_period_str, cv.positive_timedelta
-                ),
-                vol.Optional(SERVICE_DISABLE_ATTR_NAME): str,
-            },
-        )
-    )
-
-    service_enable_schema = vol.Schema({vol.Optional(SERVICE_ENABLE_ATTR_NAME): str})
-
-    hass.data[DOMAIN] = {}
+    hass.data.setdefault(DOMAIN, {})
 
     # import
     if DOMAIN in config:
@@ -86,6 +96,9 @@ async def async_setup(hass, config):
                 )
             )
 
+    # TODO: Service stuff below
+
+    # TODO: Check this? May need to refactor where we get API client
     def get_pi_hole_from_name(name):
         pi_hole = hass.data[DOMAIN].get(name)
         if pi_hole is None:
@@ -145,17 +158,17 @@ async def async_setup(hass, config):
                 await do_enable(name)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_DISABLE, disable_service_handler, schema=service_disable_schema
+        DOMAIN, SERVICE_DISABLE, disable_service_handler, schema=SERVICE_DISABLE_SCHEMA
     )
 
     hass.services.async_register(
-        DOMAIN, SERVICE_ENABLE, enable_service_handler, schema=service_enable_schema
+        DOMAIN, SERVICE_ENABLE, enable_service_handler, schema=SERVICE_ENABLE_SCHEMA
     )
 
     return True
 
 
-async def async_setup_entry(hass, entry):
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up Pi-hole entry."""
     name = entry.data[CONF_NAME]
     host = entry.data[CONF_HOST]
@@ -167,72 +180,131 @@ async def async_setup_entry(hass, entry):
 
     LOGGER.debug("Setting up %s integration with host %s", DOMAIN, host)
 
-    try:
-        session = async_get_clientsession(hass, verify_tls)
-        pi_hole = PiHoleData(
-            Hole(
-                host,
-                hass.loop,
-                session,
-                location=location,
-                tls=use_tls,
-                api_token=api_key,
-            ),
-            name,
-            disable_seconds,
-        )
-        await pi_hole.async_update()
-        hass.data[DOMAIN][name] = pi_hole
-    except HoleError as ex:
-        LOGGER.warning("Failed to connect: %s", ex)
-        raise ConfigEntryNotReady
+    session = async_get_clientsession(hass, verify_tls)
+    coordinator = PiHoleDataUpdateCoordinator(
+        hass,
+        Hole(
+            host, hass.loop, session, location=location, tls=use_tls, api_token=api_key,
+        ),
+        name,
+        disable_seconds,
+    )
+    await coordinator.async_refresh()
+    LOGGER.debug("Finished refreshing from %s, %s", host, name)
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, SENSOR_DOMAIN)
-    )
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, BINARY_SENSOR_DOMAIN)
-    )
-    if api_key and disable_seconds:
-        LOGGER.debug("Register switch for pihole %s", name)
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, SWITCH_DOMAIN)
-        )
-    else:
-        LOGGER.debug(
-            "No switch. api_key = %s and disable_seconds = %s",
-            api_key,
-            disable_seconds,
-        )
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    for domain in PLATFORM_DOMAINS:
+        # Switch domain requires an api_key
+        if api_key or domain != SWITCH_DOMAIN:
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(entry, domain)
+            )
 
     return True
 
 
 async def async_unload_entry(hass, entry):
     """Unload pi-hole entry."""
-    hass.data[DOMAIN].pop(entry.data[CONF_NAME])
-    await hass.config_entries.async_forward_entry_unload(entry, BINARY_SENSOR_DOMAIN)
-    await hass.config_entries.async_forward_entry_unload(entry, SWITCH_DOMAIN)
-    return await hass.config_entries.async_forward_entry_unload(entry, SENSOR_DOMAIN)
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, domain)
+                for domain in PLATFORM_DOMAINS
+            ]
+        )
+    )
+
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
 
 
-class PiHoleData:
+class PiHoleDataUpdateCoordinator(DataUpdateCoordinator):
     """Get the latest data and update the states."""
 
-    def __init__(self, api, name, disable_seconds):
+    def __init__(
+        self, hass: HomeAssistantType, hole: Hole, name: str, disable_seconds: int
+    ):
         """Initialize the data object."""
-        self.api = api
-        self.name = name
-        self.available = True
+        self.api = hole
         self.disable_seconds = disable_seconds
+        self.available = False
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    async def async_update(self):
+        super().__init__(
+            hass, LOGGER, name=f"{name}", update_interval=SCAN_INTERVAL,
+        )
+
+    @property
+    def unique_id(self) -> str:
+        """Return unique id for the device."""
+        return f"{self.api.host}_{self.name}"
+
+    async def _async_update_data(self) -> Dict:
         """Get the latest data from the Pi-hole."""
 
         try:
             await self.api.get_data()
+            data = self.api.data
             self.available = True
-        except HoleError:
-            LOGGER.error("Unable to fetch data from Pi-hole")
+            LOGGER.debug("We got data from the client for %s", self.name)
+            # TODO: Decide if we should raise an exception here if we have no data
+            return data
+        except HoleError as error:
             self.available = False
+            raise UpdateFailed(f"Error retrieving data form Pi-Hole: {error}")
+
+
+class PiHoleEntity(Entity):
+    """Defines a base Pi-Hole entity."""
+
+    def __init__(
+        self, *, device_id: str, name: str, coordinator: PiHoleDataUpdateCoordinator
+    ):
+        """Initialize the Pi-Hole entity."""
+        self._device_id = device_id
+        self._name = name
+        self.coordinator = coordinator
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.available
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def should_poll(self) -> bool:
+        """Return the polling requirement of the entity."""
+        return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the Pi-Hole."""
+        return self.coordinator.data
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        """Return device information about this Pi-Hole device."""
+        if self._device_id is None:
+            return None
+
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self._name,
+            "manufacturer": "Pi-hole",
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Connect to dispatcher listening for entity data notifications."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+    async def async_update(self) -> None:
+        """Update a Pi-Hole entity."""
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -5,6 +5,7 @@ from hole import Hole
 from hole.exceptions import HoleError
 import voluptuous as vol
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
@@ -184,6 +185,9 @@ async def async_setup_entry(hass, entry):
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, SENSOR_DOMAIN)
     )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, BINARY_SENSOR_DOMAIN)
+    )
 
     return True
 
@@ -191,6 +195,7 @@ async def async_setup_entry(hass, entry):
 async def async_unload_entry(hass, entry):
     """Unload pi-hole entry."""
     hass.data[DOMAIN].pop(entry.data[CONF_NAME])
+    await hass.config_entries.async_forward_entry_unload(entry, BINARY_SENSOR_DOMAIN)
     return await hass.config_entries.async_forward_entry_unload(entry, SENSOR_DOMAIN)
 
 

--- a/homeassistant/components/pi_hole/binary_sensor.py
+++ b/homeassistant/components/pi_hole/binary_sensor.py
@@ -1,0 +1,90 @@
+"""Support for getting statistical data from a Pi-hole system."""
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import CONF_NAME
+
+from .const import (
+    BINARY_SENSOR_DICT,
+    BINARY_SENSOR_LIST,
+    DOMAIN as PIHOLE_DOMAIN,
+    STATUS_ENABLED,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the pi-hole sensor."""
+    pi_hole = hass.data[PIHOLE_DOMAIN][entry.data[CONF_NAME]]
+    sensors = [
+        PiHoleBinarySensor(pi_hole, sensor_name, entry.entry_id)
+        for sensor_name in BINARY_SENSOR_LIST
+    ]
+    async_add_entities(sensors, True)
+
+
+class PiHoleBinarySensor(BinarySensorEntity):
+    """Representation of a Pi-hole binary sensor."""
+
+    def __init__(self, pi_hole, sensor_name, server_unique_id):
+        """Initialize a Pi-hole sensor."""
+        LOGGER.debug("Setting up pi-hole binary sensor %s", sensor_name)
+        self.pi_hole = pi_hole
+        self._name = pi_hole.name
+        self._condition = sensor_name
+        self._server_unique_id = server_unique_id
+
+        variable_info = BINARY_SENSOR_DICT[sensor_name]
+        self._condition_name = variable_info[0]
+        self._condition = variable_info[1]
+        self._on_value = variable_info[2]
+        self._device_class = variable_info[3]
+        self.data = {}
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self._name} {self._condition_name}"
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the sensor."""
+        return f"{self._server_unique_id}/{self._condition_name}"
+
+    @property
+    def device_info(self):
+        """Return the device information of the sensor."""
+        return {
+            "identifiers": {(PIHOLE_DOMAIN, self._server_unique_id)},
+            "name": self._name,
+            "manufacturer": "Pi-hole",
+        }
+
+    @property
+    def device_class(self):
+        """Icon to use in the frontend, if any."""
+        return self._device_class
+
+    @property
+    def is_on(self):
+        """Return the state of the device."""
+        LOGGER.debug("Condition: %s", self._condition)
+        # return self.data[self._condition] == self._on_value
+        return self.data["status"] == STATUS_ENABLED
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the Pi-Hole."""
+        return self.data
+
+    @property
+    def available(self):
+        """Could the device be accessed during the last update call."""
+        return self.pi_hole.available
+
+    async def async_update(self):
+        """Get the latest data from the Pi-hole API."""
+        LOGGER.debug("Getting updates for pihole binary sensor")
+        await self.pi_hole.async_update()
+        self.data = self.pi_hole.api.data

--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -9,6 +9,7 @@ from homeassistant import config_entries
 from homeassistant.components.pi_hole.const import (  # pylint: disable=unused-import
     CONF_DISABLE_SECONDS,
     CONF_LOCATION,
+    DEFAULT_DISABLE_SECONDS,
     DEFAULT_LOCATION,
     DEFAULT_NAME,
     DEFAULT_SSL,
@@ -113,7 +114,8 @@ class PiHoleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ): str,
                     vol.Optional(
                         CONF_DISABLE_SECONDS,
-                        default=user_input.get(CONF_DISABLE_SECONDS) or None,
+                        default=user_input.get(CONF_DISABLE_SECONDS)
+                        or DEFAULT_DISABLE_SECONDS,
                     ): int,
                     vol.Required(
                         CONF_SSL, default=user_input.get(CONF_SSL) or DEFAULT_SSL

--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.pi_hole.const import (  # pylint: disable=unused-import
+    CONF_DISABLE_SECONDS,
     CONF_LOCATION,
     DEFAULT_LOCATION,
     DEFAULT_NAME,
@@ -56,6 +57,7 @@ class PiHoleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             tls = user_input[CONF_SSL]
             verify_tls = user_input[CONF_VERIFY_SSL]
             api_token = user_input.get(CONF_API_KEY)
+            disable_seconds = user_input.get(CONF_DISABLE_SECONDS)
             endpoint = f"{host}/{location}"
 
             if await self._async_endpoint_existed(endpoint):
@@ -78,6 +80,7 @@ class PiHoleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_SSL: tls,
                         CONF_VERIFY_SSL: verify_tls,
                         CONF_API_KEY: api_token,
+                        CONF_DISABLE_SECONDS: disable_seconds,
                     },
                 )
             except HoleError as ex:
@@ -108,6 +111,10 @@ class PiHoleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_API_KEY, default=user_input.get(CONF_API_KEY) or ""
                     ): str,
+                    vol.Optional(
+                        CONF_DISABLE_SECONDS,
+                        default=user_input.get(CONF_DISABLE_SECONDS) or None,
+                    ): int,
                     vol.Required(
                         CONF_SSL, default=user_input.get(CONF_SSL) or DEFAULT_SSL
                     ): bool,

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -5,6 +5,7 @@ from homeassistant.const import UNIT_PERCENTAGE
 
 DOMAIN = "pi_hole"
 
+CONF_DISABLE_SECONDS = "disable_seconds"
 CONF_LOCATION = "location"
 
 DEFAULT_LOCATION = "admin"
@@ -23,7 +24,7 @@ STATUS_ENABLED = "enabled"
 
 ATTR_BLOCKED_DOMAINS = "domains_blocked"
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
 
 SENSOR_DICT = {
     "ads_blocked_today": ["Ads Blocked Today", "ads", "mdi:close-octagon-outline"],

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -13,6 +13,7 @@ DEFAULT_METHOD = "GET"
 DEFAULT_NAME = "Pi-Hole"
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
+DEFAULT_DISABLE_SECONDS = 30
 
 SERVICE_DISABLE = "disable"
 SERVICE_DISABLE_ATTR_DURATION = "duration"
@@ -53,7 +54,7 @@ SENSOR_DICT = {
 SENSOR_LIST = list(SENSOR_DICT)
 
 BINARY_SENSOR_DICT = {
-    "status": ["Status", "status", "enabled", None],
+    "status": ["Status", "enabled", None],
 }
 
 BINARY_SENSOR_LIST = list(BINARY_SENSOR_DICT)

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -19,6 +19,8 @@ SERVICE_DISABLE_ATTR_NAME = "name"
 SERVICE_ENABLE = "enable"
 SERVICE_ENABLE_ATTR_NAME = SERVICE_DISABLE_ATTR_NAME
 
+STATUS_ENABLED = "enabled"
+
 ATTR_BLOCKED_DOMAINS = "domains_blocked"
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
@@ -48,3 +50,9 @@ SENSOR_DICT = {
 }
 
 SENSOR_LIST = list(SENSOR_DICT)
+
+BINARY_SENSOR_DICT = {
+    "status": ["Status", "status", "enabled", None],
+}
+
+BINARY_SENSOR_LIST = list(BINARY_SENSOR_DICT)

--- a/homeassistant/components/pi_hole/sensor.py
+++ b/homeassistant/components/pi_hole/sensor.py
@@ -1,93 +1,69 @@
 """Support for getting statistical data from a Pi-hole system."""
 import logging
+from typing import Any
 
-from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 
-from .const import (
-    ATTR_BLOCKED_DOMAINS,
-    DOMAIN as PIHOLE_DOMAIN,
-    SENSOR_DICT,
-    SENSOR_LIST,
-)
+from . import PiHoleDataUpdateCoordinator, PiHoleEntity
+from .const import DOMAIN as PIHOLE_DOMAIN, SENSOR_DICT, SENSOR_LIST
 
 LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the pi-hole sensor."""
-    pi_hole = hass.data[PIHOLE_DOMAIN][entry.data[CONF_NAME]]
+    coordinator = hass.data[PIHOLE_DOMAIN][entry.entry_id]
+    server_unique_id = coordinator.unique_id
     sensors = [
-        PiHoleSensor(pi_hole, sensor_name, entry.entry_id)
+        PiHoleSensor(coordinator, sensor_name, server_unique_id)
         for sensor_name in SENSOR_LIST
     ]
     async_add_entities(sensors, True)
 
 
-class PiHoleSensor(Entity):
+class PiHoleSensor(PiHoleEntity, Entity):
     """Representation of a Pi-hole sensor."""
 
-    def __init__(self, pi_hole, sensor_name, server_unique_id):
+    def __init__(
+        self,
+        coordinator: PiHoleDataUpdateCoordinator,
+        sensor_name: str,
+        server_unique_id: str,
+    ):
         """Initialize a Pi-hole sensor."""
-        self.pi_hole = pi_hole
-        self._name = pi_hole.name
         self._condition = sensor_name
         self._server_unique_id = server_unique_id
-
         variable_info = SENSOR_DICT[sensor_name]
-        self._condition_name = variable_info[0]
+        condition_name = variable_info[0]
         self._unit_of_measurement = variable_info[1]
         self._icon = variable_info[2]
-        self.data = {}
+        super().__init__(
+            coordinator=coordinator,
+            name=f"{coordinator.name} {condition_name}",
+            device_id=server_unique_id,
+        )
 
     @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"{self._name} {self._condition_name}"
-
-    @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return the unique id of the sensor."""
-        return f"{self._server_unique_id}/{self._condition_name}"
+        return f"{self._server_unique_id}_{self._condition}"
 
     @property
-    def device_info(self):
-        """Return the device information of the sensor."""
-        return {
-            "identifiers": {(PIHOLE_DOMAIN, self._server_unique_id)},
-            "name": self._name,
-            "manufacturer": "Pi-hole",
-        }
-
-    @property
-    def icon(self):
+    def icon(self) -> str:
         """Icon to use in the frontend, if any."""
         return self._icon
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
 
     @property
-    def state(self):
+    def state(self) -> Any:
         """Return the state of the device."""
+        if self.coordinator.data is None:
+            return None
         try:
-            return round(self.data[self._condition], 2)
+            return round(self.coordinator.data.get(self._condition), 2)
         except TypeError:
-            return self.data[self._condition]
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the Pi-Hole."""
-        return {ATTR_BLOCKED_DOMAINS: self.data["domains_being_blocked"]}
-
-    @property
-    def available(self):
-        """Could the device be accessed during the last update call."""
-        return self.pi_hole.available
-
-    async def async_update(self):
-        """Get the latest data from the Pi-hole API."""
-        await self.pi_hole.async_update()
-        self.data = self.pi_hole.api.data
+            return self.coordinator.data.get(self._condition)

--- a/homeassistant/components/pi_hole/switch.py
+++ b/homeassistant/components/pi_hole/switch.py
@@ -1,0 +1,92 @@
+"""Support for getting statistical data from a Pi-hole system."""
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_NAME
+
+from .const import DOMAIN as PIHOLE_DOMAIN, STATUS_ENABLED
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the pi-hole sensor."""
+    pi_hole = hass.data[PIHOLE_DOMAIN][entry.data[CONF_NAME]]
+    switches = [PiHoleSwitch(pi_hole, entry.entry_id)]
+    async_add_entities(switches, True)
+
+
+class PiHoleSwitch(SwitchEntity):
+    """Switch that enables or disables a Pi-Hole."""
+
+    def __init__(self, pi_hole, server_unique_id):
+        """Initialize a Pi-hole switch."""
+        LOGGER.debug("Setting up pi-hole switch for %s", server_unique_id)
+        if not pi_hole.api.api_token or not pi_hole.disable_seconds:
+            LOGGER.error(
+                "Pi-hole %s must have an api_key and disable durration provided in "
+                "configuration to be enabled",
+                pi_hole.name,
+            )
+            raise ValueError("Cannot enable a Pi-Hole switch without an api_key")
+        self.pi_hole = pi_hole
+        self._name = pi_hole.name
+        self._server_unique_id = server_unique_id
+        self._duration = pi_hole.disable_seconds
+        self._force_update = False
+        self.data = {}
+
+    @property
+    def icon(self):
+        """Return switch icon."""
+        return "mdi:shield-star"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the sensor."""
+        return f"{self._server_unique_id}/switch"
+
+    @property
+    def device_info(self):
+        """Return the device information of the sensor."""
+        return {
+            "identifiers": {(PIHOLE_DOMAIN, self._server_unique_id)},
+            "name": self._name,
+            "manufacturer": "Pi-hole",
+        }
+
+    @property
+    def is_on(self):
+        """Return the state of the device."""
+        return self.data["status"] == STATUS_ENABLED
+
+    async def async_turn_on(self, **kwargs):
+        """Enable the Pi-Hole."""
+        await self.pi_hole.api.enable()
+        self.data["status"] = STATUS_ENABLED
+
+    async def async_turn_off(self, **kwargs):
+        """Disable the Pi-Hole."""
+        await self.pi_hole.api.disable(self._duration)
+        self.data["status"] = "disabled"
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the Pi-Hole."""
+        return self.data
+
+    @property
+    def available(self):
+        """Could the device be accessed during the last update call."""
+        return self.pi_hole.available
+
+    async def async_update(self):
+        """Get the latest data from the Pi-hole API."""
+        LOGGER.debug("Getting updates for pihole switch")
+        await self.pi_hole.async_update()
+        self.data = self.pi_hole.api.data

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -1,7 +1,7 @@
 """Tests for the pi_hole component."""
 from hole.exceptions import HoleError
 
-from homeassistant.components.pi_hole.const import CONF_LOCATION
+from homeassistant.components.pi_hole.const import CONF_DISABLE_SECONDS, CONF_LOCATION
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
@@ -33,6 +33,7 @@ NAME = "name"
 API_KEY = "apikey"
 SSL = False
 VERIFY_SSL = True
+DISABLE_SECONDS = 30
 
 CONF_DATA = {
     CONF_HOST: f"{HOST}:{PORT}",
@@ -41,6 +42,7 @@ CONF_DATA = {
     CONF_API_KEY: API_KEY,
     CONF_SSL: SSL,
     CONF_VERIFY_SSL: VERIFY_SSL,
+    CONF_DISABLE_SECONDS: DISABLE_SECONDS,
 }
 
 CONF_CONFIG_FLOW = {
@@ -51,6 +53,7 @@ CONF_CONFIG_FLOW = {
     CONF_API_KEY: API_KEY,
     CONF_SSL: SSL,
     CONF_VERIFY_SSL: VERIFY_SSL,
+    CONF_DISABLE_SECONDS: DISABLE_SECONDS,
 }
 
 

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -66,6 +66,9 @@ async def test_setup_minimal_config(hass):
     assert hass.states.get("sensor.pi_hole_domains_blocked").state == "0"
     assert hass.states.get("sensor.pi_hole_seen_clients").state == "0"
 
+    assert hass.states.get("binary_sensor.pi_hole_status").name == "Pi-Hole Status"
+    assert hass.states.get("binary_sensor.pi_hole_status").state == "off"
+
 
 async def test_setup_name_config(hass):
     """Tests component setup with a custom name."""

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -69,6 +69,26 @@ async def test_setup_minimal_config(hass):
     assert hass.states.get("binary_sensor.pi_hole_status").name == "Pi-Hole Status"
     assert hass.states.get("binary_sensor.pi_hole_status").state == "off"
 
+    # Since no api_key was provided, there should be no switch
+    assert hass.states.get("switch.pi_hole") is None
+
+
+async def test_setup_minimal_switch_config(hass):
+    """Tests component setup with minimal config with an api key."""
+    mocked_hole = _create_mocked_hole()
+    with _patch_config_flow_hole(mocked_hole), _patch_init_hole(mocked_hole):
+        assert await async_setup_component(
+            hass,
+            pi_hole.DOMAIN,
+            {pi_hole.DOMAIN: [{"host": "pi.hole", "api_key": "abc"}]},
+        )
+
+    await hass.async_block_till_done()
+
+    # Since no api_key was provided, there should be no switch
+    assert hass.states.get("switch.pi_hole").name == "Pi-Hole"
+    assert hass.states.get("switch.pi_hole").state == "off"
+
 
 async def test_setup_name_config(hass):
     """Tests component setup with a custom name."""


### PR DESCRIPTION
## Proposed change
The Pi-Hole sensor today includes a number of Pi-Hole metrics, but no binary sensor to see if it's enabled or a switch to enable toggling it on or off. This patch enables both a sensor and, if an API key is provided, a switch. In order to improve the refresh frequency and minimize API calls at the same time, the module has also been refactored to use a `DataUpdateCoordinator`.

The Pi-Hole disable command accepts a parameter for the number of seconds until it is re-enabled. This patch also adds a new config setting that allows customizing this value. Default is 30s.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
# Example configuration.yaml
pi_hole:
  - host: localhost:9090
    api_key: foo  # Required only for switch
    disable_seconds: 30  # Optional
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #35605
- Link to documentation pull request: 

I should have checked first, but it appears that someone has started a similar patch. There are some differences between the two approaches and I'm happy to discard or merge the branches.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
