### PR TITLE
Bump pyvizio version to 0.1.48

### DIFF
--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "VIZIO SmartCast",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.1.47"],
+  "requirements": ["pyvizio==0.1.48"],
   "codeowners": ["@raman325"],
   "config_flow": true,
   "zeroconf": ["_viziocast._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1802,7 +1802,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.47
+pyvizio==0.1.48
 
 # homeassistant.components.velux
 pyvlx==0.2.16

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -747,7 +747,7 @@ pyvera==0.3.7
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.47
+pyvizio==0.1.48
 
 # homeassistant.components.html5
 pywebpush==1.9.2


### PR DESCRIPTION
## Proposed change
Bumping `pyvizio` to 0.1.48. This version changes the connection check function that gets called on integration startup and as part of config flow validation. Previously, the connection to a device would be checked by incrementing and decrementing the volume by a step, but since that impacts the functionality of the device, even if for a brief moment, that is an undesirable outcome. The new check returns the audio settings for the device which should provide the same level of validation without impacting the use of the device.

Changelog for pyvizio (only the first is relevant to the HA integration):
- Old logic used to mess with the volume. I found an API call I can make to check the connection is valid, including access token, without having to have end user impact.
- I noticed that some calls in the Vizio synchronous class fail. This is because it is a subclass of the Vizio async class (to maintain backwards compatibility) that calls the super class function for every function. When I call a super class function that refers to another function which is defined in both the super and subclass, it runs the subclass function instead of the superclass function. The changes I made explicitly force VizioAsync functions to call other VizioAsync functions when the same function is overridden in the child class to avoid this issue.
- Added some comments to the logic for finding an app name


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36265

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
