### PR TITLE
Fix yeelight_sunflower hs_color using RGB values

### DIFF
--- a/homeassistant/components/yeelightsunflower/light.py
+++ b/homeassistant/components/yeelightsunflower/light.py
@@ -44,7 +44,7 @@ class SunflowerBulb(LightEntity):
         self._available = light.available
         self._brightness = light.brightness
         self._is_on = light.is_on
-        self._hs_color = light.rgb_color
+        self._rgb_color = light.rgb_color
         self._unique_id = light.zid
 
     @property
@@ -75,7 +75,7 @@ class SunflowerBulb(LightEntity):
     @property
     def hs_color(self):
         """Return the color property."""
-        return self._hs_color
+        return color_util.color_RGB_to_hs(*self._rgb_color)
 
     @property
     def supported_features(self):
@@ -109,4 +109,4 @@ class SunflowerBulb(LightEntity):
         self._available = self._light.available
         self._brightness = self._light.brightness
         self._is_on = self._light.is_on
-        self._hs_color = color_util.color_RGB_to_hs(*self._light.rgb_color)
+        self._rgb_color = self._light.rgb_color


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bugfix: This platform previously incorrectly set `hs_color` using RGB values, so produced the error:
```
    data[ATTR_RGB_COLOR] = color_util.color_hs_to_RGB(*hs_color)
TypeError: color_hs_to_RGB() takes 2 positional arguments but 3 were given
```

This PR fixes that by correctly setting HS using the conversion of RGB to HS.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

No additional information needed except (if relevant) that I erroneously put this together with adding unique_id in my PR: #36311  

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
