### PR TITLE
Prefer use cloud url for oauth2 for Withings

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -12,7 +12,12 @@ from homeassistant.helpers import config_entry_oauth2_flow, config_validation as
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import config_flow
-from .common import _LOGGER, NotAuthenticatedError, get_data_manager
+from .common import (
+    _LOGGER,
+    NotAuthenticatedError,
+    WithingsLocalOAuth2Implementation,
+    get_data_manager,
+)
 from .const import CONF_PROFILES, CONFIG, CREDENTIALS, DOMAIN
 
 CONFIG_SCHEMA = vol.Schema(
@@ -44,7 +49,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
 
     config_flow.WithingsFlowHandler.async_register_implementation(
         hass,
-        config_entry_oauth2_flow.LocalOAuth2Implementation(
+        WithingsLocalOAuth2Implementation(
             hass,
             DOMAIN,
             conf[CONF_CLIENT_ID],

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -20,9 +20,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.helpers.config_entry_oauth2_flow import (
+    AUTH_CALLBACK_PATH,
     AbstractOAuth2Implementation,
+    LocalOAuth2Implementation,
     OAuth2Session,
 )
+from homeassistant.helpers.network import get_url
 from homeassistant.util import dt, slugify
 
 from . import const
@@ -335,3 +338,12 @@ def get_data_manager(
     )
 
     return dm_dict[entry_id]
+
+
+class WithingsLocalOAuth2Implementation(LocalOAuth2Implementation):
+    """Oauth2 implementation that only uses the external url."""
+
+    @property
+    def redirect_uri(self) -> str:
+        """Return the redirect uri."""
+        return f"{get_url(self.hass, allow_internal=False)}{AUTH_CALLBACK_PATH}"

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -346,7 +346,5 @@ class WithingsLocalOAuth2Implementation(LocalOAuth2Implementation):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        url = get_url(
-            self.hass, allow_internal=False, prefer_cloud=True, prefer_external=True
-        )
+        url = get_url(self.hass, allow_internal=False, prefer_cloud=True)
         return f"{url}{AUTH_CALLBACK_PATH}"

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -346,4 +346,5 @@ class WithingsLocalOAuth2Implementation(LocalOAuth2Implementation):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        return f"{get_url(self.hass, allow_internal=False)}{AUTH_CALLBACK_PATH}"
+        url = get_url(self.hass, prefer_cloud=True)
+        return f"{url}{AUTH_CALLBACK_PATH}"

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -346,5 +346,7 @@ class WithingsLocalOAuth2Implementation(LocalOAuth2Implementation):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        url = get_url(self.hass, prefer_cloud=True)
+        url = get_url(
+            self.hass, allow_internal=False, prefer_cloud=True, prefer_external=True
+        )
         return f"{url}{AUTH_CALLBACK_PATH}"

--- a/tests/components/withings/common.py
+++ b/tests/components/withings/common.py
@@ -22,6 +22,7 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
+    CONF_EXTERNAL_URL,
     CONF_UNIT_SYSTEM,
     CONF_UNIT_SYSTEM_METRIC,
 )
@@ -56,8 +57,11 @@ async def setup_hass(hass: HomeAssistant) -> dict:
     profiles = ["Person0", "Person1", "Person2", "Person3", "Person4"]
 
     hass_config = {
-        "homeassistant": {CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC},
-        api.DOMAIN: {"base_url": "http://localhost/"},
+        "homeassistant": {
+            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
+            CONF_EXTERNAL_URL: "http://example.local/",
+        },
+        api.DOMAIN: {},
         http.DOMAIN: {"server_port": 8080},
         const.DOMAIN: {
             CONF_CLIENT_ID: "my_client_id",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The recent deprecation of api.base_url and subsequent switch that all OAuth2 urls are generate using the internal URL has caused a lot of reported issues with the Withings integration. The Withings service requires a publicly accessible URL when setting up the account (they check with HEAD requests). Sending the internal URL to the service when performing OAuth2 calls results in failures and a lot of confusion for uses who's best workaround is to set their internal URL in HA to a publicly accessible URL.
This change forces all Withings OAuth2 calls to always use the external URL to avoid this confusion.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36172, fixes #36053, fixes #26924
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13643

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
