### PR TITLE
Add attribute templates to template vacuum

### DIFF
--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -53,6 +53,7 @@ CONF_VACUUMS = "vacuums"
 CONF_BATTERY_LEVEL_TEMPLATE = "battery_level_template"
 CONF_FAN_SPEED_LIST = "fan_speeds"
 CONF_FAN_SPEED_TEMPLATE = "fan_speed_template"
+CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 _VALID_STATES = [
@@ -71,6 +72,9 @@ VACUUM_SCHEMA = vol.Schema(
         vol.Optional(CONF_BATTERY_LEVEL_TEMPLATE): cv.template,
         vol.Optional(CONF_FAN_SPEED_TEMPLATE): cv.template,
         vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
+        vol.Optional(CONF_ATTRIBUTE_TEMPLATES, default={}): vol.Schema(
+            {cv.string: cv.template}
+        ),
         vol.Required(SERVICE_START): cv.SCRIPT_SCHEMA,
         vol.Optional(SERVICE_PAUSE): cv.SCRIPT_SCHEMA,
         vol.Optional(SERVICE_STOP): cv.SCRIPT_SCHEMA,
@@ -99,6 +103,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         battery_level_template = device_config.get(CONF_BATTERY_LEVEL_TEMPLATE)
         fan_speed_template = device_config.get(CONF_FAN_SPEED_TEMPLATE)
         availability_template = device_config.get(CONF_AVAILABILITY_TEMPLATE)
+        attribute_templates = device_config.get(CONF_ATTRIBUTE_TEMPLATES)
 
         start_action = device_config[SERVICE_START]
         pause_action = device_config.get(SERVICE_PAUSE)
@@ -117,8 +122,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             CONF_AVAILABILITY_TEMPLATE: availability_template,
         }
 
-        initialise_templates(hass, templates)
-        entity_ids = extract_entities(device, "vacuum", None, templates)
+        initialise_templates(hass, templates, attribute_templates)
+        entity_ids = extract_entities(device, "vacuum", None, templates, attribute_templates)
 
         vacuums.append(
             TemplateVacuum(
@@ -138,6 +143,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 set_fan_speed_action,
                 fan_speed_list,
                 entity_ids,
+                attribute_templates,
             )
         )
 
@@ -165,6 +171,7 @@ class TemplateVacuum(StateVacuumEntity):
         set_fan_speed_action,
         fan_speed_list,
         entity_ids,
+        attribute_templates,
     ):
         """Initialize the vacuum."""
         self.hass = hass
@@ -178,6 +185,8 @@ class TemplateVacuum(StateVacuumEntity):
         self._fan_speed_template = fan_speed_template
         self._availability_template = availability_template
         self._supported_features = SUPPORT_START
+        self._attribute_templates = attribute_templates
+        self._attributes = {}
 
         self._start_script = Script(hass, start_action)
 
@@ -264,6 +273,11 @@ class TemplateVacuum(StateVacuumEntity):
     def available(self) -> bool:
         """Return if the device is available."""
         return self._available
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
 
     async def async_start(self):
         """Start or resume the cleaning task."""
@@ -419,3 +433,13 @@ class TemplateVacuum(StateVacuumEntity):
                     self._name,
                     ex,
                 )
+        # Update attribute if attribute template is defined
+        if self._attribute_templates is not None:
+            attrs = {}
+            for key, value in self._attribute_templates.items():
+                try:
+                    attrs[key] = value.async_render()
+                except TemplateError as err:
+                    _LOGGER.error("Error rendering attribute %s: %s", key, err)
+
+            self._attributes = attrs

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -123,7 +123,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         }
 
         initialise_templates(hass, templates, attribute_templates)
-        entity_ids = extract_entities(device, "vacuum", None, templates, attribute_templates)
+        entity_ids = extract_entities(
+            device, "vacuum", None, templates, attribute_templates
+        )
 
         vacuums.append(
             TemplateVacuum(

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -590,6 +590,9 @@ async def _register_components(hass):
                 },
             },
             "fan_speeds": ["low", "medium", "high"],
+            "attribute_templates": {
+                "test_attribute": "It {{ states.sensor.test_state.state }}."
+            },
         }
 
         assert await setup.async_setup_component(

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -307,12 +307,14 @@ async def test_attribute_templates(hass, calls):
     await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.test_template_vacuum")
-    assert state.attributes.get("test_attribute") == "It ."
+    attributes = state.attributes
+    assert attributes.get("test_attribute") == "It ."
 
     hass.states.set("sensor.test_state", "Works")
     await hass.block_till_done()
     state = hass.states.get("vacuum.test_template_vacuum")
-    assert state.attributes["test_attribute"] == "It Works."
+    attributes = state.attributes
+    assert attributes["test_attribute"] == "It Works."
 
 
 async def test_invalid_attribute_template(hass, caplog):
@@ -335,7 +337,7 @@ async def test_invalid_attribute_template(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 2
+    assert hass.states.async_all() == []
     await hass.helpers.entity_component.async_update_entity("sensor.invalid_template")
 
     assert ("Error rendering attribute test_attribute") in caplog.text

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -311,7 +311,7 @@ async def test_attribute_templates(hass, calls):
     attributes = state.attributes
     assert attributes.get("test_attribute") == "It ."
 
-    hass.states.async_set("sensor.test_state", "Works")
+    hass.states.async_set("sensor.test_state.state", "Works")
     await hass.async_block_till_done()
     state = hass.states.get("vacuum.test_template_vacuum")
     attributes = state.attributes
@@ -339,7 +339,7 @@ async def test_invalid_attribute_template(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.async_all() == []
+    assert len(hass.states.async_all()) == 2
     await hass.helpers.entity_component.async_update_entity("sensor.invalid_template")
 
     assert ("Error rendering attribute test_attribute") in caplog.text

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -311,7 +311,7 @@ async def test_attribute_templates(hass, calls):
     attributes = state.attributes
     assert attributes.get("test_attribute") == "It ."
 
-    hass.states.set("sensor.test_state", "Works")
+    hass.states.async_set("sensor.test_state", "Works")
     await hass.block_till_done()
     state = hass.states.get("vacuum.test_template_vacuum")
     attributes = state.attributes
@@ -328,7 +328,7 @@ async def test_invalid_attribute_template(hass, caplog):
                 "platform": "template",
                 "vacuums": {
                     "invalid_template": {
-                        "value_template": "{{ 'docked' }}",
+                        "value_template": "{{ states('input_select.state') }}",
                         "start": {"service": "script.vacuum_start"},
                         "attribute_templates": {
                             "test_attribute": "{{ states.sensor.unknown.attributes.picture }}"

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -323,7 +323,7 @@ async def test_invalid_attribute_template(hass, caplog):
         {
             "vacuum": {
                 "platform": "template",
-                "vacuum": {
+                "vacuums": {
                     "invalid_template": {
                         "value_template": "{{ 'docked' }}",
                         "attribute_templates": {

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -310,7 +310,7 @@ async def test_attribute_templates(hass, calls):
     assert state.attributes.get("test_attribute") == "It ."
 
     hass.states.set("sensor.test_state", "Works")
-    hass.block_till_done()
+    await hass.block_till_done()
     state = hass.states.get("vacuum.test_template_vacuum")
     assert state.attributes["test_attribute"] == "It Works."
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -293,6 +293,7 @@ async def test_attribute_templates(hass, calls):
                 "vacuums": {
                     "test_template_vacuum": {
                         "value_template": "{{ 'cleaning' }}",
+                        "start": {"service": "script.vacuum_start"},
                         "attribute_templates": {
                             "test_attribute": "It {{ states.sensor.test_state.state }}."
                         },
@@ -328,6 +329,7 @@ async def test_invalid_attribute_template(hass, caplog):
                 "vacuums": {
                     "invalid_template": {
                         "value_template": "{{ 'docked' }}",
+                        "start": {"service": "script.vacuum_start"},
                         "attribute_templates": {
                             "test_attribute": "{{ states.sensor.unknown.attributes.picture }}"
                         },

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -281,37 +281,38 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
     assert hass.states.get("vacuum.test_template_vacuum") != STATE_UNAVAILABLE
     assert ("UndefinedError: 'x' is undefined") in caplog.text
 
-    def test_attribute_templates(self):
-        """Test attribute_templates template."""
-        assert await setup.async_setup_component(
-            hass,
-            "vacuum",
-            {
-                "vacuum": {
-                    "platform": "template",
-                    "vacuums": {
-                        "test_template_vacuum": {
-                            "value_template": "{{ 'cleaning' }}",
-                            "attribute_templates": {
-                                "test_attribute": "It {{ states.sensor.test_state.state }}."
-                            },
-                        }
-                    },
-                }
-            },
-        )
 
-        await hass.async_block_till_done()
-        await hass.async_start()
-        await hass.async_block_till_done()
+async def test_attribute_templates(hass, calls):
+    """Test attribute_templates template."""
+    assert await setup.async_setup_component(
+        hass,
+        "vacuum",
+        {
+            "vacuum": {
+                "platform": "template",
+                "vacuums": {
+                    "test_template_vacuum": {
+                        "value_template": "{{ 'cleaning' }}",
+                        "attribute_templates": {
+                            "test_attribute": "It {{ states.sensor.test_state.state }}."
+                        },
+                    }
+                },
+            }
+        },
+    )
 
-        state = self.hass.states.get("vacuum.test_template_vacuum")
-        assert state.attributes.get("test_attribute") == "It ."
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
-        self.hass.states.set("sensor.test_state", "Works")
-        self.hass.block_till_done()
-        state = self.hass.states.get("vacuum.test_template_vacuum")
-        assert state.attributes["test_attribute"] == "It Works."
+    state = hass.states.get("vacuum.test_template_vacuum")
+    assert state.attributes.get("test_attribute") == "It ."
+
+    hass.states.set("sensor.test_state", "Works")
+    hass.block_till_done()
+    state = hass.states.get("vacuum.test_template_vacuum")
+    assert state.attributes["test_attribute"] == "It Works."
 
 # End of template tests #
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -315,6 +315,32 @@ async def test_attribute_templates(hass, calls):
     assert state.attributes["test_attribute"] == "It Works."
 
 
+async def test_invalid_attribute_template(hass, caplog):
+    """Test that errors are logged if rendering template fails."""
+    assert await setup.async_setup_component(
+        hass,
+        "vacuum",
+        {
+            "vacuum": {
+                "platform": "template",
+                "vacuum": {
+                    "invalid_template": {
+                        "value_template": "{{ 'docked' }}",
+                        "attribute_templates": {
+                            "test_attribute": "{{ states.sensor.unknown.attributes.picture }}"
+                        },
+                    }
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 2
+    await hass.helpers.entity_component.async_update_entity("sensor.invalid_template")
+
+    assert ("Error rendering attribute test_attribute") in caplog.text
+
+
 # End of template tests #
 
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -314,6 +314,7 @@ async def test_attribute_templates(hass, calls):
     state = hass.states.get("vacuum.test_template_vacuum")
     assert state.attributes["test_attribute"] == "It Works."
 
+
 # End of template tests #
 
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -312,7 +312,7 @@ async def test_attribute_templates(hass, calls):
     assert attributes.get("test_attribute") == "It ."
 
     hass.states.async_set("sensor.test_state", "Works")
-    await hass.block_till_done()
+    await hass.async_block_till_done()
     state = hass.states.get("vacuum.test_template_vacuum")
     attributes = state.attributes
     assert attributes["test_attribute"] == "It Works."
@@ -331,7 +331,7 @@ async def test_invalid_attribute_template(hass, caplog):
                         "value_template": "{{ states('input_select.state') }}",
                         "start": {"service": "script.vacuum_start"},
                         "attribute_templates": {
-                            "test_attribute": "{{ states.sensor.unknown.attributes.picture }}"
+                            "test_attribute": "{{ this_function_does_not_exist() }}"
                         },
                     }
                 },

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -308,14 +308,15 @@ async def test_attribute_templates(hass, calls):
     await hass.async_block_till_done()
 
     state = hass.states.get("vacuum.test_template_vacuum")
-    attributes = state.attributes
-    assert attributes.get("test_attribute") == "It ."
+    assert state.attributes["test_attribute"] == "It ."
 
-    hass.states.async_set("sensor.test_state.state", "Works")
+    hass.states.async_set("sensor.test_state", "Works")
     await hass.async_block_till_done()
+    await hass.helpers.entity_component.async_update_entity(
+        "vacuum.test_template_vacuum"
+    )
     state = hass.states.get("vacuum.test_template_vacuum")
-    attributes = state.attributes
-    assert attributes["test_attribute"] == "It Works."
+    assert state.attributes["test_attribute"] == "It Works."
 
 
 async def test_invalid_attribute_template(hass, caplog):
@@ -339,8 +340,8 @@ async def test_invalid_attribute_template(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 2
-    await hass.helpers.entity_component.async_update_entity("sensor.invalid_template")
+    assert len(hass.states.async_all()) == 1
+    await hass.helpers.entity_component.async_update_entity("vacuum.invalid_template")
 
     assert ("Error rendering attribute test_attribute") in caplog.text
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Add attribute templates to template vacuum

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
  - platform: template
    vacuums:
      samsung_vacuum:
        friendly_name: Samsung POWERbot Star Wars™
        attribute_templates:
          status: >
            {% if (states('sensor.robot_vacuum_robot_cleaner_movement') == "after" and states('sensor.robot_vacuum_robot_cleaner_cleaning_mode') == "stop")  %}
              Charging to Resume
            {% elif states('sensor.robot_vacuum_robot_cleaner_cleaning_mode') == "auto" %}
              Cleaning
            {% else %}
              Charging
            {% endif %}
        value_template: >
          {% if (states('sensor.robot_vacuum_robot_cleaner_movement') == "charging" or states('sensor.robot_vacuum_robot_cleaner_movement') == "after") %}
            docked
          {% else %}
            {{ states('sensor.robot_vacuum_robot_cleaner_movement') }}
          {% endif %}
        battery_level_template: "{{ states('sensor.robot_vacuum_battery')|int }}"
        fan_speed_template: >
          {% if states('sensor.robot_vacuum_robot_cleaner_turbo_mode') == 'on' %}
            Turbo
          {% else %}
            Normal
          {% endif %}
        start:
          - service: scene.turn_on
            data:
              entity_id: scene.start_cleaning
        return_to_base:
          - service: scene.turn_on
            data:
              entity_id: scene.charge_vacuum
        set_fan_speed:
          - service: script.samsung_vacuum_fan_speed
            data_template:
              speed: "{{ fan_speed }}"
        fan_speeds:
          - Turbo
          - Normal
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/please-add-attribute-templates-to-template-vacuum-and-other-templates-that-are-missing-it/199932
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13733

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
