### PR TITLE
Use custom endpoint for wirelesstag callbacks

### DIFF
--- a/homeassistant/components/wirelesstag/binary_sensor.py
+++ b/homeassistant/components/wirelesstag/binary_sensor.py
@@ -138,8 +138,8 @@ class WirelessTagBinarySensor(WirelessTagBaseSensor, BinarySensorEntity):
         return self.principal_value
 
     @callback
-    def _on_binary_event_callback(self, event):
+    def _on_binary_event_callback(self, data):
         """Update state from arrived push notification."""
         # state should be 'on' or 'off'
-        self._state = event.data.get("state")
+        self._state = data.get("state")
         self.async_write_ha_state()

--- a/homeassistant/components/wirelesstag/manifest.json
+++ b/homeassistant/components/wirelesstag/manifest.json
@@ -3,5 +3,6 @@
   "name": "Wireless Sensor Tags",
   "documentation": "https://www.home-assistant.io/integrations/wirelesstag",
   "requirements": ["wirelesstagpy==0.4.0"],
+  "dependencies": ["http"],
   "codeowners": []
 }

--- a/homeassistant/components/wirelesstag/sensor.py
+++ b/homeassistant/components/wirelesstag/sensor.py
@@ -108,9 +108,9 @@ class WirelessTagSensor(WirelessTagBaseSensor):
         return self._tag.sensor[self._sensor_type]
 
     @callback
-    def _update_tag_info_callback(self, event):
+    def _update_tag_info_callback(self, data):
         """Handle push notification sent by tag manager."""
-        _LOGGER.debug("Entity to update state: %s event data: %s", self, event.data)
-        new_value = self._sensor.value_from_update_event(event.data)
+        _LOGGER.debug("Entity to update state: %s data: %s", self, data)
+        new_value = self._sensor.value_from_update_event(data)
         self._state = self.decorate_value(new_value)
         self.async_write_ha_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current implementation of WirelessTag inserts a callback url into the tagmanager that posts the change on the generic events homeassistant api. It required the user to add the tag managers ip as a trusted_network to allow anonymous calling. It would that, by design, the ability to use trusted_network to bypass authentication for apis has changed that breaks WirelessTag.

The tagmanager has very limited options with how much it can post and how long the urls can be that it can call. This set of changes removes calling into the generic event api and sets an endpoint just for the wirelesstag manager to call.

`Tag Manager cannot handle URL + verb + content longer than 148 characters`

Going forward: Maybe have the code create a webhook type url, one with a guid it in that is never persisted. Use that guid in the url that is passed to the tagmanager and the verify the url called contains that tag. A little extra security.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```
wirelesstag:
  username: username
  password: password
```


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
