### PR TITLE
Swap title and album names for streams in forked_daapd

### DIFF
--- a/homeassistant/components/forked_daapd/media_player.py
+++ b/homeassistant/components/forked_daapd/media_player.py
@@ -504,6 +504,10 @@ class ForkedDaapdMaster(MediaPlayerEntity):
     @property
     def media_title(self):
         """Title of current playing media."""
+        # Use album field when data_kind is url
+        # https://github.com/ejurgensen/forked-daapd/issues/351
+        if self._track_info["data_kind"] == "url":
+            return self._track_info["album"]
         return self._track_info["title"]
 
     @property
@@ -514,6 +518,10 @@ class ForkedDaapdMaster(MediaPlayerEntity):
     @property
     def media_album_name(self):
         """Album name of current playing media, music track only."""
+        # Use title field when data_kind is url
+        # https://github.com/ejurgensen/forked-daapd/issues/351
+        if self._track_info["data_kind"] == "url":
+            return self._track_info["title"]
         return self._track_info["album"]
 
     @property

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -364,9 +364,9 @@ def test_master_state(hass, mock_api_object):
     assert state.attributes[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
     assert state.attributes[ATTR_MEDIA_DURATION] == 0.05
     assert state.attributes[ATTR_MEDIA_POSITION] == 0.005
-    assert state.attributes[ATTR_MEDIA_TITLE] == "Short TTS file"
+    assert state.attributes[ATTR_MEDIA_TITLE] == "No album"  # reversed for url
     assert state.attributes[ATTR_MEDIA_ARTIST] == "Google"
-    assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "No album"
+    assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "Short TTS file"  # reversed
     assert state.attributes[ATTR_MEDIA_ALBUM_ARTIST] == "The xx"
     assert state.attributes[ATTR_MEDIA_TRACK] == 1
     assert not state.attributes[ATTR_MEDIA_SHUFFLE]
@@ -466,7 +466,7 @@ async def test_last_outputs_master(hass, mock_api_object):
     assert mock_api_object.set_enabled_outputs.call_count == 2
 
 
-async def test_bunch_of_stuff_master(hass, mock_api_object, get_request_return_values):
+async def test_bunch_of_stuff_master(hass, get_request_return_values, mock_api_object):
     """Run bunch of stuff."""
     await _service_call(hass, TEST_MASTER_ENTITY_NAME, SERVICE_TURN_ON)
     await _service_call(hass, TEST_MASTER_ENTITY_NAME, SERVICE_TURN_OFF)
@@ -710,6 +710,9 @@ async def test_librespot_java_stuff(
     await hass.async_block_till_done()
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     assert state.attributes[ATTR_INPUT_SOURCE] == "librespot-java (pipe)"
+    # test title and album not reversed when data_kind not url
+    assert state.attributes[ATTR_MEDIA_TITLE] == "librespot-java"
+    assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "some album"
 
 
 async def test_librespot_java_play_media(hass, pipe_control_api_object):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The forked-daapd server intentionally reverses the album and title fields when playing http source material such as internet radio, as some devices can only display one field and the album field (playlist name) may be more useful than the song title. Since HA can display both fields, it is not necessary to leave these reversed, so this PR re-reverses them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36349
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
