### PR TITLE
ONVIF device triggers and homeassistant event

### DIFF
--- a/homeassistant/components/onvif/binary_sensor.py
+++ b/homeassistant/components/onvif/binary_sensor.py
@@ -67,7 +67,7 @@ class ONVIFBinarySensor(ONVIFBaseEntity, BinarySensorEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        return self.device.events.get_uid(self.uid).entity_enabled
+        return self.device.events.get_uid(self.uid).enabled
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -12,7 +12,10 @@ DEFAULT_PASSWORD = "888888"
 DEFAULT_ARGUMENTS = "-pred 1"
 
 CONF_DEVICE_ID = "deviceid"
+CONF_ONVIF_EVENT = "onvif_event"
 CONF_RTSP_TRANSPORT = "rtsp_transport"
+CONF_SUBTYPE = "subtype"
+CONF_UNIQUE_ID = "unique_id"
 
 RTSP_TRANS_PROTOCOLS = ["tcp", "udp", "udp_multicast", "http"]
 

--- a/homeassistant/components/onvif/device_trigger.py
+++ b/homeassistant/components/onvif/device_trigger.py
@@ -1,0 +1,74 @@
+"""Provides device automations for ONVIF."""
+from typing import List
+
+import voluptuous as vol
+
+from homeassistant.components.automation import (
+    AutomationActionType,
+    event as automation_event,
+)
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import CONF_SUBTYPE, CONF_UNIQUE_ID, DOMAIN
+from .device import ONVIFDevice
+
+TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_UNIQUE_ID): str,
+        vol.Required(CONF_TYPE): str,
+        vol.Required(CONF_SUBTYPE): str,
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device triggers for ONVIF devices."""
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_conf = device_registry.async_get(device_id)
+
+    triggers = []
+    for entry_id in device_conf.config_entries:
+        config_entry: ConfigEntry = hass.config_entries.async_get_entry(entry_id)
+
+        if config_entry.domain != DOMAIN:
+            continue
+
+        device: ONVIFDevice = hass.data[DOMAIN][config_entry.unique_id]
+        for event in device.events.get_platform("event"):
+            triggers.append(
+                {
+                    CONF_PLATFORM: "device",
+                    CONF_DEVICE_ID: device_id,
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_UNIQUE_ID: event.uid,
+                    CONF_TYPE: "event",
+                    CONF_SUBTYPE: event.name,
+                }
+            )
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+
+    event_config = {
+        automation_event.CONF_PLATFORM: "event",
+        automation_event.CONF_EVENT_TYPE: "onvif_event",
+        automation_event.CONF_EVENT_DATA: {CONF_UNIQUE_ID: config[CONF_UNIQUE_ID]},
+    }
+
+    event_config = automation_event.TRIGGER_SCHEMA(event_config)
+    return await automation_event.async_attach_trigger(
+        hass, event_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -10,7 +10,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util import dt as dt_util
 
-from .const import LOGGER
+from .const import CONF_ONVIF_EVENT, CONF_UNIQUE_ID, LOGGER
 from .models import Event
 from .parsers import PARSERS
 
@@ -167,13 +167,24 @@ class EventManager:
                     UNHANDLED_TOPICS.add(topic)
                 continue
 
-            event = await parser(self.unique_id, msg)
+            event: Event = await parser(self.unique_id, msg)
 
             if not event:
                 LOGGER.warning("Unable to parse event from %s: %s", self.unique_id, msg)
                 return
 
+            if self._events.get(event.uid) is None:
+                LOGGER.info(
+                    "Registered %s as a(n) %s with unique id: %s",
+                    event.name,
+                    event.platform,
+                    event.uid,
+                )
+
             self._events[event.uid] = event
+
+            if event.platform == "event" and event.enabled:
+                self.hass.bus.fire(CONF_ONVIF_EVENT, {CONF_UNIQUE_ID: event.uid})
 
     def get_uid(self, uid) -> Event:
         """Retrieve event for given id."""

--- a/homeassistant/components/onvif/models.py
+++ b/homeassistant/components/onvif/models.py
@@ -70,4 +70,4 @@ class Event:
     device_class: str = None
     unit_of_measurement: str = None
     value: Any = None
-    entity_enabled: bool = True
+    enabled: bool = True

--- a/homeassistant/components/onvif/parsers.py
+++ b/homeassistant/components/onvif/parsers.py
@@ -214,6 +214,35 @@ async def async_parse_cell_motion_detector(uid: str, msg) -> Event:
         return None
 
 
+@PARSERS.register("tns1:RuleEngine/LineDetector/Crossed")
+# pylint: disable=protected-access
+async def async_parse_line_crossed(uid: str, msg) -> Event:
+    """Handle parsing event message.
+
+    Topic: tns1:RuleEngine/LineDetector/Crossed
+    """
+    try:
+        video_source = ""
+        video_analytics = ""
+        rule = ""
+        for source in msg.Message._value_1.Source.SimpleItem:
+            if source.Name == "VideoSourceConfigurationToken":
+                video_source = source.Value
+            if source.Name == "VideoAnalyticsConfigurationToken":
+                video_analytics = source.Value
+            if source.Name == "Rule":
+                rule = source.Value
+
+        return Event(
+            f"{uid}_{msg.Topic._value_1}_{video_source}_{video_analytics}_{rule}",
+            f"{rule} Line Crossed",
+            "event",
+            enabled=msg.Message._value_1.PropertyOperation != "Initialized",
+        )
+    except (AttributeError, KeyError):
+        return None
+
+
 @PARSERS.register("tns1:RuleEngine/TamperDetector/Tamper")
 # pylint: disable=protected-access
 async def async_parse_tamper_detector(uid: str, msg) -> Event:
@@ -329,7 +358,7 @@ async def async_parse_last_reset(uid: str, msg) -> Event:
             dt_util.as_local(
                 dt_util.parse_datetime(msg.Message._value_1.Data.SimpleItem[0].Value)
             ),
-            entity_enabled=False,
+            enabled=False,
         )
     except (AttributeError, KeyError, ValueError):
         return None
@@ -352,7 +381,7 @@ async def async_parse_last_clock_sync(uid: str, msg) -> Event:
             dt_util.as_local(
                 dt_util.parse_datetime(msg.Message._value_1.Data.SimpleItem[0].Value)
             ),
-            entity_enabled=False,
+            enabled=False,
         )
     except (AttributeError, KeyError, ValueError):
         return None

--- a/homeassistant/components/onvif/sensor.py
+++ b/homeassistant/components/onvif/sensor.py
@@ -70,7 +70,7 @@ class ONVIFSensor(ONVIFBaseEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        return self.device.events.get_uid(self.uid).entity_enabled
+        return self.device.events.get_uid(self.uid).enabled
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/onvif/strings.json
+++ b/homeassistant/components/onvif/strings.json
@@ -55,5 +55,10 @@
         "title": "ONVIF Device Options"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "event": "{subtype} was fired"
+    }
   }
 }

--- a/homeassistant/components/onvif/translations/en.json
+++ b/homeassistant/components/onvif/translations/en.json
@@ -13,8 +13,8 @@
         "step": {
             "auth": {
                 "data": {
-                    "password": "Password",
-                    "username": "Username"
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "username": "[%key:common::config_flow::data::username%]"
                 },
                 "title": "Configure authentication"
             },
@@ -33,9 +33,9 @@
             },
             "manual_input": {
                 "data": {
-                    "host": "Host",
+                    "host": "[%key:common::config_flow::data::host%]",
                     "name": "Name",
-                    "port": "Port"
+                    "port": "[%key:common::config_flow::data::port%]"
                 },
                 "title": "Configure ONVIF device"
             },
@@ -43,6 +43,11 @@
                 "description": "By clicking submit, we will search your network for ONVIF devices that support Profile S.\n\nSome manufacturers have started to disable ONVIF by default. Please ensure ONVIF is enabled in your camera's configuration.",
                 "title": "ONVIF device setup"
             }
+        }
+    },
+    "device_automation": {
+        "trigger_type": {
+            "event": "{subtype} was fired"
         }
     },
     "options": {

--- a/tests/components/onvif/test_device_trigger.py
+++ b/tests/components/onvif/test_device_trigger.py
@@ -1,0 +1,124 @@
+"""The tests for ONVIF device triggers."""
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.onvif import DOMAIN
+from homeassistant.components.onvif.device import ONVIFDevice
+from homeassistant.components.onvif.event import (
+    CONF_ONVIF_EVENT,
+    CONF_UNIQUE_ID,
+    Event,
+    EventManager,
+)
+from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+)
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_triggers(hass, device_reg):
+    """Test we get the expected triggers from a onvif."""
+    # Add ONVIF config entry
+    onvif_config_entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="12:34:56:AB:CD:EF", data={}
+    )
+    onvif_config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=onvif_config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
+    # Add another config entry for this device
+    unifi_config_entry = MockConfigEntry(
+        domain="unifi", unique_id="12:34:56:AB:CD:EF", data={}
+    )
+    unifi_config_entry.add_to_hass(hass)
+    device_reg.async_get_or_create(
+        config_entry_id=unifi_config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
+    # Create device and mock event
+    device = ONVIFDevice(hass, onvif_config_entry)
+    device.events = EventManager(hass, None, onvif_config_entry.unique_id)
+    # pylint: disable=protected-access
+    device.events._events = {
+        f"{onvif_config_entry.unique_id}_tns1:RuleEngine/LineDetector/Crossed_0_0_0": Event(
+            f"{onvif_config_entry.unique_id}_tns1:RuleEngine/LineDetector/Crossed_0_0_0",
+            "0 Line Crossed",
+            "event",
+        )
+    }
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][onvif_config_entry.unique_id] = device
+
+    # Only expect triggers for ONVIF domain
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "event",
+            "subtype": "0 Line Crossed",
+            "device_id": device_entry.id,
+            "unique_id": f"{onvif_config_entry.unique_id}_tns1:RuleEngine/LineDetector/Crossed_0_0_0",
+        },
+    ]
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_if_fires_on_event(hass, calls):
+    """Test that onvif_event triggers firing."""
+    event_uid = "12:34:56:AB:CD:EF_tns1:RuleEngine/LineDetector/Crossed_0_0_0"
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "type": "event",
+                        "subtype": "0 Line Crossed",
+                        "unique_id": event_uid,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "{{ trigger.platform}} - "
+                                "{{ trigger.event.event_type}} - {{ trigger.event.data.unique_id}}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fire event
+    hass.bus.fire(CONF_ONVIF_EVENT, {CONF_UNIQUE_ID: event_uid})
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == f"device - {CONF_ONVIF_EVENT} - {event_uid}"


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request allows us to handle firing home assistant events for ONVIF events that can not be represented via entities as they have no state.  To make it easier to use in automations, it also implements device triggers for these events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13660

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
