### PR TITLE
Update aioharmony to include support for XMPP connectivity to Hub

### DIFF
--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -2,7 +2,7 @@
   "domain": "harmony",
   "name": "Logitech Harmony Hub",
   "documentation": "https://www.home-assistant.io/integrations/harmony",
-  "requirements": ["aioharmony==0.2.3"],
+  "requirements": ["aioharmony==0.2.4"],
   "codeowners": ["@ehendrix23", "@bramkragten", "@bdraco"],
   "ssdp": [
     {

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -2,7 +2,7 @@
   "domain": "harmony",
   "name": "Logitech Harmony Hub",
   "documentation": "https://www.home-assistant.io/integrations/harmony",
-  "requirements": ["aioharmony==0.1.13"],
+  "requirements": ["aioharmony==0.2.3"],
   "codeowners": ["@ehendrix23", "@bramkragten", "@bdraco"],
   "ssdp": [
     {

--- a/homeassistant/components/harmony/util.py
+++ b/homeassistant/components/harmony/util.py
@@ -9,11 +9,10 @@ from .const import DOMAIN
 
 def find_unique_id_for_remote(harmony: HarmonyAPI):
     """Find the unique id for both websocket and xmpp clients."""
-    websocket_unique_id = harmony.hub_config.info.get("activeRemoteId")
-    if websocket_unique_id is not None:
-        return str(websocket_unique_id)
+    if harmony.hub_id is not None:
+        return str(harmony.hub_id)
 
-    # fallback to the xmpp unique id if websocket is not available
+    # fallback timeStampHash if Hub ID is not available
     return harmony.config["global"]["timeStampHash"].split(";")[-1]
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -178,7 +178,7 @@ aioftp==0.12.0
 aioguardian==0.2.3
 
 # homeassistant.components.harmony
-aioharmony==0.1.13
+aioharmony==0.2.3
 
 # homeassistant.components.homekit_controller
 aiohomekit[IP]==0.2.38

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -178,7 +178,7 @@ aioftp==0.12.0
 aioguardian==0.2.3
 
 # homeassistant.components.harmony
-aioharmony==0.2.3
+aioharmony==0.2.4
 
 # homeassistant.components.homekit_controller
 aiohomekit[IP]==0.2.38

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -85,7 +85,7 @@ aiofreepybox==0.0.8
 aioguardian==0.2.3
 
 # homeassistant.components.harmony
-aioharmony==0.1.13
+aioharmony==0.2.3
 
 # homeassistant.components.homekit_controller
 aiohomekit[IP]==0.2.38

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -85,7 +85,7 @@ aiofreepybox==0.0.8
 aioguardian==0.2.3
 
 # homeassistant.components.harmony
-aioharmony==0.2.3
+aioharmony==0.2.4
 
 # homeassistant.components.homekit_controller
 aiohomekit[IP]==0.2.38


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update to aioharmony 0.2.4

Changes
-------
0.2.0. New:
Support for XMPP. If XMPP is enabled on Hub then that will be used, otherwise fallback to web sockets. There are no changes to the API for this. XMPP has to be explicitly enabled on the Harmony HUB. To do so open the Harmony app and go to: Menu > Harmony Setup > Add/Edit Devices & Activities > Remote & Hub > Enable XMPP Same steps can be followed to disable XMPP again.
Log entries from responsehandler class will now include ip address of HUB for easier identification
0.2.1 Fixed:
Fixed issue in sending commands to HUB wbe using XMPP protocol.
0.2.2 Fixed:
Added closing code from aiohttp for web sockets in debug logging if closing code provided.
Fixed further potential issue where on some OS's sockets would not be closed by now force closing them (merge from 0.1.13)
Fixed listen parameter as it would just exit instead of continuously wait.
0.2.3 Changed:
Updated requirement for slixmpp to 1.5.2 as that version works with Home Assistant
0.2.4 Fixed:
Friendly Name of Harmony HUB was not retrieved anymore, this is now available again
Remote ID was not retrieved anymore, this is now available again
If HUB disconnects when retrieving information then retrieval will be retried.
Executing aioharmony with option show_detailed_config will now show all config retrieved from HUB

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This PR updates aioharmony to 0.2.3. The update library also supports connectivity to Harmony Hub using XMPP.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
