### PR TITLE
Stable device id when a deleted device is restored

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -427,12 +427,12 @@ class DeviceRegistry:
             if config_entries == {config_entry_id}:
                 # Permanently remove the device from the device registry.
                 del self.deleted_devices[deleted_device.id]
-                self.async_schedule_save()
             else:
                 config_entries = config_entries - {config_entry_id}
                 self.deleted_devices[deleted_device.id] = attr.evolve(
                     deleted_device, config_entries=config_entries
                 )
+            self.async_schedule_save()
 
     @callback
     def async_clear_area_id(self, area_id: str) -> None:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -381,6 +381,7 @@ class DeviceRegistry:
         if data is not None:
             for device in data["devices"]:
                 devices[device["id"]] = deserialize_device_entry(device)
+            # Introduced in 0.111
             if "deleted_devices" in data:
                 for device in data["deleted_devices"]:
                     deleted_devices[device["id"]] = deserialize_device_entry(device)

--- a/tests/common.py
+++ b/tests/common.py
@@ -381,10 +381,11 @@ def mock_area_registry(hass, mock_entries=None):
     return registry
 
 
-def mock_device_registry(hass, mock_entries=None):
+def mock_device_registry(hass, mock_entries=None, mock_deleted_entries=None):
     """Mock the Device Registry."""
     registry = device_registry.DeviceRegistry(hass)
     registry.devices = mock_entries or OrderedDict()
+    registry.deleted_devices = mock_deleted_entries or OrderedDict()
 
     hass.data[device_registry.DATA_REGISTRY] = registry
     return registry

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -153,11 +153,28 @@ async def test_loading_from_storage(hass, hass_storage):
                     "area_id": "12345A",
                     "name_by_user": "Test Friendly Name",
                 }
-            ]
+            ],
+            "deleted_devices": [
+                {
+                    "config_entries": ["1234"],
+                    "connections": [["Zigbee", "23.45.67.89.01"]],
+                    "id": "bcdefghijklmn",
+                    "identifiers": [["serial", "34:56:AB:CD:EF:12"]],
+                    "manufacturer": "manufacturer",
+                    "model": "model",
+                    "name": "name",
+                    "sw_version": "version",
+                    "entry_type": "service",
+                    "area_id": "12345A",
+                    "name_by_user": "Test Friendly Name",
+                }
+            ],
         },
     }
 
     registry = await device_registry.async_get_registry(hass)
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 1
 
     entry = registry.async_get_or_create(
         config_entry_id="1234",
@@ -224,6 +241,49 @@ async def test_removing_config_entries(hass, registry, update_events):
     assert update_events[4]["device_id"] == entry3.id
 
 
+async def test_deleted_device_removing_config_entries(hass, registry, update_events):
+    """Make sure we do not get duplicate entries."""
+    entry = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 0
+
+    registry.async_remove_device(entry.id)
+
+    assert len(registry.devices) == 0
+    assert len(registry.deleted_devices) == 1
+
+    await hass.async_block_till_done()
+    assert len(update_events) == 2
+    assert update_events[0]["action"] == "create"
+    assert update_events[1]["action"] == "remove"
+
+    registry.async_clear_config_entry("123")
+    assert len(registry.devices) == 0
+    assert len(registry.deleted_devices) == 0
+
+    # No event when a deleted device is purged
+    await hass.async_block_till_done()
+    assert len(update_events) == 2
+
+    # Re-add, expect new device id
+    entry2 = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert entry.id != entry2.id
+
+
 async def test_removing_area_id(registry):
     """Make sure we can clear area id."""
     entry = registry.async_get_or_create(
@@ -237,6 +297,36 @@ async def test_removing_area_id(registry):
     entry_w_area = registry.async_update_device(entry.id, area_id="12345A")
 
     registry.async_clear_area_id("12345A")
+    entry_wo_area = registry.async_get_device({("bridgeid", "0123")}, set())
+
+    assert not entry_wo_area.area_id
+    assert entry_w_area != entry_wo_area
+
+
+async def test_deleted_device_removing_area_id(registry):
+    """Make sure we can clear area id of deleted device."""
+    entry = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    entry_w_area = registry.async_update_device(entry.id, area_id="12345A")
+
+    registry.async_remove_device(entry.id)
+    registry.async_clear_area_id("12345A")
+
+    entry2 = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+    assert entry.id == entry2.id
+
     entry_wo_area = registry.async_get_device({("bridgeid", "0123")}, set())
 
     assert not entry_wo_area.area_id
@@ -320,7 +410,19 @@ async def test_loading_saving_data(hass, registry):
         via_device=("hue", "0123"),
     )
 
+    orig_light2 = registry.async_get_or_create(
+        config_entry_id="456",
+        connections=set(),
+        identifiers={("hue", "789")},
+        manufacturer="manufacturer",
+        model="light",
+        via_device=("hue", "0123"),
+    )
+
+    registry.async_remove_device(orig_light2.id)
+
     assert len(registry.devices) == 2
+    assert len(registry.deleted_devices) == 1
 
     orig_via = registry.async_update_device(
         orig_via.id, area_id="mock-area-id", name_by_user="mock-name-by-user"
@@ -333,6 +435,7 @@ async def test_loading_saving_data(hass, registry):
 
     # Ensure same order
     assert list(registry.devices) == list(registry2.devices)
+    assert list(registry.deleted_devices) == list(registry2.deleted_devices)
 
     new_via = registry2.async_get_device({("hue", "0123")}, set())
     new_light = registry2.async_get_device({("hue", "456")}, set())
@@ -584,3 +687,54 @@ async def test_cleanup_entity_registry_change(hass):
         ent_reg.async_remove(entity.entity_id)
         await hass.async_block_till_done()
         assert len(mock_call.mock_calls) == 2
+
+
+async def test_restore_device(hass, registry, update_events):
+    """Make sure device id is stable."""
+    entry = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 0
+
+    registry.async_remove_device(entry.id)
+
+    assert len(registry.devices) == 0
+    assert len(registry.deleted_devices) == 1
+
+    entry2 = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
+        identifiers={("bridgeid", "4567")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+    entry3 = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert entry.id == entry3.id
+    assert entry.id != entry2.id
+    assert len(registry.devices) == 2
+    assert len(registry.deleted_devices) == 0
+
+    await hass.async_block_till_done()
+
+    assert len(update_events) == 4
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["device_id"] == entry.id
+    assert update_events[1]["action"] == "remove"
+    assert update_events[1]["device_id"] == entry.id
+    assert update_events[2]["action"] == "create"
+    assert update_events[2]["device_id"] == entry2.id
+    assert update_events[3]["action"] == "create"
+    assert update_events[3]["device_id"] == entry3.id

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -764,6 +764,10 @@ async def test_restore_device(hass, registry, update_events):
     assert len(registry.devices) == 2
     assert len(registry.deleted_devices) == 0
 
+    assert isinstance(entry3.config_entries, set)
+    assert isinstance(entry3.connections, set)
+    assert isinstance(entry3.identifiers, set)
+
     await hass.async_block_till_done()
 
     assert len(update_events) == 4

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -160,13 +160,6 @@ async def test_loading_from_storage(hass, hass_storage):
                     "connections": [["Zigbee", "23.45.67.89.01"]],
                     "id": "bcdefghijklmn",
                     "identifiers": [["serial", "34:56:AB:CD:EF:12"]],
-                    "manufacturer": "manufacturer",
-                    "model": "model",
-                    "name": "name",
-                    "sw_version": "version",
-                    "entry_type": "service",
-                    "area_id": "12345A",
-                    "name_by_user": "Test Friendly Name",
                 }
             ],
         },
@@ -188,6 +181,20 @@ async def test_loading_from_storage(hass, hass_storage):
     assert entry.name_by_user == "Test Friendly Name"
     assert entry.entry_type == "service"
     assert isinstance(entry.config_entries, set)
+    assert isinstance(entry.connections, set)
+    assert isinstance(entry.identifiers, set)
+
+    entry = registry.async_get_or_create(
+        config_entry_id="1234",
+        connections={("Zigbee", "23.45.67.89.01")},
+        identifiers={("serial", "34:56:AB:CD:EF:12")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+    assert entry.id == "bcdefghijklmn"
+    assert isinstance(entry.config_entries, set)
+    assert isinstance(entry.connections, set)
+    assert isinstance(entry.identifiers, set)
 
 
 async def test_removing_config_entries(hass, registry, update_events):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure stable device id when a deleted device is restored.
The trigger for this PR is to not break device automations if a device is accidentally deleted and then added again.

A deleted device will be stored in the device registry in a `deleted_devices` list.
When adding a new device, a lookup will be done in the `deleted_devices` before issuing a new device id.

- All device information is stored in the `deleted_devices` list and will thus be restored
- When removing an area, this will also be done on any matching`deleted_devices`
- When removing a config entry, matching `deleted_devices` will be permanently purged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #36279 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
