### PR TITLE
Add additional sensors to Plugwise integration

### DIFF
--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -69,8 +69,28 @@ ENERGY_SENSOR_MAP = {
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],
+    "electricity_consumed_peak_interval": [
+        "Consumed Power Interval",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
+    "electricity_consumed_off_peak_interval": [
+        "Consumed Power Interval (off peak)",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
     "electricity_produced_interval": [
         "Produced Power Interval",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
+    "electricity_produced_peak_interval": [
+        "Produced Power Interval",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
+    "electricity_produced_off_peak_interval": [
+        "Produced Power Interval (off peak)",
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],


### PR DESCRIPTION
## Proposed change
Disclose interval measures for off-peak and peak measurements on P1 by a request from the community. Interval was (up to now) only provided for single-tariff P1s.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

