### PR TITLE
Prevent double ZHA channel initialization

### DIFF
--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -263,8 +263,13 @@ class ZHADevice(LogMixin):
 
     @property
     def available(self):
-        """Return True if sensor is available."""
+        """Return True if device is available."""
         return self._available
+
+    @available.setter
+    def available(self, new_availability: bool) -> None:
+        """Set device availability."""
+        self._available = new_availability
 
     @property
     def zigbee_signature(self) -> Dict[str, Any]:
@@ -273,10 +278,6 @@ class ZHADevice(LogMixin):
             ATTR_NODE_DESCRIPTOR: str(self._zigpy_device.node_desc),
             ATTR_ENDPOINTS: self._channels.zigbee_signature,
         }
-
-    def set_available(self, available):
-        """Set availability from restore and prevent signals."""
-        self._available = available
 
     @classmethod
     def new(

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -498,7 +498,7 @@ class ZHAGateway:
             if device.status is DeviceStatus.INITIALIZED:
                 device.update_available(available)
             else:
-                device.set_available(available)
+                device.available = available
 
     async def async_update_device_storage(self):
         """Update the devices in the store."""

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -485,16 +485,20 @@ class ZHAGateway:
         self, sender, profile, cluster, src_ep, dst_ep, message
     ):
         """Handle tasks when a device becomes available."""
-        self.async_update_device(sender)
+        self.async_update_device(sender, available=True)
 
     @callback
-    def async_update_device(self, sender: zigpy_dev.Device, available: bool = True):
+    def async_update_device(
+        self, sender: zigpy_dev.Device, available: bool = True
+    ) -> None:
         """Update device that has just become available."""
         if sender.ieee in self.devices:
             device = self.devices[sender.ieee]
             # avoid a race condition during new joins
             if device.status is DeviceStatus.INITIALIZED:
                 device.update_available(available)
+            else:
+                device.set_available(available)
 
     async def async_update_device_storage(self):
         """Update the devices in the store."""

--- a/homeassistant/components/zha/core/patches.py
+++ b/homeassistant/components/zha/core/patches.py
@@ -7,8 +7,7 @@ def apply_application_controller_patch(zha_gateway):
     def handle_message(sender, profile, cluster, src_ep, dst_ep, message):
         """Handle message from a device."""
         if (
-            not sender.initializing
-            and sender.ieee in zha_gateway.devices
+            sender.ieee in zha_gateway.devices
             and not zha_gateway.devices[sender.ieee].available
         ):
             zha_gateway.async_device_became_available(

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -211,7 +211,7 @@ class ZhaEntity(BaseZhaEntity, RestoreEntity):
             if not self.zha_device.is_mains_powered:
                 # mains powered devices will get real time state
                 self.async_restore_last_state(last_state)
-            self._zha_device.set_available(True)
+            self._zha_device.available = True
 
     async def async_update(self) -> None:
         """Retrieve latest state."""

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -42,7 +42,7 @@ async def device_switch(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_SWITCH_DEVICE,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -65,7 +65,7 @@ async def device_groupable(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -266,7 +266,7 @@ async def test_list_groupable_devices(zha_client, device_groupable):
 
     # Make sure there are no groupable devices when the device is unavailable
     # Make device unavailable
-    device_groupable.set_available(False)
+    device_groupable.available = False
 
     await zha_client.send_json({ID: 11, TYPE: "zha/devices/groupable"})
 

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -65,7 +65,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
         node_descriptor=b"\xf8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -83,7 +83,7 @@ async def device_fan_1(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -105,7 +105,7 @@ async def device_fan_2(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -58,7 +58,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
         node_descriptor=b"\xf8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -82,7 +82,7 @@ async def device_light_1(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -106,7 +106,7 @@ async def device_light_2(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -88,7 +88,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
         node_descriptor=b"\xf8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -114,7 +114,7 @@ async def device_light_1(hass, zigpy_device_mock, zha_device_joined):
         nwk=0xB79D,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -140,7 +140,7 @@ async def device_light_2(hass, zigpy_device_mock, zha_device_joined):
         nwk=0xC79E,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -166,7 +166,7 @@ async def device_light_3(hass, zigpy_device_mock, zha_device_joined):
         nwk=0xB89F,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -56,7 +56,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
         node_descriptor=b"\xf8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -75,7 +75,7 @@ async def device_switch_1(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 
@@ -94,7 +94,7 @@ async def device_switch_2(hass, zigpy_device_mock, zha_device_joined):
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
     zha_device = await zha_device_joined(zigpy_device)
-    zha_device.set_available(True)
+    zha_device.available = True
     return zha_device
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During HA Core restart, when restoring Zigbee devices, it was possible for certain ZHA channels to be initialized twice, putting unnecessary traffic on the network. This PR fixes this issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
