### PR TITLE
Do not show graphite warnings if no new_state in event

### DIFF
--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -139,7 +139,16 @@ class GraphiteFeeder(threading.Thread):
                 _LOGGER.debug("Event processing thread stopped")
                 self._queue.task_done()
                 return
-            if event.event_type == EVENT_STATE_CHANGED and event.data.get("new_state"):
+            if event.event_type == EVENT_STATE_CHANGED:
+                if not event.data.get("new_state"):
+                    _LOGGER.debug(
+                        "Skipping %s without new_state for %s",
+                        event.event_type,
+                        event.data["entity_id"],
+                    )
+                    self._queue.task_done()
+                    continue
+
                 _LOGGER.debug(
                     "Processing STATE_CHANGED event for %s", event.data["entity_id"]
                 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It is not correct to show warning about "unexpected event type" if EVENT_STATE_CHANGED have no new_state field.
We should show this warning only if it is real unexpected event type.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.