### PR TITLE
Add config option to set a custom CA

### DIFF
--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -27,9 +27,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Load the saved entities."""
     host = entry.data[CONF_HOST]
     port = entry.data[CONF_PORT]
-    ca_cert = entry.data.get(CONF_CA_CERT, None)
 
-    coordinator = CertExpiryDataUpdateCoordinator(hass, host, port, ca_cert)
+    coordinator = CertExpiryDataUpdateCoordinator(hass, entry)
+    await coordinator.async_set_options()
     await coordinator.async_refresh()
 
     if not coordinator.last_update_success:
@@ -55,16 +55,21 @@ async def async_unload_entry(hass, entry):
 class CertExpiryDataUpdateCoordinator(DataUpdateCoordinator[datetime]):
     """Class to manage fetching Cert Expiry data from single endpoint."""
 
-    def __init__(self, hass, host, port, ca_cert):
+    def __init__(self, hass, config_entry):
         """Initialize global Cert Expiry data updater."""
-        self.host = host
-        self.port = port
-        self.ca_cert = ca_cert
+        self.config_entry = config_entry
         self.cert_error = None
         self.is_cert_valid = False
 
-        display_port = f":{port}" if port != DEFAULT_PORT else ""
-        name = f"{self.host}{display_port}"
+        self.unique_id = (
+            f"{self.config_entry.data[CONF_HOST]}:{self.config_entry.data[CONF_PORT]}"
+        )
+
+        display_port = config_entry.options.get(
+            CONF_PORT, config_entry.data.get(CONF_PORT, "")
+        )
+        host = config_entry.options.get(CONF_HOST, config_entry.data.get(CONF_HOST))
+        name = f"{host}{display_port}"
 
         super().__init__(
             hass,
@@ -75,18 +80,39 @@ class CertExpiryDataUpdateCoordinator(DataUpdateCoordinator[datetime]):
 
     async def _async_update_data(self) -> Optional[datetime]:
         """Fetch certificate."""
+
         try:
             timestamp = await get_cert_expiry_timestamp(
-                self.hass, self.host, self.port, self.ca_cert
+                self.hass,
+                self.config_entry.options[CONF_HOST],
+                self.config_entry.options[CONF_PORT],
+                self.config_entry.options[CONF_CA_CERT],
             )
         except TemporaryFailure as err:
             raise UpdateFailed(err.args[0]) from err
         except ValidationFailure as err:
             self.cert_error = err
             self.is_cert_valid = False
-            _LOGGER.error("Certificate validation error: %s [%s]", self.host, err)
+            _LOGGER.error(
+                "Certificate validation error: %s [%s]",
+                self.config_entry.options[CONF_HOST],
+                err,
+            )
             return None
 
         self.cert_error = None
         self.is_cert_valid = True
         return timestamp
+
+    async def async_set_options(self):
+        """Set options for cert_expiry entry."""
+        if not self.config_entry.options:
+            data = {**self.config_entry.data}
+            options = {
+                CONF_HOST: data.pop(CONF_HOST, ""),
+                CONF_PORT: data.pop(CONF_PORT, DEFAULT_PORT),
+                CONF_CA_CERT: data.pop(CONF_CA_CERT, ""),
+            }
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=data, options=options
+            )

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
+from ...core import callback
 from .const import CONF_CA_CERT, DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
 from .errors import (
     ConnectionRefused,
@@ -71,10 +72,7 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.error("Config import failed for %s", user_input[CONF_HOST])
                 return self.async_abort(reason="import_failed")
         else:
-            user_input = {}
-            user_input[CONF_HOST] = ""
-            user_input[CONF_PORT] = DEFAULT_PORT
-            user_input[CONF_CA_CERT] = ""
+            user_input = {CONF_HOST: "", CONF_PORT: DEFAULT_PORT, CONF_CA_CERT: ""}
 
         return self.async_show_form(
             step_id="user",
@@ -96,3 +94,41 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Only host was required in the yaml file all other fields are optional
         """
         return await self.async_step_user(user_input)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Set the options flow handler for cert_expiry."""
+
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """The option flow handler for cert_expiry."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage cert_expiry options."""
+        if user_input is not None:
+            ca_cert = user_input.get(CONF_CA_CERT, "")
+            data = self.config_entry.options.copy()
+            if ca_cert != "":
+                data[CONF_CA_CERT] = ca_cert
+            else:
+                data.pop(CONF_CA_CERT, None)
+            return self.async_create_entry(title="", data=data)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_CA_CERT,
+                        default=self.config_entry.options.get(CONF_CA_CERT, ""),
+                    ): str
+                }
+            ),
+        )

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -66,7 +66,10 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data = {CONF_HOST: host, CONF_PORT: port}
                 if ca_cert != "":
                     data[CONF_CA_CERT] = ca_cert
-                return self.async_create_entry(title=title, data=data,)
+                return self.async_create_entry(
+                    title=title,
+                    data=data,
+                )
             if (  # pylint: disable=no-member
                 self.context["source"] == config_entries.SOURCE_IMPORT
             ):

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -61,10 +61,10 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if await self._test_connection(user_input):
                 title_port = f":{port}" if port != DEFAULT_PORT else ""
                 title = f"{host}{title_port}"
-                return self.async_create_entry(
-                    title=title,
-                    data={CONF_HOST: host, CONF_PORT: port, CONF_CA_CERT: ca_cert},
-                )
+                data = {CONF_HOST: host, CONF_PORT: port}
+                if ca_cert != "":
+                    data[CONF_CA_CERT] = ca_cert
+                return self.async_create_entry(title=title, data=data,)
             if (  # pylint: disable=no-member
                 self.context["source"] == config_entries.SOURCE_IMPORT
             ):

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
-from .const import DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
+from .const import CONF_CA_CERT, DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
 from .errors import (
     ConnectionRefused,
     ConnectionTimeout,
@@ -35,6 +35,7 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.hass,
                 user_input[CONF_HOST],
                 user_input.get(CONF_PORT, DEFAULT_PORT),
+                user_input.get(CONF_CA_CERT, None),
             )
             return True
         except ResolveFailed:
@@ -53,6 +54,7 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = user_input[CONF_HOST]
             port = user_input.get(CONF_PORT, DEFAULT_PORT)
+            ca_cert = user_input.get(CONF_CA_CERT, "")
             await self.async_set_unique_id(f"{host}:{port}")
             self._abort_if_unique_id_configured()
 
@@ -61,7 +63,7 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 title = f"{host}{title_port}"
                 return self.async_create_entry(
                     title=title,
-                    data={CONF_HOST: host, CONF_PORT: port},
+                    data={CONF_HOST: host, CONF_PORT: port, CONF_CA_CERT: ca_cert},
                 )
             if (  # pylint: disable=no-member
                 self.context["source"] == config_entries.SOURCE_IMPORT
@@ -72,6 +74,7 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input = {}
             user_input[CONF_HOST] = ""
             user_input[CONF_PORT] = DEFAULT_PORT
+            user_input[CONF_CA_CERT] = ""
 
         return self.async_show_form(
             step_id="user",
@@ -81,6 +84,7 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(
                         CONF_PORT, default=user_input.get(CONF_PORT, DEFAULT_PORT)
                     ): int,
+                    vol.Optional(CONF_CA_CERT, default=user_input[CONF_CA_CERT]): str,
                 }
             ),
             errors=self._errors,

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -6,8 +6,8 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import callback
 
-from ...core import callback
 from .const import CONF_CA_CERT, DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
 from .errors import (
     ConnectionRefused,

--- a/homeassistant/components/cert_expiry/const.py
+++ b/homeassistant/components/cert_expiry/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "cert_expiry"
 DEFAULT_PORT = 443
 TIMEOUT = 10.0
+CONF_CA_CERT = "ca_cert"

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -1,5 +1,5 @@
 """Counter for the days until an HTTPS (TLS) certificate will expire."""
-from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
@@ -20,13 +20,12 @@ from homeassistant.util import dt
 
 from .const import CONF_CA_CERT, DEFAULT_PORT, DOMAIN
 
-SCAN_INTERVAL = timedelta(hours=12)
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_CA_CERT): cv.string,
     }
 )
 
@@ -78,8 +77,9 @@ class CertExpiryEntity(CoordinatorEntity):
             "is_valid": self.coordinator.is_cert_valid,
             "error": str(self.coordinator.cert_error),
         }
-        if self.coordinator.ca_cert:
-            attributes[CONF_CA_CERT] = self.coordinator.ca_cert
+        ca_cert = self.coordinator.config_entry.options[CONF_CA_CERT]
+        if ca_cert:
+            attributes[CONF_CA_CERT] = ca_cert
         return attributes
 
 
@@ -89,7 +89,7 @@ class SSLCertificateDays(CertExpiryEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"Cert Expiry ({self.coordinator.name})"
+        return f"Cert Expiry ({self.coordinator.config_entry.title})"
 
     @property
     def state(self):
@@ -103,7 +103,7 @@ class SSLCertificateDays(CertExpiryEntity):
     @property
     def unique_id(self):
         """Return a unique id for the sensor."""
-        return f"{self.coordinator.host}:{self.coordinator.port}"
+        return self.coordinator.unique_id
 
     @property
     def unit_of_measurement(self):
@@ -122,7 +122,7 @@ class SSLCertificateTimestamp(CertExpiryEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"Cert Expiry Timestamp ({self.coordinator.name})"
+        return f"Cert Expiry Timestamp ({self.coordinator.config_entry.title})"
 
     @property
     def state(self):
@@ -134,4 +134,4 @@ class SSLCertificateTimestamp(CertExpiryEntity):
     @property
     def unique_id(self):
         """Return a unique id for the sensor."""
-        return f"{self.coordinator.host}:{self.coordinator.port}-timestamp"
+        return f"{self.coordinator.unique_id}-timestamp"

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt
 
-from .const import DEFAULT_PORT, DOMAIN
+from .const import CONF_CA_CERT, DEFAULT_PORT, DOMAIN
 
 SCAN_INTERVAL = timedelta(hours=12)
 
@@ -26,6 +26,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_CA_CERT): cv.string,
     }
 )
 
@@ -73,10 +74,13 @@ class CertExpiryEntity(CoordinatorEntity):
     @property
     def device_state_attributes(self):
         """Return additional sensor state attributes."""
-        return {
+        attributes = {
             "is_valid": self.coordinator.is_cert_valid,
             "error": str(self.coordinator.cert_error),
         }
+        if self.coordinator.ca_cert:
+            attributes[CONF_CA_CERT] = self.coordinator.ca_cert
+        return attributes
 
 
 class SSLCertificateDays(CertExpiryEntity):

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -29,6 +29,9 @@
           "ca_cert": "Path of CA certificate"
         }
       }
+    },
+    "error": {
+      "ca_cert_not_accessible": "The CA certificate could not be found"
     }
   }
 }

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -21,5 +21,14 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "import_failed": "Import from config failed"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "ca_cert": "Path of CA certificate"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -7,7 +7,8 @@
         "data": {
           "name": "The name of the certificate",
           "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "port": "[%key:common::config_flow::data::port%]",
+          "ca_cert": "Path of CA certificate"
         }
       }
     },

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -26,6 +26,7 @@
     "step": {
       "init": {
         "data": {
+          "title": "Use a custom CA certificate",
           "ca_cert": "Path of CA certificate"
         }
       }

--- a/tests/components/cert_expiry/const.py
+++ b/tests/components/cert_expiry/const.py
@@ -1,3 +1,4 @@
 """Constants for cert_expiry tests."""
 PORT = 443
 HOST = "example.com"
+CA_CERT = "/some/ca.crt"

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -285,9 +285,10 @@ async def test_options_flow_handler(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={CONF_CA_CERT: CA_CERT}
-    )
+    with patch("os.path.isfile", return_value=True):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_CA_CERT: CA_CERT}
+        )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
@@ -298,7 +299,7 @@ async def test_options_flow_handler(hass):
 
 
 async def test_options_flow_handler_remove_custom_ca(hass):
-    """Test options handler."""
+    """Test options handler with resetting the ca file."""
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -312,9 +313,34 @@ async def test_options_flow_handler_remove_custom_ca(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={CONF_CA_CERT: ""}
-    )
+    with patch("os.path.isfile", return_value=True):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_CA_CERT: ""}
+        )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {CONF_HOST: HOST, CONF_PORT: PORT}
+
+
+async def test_options_flow_handler_invalid_file(hass):
+    """Test options handler with a not existing file."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+        title=HOST,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    with patch("os.path.isfile", return_value=False):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_CA_CERT: CA_CERT}
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_CA_CERT: "ca_cert_not_accessible"}

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -84,6 +84,7 @@ async def test_import_host_only(hass):
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == DEFAULT_PORT
+    assert result["data"].get(CONF_CA_CERT) is None
     assert result["result"].unique_id == f"{HOST}:{DEFAULT_PORT}"
 
 
@@ -106,6 +107,7 @@ async def test_import_host_and_port(hass):
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
+    assert result["data"].get(CONF_CA_CERT) is None
     assert result["result"].unique_id == f"{HOST}:{PORT}"
 
 
@@ -148,6 +150,7 @@ async def test_import_with_name(hass):
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == PORT
+    assert result["data"].get(CONF_CA_CERT) is None
     assert result["result"].unique_id == f"{HOST}:{PORT}"
 
 
@@ -170,8 +173,8 @@ async def test_import_with_ca(hass):
     assert result["title"] == HOST
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == DEFAULT_PORT
-    assert result["result"].unique_id == f"{HOST}:{DEFAULT_PORT}"
     assert result["data"][CONF_CA_CERT] == CA_CERT
+    assert result["result"].unique_id == f"{HOST}:{DEFAULT_PORT}"
 
 
 async def test_bad_import(hass):

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -268,3 +268,53 @@ async def test_import_with_unavailable_ca_cert(hass):
     assert result["data"][CONF_PORT] == DEFAULT_PORT
     assert result["result"].unique_id == f"{HOST}:{DEFAULT_PORT}"
     assert result["data"][CONF_CA_CERT] == CA_CERT
+
+
+async def test_options_flow_handler(hass):
+    """Test options handler."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_HOST: HOST, CONF_PORT: PORT},
+        unique_id=f"{HOST}:{PORT}",
+        title=HOST,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_CA_CERT: CA_CERT}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert config_entry.options == {
+        CONF_HOST: HOST,
+        CONF_PORT: PORT,
+        CONF_CA_CERT: CA_CERT,
+    }
+
+
+async def test_options_flow_handler_remove_custom_ca(hass):
+    """Test options handler."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_HOST: HOST, CONF_PORT: PORT, CONF_CA_CERT: CA_CERT},
+        unique_id=f"{HOST}:{PORT}",
+        title=HOST,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_CA_CERT: ""}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert config_entry.options == {CONF_HOST: HOST, CONF_PORT: PORT}

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -1,14 +1,14 @@
 """Tests for Cert Expiry setup."""
 from datetime import timedelta
 
-from homeassistant.components.cert_expiry.const import DOMAIN
+from homeassistant.components.cert_expiry.const import CONF_CA_CERT, DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from .const import HOST, PORT
+from .const import CA_CERT, HOST, PORT
 from .helpers import future_timestamp, static_datetime
 
 from tests.async_mock import patch
@@ -21,6 +21,12 @@ async def test_setup_with_config(hass):
         SENSOR_DOMAIN: [
             {"platform": DOMAIN, CONF_HOST: HOST, CONF_PORT: PORT},
             {"platform": DOMAIN, CONF_HOST: HOST, CONF_PORT: 888},
+            {
+                "platform": DOMAIN,
+                CONF_HOST: HOST,
+                CONF_PORT: 666,
+                CONF_CA_CERT: CA_CERT,
+            },
         ],
     }
     assert await async_setup_component(hass, SENSOR_DOMAIN, config) is True
@@ -38,7 +44,7 @@ async def test_setup_with_config(hass):
     ):
         await hass.async_block_till_done()
 
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 3
 
 
 async def test_update_unique_id(hass):

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -1,14 +1,14 @@
 """Tests for Cert Expiry setup."""
 from datetime import timedelta
 
-from homeassistant.components.cert_expiry.const import CONF_CA_CERT, DOMAIN
+from homeassistant.components.cert_expiry.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from .const import CA_CERT, HOST, PORT
+from .const import HOST, PORT
 from .helpers import future_timestamp, static_datetime
 
 from tests.async_mock import patch
@@ -21,12 +21,6 @@ async def test_setup_with_config(hass):
         SENSOR_DOMAIN: [
             {"platform": DOMAIN, CONF_HOST: HOST, CONF_PORT: PORT},
             {"platform": DOMAIN, CONF_HOST: HOST, CONF_PORT: 888},
-            {
-                "platform": DOMAIN,
-                CONF_HOST: HOST,
-                CONF_PORT: 666,
-                CONF_CA_CERT: CA_CERT,
-            },
         ],
     }
     assert await async_setup_component(hass, SENSOR_DOMAIN, config) is True
@@ -44,7 +38,7 @@ async def test_setup_with_config(hass):
     ):
         await hass.async_block_till_done()
 
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 3
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
 
 
 async def test_update_unique_id(hass):
@@ -75,6 +69,7 @@ async def test_unload_config_entry(mock_now, hass):
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
         unique_id=f"{HOST}:{PORT}",
+        title=HOST,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -3,12 +3,12 @@ from datetime import timedelta
 import socket
 import ssl
 
-from homeassistant.components.cert_expiry.const import DOMAIN
+from homeassistant.components.cert_expiry.const import CONF_CA_CERT, DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 from homeassistant.const import CONF_HOST, CONF_PORT, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.util.dt import utcnow
 
-from .const import HOST, PORT
+from .const import CA_CERT, HOST, PORT
 from .helpers import future_timestamp, static_datetime
 
 from tests.async_mock import patch
@@ -40,6 +40,7 @@ async def test_async_setup_entry(mock_now, hass):
     assert state.state == "100"
     assert state.attributes.get("error") == "None"
     assert state.attributes.get("is_valid")
+    assert state.attributes.get("ca_cert") is None
 
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is not None
@@ -47,6 +48,43 @@ async def test_async_setup_entry(mock_now, hass):
     assert state.state == timestamp.isoformat()
     assert state.attributes.get("error") == "None"
     assert state.attributes.get("is_valid")
+    assert state.attributes.get("ca_cert") is None
+
+
+@patch("homeassistant.util.dt.utcnow", return_value=static_datetime())
+async def test_async_setup_entry_with_ca_cert(mock_now, hass):
+    """Test async_setup_entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT, CONF_CA_CERT: CA_CERT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    timestamp = future_timestamp(100)
+
+    with patch(
+        "homeassistant.components.cert_expiry.get_cert_expiry_timestamp",
+        return_value=timestamp,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "100"
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+    assert state.attributes.get("ca_cert") == "/some/ca.crt"
+
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == timestamp.isoformat()
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")
+    assert state.attributes.get("ca_cert") == "/some/ca.crt"
 
 
 async def test_async_setup_entry_bad_cert(hass):
@@ -101,6 +139,45 @@ async def test_async_setup_entry_host_unavailable(hass):
 
     state = hass.states.get("sensor.cert_expiry_example_com")
     assert state is None
+
+
+@patch("homeassistant.util.dt.utcnow", return_value=static_datetime())
+async def test_async_setup_entry_with_unavailalbe_ca_cert(mock_now, hass):
+    """Test async_setup_entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_PORT: PORT, CONF_CA_CERT: CA_CERT},
+        unique_id=f"{HOST}:{PORT}",
+    )
+
+    with patch(
+        "homeassistant.components.cert_expiry.helper.get_cert",
+        side_effect=FileNotFoundError,
+    ):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cert_expiry_example_com")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "0"
+    assert (
+        state.attributes.get("error")
+        == "CA certificate file '/some/ca.crt' is not accessible"
+    )
+    assert not state.attributes.get("is_valid")
+    assert state.attributes.get("ca_cert") == "/some/ca.crt"
+
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert (
+        state.attributes.get("error")
+        == "CA certificate file '/some/ca.crt' is not accessible"
+    )
+    assert not state.attributes.get("is_valid")
+    assert state.attributes.get("ca_cert") == "/some/ca.crt"
 
 
 async def test_update_sensor(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces an new option to the cert_expiry integration. Now its possible to specify an own CA certificate to check against. This is helpful for an environment with self-signed certificates. If new certificate is specified, its using the system root CA's like it did before.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: cert_expiry
    host: homeassistant.local
    ca_certfile: /ssl/myca.crt #Must be replaced with the ca certificate of the signed certificate for the host

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13671

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
