### PR TITLE
Bump pychromecast to 6.0.0

### DIFF
--- a/homeassistant/components/cast/discovery.py
+++ b/homeassistant/components/cast/discovery.py
@@ -84,11 +84,12 @@ def setup_internal_discovery(hass: HomeAssistant) -> None:
         )
 
     _LOGGER.debug("Starting internal pychromecast discovery.")
-    listener, browser = pychromecast.start_discovery(
+    listener = pychromecast.CastListener(
         internal_add_callback,
         internal_remove_callback,
-        ChromeCastZeroconf.get_zeroconf(),
+        internal_add_callback,  # Use internal_add_callback also for updates
     )
+    browser = pychromecast.start_discovery(listener, ChromeCastZeroconf.get_zeroconf())
 
     def stop_discovery(event):
         """Stop discovery of new chromecasts."""

--- a/homeassistant/components/cast/discovery.py
+++ b/homeassistant/components/cast/discovery.py
@@ -3,7 +3,6 @@ import logging
 import threading
 
 import pychromecast
-import zeroconf
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -85,13 +84,10 @@ def setup_internal_discovery(hass: HomeAssistant) -> None:
         )
 
     _LOGGER.debug("Starting internal pychromecast discovery.")
-    listener = pychromecast.discovery.CastListener(
-        internal_add_callback, internal_remove_callback
-    )
-    browser = zeroconf.ServiceBrowser(
-        ChromeCastZeroconf.get_zeroconf() or zeroconf.Zeroconf(),
-        "_googlecast._tcp.local.",
-        listener,
+    listener, browser = pychromecast.start_discovery(
+        internal_add_callback,
+        internal_remove_callback,
+        ChromeCastZeroconf.get_zeroconf(),
     )
 
     def stop_discovery(event):

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==5.3.0"],
+  "requirements": ["pychromecast==6.0.0"],
   "after_dependencies": ["cloud","zeroconf"],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": ["@emontnemery"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1245,7 +1245,7 @@ pycfdns==0.0.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==5.3.0
+pychromecast==6.0.0
 
 # homeassistant.components.cmus
 pycmus==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -536,7 +536,7 @@ pyblackbird==0.5
 pybotvac==0.0.17
 
 # homeassistant.components.cast
-pychromecast==5.3.0
+pychromecast==6.0.0
 
 # homeassistant.components.coolmaster
 pycoolmasternet==0.0.4

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -80,19 +80,16 @@ async def async_setup_cast_internal_discovery(hass, config=None, discovery_info=
     browser = MagicMock(zc={})
 
     with patch(
-        "homeassistant.components.cast.discovery.pychromecast.discovery.CastListener",
-        return_value=listener,
-    ) as cast_listener, patch(
-        "homeassistant.components.cast.discovery.zeroconf.ServiceBrowser",
-        return_value=browser,
-    ):
+        "homeassistant.components.cast.discovery.pychromecast.start_discovery",
+        return_value=(listener, browser),
+    ) as start_discovery:
         add_entities = await async_setup_cast(hass, config, discovery_info)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-        assert cast_listener.call_count == 1
+        assert start_discovery.call_count == 1
 
-        discovery_callback = cast_listener.call_args[0][0]
+        discovery_callback = start_discovery.call_args[0][0]
 
     def discover_chromecast(service_name: str, info: ChromecastInfo) -> None:
         """Discover a chromecast device."""
@@ -120,12 +117,9 @@ async def async_setup_media_player_cast(hass: HomeAssistantType, info: Chromecas
         "homeassistant.components.cast.discovery.pychromecast.get_chromecast_from_service",
         return_value=chromecast,
     ) as get_chromecast, patch(
-        "homeassistant.components.cast.discovery.pychromecast.discovery.CastListener",
-        return_value=listener,
-    ) as cast_listener, patch(
-        "homeassistant.components.cast.discovery.zeroconf.ServiceBrowser",
-        return_value=browser,
-    ):
+        "homeassistant.components.cast.discovery.pychromecast.start_discovery",
+        return_value=(listener, browser),
+    ) as start_discovery:
         await async_setup_component(
             hass,
             "media_player",
@@ -134,7 +128,7 @@ async def async_setup_media_player_cast(hass: HomeAssistantType, info: Chromecas
 
         await hass.async_block_till_done()
 
-        discovery_callback = cast_listener.call_args[0][0]
+        discovery_callback = start_discovery.call_args[0][0]
 
         def discover_chromecast(service_name: str, info: ChromecastInfo) -> None:
             """Discover a chromecast device."""
@@ -159,17 +153,15 @@ async def async_setup_media_player_cast(hass: HomeAssistantType, info: Chromecas
 async def test_start_discovery_called_once(hass):
     """Test pychromecast.start_discovery called exactly once."""
     with patch(
-        "homeassistant.components.cast.discovery.pychromecast.discovery.CastListener",
-    ) as cast_listener, patch(
-        "homeassistant.components.cast.discovery.zeroconf.ServiceBrowser",
-        return_value=Mock(),
-    ):
+        "homeassistant.components.cast.discovery.pychromecast.start_discovery",
+        return_value=(None, Mock()),
+    ) as start_discovery:
         await async_setup_cast(hass)
 
-        assert cast_listener.call_count == 1
+        assert start_discovery.call_count == 1
 
         await async_setup_cast(hass)
-        assert cast_listener.call_count == 1
+        assert start_discovery.call_count == 1
 
 
 async def test_stop_discovery_called_on_stop(hass):
@@ -177,15 +169,13 @@ async def test_stop_discovery_called_on_stop(hass):
     browser = MagicMock(zc={})
 
     with patch(
-        "homeassistant.components.cast.discovery.pychromecast.discovery.CastListener",
-    ) as cast_listener, patch(
-        "homeassistant.components.cast.discovery.zeroconf.ServiceBrowser",
-        return_value=browser,
-    ):
+        "homeassistant.components.cast.discovery.pychromecast.start_discovery",
+        return_value=(None, browser),
+    ) as start_discovery:
         # start_discovery should be called with empty config
         await async_setup_cast(hass, {})
 
-        assert cast_listener.call_count == 1
+        assert start_discovery.call_count == 1
 
     with patch(
         "homeassistant.components.cast.discovery.pychromecast.stop_discovery"
@@ -197,15 +187,13 @@ async def test_stop_discovery_called_on_stop(hass):
         stop_discovery.assert_called_once_with(browser)
 
     with patch(
-        "homeassistant.components.cast.discovery.pychromecast.discovery.CastListener",
-    ) as cast_listener, patch(
-        "homeassistant.components.cast.discovery.zeroconf.ServiceBrowser",
-        return_value=browser,
-    ):
+        "homeassistant.components.cast.discovery.pychromecast.start_discovery",
+        return_value=(None, browser),
+    ) as start_discovery:
         # start_discovery should be called again on re-startup
         await async_setup_cast(hass)
 
-        assert cast_listener.call_count == 1
+        assert start_discovery.call_count == 1
 
 
 async def test_create_cast_device_without_uuid(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pychromecast to 6.0.0
This adapts pychromecast to zeroconf 0.27

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
