### PR TITLE
Add snapcast stream sensor and add feature to hide groups

### DIFF
--- a/homeassistant/components/snapcast/__init__.py
+++ b/homeassistant/components/snapcast/__init__.py
@@ -1,1 +1,86 @@
 """The snapcast component."""
+import logging
+import socket
+
+
+import voluptuous as vol
+
+import snapcast.control
+from snapcast.control.server import CONTROL_PORT
+
+from homeassistant.helpers.discovery import async_load_platform
+
+from homeassistant.helpers import config_validation as cv, entity_platform
+
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+)
+
+from .const import (
+    ATTR_LATENCY,
+    ATTR_MASTER,
+    CLIENT_PREFIX,
+    CLIENT_SUFFIX,
+    DATA_KEY,
+    GROUP_PREFIX,
+    GROUP_SUFFIX,
+    SERVICE_JOIN,
+    SERVICE_RESTORE,
+    SERVICE_SET_LATENCY,
+    SERVICE_SNAPSHOT,
+    SERVICE_UNJOIN,
+    GROUP_DISABLE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+#   {vol.Required(CONF_HOST): cv.string, vol.Optional(CONF_PORT): cv.port}
+# )
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DATA_KEY: vol.Schema(
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Optional(CONF_PORT): cv.port,
+                vol.Optional(GROUP_DISABLE): cv.boolean,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """setup of platform"""
+    conf = config.get(DATA_KEY)
+    host = conf.get(CONF_HOST)
+    port = conf.get(CONF_PORT, CONTROL_PORT)
+
+    try:
+        server = await snapcast.control.create_server(
+            hass.loop, host, port, reconnect=True
+        )
+
+    except socket.gaierror:
+        _LOGGER.error("Could not connect to Snapcast server at %s:%d", host, port)
+        return
+
+    # Note: Host part is needed, when using multiple snapservers
+    hpid = f"{host}:{port}"
+
+    hass.data[DATA_KEY] = {
+        "server": server,
+        "hpid": hpid,
+        GROUP_DISABLE: conf.get(GROUP_DISABLE, False),
+    }
+
+    hass.async_create_task(
+        async_load_platform(hass, "media_player", DATA_KEY, {}, config)
+    )
+
+    hass.async_create_task(async_load_platform(hass, "sensor", DATA_KEY, {}, config))
+
+    return True

--- a/homeassistant/components/snapcast/const.py
+++ b/homeassistant/components/snapcast/const.py
@@ -6,6 +6,8 @@ GROUP_PREFIX = "snapcast_group_"
 GROUP_SUFFIX = "Snapcast Group"
 CLIENT_PREFIX = "snapcast_client_"
 CLIENT_SUFFIX = "Snapcast Client"
+STREAM_PREFIX = "snapcast_stream_"
+STREAM_SUFFIX = "Snapcast Stream"
 
 SERVICE_SNAPSHOT = "snapshot"
 SERVICE_RESTORE = "restore"
@@ -15,3 +17,10 @@ SERVICE_SET_LATENCY = "set_latency"
 
 ATTR_MASTER = "master"
 ATTR_LATENCY = "latency"
+
+SERVER = "server"
+HPID = "hpid"
+DEVICES = "devices"
+STREAM = "streams"
+
+GROUP_DISABLE = "hide_groups"

--- a/homeassistant/components/snapcast/manifest.json
+++ b/homeassistant/components/snapcast/manifest.json
@@ -2,6 +2,6 @@
   "domain": "snapcast",
   "name": "Snapcast",
   "documentation": "https://www.home-assistant.io/integrations/snapcast",
-  "requirements": ["snapcast==2.0.10"],
+  "requirements": ["snapcast==2.1.1"],
   "codeowners": []
 }

--- a/homeassistant/components/snapcast/sensor.py
+++ b/homeassistant/components/snapcast/sensor.py
@@ -1,0 +1,52 @@
+"""Platform for sensor integration."""
+from homeassistant.helpers.entity import Entity
+
+from .const import (
+    STREAM_PREFIX,
+    DATA_KEY,
+    SERVER,
+    HPID,
+    STREAM,
+)
+
+
+from homeassistant.const import (
+    STATE_IDLE,
+    STATE_PLAYING,
+    STATE_UNKNOWN,
+)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+    server = hass.data[DATA_KEY][SERVER]
+    hpid = hass.data[DATA_KEY][HPID]
+
+    streams = [SnapcastStreamSensor(stream, hpid) for stream in server.streams]
+
+    hass.data[DATA_KEY][STREAM] = streams
+    async_add_entities(streams)
+
+
+class SnapcastStreamSensor(Entity):
+    """Representation of a sensor."""
+
+    def __init__(self, stream, uid_part):
+        """Initialize the sensor."""
+        stream.set_callback(self.schedule_update_ha_state)
+        self._stream = stream
+        self._uid = f"{STREAM_PREFIX}{uid_part}_{self._stream.identifier}"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{STREAM_PREFIX}{self._stream.friendly_name}"
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return {
+            "idle": STATE_IDLE,
+            "playing": STATE_PLAYING,
+            "unknown": STATE_UNKNOWN,
+        }.get(self._stream.status, STATE_UNKNOWN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Snapcast is now not instantiated from the media player anymore.
The configuration has been moved under `snapcast:` as its own platform.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Added sensor with streams in snapcast. The sensor will show the status of the stream. This can be: playing, idle or unavailable.
Also adding a boolean to not create groups in home assistant. If you only use the players and not the groups, set `hide_groups` to `True`. Default value is `False`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
snapcast:
  host: 192.168.1.100
  port: 1705
  hide_groups: True

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
