### PR TITLE
Refactor remote_rpi_gpio and add tests

### DIFF
--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -1,9 +1,6 @@
 """Support for controlling GPIO pins of a Raspberry Pi."""
 import logging
 
-from gpiozero import LED, Button
-from gpiozero.pins.pigpio import PiGPIOFactory
-
 _LOGGER = logging.getLogger(__name__)
 
 CONF_BOUNCETIME = "bouncetime"
@@ -14,50 +11,14 @@ DEFAULT_BOUNCETIME = 50
 DEFAULT_INVERT_LOGIC = False
 DEFAULT_PULL_MODE = "UP"
 
+# The domain of your component. Should be equal to the name of your component.
 DOMAIN = "remote_rpi_gpio"
+
+# List of integration names (string) your integration depends upon.
+DEPENDENCIES = []
 
 
 def setup(hass, config):
-    """Set up the Raspberry Pi Remote GPIO component."""
+    """Set up remote_rpi_gpio."""
+    _LOGGER.info("loading %s completed.", DOMAIN)
     return True
-
-
-def setup_output(address, port, invert_logic):
-    """Set up a GPIO as output."""
-
-    try:
-        return LED(port, active_high=invert_logic, pin_factory=PiGPIOFactory(address))
-    except (ValueError, IndexError, KeyError):
-        return None
-
-
-def setup_input(address, port, pull_mode, bouncetime):
-    """Set up a GPIO as input."""
-
-    if pull_mode == "UP":
-        pull_gpio_up = True
-    elif pull_mode == "DOWN":
-        pull_gpio_up = False
-
-    try:
-        return Button(
-            port,
-            pull_up=pull_gpio_up,
-            bounce_time=bouncetime,
-            pin_factory=PiGPIOFactory(address),
-        )
-    except (ValueError, IndexError, KeyError, OSError):
-        return None
-
-
-def write_output(switch, value):
-    """Write a value to a GPIO."""
-    if value == 1:
-        switch.on()
-    if value == 0:
-        switch.off()
-
-
-def read_input(button):
-    """Read a value from a GPIO."""
-    return button.is_pressed

--- a/homeassistant/components/remote_rpi_gpio/manifest.json
+++ b/homeassistant/components/remote_rpi_gpio/manifest.json
@@ -2,6 +2,6 @@
   "domain": "remote_rpi_gpio",
   "name": "remote_rpi_gpio",
   "documentation": "https://www.home-assistant.io/integrations/remote_rpi_gpio",
-  "requirements": ["gpiozero==1.5.1"],
+  "requirements": ["gpiozero==1.5.1", "pigpio==1.46"],
   "codeowners": []
 }

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -1,14 +1,15 @@
 """Allows to configure a switch using RPi GPIO."""
 import logging
 
+from gpiozero import LED
+from gpiozero.pins.pigpio import PiGPIOFactory
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import CONF_HOST, DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 
 from . import CONF_INVERT_LOGIC, DEFAULT_INVERT_LOGIC
-from .. import remote_rpi_gpio
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +26,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
+def setup_switch(address, port, name, invert_logic=False):
+    """Set up a switch."""
+    _LOGGER.debug(
+        "setting up output %s on %s port %s %s",
+        name,
+        address,
+        port,
+        "inverted" if invert_logic else "",
+    )
+    led = LED(port, active_high=not invert_logic, pin_factory=PiGPIOFactory(address))
+    new_switch = RemoteRPiGPIOSwitch(name, led)
+    return new_switch
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Remote Raspberry PI GPIO devices."""
     address = config[CONF_HOST]
@@ -34,23 +49,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     devices = []
     for port, name in ports.items():
         try:
-            led = remote_rpi_gpio.setup_output(address, port, invert_logic)
+
+            new_switch = setup_switch(address, port, name, invert_logic)
+            devices.append(new_switch)
         except (ValueError, IndexError, KeyError, OSError):
             return
-        new_switch = RemoteRPiGPIOSwitch(name, led, invert_logic)
-        devices.append(new_switch)
 
     add_entities(devices)
 
 
-class RemoteRPiGPIOSwitch(SwitchDevice):
+class RemoteRPiGPIOSwitch(SwitchEntity):
     """Representation of a Remtoe Raspberry Pi GPIO."""
 
-    def __init__(self, name, led, invert_logic):
+    def __init__(self, name, led):
         """Initialize the pin."""
         self._name = name or DEVICE_DEFAULT_NAME
-        self._state = False
-        self._invert_logic = invert_logic
         self._switch = led
 
     @property
@@ -66,21 +79,21 @@ class RemoteRPiGPIOSwitch(SwitchDevice):
     @property
     def assumed_state(self):
         """If unable to access real state of the entity."""
-        return True
+        return False
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state
+        return self._switch.is_lit
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        remote_rpi_gpio.write_output(self._switch, 0 if self._invert_logic else 1)
-        self._state = True
+        _LOGGER.debug("turn on switch %s %s", self._name, self._switch.pin)
+        self._switch.on()
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        remote_rpi_gpio.write_output(self._switch, 1 if self._invert_logic else 0)
-        self._state = False
+        _LOGGER.debug("turn off switch %s %s", self._name, self._switch.pin)
+        self._switch.off()
         self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1063,6 +1063,9 @@ pifacedigitalio==3.0.5
 # homeassistant.components.piglow
 piglow==1.2.4
 
+# homeassistant.components.remote_rpi_gpio
+pigpio==1.46
+
 # homeassistant.components.pilight
 pilight==0.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -293,6 +293,9 @@ google-api-python-client==1.6.4
 # homeassistant.components.google_pubsub
 google-cloud-pubsub==0.39.1
 
+# homeassistant.components.remote_rpi_gpio
+gpiozero==1.5.1
+
 # homeassistant.components.griddy
 griddypower==0.1.0
 
@@ -443,6 +446,9 @@ pdunehd==1.3.1
 # homeassistant.components.pandora
 # homeassistant.components.unifi_direct
 pexpect==4.6.0
+
+# homeassistant.components.remote_rpi_gpio
+pigpio==1.46
 
 # homeassistant.components.pilight
 pilight==0.1.1

--- a/tests/components/remote_rpi_gpio/__init__.py
+++ b/tests/components/remote_rpi_gpio/__init__.py
@@ -1,0 +1,1 @@
+"""Remote Raspberry PI GPIO Tests."""

--- a/tests/components/remote_rpi_gpio/test_init.py
+++ b/tests/components/remote_rpi_gpio/test_init.py
@@ -1,0 +1,27 @@
+"""test setup."""
+
+import unittest
+
+import homeassistant.components.remote_rpi_gpio as remote_rpi_gpio
+from homeassistant.setup import setup_component
+
+from tests.common import assert_setup_component, get_test_home_assistant
+
+
+class TestRemoteRpiGpioSetup(unittest.TestCase):
+    """Test the remote module."""
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    # pylint: disable=invalid-name
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_empty_setup(self):
+        """Test setup with configuration missing required entries."""
+        with assert_setup_component(0):
+            assert setup_component(self.hass, remote_rpi_gpio.DOMAIN, {})

--- a/tests/components/remote_rpi_gpio/test_switch.py
+++ b/tests/components/remote_rpi_gpio/test_switch.py
@@ -1,0 +1,90 @@
+"""test remote_rpi_gpio switch."""
+
+import logging
+import unittest
+
+import homeassistant.components.remote_rpi_gpio as remote_rpi_gpio
+from homeassistant.components.remote_rpi_gpio.switch import setup_switch
+from homeassistant.setup import setup_component
+
+from tests.async_mock import PropertyMock, patch
+from tests.common import assert_setup_component, get_test_home_assistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def patch_led(led, invert_logic=False):
+    """Patch a led for testing."""
+    status = False
+    active_high = not invert_logic
+
+    def get_status(*args, **kwargs):
+        _LOGGER.debug("status %s", status)
+        return status
+
+    def set_on(*args, **kwargs):
+        nonlocal status
+        _LOGGER.debug("turning on")
+        status = active_high
+
+    def set_off(*args, **kwargs):
+        nonlocal status
+        _LOGGER.debug("turning off")
+        status = not active_high
+
+    type(led).is_lit = PropertyMock(side_effect=get_status)
+    led.on.side_effect = set_on
+    led.off.side_effect = set_off
+
+    return led
+
+
+class TestRemoteRpiGpioSwitch(unittest.TestCase):
+    """Test the remote module."""
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    # pylint: disable=invalid-name
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch("homeassistant.components.remote_rpi_gpio.switch.LED")
+    @patch("homeassistant.components.remote_rpi_gpio.switch.PiGPIOFactory")
+    def test_switch_setup(self, LED, PiGPIOFactory):
+        """Test setup with configuration missing required entries."""
+        with assert_setup_component(1, "switch"):
+            assert setup_component(
+                self.hass,
+                "switch",
+                {
+                    "switch": [
+                        {
+                            "platform": remote_rpi_gpio.DOMAIN,
+                            "host": "127.0.0.127",
+                            "ports": {17: "rpi_gpio17"},
+                        }
+                    ]
+                },
+            )
+
+    @patch("homeassistant.components.remote_rpi_gpio.switch.LED")
+    @patch("homeassistant.components.remote_rpi_gpio.switch.PiGPIOFactory")
+    def test_switch_on(self, LED, PiGPIOFactory):
+        """Test setup with configuration missing required entries."""
+        invert_logic = False
+        pi_switch = setup_switch("127.0.0.127", 17, "rpi_gpio17", invert_logic)
+        assert pi_switch is not None
+
+        pi_switch.hass = self.hass
+        # pylint: disable=protected-access
+        patch_led(pi_switch._switch, invert_logic)
+
+        assert not pi_switch.is_on
+        pi_switch.turn_on()
+        assert pi_switch.is_on
+        pi_switch.turn_off()
+        assert not pi_switch.is_on


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix double invert on remote_rpi_gpio switch (#24571)
- Add tests for remote_rpi_gpio switch

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
switch:
  - platform: remote_rpi_gpio
    host: 10.0.1.20
    ports:
      16: Hallway Lights
      17: Living Room Lights
      18: Dining Room Light
      19: Balcony Light
      20: Kitchen Lights
      21: Bathroom Lights
      22: Bedroom Light
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24571
- This PR is related to issue: #34390, incorporates that changes
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
