### PR TITLE
Add LTE switch to Freebox

### DIFF
--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 
 from aiofreepybox import Freepybox
 from aiofreepybox.api.wifi import Wifi
+from aiofreepybox.api.connection import Connection
 from aiofreepybox.exceptions import HttpRequestError
 
 from homeassistant.config_entries import ConfigEntry
@@ -181,6 +182,11 @@ class FreeboxRouter:
     def wifi(self) -> Wifi:
         """Return the wifi."""
         return self._api.wifi
+
+    @property
+    def connection(self) -> Connection:
+        """Return the connection."""
+        return self._api.connection
 
 
 async def get_api(hass: HomeAssistantType, host: str) -> Freepybox:

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -31,6 +31,26 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
+class FixedConnection(Connection):
+
+    lte_configuration_data_schema = {
+        'enabled': True
+    }
+
+    async def get_lte_config(self):
+        '''
+        Get lte connection configuration
+        '''
+        return await self._access.get('connection/lte/config/')
+
+    async def set_lte_config(self, lte_configuration_data=lte_configuration_data_schema):
+        '''
+        Update lte connection configuration
+        
+        /!\ Requires system config permission. Go to {FreeboxURL}#Fbx.os.app.settings.Accounts and allow the permission manually.
+        '''
+        await self._access.put('connection/lte/config/', lte_configuration_data)
+
 
 class FreeboxRouter:
     """Representation of a Freebox router."""
@@ -184,9 +204,11 @@ class FreeboxRouter:
         return self._api.wifi
 
     @property
-    def connection(self) -> Connection:
+    def connection(self) -> FixedConnection:
         """Return the connection."""
-        return self._api.connection
+        con = self._api.connection
+        con.__class__ = FixedConnection
+        return con
 
 
 async def get_api(hass: HomeAssistantType, host: str) -> Freepybox:

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -20,6 +20,7 @@ async def async_setup_entry(
     """Set up the switch."""
     router = hass.data[DOMAIN][entry.unique_id]
     async_add_entities([FreeboxWifiSwitch(router)], True)
+    async_add_entities([FreeboxLteSwitch(router)], True)
 
 
 class FreeboxWifiSwitch(SwitchEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the ability to control LTE in Freebox Delta the same way WiFi is controlled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The addition of the switch requires additional permissions that seemingly cannot be granted from the API. Users are required to grant permission manually in the Freebox settings. Also knowing whether the switch is available on the targeted Freebox or not is not implemented yet. Any help appreciated.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
