### PR TITLE
Add entity list to light and cover group attributes

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -201,11 +201,9 @@ class CoverGroup(CoverEntity):
         return self._tilt_position
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes for the cover group."""
-        data = getattr(super(), "state_attributes", {})
-        data[ATTR_ENTITY_ID] = self._entities
-        return data
+        return {ATTR_ENTITY_ID: self._entities}
 
     async def async_open_cover(self, **kwargs):
         """Move the covers up."""

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -200,6 +200,13 @@ class CoverGroup(CoverEntity):
         """Return current tilt position for all covers."""
         return self._tilt_position
 
+    @property
+    def state_attributes(self):
+        """Return the state attributes for the cover group."""
+        data = getattr(super(), "state_attributes", {})
+        data[ATTR_ENTITY_ID] = self._entities
+        return data
+
     async def async_open_cover(self, **kwargs):
         """Move the covers up."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_OPEN_CLOSE]}

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -183,6 +183,13 @@ class LightGroup(light.LightEntity):
         """No polling needed for a light group."""
         return False
 
+    @property
+    def state_attributes(self):
+        """Return the state attributes for the light group."""
+        data = getattr(super(), "state_attributes", {})
+        data[ATTR_ENTITY_ID] = self._entity_ids
+        return data
+
     async def async_turn_on(self, **kwargs):
         """Forward the turn_on command to all lights in the light group."""
         data = {ATTR_ENTITY_ID: self._entity_ids}

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -184,11 +184,9 @@ class LightGroup(light.LightEntity):
         return False
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes for the light group."""
-        data = getattr(super(), "state_attributes", {})
-        data[ATTR_ENTITY_ID] = self._entity_ids
-        return data
+        return {ATTR_ENTITY_ID: self._entities}
 
     async def async_turn_on(self, **kwargs):
         """Forward the turn_on command to all lights in the light group."""

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -186,7 +186,7 @@ class LightGroup(light.LightEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes for the light group."""
-        return {ATTR_ENTITY_ID: self._entities}
+        return {ATTR_ENTITY_ID: self._entity_ids}
 
     async def async_turn_on(self, **kwargs):
         """Forward the turn_on command to all lights in the light group."""

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -86,6 +86,12 @@ async def test_attributes(hass, setup_comp):
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_CLOSED
     assert state.attributes[ATTR_FRIENDLY_NAME] == DEFAULT_NAME
+    assert state.attributes[ATTR_ENTITY_ID] == [
+        DEMO_COVER,
+        DEMO_COVER_POS,
+        DEMO_COVER_TILT,
+        DEMO_TILT,
+    ]
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
     assert ATTR_CURRENT_POSITION not in state.attributes

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -34,17 +34,25 @@ from tests.async_mock import MagicMock
 
 async def test_default_state(hass):
     """Test light group default state."""
+    hass.states.async_set("light.kitchen", "on")
     await async_setup_component(
         hass,
         LIGHT_DOMAIN,
-        {LIGHT_DOMAIN: {"platform": DOMAIN, "entities": [], "name": "Bedroom Group"}},
+        {
+            LIGHT_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["light.kitchen", "light.bedroom"],
+                "name": "Bedroom Group",
+            }
+        },
     )
     await hass.async_block_till_done()
 
     state = hass.states.get("light.bedroom_group")
     assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_ON
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+    assert state.attributes.get(ATTR_ENTITY_ID) == ["light.kitchen", "light.bedroom"]
     assert state.attributes.get(ATTR_BRIGHTNESS) is None
     assert state.attributes.get(ATTR_HS_COLOR) is None
     assert state.attributes.get(ATTR_COLOR_TEMP) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Expose the entity list of a light or cover group as an attribute.
This aligns the functionality with ordinary groups and could be useful for template base automations or frontend representation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
light:
  - platform: group
    entities:
      - light.bed_light
      - light.ceiling_lights
      - light.kitchen_lights
```
![image](https://user-images.githubusercontent.com/1299821/83884405-21362500-a745-11ea-8c06-776965a7e90d.png)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
