### PR TITLE
Fix WLED power and brightness with WLED 0.10+

### DIFF
--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -3,7 +3,7 @@
   "name": "WLED",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wled",
-  "requirements": ["wled==0.4.1"],
+  "requirements": ["wled==0.4.2"],
   "zeroconf": ["_wled._tcp.local."],
   "codeowners": ["@frenck"],
   "quality_scale": "platinum"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2201,7 +2201,7 @@ wirelesstagpy==0.4.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.4.1
+wled==0.4.2
 
 # homeassistant.components.xbee
 xbee-helper==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -910,7 +910,7 @@ wiffi==1.0.0
 withings-api==2.1.3
 
 # homeassistant.components.wled
-wled==0.4.1
+wled==0.4.2
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     ATTR_ICON,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
@@ -50,7 +51,7 @@ async def test_rgb_light_state(
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
     # First segment of the strip
-    state = hass.states.get("light.wled_rgb_light")
+    state = hass.states.get("light.wled_rgb_light_segment_0")
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 127
     assert state.attributes.get(ATTR_EFFECT) == "Solid"
@@ -64,12 +65,12 @@ async def test_rgb_light_state(
     assert state.attributes.get(ATTR_SPEED) == 32
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("light.wled_rgb_light")
+    entry = entity_registry.async_get("light.wled_rgb_light_segment_0")
     assert entry
     assert entry.unique_id == "aabbccddeeff_0"
 
     # Second segment of the strip
-    state = hass.states.get("light.wled_rgb_light_1")
+    state = hass.states.get("light.wled_rgb_light_segment_1")
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 127
     assert state.attributes.get(ATTR_EFFECT) == "Blink"
@@ -83,22 +84,32 @@ async def test_rgb_light_state(
     assert state.attributes.get(ATTR_SPEED) == 16
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("light.wled_rgb_light_1")
+    entry = entity_registry.async_get("light.wled_rgb_light_segment_1")
     assert entry
     assert entry.unique_id == "aabbccddeeff_1"
 
+    # Test master control of the lightstrip
+    state = hass.states.get("light.wled_rgb_light_master")
+    assert state
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 127
+    assert state.state == STATE_ON
 
-async def test_switch_change_state(
+    entry = entity_registry.async_get("light.wled_rgb_light_master")
+    assert entry
+    assert entry.unique_id == "aabbccddeeff"
+
+
+async def test_segment_change_state(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
 ) -> None:
-    """Test the change of state of the WLED switches."""
+    """Test the change of state of the WLED segments."""
     await init_integration(hass, aioclient_mock)
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_TRANSITION: 5},
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_TRANSITION: 5},
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -106,14 +117,14 @@ async def test_switch_change_state(
             on=False, segment_id=0, transition=50,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
             {
                 ATTR_BRIGHTNESS: 42,
                 ATTR_EFFECT: "Chase",
-                ATTR_ENTITY_ID: "light.wled_rgb_light",
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
                 ATTR_RGB_COLOR: [255, 0, 0],
                 ATTR_TRANSITION: 5,
             },
@@ -129,16 +140,79 @@ async def test_switch_change_state(
             transition=50,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_COLOR_TEMP: 400},
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_COLOR_TEMP: 400},
             blocking=True,
         )
         await hass.async_block_till_done()
         light_mock.assert_called_once_with(
             color_primary=(255, 159, 70), on=True, segment_id=0,
+        )
+
+
+async def test_master_change_state(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+) -> None:
+    """Test the change of state of the WLED master light control."""
+    await init_integration(hass, aioclient_mock)
+
+    with patch("wled.WLED.master") as light_mock:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_master", ATTR_TRANSITION: 5},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        light_mock.assert_called_once_with(
+            on=False, transition=50,
+        )
+
+    with patch("wled.WLED.master") as light_mock:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_BRIGHTNESS: 42,
+                ATTR_ENTITY_ID: "light.wled_rgb_light_master",
+                ATTR_TRANSITION: 5,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        light_mock.assert_called_once_with(
+            brightness=42, on=True, transition=50,
+        )
+
+    with patch("wled.WLED.master") as light_mock:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_master", ATTR_TRANSITION: 5},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        light_mock.assert_called_once_with(
+            on=False, transition=50,
+        )
+
+    with patch("wled.WLED.master") as light_mock:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_BRIGHTNESS: 42,
+                ATTR_ENTITY_ID: "light.wled_rgb_light_master",
+                ATTR_TRANSITION: 5,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        light_mock.assert_called_once_with(
+            brightness=42, on=True, transition=50,
         )
 
 
@@ -148,27 +222,109 @@ async def test_dynamically_handle_segments(
     """Test if a new/deleted segment is dynamically added/removed."""
     await init_integration(hass, aioclient_mock)
 
-    assert hass.states.get("light.wled_rgb_light")
-    assert hass.states.get("light.wled_rgb_light_1")
+    assert hass.states.get("light.wled_rgb_light_master")
+    assert hass.states.get("light.wled_rgb_light_segment_0")
+    assert hass.states.get("light.wled_rgb_light_segment_1")
 
     data = json.loads(load_fixture("wled/rgb_single_segment.json"))
     device = WLEDDevice(data)
 
-    # Test removal if segment went missing
+    # Test removal if segment went missing, including the master entity
     with patch(
         "homeassistant.components.wled.WLED.update", return_value=device,
     ):
         async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
         await hass.async_block_till_done()
-        assert hass.states.get("light.wled_rgb_light")
-        assert not hass.states.get("light.wled_rgb_light_1")
+        assert hass.states.get("light.wled_rgb_light_segment_0")
+        assert not hass.states.get("light.wled_rgb_light_segment_1")
+        assert not hass.states.get("light.wled_rgb_light_master")
 
-    # Test adding if segment shows up again
+    # Test adding if segment shows up again, including the master entity
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.wled_rgb_light")
-    assert hass.states.get("light.wled_rgb_light_1")
+    assert hass.states.get("light.wled_rgb_light_master")
+    assert hass.states.get("light.wled_rgb_light_segment_0")
+    assert hass.states.get("light.wled_rgb_light_segment_1")
+
+
+async def test_single_segment_behavior(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+) -> None:
+    """Test the behavior of the integration with a single segment."""
+    await init_integration(hass, aioclient_mock)
+
+    data = json.loads(load_fixture("wled/rgb_single_segment.json"))
+    device = WLEDDevice(data)
+
+    # Test absent master
+    with patch(
+        "homeassistant.components.wled.WLED.update", return_value=device,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+        await hass.async_block_till_done()
+
+        assert not hass.states.get("light.wled_rgb_light_master")
+
+        state = hass.states.get("light.wled_rgb_light_segment_0")
+        assert state
+        assert state.state == STATE_ON
+
+    # Test segment brightness takes master into account
+    device.state.brightness = 100
+    device.state.segments[0].brightness = 255
+    with patch(
+        "homeassistant.components.wled.WLED.update", return_value=device,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("light.wled_rgb_light_segment_0")
+        assert state
+        assert state.attributes.get(ATTR_BRIGHTNESS) == 100
+
+    # Test segment is off when master is off
+    device.state.on = False
+    with patch(
+        "homeassistant.components.wled.WLED.update", return_value=device,
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+        await hass.async_block_till_done()
+        state = hass.states.get("light.wled_rgb_light_segment_0")
+        assert state
+        assert state.state == STATE_OFF
+
+    # Test master is turned off when turning off a single segment
+    with patch("wled.WLED.master") as master_mock:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_TRANSITION: 5},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        master_mock.assert_called_once_with(
+            on=False, transition=50,
+        )
+
+    # Test master is turned on when turning on a single segment, and segment
+    # brightness is set to 255.
+    with patch("wled.WLED.master") as master_mock, patch(
+        "wled.WLED.segment"
+    ) as segment_mock:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+                ATTR_TRANSITION: 5,
+                ATTR_BRIGHTNESS: 42,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        master_mock.assert_called_once_with(on=True, transition=50, brightness=42)
+        segment_mock.assert_called_once_with(on=True, segment_id=0, brightness=255)
 
 
 async def test_light_error(
@@ -182,12 +338,12 @@ async def test_light_error(
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "light.wled_rgb_light"},
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
-        state = hass.states.get("light.wled_rgb_light")
+        state = hass.states.get("light.wled_rgb_light_segment_0")
         assert state.state == STATE_ON
         assert "Invalid response from API" in caplog.text
 
@@ -199,17 +355,17 @@ async def test_light_connection_error(
     await init_integration(hass, aioclient_mock)
 
     with patch("homeassistant.components.wled.WLED.update"), patch(
-        "homeassistant.components.wled.WLED.light", side_effect=WLEDConnectionError
+        "homeassistant.components.wled.WLED.segment", side_effect=WLEDConnectionError
     ):
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "light.wled_rgb_light"},
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
-        state = hass.states.get("light.wled_rgb_light")
+        state = hass.states.get("light.wled_rgb_light_segment_0")
         assert state.state == STATE_UNAVAILABLE
 
 
@@ -224,7 +380,7 @@ async def test_rgbw_light(
     assert state.attributes.get(ATTR_HS_COLOR) == (0.0, 100.0)
     assert state.attributes.get(ATTR_WHITE_VALUE) == 139
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
@@ -236,7 +392,7 @@ async def test_rgbw_light(
             on=True, segment_id=0, color_primary=(255, 159, 70, 139),
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
@@ -248,7 +404,7 @@ async def test_rgbw_light(
             color_primary=(255, 0, 0, 100), on=True, segment_id=0,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
@@ -271,13 +427,13 @@ async def test_effect_service(
     """Test the effect service of a WLED light."""
     await init_integration(hass, aioclient_mock)
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,
             {
                 ATTR_EFFECT: "Rainbow",
-                ATTR_ENTITY_ID: "light.wled_rgb_light",
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
                 ATTR_INTENSITY: 200,
                 ATTR_REVERSE: True,
                 ATTR_SPEED: 100,
@@ -289,11 +445,11 @@ async def test_effect_service(
             effect="Rainbow", intensity=200, reverse=True, segment_id=0, speed=100,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,
-            {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_EFFECT: 9},
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_EFFECT: 9},
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -301,12 +457,12 @@ async def test_effect_service(
             segment_id=0, effect=9,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,
             {
-                ATTR_ENTITY_ID: "light.wled_rgb_light",
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
                 ATTR_INTENSITY: 200,
                 ATTR_REVERSE: True,
                 ATTR_SPEED: 100,
@@ -318,13 +474,13 @@ async def test_effect_service(
             intensity=200, reverse=True, segment_id=0, speed=100,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,
             {
                 ATTR_EFFECT: "Rainbow",
-                ATTR_ENTITY_ID: "light.wled_rgb_light",
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
                 ATTR_REVERSE: True,
                 ATTR_SPEED: 100,
             },
@@ -335,13 +491,13 @@ async def test_effect_service(
             effect="Rainbow", reverse=True, segment_id=0, speed=100,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,
             {
                 ATTR_EFFECT: "Rainbow",
-                ATTR_ENTITY_ID: "light.wled_rgb_light",
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
                 ATTR_INTENSITY: 200,
                 ATTR_SPEED: 100,
             },
@@ -352,13 +508,13 @@ async def test_effect_service(
             effect="Rainbow", intensity=200, segment_id=0, speed=100,
         )
 
-    with patch("wled.WLED.light") as light_mock:
+    with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,
             {
                 ATTR_EFFECT: "Rainbow",
-                ATTR_ENTITY_ID: "light.wled_rgb_light",
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
                 ATTR_INTENSITY: 200,
                 ATTR_REVERSE: True,
             },
@@ -381,11 +537,11 @@ async def test_effect_service_error(
         await hass.services.async_call(
             DOMAIN,
             SERVICE_EFFECT,
-            {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_EFFECT: 9},
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_EFFECT: 9},
             blocking=True,
         )
         await hass.async_block_till_done()
 
-        state = hass.states.get("light.wled_rgb_light")
+        state = hass.states.get("light.wled_rgb_light_segment_0")
         assert state.state == STATE_ON
         assert "Invalid response from API" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

WLED 0.10 introduced the possibility to control individual segments of a single LED strip and gave those individual power and brightness states/controls.

This was implemented in #36091, however, it didn't work out as documented/expected. Resulting in a current broken state of the integration when using the current stable version of WLED: 0.10

### The problem

WLED has brightness & power controls on device level AND on an individual segment level. Basically, they are not related. If one controls the master levels, the segment levels won't reflect that change. e.g., turning off a device, does not turn off the segments. Turning on a segment, does not turn on the device.

Brightness is similar, except the final brightness is calculated based on both the master & individual segment brightness.

I've checked with the author of WLED to see what is going on, as this isn't documented, so it might have been a bug. As it turns out, it isn't a bug.

### Current state

The current state of the component does not take that into account. Hence, the on/off light state is incorrect / not working, and brightness works partially right now.

### The Fix

This PR implements a fix for this, to be both userfriendly when having just 1 segment (whole strip), but having full control when implementing multiple segments. In such a way it fixes the current issues.


If 1 segment is defined (single control the whole LED strip):

- 1 Light entity is created. It takes the master controls into account, making is just a simple light in Home Assistant.

When 2 or more segments are defined:

- A master control light is created additionally. The additional light gives control over the master power and brightness. 
- Other light entities will no longer control master to stay close to WLED functionality.

### Additionally

This PR bump `wled` to v0.4.2. Changelog <https://github.com/frenck/python-wled/releases/tag/v0.4.2>.

Existing tests are adjusted and new ones provided to keep a 100% coverage on the full integration.

Documentation has a PR open as well, to document this behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36440
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13686

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
