### PR TITLE
Fix deCONZ groups don't report ctmax/min

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -228,6 +228,16 @@ class DeconzGroup(DeconzLight):
         self._unique_id = f"{group_id_base}-{self._device.deconz_id}"
 
     @property
+    def max_mireds(self):
+        """Group don't report ctmax."""
+        return super(DeconzLight, self).max_mireds
+
+    @property
+    def min_mireds(self):
+        """Group don't report ctmin."""
+        return super(DeconzLight, self).min_mireds
+
+    @property
     def unique_id(self):
         """Return a unique identifier for this device."""
         return self._unique_id

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -82,7 +82,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_group(gateway.api.groups.values())
 
 
-class DeconzLight(DeconzDevice, LightEntity):
+class DeconzBaseLight(DeconzDevice, LightEntity):
     """Representation of a deCONZ light."""
 
     def __init__(self, device, gateway):
@@ -129,16 +129,6 @@ class DeconzLight(DeconzDevice, LightEntity):
         if self._device.colormode in ("xy", "hs") and self._device.xy:
             return color_util.color_xy_to_hs(*self._device.xy)
         return None
-
-    @property
-    def max_mireds(self):
-        """Return the warmest color_temp that this light supports."""
-        return self._device.ctmax or super().max_mireds
-
-    @property
-    def min_mireds(self):
-        """Return the coldest color_temp that this light supports."""
-        return self._device.ctmin or super().min_mireds
 
     @property
     def is_on(self):
@@ -214,7 +204,21 @@ class DeconzLight(DeconzDevice, LightEntity):
         return attributes
 
 
-class DeconzGroup(DeconzLight):
+class DeconzLight(DeconzBaseLight):
+    """Representation of a deCONZ light."""
+
+    @property
+    def max_mireds(self):
+        """Return the warmest color_temp that this light supports."""
+        return self._device.ctmax or super().max_mireds
+
+    @property
+    def min_mireds(self):
+        """Return the coldest color_temp that this light supports."""
+        return self._device.ctmin or super().min_mireds
+
+
+class DeconzGroup(DeconzBaseLight):
     """Representation of a deCONZ group."""
 
     def __init__(self, device, gateway):
@@ -226,16 +230,6 @@ class DeconzGroup(DeconzLight):
             group_id_base = self.gateway.config_entry.data[CONF_GROUP_ID_BASE]
 
         self._unique_id = f"{group_id_base}-{self._device.deconz_id}"
-
-    @property
-    def max_mireds(self):
-        """Group don't report ctmax."""
-        return super(DeconzLight, self).max_mireds
-
-    @property
-    def min_mireds(self):
-        """Group don't report ctmin."""
-        return super(DeconzLight, self).min_mireds
 
     @property
     def unique_id(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36427
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
