### PR TITLE
Clean up command learning in the Broadlink integration

### DIFF
--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 from base64 import b64decode, b64encode
 from binascii import unhexlify
-from datetime import timedelta
 import logging
 import re
 
@@ -13,7 +12,7 @@ from homeassistant.const import CONF_HOST
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.dt import utcnow
 
-from .const import CONF_PACKET, DOMAIN, SERVICE_LEARN, SERVICE_SEND
+from .const import CONF_PACKET, DOMAIN, LEARNING_TIMEOUT, SERVICE_LEARN, SERVICE_SEND
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,7 +83,7 @@ async def async_setup_service(hass, host, device):
 
         _LOGGER.info("Press the key you want Home Assistant to learn")
         start_time = utcnow()
-        while (utcnow() - start_time) < timedelta(seconds=20):
+        while (utcnow() - start_time) < LEARNING_TIMEOUT:
             await asyncio.sleep(1)
             try:
                 packet = await device.async_request(device.api.check_data)

--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -1,13 +1,16 @@
 """Constants for broadlink platform."""
+from datetime import timedelta
+
 CONF_PACKET = "packet"
 
-DEFAULT_LEARNING_TIMEOUT = 20
 DEFAULT_NAME = "Broadlink"
 DEFAULT_PORT = 80
 DEFAULT_RETRY = 3
 DEFAULT_TIMEOUT = 5
 
 DOMAIN = "broadlink"
+
+LEARNING_TIMEOUT = timedelta(seconds=30)
 
 SERVICE_LEARN = "learn"
 SERVICE_SEND = "send"

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -24,7 +24,6 @@ from homeassistant.components.remote import (
     ATTR_DELAY_SECS,
     ATTR_DEVICE,
     ATTR_NUM_REPEATS,
-    ATTR_TIMEOUT,
     DEFAULT_DELAY_SECS,
     DOMAIN as COMPONENT,
     PLATFORM_SCHEMA,
@@ -40,10 +39,10 @@ from homeassistant.util.dt import utcnow
 
 from . import DOMAIN, data_packet, hostname, mac_address
 from .const import (
-    DEFAULT_LEARNING_TIMEOUT,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
+    LEARNING_TIMEOUT,
     RM4_TYPES,
     RM_TYPES,
 )
@@ -74,10 +73,7 @@ SERVICE_SEND_SCHEMA = MINIMUM_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_LEARN_SCHEMA = MINIMUM_SERVICE_SCHEMA.extend(
-    {
-        vol.Optional(ATTR_ALTERNATIVE, default=False): cv.boolean,
-        vol.Optional(ATTR_TIMEOUT, default=DEFAULT_LEARNING_TIMEOUT): cv.positive_int,
-    }
+    {vol.Optional(ATTR_ALTERNATIVE, default=False): cv.boolean}
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -267,7 +263,6 @@ class BroadlinkRemote(RemoteEntity):
         commands = kwargs[ATTR_COMMAND]
         device = kwargs[ATTR_DEVICE]
         toggle = kwargs[ATTR_ALTERNATIVE]
-        timeout = kwargs[ATTR_TIMEOUT]
 
         if not self._state:
             return
@@ -275,43 +270,29 @@ class BroadlinkRemote(RemoteEntity):
         should_store = False
         for command in commands:
             try:
-                should_store |= await self._async_learn_code(
-                    command, device, toggle, timeout
-                )
-            except (AuthorizationError, DeviceOfflineError):
+                code = await self._async_learn_command(command)
+                if toggle:
+                    code = [code, await self._async_learn_command(command)]
+            except (AuthorizationError, DeviceOfflineError) as err_msg:
+                _LOGGER.error("Failed to learn '%s': %s", command, err_msg)
                 break
-            except BroadlinkException:
-                pass
+            except (BroadlinkException, TimeoutError) as err_msg:
+                _LOGGER.error("Failed to learn '%s': %s", command, err_msg)
+                continue
+            else:
+                self._codes.setdefault(device, {}).update({command: code})
+                should_store = True
 
         if should_store:
             await self._code_storage.async_save(self._codes)
 
-    async def _async_learn_code(self, command, device, toggle, timeout):
-        """Learn a code from a remote.
-
-        Capture an additional code for toggle commands.
-        """
+    async def _async_learn_command(self, command):
+        """Learn a command from a remote."""
         try:
-            if not toggle:
-                code = await self._async_capture_code(command, timeout)
-            else:
-                code = [
-                    await self._async_capture_code(command, timeout),
-                    await self._async_capture_code(command, timeout),
-                ]
-        except TimeoutError:
-            _LOGGER.error("Failed to learn '%s/%s': No code received", command, device)
-            return False
+            await self.device.async_request(self.device.api.enter_learning)
         except BroadlinkException as err_msg:
-            _LOGGER.error("Failed to learn '%s/%s': %s", command, device, err_msg)
+            _LOGGER.debug("Failed to enter learning mode: %s", err_msg)
             raise
-
-        self._codes.setdefault(device, {}).update({command: code})
-        return True
-
-    async def _async_capture_code(self, command, timeout):
-        """Enter learning mode and capture a code from a remote."""
-        await self.device.async_request(self.device.api.enter_learning)
 
         self.hass.components.persistent_notification.async_create(
             f"Press the '{command}' button.",
@@ -319,22 +300,17 @@ class BroadlinkRemote(RemoteEntity):
             notification_id="learn_command",
         )
 
-        code = None
-        start_time = utcnow()
-        while (utcnow() - start_time) < timedelta(seconds=timeout):
-            await asyncio.sleep(1)
-            try:
-                code = await self.device.async_request(self.device.api.check_data)
-            except (ReadError, StorageError):
-                continue
-            else:
-                break
-
-        self.hass.components.persistent_notification.async_dismiss(
-            notification_id="learn_command"
-        )
-
-        if code is None:
-            raise TimeoutError
-
-        return b64encode(code).decode("utf8")
+        try:
+            start_time = utcnow()
+            while (utcnow() - start_time) < LEARNING_TIMEOUT:
+                await asyncio.sleep(1)
+                try:
+                    code = await self.device.async_request(self.device.api.check_data)
+                except (ReadError, StorageError):
+                    continue
+                return b64encode(code).decode("utf8")
+            raise TimeoutError("No code received")
+        finally:
+            self.hass.components.persistent_notification.async_dismiss(
+                notification_id="learn_command"
+            )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The timeout option has been removed from the command learning service because it does not work properly. The device has a fixed timeout of 30 secs, which cannot be changed.

To adapt to these changes, users need to remove `timeout: num_secs` from calls to the `broadlink.learn_command` service.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up the command learning service and remove the timeout option, which is useless.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
script:
  learn_tv_power:
    sequence:
      - service: remote.learn_command
        data:
          entity_id: remote.bedroom
          device: tv
          command: power
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13635

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
