### PR TITLE
Use builtin mock

### DIFF
--- a/tests/components/gogogate2/conftest.py
+++ b/tests/components/gogogate2/conftest.py
@@ -1,11 +1,12 @@
 """Fixtures for tests."""
 
-from mock import patch
 import pytest
 
 from homeassistant.core import HomeAssistant
 
 from .common import ComponentFactory
+
+from tests.async_mock import patch
 
 
 @pytest.fixture()

--- a/tests/components/marytts/test_tts.py
+++ b/tests/components/marytts/test_tts.py
@@ -4,8 +4,6 @@ import os
 import shutil
 from urllib.parse import urlencode
 
-from mock import Mock, patch
-
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as DOMAIN_MP,
@@ -16,6 +14,7 @@ from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import HTTP_INTERNAL_SERVER_ERROR
 from homeassistant.setup import setup_component
 
+from tests.async_mock import Mock, patch
 from tests.common import assert_setup_component, get_test_home_assistant, mock_service
 
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -2,7 +2,6 @@
 import datetime
 from typing import Union
 
-import mock
 from py17track.package import Package
 import pytest
 
@@ -14,6 +13,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
 
+from tests.async_mock import MagicMock, patch
 from tests.common import async_fire_time_changed
 
 VALID_CONFIG_MINIMAL = {
@@ -113,7 +113,7 @@ class ProfileMock:
 @pytest.fixture(autouse=True, name="mock_client")
 def fixture_mock_client():
     """Mock py17track client."""
-    with mock.patch(
+    with patch(
         "homeassistant.components.seventeentrack.sensor.SeventeenTrackClient",
         new=ClientMock,
     ):
@@ -137,7 +137,7 @@ async def _goto_future(hass, future=None):
     """Move to future."""
     if not future:
         future = utcnow() + datetime.timedelta(minutes=10)
-    with mock.patch("homeassistant.util.utcnow", return_value=future):
+    with patch("homeassistant.util.utcnow", return_value=future):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
@@ -245,7 +245,7 @@ async def test_delivered_not_shown(hass):
     )
     ProfileMock.package_list = [package]
 
-    hass.components.persistent_notification = mock.MagicMock()
+    hass.components.persistent_notification = MagicMock()
     await _setup_seventeentrack(hass, VALID_CONFIG_FULL_NO_DELIVERED)
     assert not hass.states.async_entity_ids()
     hass.components.persistent_notification.create.assert_called()
@@ -258,7 +258,7 @@ async def test_delivered_shown(hass):
     )
     ProfileMock.package_list = [package]
 
-    hass.components.persistent_notification = mock.MagicMock()
+    hass.components.persistent_notification = MagicMock()
     await _setup_seventeentrack(hass, VALID_CONFIG_FULL)
 
     assert hass.states.get("sensor.seventeentrack_package_456") is not None
@@ -283,7 +283,7 @@ async def test_becomes_delivered_not_shown_notification(hass):
     )
     ProfileMock.package_list = [package_delivered]
 
-    hass.components.persistent_notification = mock.MagicMock()
+    hass.components.persistent_notification = MagicMock()
     await _goto_future(hass)
 
     hass.components.persistent_notification.create.assert_called()

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -2,13 +2,13 @@
 
 from typing import Callable, Dict, NamedTuple, Tuple
 
-from mock import MagicMock
 import pyvera as pv
 
 from homeassistant.components.vera.const import CONF_CONTROLLER, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.async_mock import MagicMock
 from tests.common import MockConfigEntry
 
 SetupCallback = Callable[[pv.VeraController, dict], None]

--- a/tests/components/vera/conftest.py
+++ b/tests/components/vera/conftest.py
@@ -1,9 +1,10 @@
 """Fixtures for tests."""
 
-from mock import patch
 import pytest
 
 from .common import ComponentFactory
+
+from tests.async_mock import patch
 
 
 @pytest.fixture()

--- a/tests/components/vera/test_config_flow.py
+++ b/tests/components/vera/test_config_flow.py
@@ -1,5 +1,4 @@
 """Vera tests."""
-from mock import patch
 from requests.exceptions import RequestException
 
 from homeassistant import config_entries, data_entry_flow
@@ -12,7 +11,7 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-from tests.async_mock import MagicMock
+from tests.async_mock import MagicMock, patch
 from tests.common import MockConfigEntry
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove all places where we did `import mock` and use our built-in mock.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
