### PR TITLE
Alexa media player only include equalizer if supported sound mode

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1803,6 +1803,13 @@ class AlexaEqualizerController(AlexaCapability):
     """
 
     supported_locales = {"en-US"}
+    valid_sound_modes = {
+        "MOVIE",
+        "MUSIC",
+        "NIGHT",
+        "SPORT",
+        "TV",
+    }
 
     def name(self):
         """Return the Alexa API name of this interface."""
@@ -1821,34 +1828,33 @@ class AlexaEqualizerController(AlexaCapability):
             raise UnsupportedProperty(name)
 
         sound_mode = self.entity.attributes.get(media_player.ATTR_SOUND_MODE)
-        if sound_mode and sound_mode.upper() in (
-            "MOVIE",
-            "MUSIC",
-            "NIGHT",
-            "SPORT",
-            "TV",
-        ):
+        if sound_mode and sound_mode.upper() in self.valid_sound_modes:
             return sound_mode.upper()
 
         return None
 
     def configurations(self):
-        """Return the sound modes supported in the configurations object.
-
-        Valid Values for modes are: MOVIE, MUSIC, NIGHT, SPORT, TV.
-        """
+        """Return the sound modes supported in the configurations object."""
         configurations = None
-        sound_mode_list = self.entity.attributes.get(media_player.ATTR_SOUND_MODE_LIST)
-        if sound_mode_list:
-            supported_sound_modes = [
-                {"name": sound_mode.upper()}
-                for sound_mode in sound_mode_list
-                if sound_mode.upper() in ("MOVIE", "MUSIC", "NIGHT", "SPORT", "TV")
-            ]
-
+        supported_sound_modes = self.get_valid_inputs(
+            self.entity.attributes.get(media_player.ATTR_SOUND_MODE_LIST, [])
+        )
+        if supported_sound_modes:
             configurations = {"modes": {"supported": supported_sound_modes}}
 
         return configurations
+
+    @classmethod
+    def get_valid_inputs(cls, sound_mode_list):
+        """Return list of supported inputs."""
+        input_list = []
+        for sound_mode in sound_mode_list:
+            sound_mode = sound_mode.upper()
+
+            if sound_mode in cls.valid_sound_modes:
+                input_list.append({"name": sound_mode})
+
+        return input_list
 
 
 class AlexaTimeHoldController(AlexaCapability):

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1803,7 +1803,7 @@ class AlexaEqualizerController(AlexaCapability):
     """
 
     supported_locales = {"en-US"}
-    valid_sound_modes = {
+    VALID_SOUND_MODES = {
         "MOVIE",
         "MUSIC",
         "NIGHT",
@@ -1828,7 +1828,7 @@ class AlexaEqualizerController(AlexaCapability):
             raise UnsupportedProperty(name)
 
         sound_mode = self.entity.attributes.get(media_player.ATTR_SOUND_MODE)
-        if sound_mode and sound_mode.upper() in self.valid_sound_modes:
+        if sound_mode and sound_mode.upper() in self.VALID_SOUND_MODES:
             return sound_mode.upper()
 
         return None
@@ -1851,7 +1851,7 @@ class AlexaEqualizerController(AlexaCapability):
         for sound_mode in sound_mode_list:
             sound_mode = sound_mode.upper()
 
-            if sound_mode in cls.valid_sound_modes:
+            if sound_mode in cls.VALID_SOUND_MODES:
                 input_list.append({"name": sound_mode})
 
         return input_list

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -547,7 +547,11 @@ class MediaPlayerCapabilities(AlexaEntity):
             yield AlexaChannelController(self.entity)
 
         if supported & media_player.const.SUPPORT_SELECT_SOUND_MODE:
-            yield AlexaEqualizerController(self.entity)
+            inputs = AlexaInputController.get_valid_inputs(
+                self.entity.attributes.get(media_player.const.ATTR_SOUND_MODE_LIST, [])
+            )
+            if len(inputs) > 0:
+                yield AlexaEqualizerController(self.entity)
 
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.hass)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -3297,8 +3297,8 @@ async def test_media_player_eq_modes(hass):
         assert call.data["sound_mode"] == mode.lower()
 
 
-async def test_media_player_sound_mode_list_none(hass):
-    """Test EqualizerController bands directive not supported."""
+async def test_media_player_sound_mode_list_unsupported(hass):
+    """Test EqualizerController with unsupported sound modes."""
     device = (
         "media_player.test",
         "on",
@@ -3306,12 +3306,17 @@ async def test_media_player_sound_mode_list_none(hass):
             "friendly_name": "Test media player",
             "supported_features": SUPPORT_SELECT_SOUND_MODE,
             "sound_mode": "unknown",
-            "sound_mode_list": None,
+            "sound_mode_list": ["unsupported", "non-existing"],
         },
     )
     appliance = await discovery_test(device, hass)
     assert appliance["endpointId"] == "media_player#test"
     assert appliance["friendlyName"] == "Test media player"
+
+    # Test equalizer controller is not there
+    assert_endpoint_capabilities(
+        appliance, "Alexa", "Alexa.PowerController", "Alexa.EndpointHealth",
+    )
 
 
 async def test_media_player_eq_bands_not_supported(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alexa media players will only yield the equalizer controller if there is at least 1 supported sound mode.

Probably fixes #34029

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
