### PR TITLE
Update plugwise to async and config_flow switch part

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -607,6 +607,7 @@ omit =
     homeassistant/components/plugwise/binary_sensor.py
     homeassistant/components/plugwise/climate.py
     homeassistant/components/plugwise/sensor.py
+    homeassistant/components/plugwise/switch.py
     homeassistant/components/plum_lightpad/*
     homeassistant/components/pocketcasts/sensor.py
     homeassistant/components/point/*

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_PLATFORMS = ["sensor"]
-ALL_PLATFORMS = ["binary_sensor", "climate", "sensor"]
+ALL_PLATFORMS = ["binary_sensor", "climate", "sensor", "switch"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -1,0 +1,86 @@
+"""Plugwise Switch component for HomeAssistant."""
+
+import logging
+
+from Plugwise_Smile.Smile import Smile
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import callback
+
+from . import SmileGateway
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Smile switches from a config entry."""
+    api = hass.data[DOMAIN][config_entry.entry_id]["api"]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+
+    entities = []
+    all_devices = api.get_all_devices()
+    for dev_id, device_properties in all_devices.items():
+        if "plug" in device_properties["types"]:
+            model = "Metered Switch"
+            entities.append(
+                PwSwitch(api, coordinator, device_properties["name"], dev_id, model,)
+            )
+
+    async_add_entities(entities, True)
+
+
+class PwSwitch(SmileGateway, SwitchEntity):
+    """Representation of a Plugwise plug."""
+
+    def __init__(self, api, coordinator, name, dev_id, model):
+        """Set up the Plugwise API."""
+        super().__init__(api, coordinator, name, dev_id)
+
+        self._model = model
+
+        self._is_on = False
+
+        self._unique_id = f"{dev_id}-plug"
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._is_on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        try:
+            state_on = await self._api.set_relay_state(self._dev_id, "on")
+            if state_on:
+                self._is_on = True
+                self.async_write_ha_state()
+        except Smile.PlugwiseError:
+            _LOGGER.error("Error while communicating to device")
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        try:
+            state_off = await self._api.set_relay_state(self._dev_id, "off")
+            if state_off:
+                self._is_on = False
+                self.async_write_ha_state()
+        except Smile.PlugwiseError:
+            _LOGGER.error("Error while communicating to device")
+
+    @callback
+    def _async_process_data(self):
+        """Update the data from the Plugs."""
+        _LOGGER.debug("Update switch called")
+
+        data = self._api.get_device_data(self._dev_id)
+
+        if not data:
+            _LOGGER.error("Received no data for device %s.", self._name)
+            self.async_write_ha_state()
+            return
+
+        if "relay" in data:
+            self._is_on = data["relay"]
+
+        self.async_write_ha_state()

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if "plug" in device_properties["types"]:
             model = "Metered Switch"
             entities.append(
-                PwSwitch(api, coordinator, device_properties["name"], dev_id, model,)
+                PwSwitch(api, coordinator, device_properties["name"], dev_id, model)
             )
 
     async_add_entities(entities, True)

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -60,8 +60,7 @@ class PwSwitch(SmileGateway, SwitchEntity):
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
         try:
-            state_off = await self._api.set_relay_state(self._dev_id, "off")
-            if state_off:
+            if await self._api.set_relay_state(self._dev_id, "off"):
                 self._is_on = False
                 self.async_write_ha_state()
         except Smile.PlugwiseError:

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -51,8 +51,7 @@ class PwSwitch(SmileGateway, SwitchEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
         try:
-            state_on = await self._api.set_relay_state(self._dev_id, "on")
-            if state_on:
+            if await self._api.set_relay_state(self._dev_id, "on"):
                 self._is_on = True
                 self.async_write_ha_state()
         except Smile.PlugwiseError:


### PR DESCRIPTION
## Proposed change

See #33691 as 'parent'-PR. This PR is the last of three 'child'-PRs for the parent. It adds the `switch` platform providing for Plugwise 'Plugs' in climate setups. 



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This PR accompanies #33691 (and #36219) but provides additional binary_sensors for climate setups with heater elements. This concludes the changes started in #33691 (async, config-flow and multiple platforms) - leaving code improvement by adding tests which is currently in draft state (as binary_sensor and switch still needed to be added)

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #33691 #36219 #36378
- Link to documentation pull request: home-assistant/home-assistant.io#12738

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum