### PR TITLE
Prevent possible secret values to show up in deprecation logs

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -657,30 +657,30 @@ def deprecated(
 
     if replacement_key and invalidation_version:
         warning = (
-            "The '{key}' option (with value '{value}') is"
-            " deprecated, please replace it with '{replacement_key}'."
+            "The '{key}' option is deprecated,"
+            " please replace it with '{replacement_key}'."
             " This option will become invalid in version"
             " {invalidation_version}"
         )
     elif replacement_key:
         warning = (
-            "The '{key}' option (with value '{value}') is"
-            " deprecated, please replace it with '{replacement_key}'"
+            "The '{key}' option is deprecated,"
+            " please replace it with '{replacement_key}'"
         )
     elif invalidation_version:
         warning = (
-            "The '{key}' option (with value '{value}') is"
-            " deprecated, please remove it from your configuration."
+            "The '{key}' option is deprecated,"
+            " please remove it from your configuration."
             " This option will become invalid in version"
             " {invalidation_version}"
         )
     else:
         warning = (
-            "The '{key}' option (with value '{value}') is"
-            " deprecated, please remove it from your configuration"
+            "The '{key}' option is deprecated,"
+            " please remove it from your configuration"
         )
 
-    def check_for_invalid_version(value: Optional[Any]) -> None:
+    def check_for_invalid_version() -> None:
         """Raise error if current version has reached invalidation."""
         if not invalidation_version:
             return
@@ -689,7 +689,6 @@ def deprecated(
             raise vol.Invalid(
                 warning.format(
                     key=key,
-                    value=value,
                     replacement_key=replacement_key,
                     invalidation_version=invalidation_version,
                 )
@@ -698,19 +697,20 @@ def deprecated(
     def validator(config: Dict) -> Dict:
         """Check if key is in config and log warning."""
         if key in config:
-            value = config[key]
-            check_for_invalid_version(value)
+            check_for_invalid_version()
             KeywordStyleAdapter(logging.getLogger(module_name)).warning(
                 warning,
                 key=key,
-                value=value,
                 replacement_key=replacement_key,
                 invalidation_version=invalidation_version,
             )
+
+            value = config[key]
             if replacement_key:
                 config.pop(key)
         else:
             value = default
+
         keys = [key]
         if replacement_key:
             keys.append(replacement_key)

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -548,8 +548,7 @@ def test_deprecated_with_no_optionals(caplog, schema):
         "homeassistant.helpers.config_validation",
     ]
     assert (
-        "The 'mars' option (with value 'True') is deprecated, "
-        "please remove it from your configuration"
+        "The 'mars' option is deprecated, " "please remove it from your configuration"
     ) in caplog.text
     assert test_data == output
 
@@ -582,8 +581,7 @@ def test_deprecated_with_replacement_key(caplog, schema):
     output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 1
     assert (
-        "The 'mars' option (with value 'True') is deprecated, "
-        "please replace it with 'jupiter'"
+        "The 'mars' option is deprecated, " "please replace it with 'jupiter'"
     ) in caplog.text
     assert {"jupiter": True} == output
 
@@ -617,7 +615,7 @@ def test_deprecated_with_invalidation_version(caplog, schema, version):
     )
 
     message = (
-        "The 'mars' option (with value 'True') is deprecated, "
+        "The 'mars' option is deprecated, "
         "please remove it from your configuration. "
         "This option will become invalid in version 1.0.0"
     )
@@ -643,7 +641,7 @@ def test_deprecated_with_invalidation_version(caplog, schema, version):
     with pytest.raises(vol.MultipleInvalid) as exc_info:
         invalidated_schema(test_data)
     assert str(exc_info.value) == (
-        "The 'mars' option (with value 'True') is deprecated, "
+        "The 'mars' option is deprecated, "
         "please remove it from your configuration. This option will "
         "become invalid in version 0.1.0"
     )
@@ -671,7 +669,7 @@ def test_deprecated_with_replacement_key_and_invalidation_version(
     )
 
     warning = (
-        "The 'mars' option (with value 'True') is deprecated, "
+        "The 'mars' option is deprecated, "
         "please replace it with 'jupiter'. This option will become "
         "invalid in version 1.0.0"
     )
@@ -703,7 +701,7 @@ def test_deprecated_with_replacement_key_and_invalidation_version(
     with pytest.raises(vol.MultipleInvalid) as exc_info:
         invalidated_schema(test_data)
     assert str(exc_info.value) == (
-        "The 'mars' option (with value 'True') is deprecated, "
+        "The 'mars' option is deprecated, "
         "please replace it with 'jupiter'. This option will become "
         "invalid in version 0.1.0"
     )
@@ -725,8 +723,7 @@ def test_deprecated_with_default(caplog, schema):
     assert len(caplog.records) == 1
     assert caplog.records[0].name == __name__
     assert (
-        "The 'mars' option (with value 'True') is deprecated, "
-        "please remove it from your configuration"
+        "The 'mars' option is deprecated, " "please remove it from your configuration"
     ) in caplog.text
     assert test_data == output
 
@@ -759,8 +756,7 @@ def test_deprecated_with_replacement_key_and_default(caplog, schema):
     output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 1
     assert (
-        "The 'mars' option (with value 'True') is deprecated, "
-        "please replace it with 'jupiter'"
+        "The 'mars' option is deprecated, " "please replace it with 'jupiter'"
     ) in caplog.text
     assert {"jupiter": True} == output
 
@@ -792,8 +788,7 @@ def test_deprecated_with_replacement_key_and_default(caplog, schema):
     output = deprecated_schema_with_default(test_data.copy())
     assert len(caplog.records) == 1
     assert (
-        "The 'mars' option (with value 'True') is deprecated, "
-        "please replace it with 'jupiter'"
+        "The 'mars' option is deprecated, " "please replace it with 'jupiter'"
     ) in caplog.text
     assert {"jupiter": True} == output
 
@@ -828,7 +823,7 @@ def test_deprecated_with_replacement_key_invalidation_version_default(
     output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 1
     assert (
-        "The 'mars' option (with value 'True') is deprecated, "
+        "The 'mars' option is deprecated, "
         "please replace it with 'jupiter'. This option will become "
         "invalid in version 1.0.0"
     ) in caplog.text
@@ -855,7 +850,7 @@ def test_deprecated_with_replacement_key_invalidation_version_default(
     with pytest.raises(vol.MultipleInvalid) as exc_info:
         invalidated_schema(test_data)
     assert str(exc_info.value) == (
-        "The 'mars' option (with value 'True') is deprecated, "
+        "The 'mars' option is deprecated, "
         "please replace it with 'jupiter'. This option will become "
         "invalid in version 0.1.0"
     )

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -548,7 +548,7 @@ def test_deprecated_with_no_optionals(caplog, schema):
         "homeassistant.helpers.config_validation",
     ]
     assert (
-        "The 'mars' option is deprecated, " "please remove it from your configuration"
+        "The 'mars' option is deprecated, please remove it from your configuration"
     ) in caplog.text
     assert test_data == output
 
@@ -581,7 +581,7 @@ def test_deprecated_with_replacement_key(caplog, schema):
     output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 1
     assert (
-        "The 'mars' option is deprecated, " "please replace it with 'jupiter'"
+        "The 'mars' option is deprecated, please replace it with 'jupiter'"
     ) in caplog.text
     assert {"jupiter": True} == output
 
@@ -723,7 +723,7 @@ def test_deprecated_with_default(caplog, schema):
     assert len(caplog.records) == 1
     assert caplog.records[0].name == __name__
     assert (
-        "The 'mars' option is deprecated, " "please remove it from your configuration"
+        "The 'mars' option is deprecated, please remove it from your configuration"
     ) in caplog.text
     assert test_data == output
 
@@ -756,7 +756,7 @@ def test_deprecated_with_replacement_key_and_default(caplog, schema):
     output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 1
     assert (
-        "The 'mars' option is deprecated, " "please replace it with 'jupiter'"
+        "The 'mars' option is deprecated, please replace it with 'jupiter'"
     ) in caplog.text
     assert {"jupiter": True} == output
 
@@ -788,7 +788,7 @@ def test_deprecated_with_replacement_key_and_default(caplog, schema):
     output = deprecated_schema_with_default(test_data.copy())
     assert len(caplog.records) == 1
     assert (
-        "The 'mars' option is deprecated, " "please replace it with 'jupiter'"
+        "The 'mars' option is deprecated, please replace it with 'jupiter'"
     ) in caplog.text
     assert {"jupiter": True} == output
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR removes the use of configuration values in deprecation log messages.
These values may contain sensitive data, as the values are already resolved as secrets as well.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35864
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
