### PR TITLE
Change deCONZ sensor device classes

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -94,11 +94,6 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
         return DEVICE_CLASS.get(type(self._device))
 
     @property
-    def icon(self):
-        """Return the icon to use in the frontend."""
-        return self._device.SENSOR_ICON
-
-    @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         attr = {}

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -1,13 +1,5 @@
 """Support for deCONZ binary sensors."""
-from pydeconz.sensor import (
-    CarbonMonoxide,
-    Fire,
-    GenericFlag,
-    OpenClose,
-    Presence,
-    Vibration,
-    Water,
-)
+from pydeconz.sensor import CarbonMonoxide, Fire, OpenClose, Presence, Vibration, Water
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_GAS,
@@ -33,7 +25,6 @@ ATTR_VIBRATIONSTRENGTH = "vibrationstrength"
 DEVICE_CLASS = {
     CarbonMonoxide: DEVICE_CLASS_GAS,
     Fire: DEVICE_CLASS_SMOKE,
-    GenericFlag: "",
     OpenClose: DEVICE_CLASS_OPENING,
     Presence: DEVICE_CLASS_MOTION,
     Vibration: DEVICE_CLASS_VIBRATION,
@@ -100,7 +91,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of the sensor."""
-        return DEVICE_CLASS[type(self._device)]
+        return DEVICE_CLASS.get(type(self._device))
 
     @property
     def icon(self):

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -1,7 +1,23 @@
 """Support for deCONZ binary sensors."""
-from pydeconz.sensor import Presence, Vibration
+from pydeconz.sensor import (
+    CarbonMonoxide,
+    Fire,
+    GenericFlag,
+    OpenClose,
+    Presence,
+    Vibration,
+    Water,
+)
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_GAS,
+    DEVICE_CLASS_MOISTURE,
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_OPENING,
+    DEVICE_CLASS_SMOKE,
+    DEVICE_CLASS_VIBRATION,
+    BinarySensorEntity,
+)
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -13,6 +29,16 @@ from .gateway import get_gateway_from_config_entry
 ATTR_ORIENTATION = "orientation"
 ATTR_TILTANGLE = "tiltangle"
 ATTR_VIBRATIONSTRENGTH = "vibrationstrength"
+
+DEVICE_CLASS = {
+    CarbonMonoxide: DEVICE_CLASS_GAS,
+    Fire: DEVICE_CLASS_SMOKE,
+    GenericFlag: "",
+    OpenClose: DEVICE_CLASS_OPENING,
+    Presence: DEVICE_CLASS_MOTION,
+    Vibration: DEVICE_CLASS_VIBRATION,
+    Water: DEVICE_CLASS_MOISTURE,
+}
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -74,7 +100,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of the sensor."""
-        return self._device.SENSOR_CLASS
+        return DEVICE_CLASS[type(self._device)]
 
     @property
     def icon(self):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -1,10 +1,8 @@
 """Support for deCONZ sensors."""
 from pydeconz.sensor import (
-    Alarm,
     Battery,
     Consumption,
     Daylight,
-    GenericStatus,
     Humidity,
     LightLevel,
     Power,
@@ -42,10 +40,6 @@ ATTR_DAYLIGHT = "daylight"
 ATTR_EVENT_ID = "event_id"
 
 DEVICE_CLASS = {
-    Alarm: "motion",
-    Consumption: "consumption",
-    Daylight: "daylight",
-    GenericStatus: "",
     Humidity: DEVICE_CLASS_HUMIDITY,
     LightLevel: DEVICE_CLASS_ILLUMINANCE,
     Power: DEVICE_CLASS_POWER,
@@ -141,7 +135,7 @@ class DeconzSensor(DeconzDevice):
     @property
     def device_class(self):
         """Return the class of the sensor."""
-        return DEVICE_CLASS[type(self._device)]
+        return DEVICE_CLASS.get(type(self._device))
 
     @property
     def icon(self):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -21,6 +21,10 @@ from homeassistant.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
+    ENERGY_KILO_WATT_HOUR,
+    POWER_WATT,
+    PRESSURE_HPA,
+    TEMP_CELSIUS,
     UNIT_PERCENTAGE,
 )
 from homeassistant.core import callback
@@ -45,6 +49,21 @@ DEVICE_CLASS = {
     Power: DEVICE_CLASS_POWER,
     Pressure: DEVICE_CLASS_PRESSURE,
     Temperature: DEVICE_CLASS_TEMPERATURE,
+}
+
+ICON = {
+    Daylight: "mdi:white-balance-sunny",
+    Pressure: "mdi:gauge",
+    Temperature: "mdi:thermometer",
+}
+
+UNIT_OF_MEASUREMENT = {
+    Consumption: ENERGY_KILO_WATT_HOUR,
+    Humidity: UNIT_PERCENTAGE,
+    LightLevel: "lx",
+    Power: POWER_WATT,
+    Pressure: PRESSURE_HPA,
+    Temperature: TEMP_CELSIUS,
 }
 
 
@@ -140,12 +159,12 @@ class DeconzSensor(DeconzDevice):
     @property
     def icon(self):
         """Return the icon to use in the frontend."""
-        return self._device.SENSOR_ICON
+        return ICON.get(type(self._device))
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this sensor."""
-        return self._device.SENSOR_UNIT
+        return UNIT_OF_MEASUREMENT.get(type(self._device))
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -1,11 +1,16 @@
 """Support for deCONZ sensors."""
 from pydeconz.sensor import (
+    Alarm,
     Battery,
     Consumption,
     Daylight,
+    GenericStatus,
+    Humidity,
     LightLevel,
     Power,
+    Pressure,
     Switch,
+    Temperature,
     Thermostat,
 )
 
@@ -13,6 +18,11 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     ATTR_VOLTAGE,
     DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
     UNIT_PERCENTAGE,
 )
 from homeassistant.core import callback
@@ -30,6 +40,18 @@ ATTR_CURRENT = "current"
 ATTR_POWER = "power"
 ATTR_DAYLIGHT = "daylight"
 ATTR_EVENT_ID = "event_id"
+
+DEVICE_CLASS = {
+    Alarm: "motion",
+    Consumption: "consumption",
+    Daylight: "daylight",
+    GenericStatus: "",
+    Humidity: DEVICE_CLASS_HUMIDITY,
+    LightLevel: DEVICE_CLASS_ILLUMINANCE,
+    Power: DEVICE_CLASS_POWER,
+    Pressure: DEVICE_CLASS_PRESSURE,
+    Temperature: DEVICE_CLASS_TEMPERATURE,
+}
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -119,7 +141,7 @@ class DeconzSensor(DeconzDevice):
     @property
     def device_class(self):
         """Return the class of the sensor."""
-        return self._device.SENSOR_CLASS
+        return DEVICE_CLASS[type(self._device)]
 
     @property
     def icon(self):

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -88,6 +88,7 @@ async def test_binary_sensors(hass):
 
     vibration_sensor = hass.states.get("binary_sensor.vibration_sensor")
     assert vibration_sensor.state == "on"
+    assert vibration_sensor.attributes["device_class"] == "vibration"
 
     state_changed_event = {
         "t": "event",

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -3,6 +3,10 @@ from copy import deepcopy
 
 from homeassistant.components import deconz
 import homeassistant.components.binary_sensor as binary_sensor
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_VIBRATION,
+)
 from homeassistant.setup import async_setup_component
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
@@ -79,6 +83,7 @@ async def test_binary_sensors(hass):
 
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
     assert presence_sensor.state == "off"
+    assert presence_sensor.attributes["device_class"] == DEVICE_CLASS_MOTION
 
     temperature_sensor = hass.states.get("binary_sensor.temperature_sensor")
     assert temperature_sensor is None
@@ -88,7 +93,7 @@ async def test_binary_sensors(hass):
 
     vibration_sensor = hass.states.get("binary_sensor.vibration_sensor")
     assert vibration_sensor.state == "on"
-    assert vibration_sensor.attributes["device_class"] == "vibration"
+    assert vibration_sensor.attributes["device_class"] == DEVICE_CLASS_VIBRATION
 
     state_changed_event = {
         "t": "event",

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -144,7 +144,7 @@ async def test_sensors(hass):
 
     consumption_sensor = hass.states.get("sensor.consumption_sensor")
     assert consumption_sensor.state == "0.002"
-    assert consumption_sensor.attributes["device_class"] == "consumption"
+    assert "device_class" not in consumption_sensor.attributes
 
     state_changed_event = {
         "t": "event",

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -3,6 +3,11 @@ from copy import deepcopy
 
 from homeassistant.components import deconz
 import homeassistant.components.sensor as sensor
+from homeassistant.const import (
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_POWER,
+)
 from homeassistant.setup import async_setup_component
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
@@ -112,6 +117,7 @@ async def test_sensors(hass):
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
     assert light_level_sensor.state == "999.8"
+    assert light_level_sensor.attributes["device_class"] == DEVICE_CLASS_ILLUMINANCE
 
     presence_sensor = hass.states.get("sensor.presence_sensor")
     assert presence_sensor is None
@@ -127,15 +133,18 @@ async def test_sensors(hass):
 
     switch_2_battery_level = hass.states.get("sensor.switch_2_battery_level")
     assert switch_2_battery_level.state == "100"
+    assert switch_2_battery_level.attributes["device_class"] == DEVICE_CLASS_BATTERY
 
     daylight_sensor = hass.states.get("sensor.daylight_sensor")
     assert daylight_sensor is None
 
     power_sensor = hass.states.get("sensor.power_sensor")
     assert power_sensor.state == "6"
+    assert power_sensor.attributes["device_class"] == DEVICE_CLASS_POWER
 
     consumption_sensor = hass.states.get("sensor.consumption_sensor")
     assert consumption_sensor.state == "0.002"
+    assert consumption_sensor.attributes["device_class"] == "consumption"
 
     state_changed_event = {
         "t": "event",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Updated binary sensor and sensor device classes to follow official ones

Binary sensor device classes:
- Carbon monoxide changed to gas
- Vibration changed to vibration

Sensor device classes:
- Alarm has been removed
- Consumption has been removed
- Daylight has been removed
- Power has been added as power

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34764
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
