### PR TITLE
Add service select scene to Yamaha Hifi media player

### DIFF
--- a/homeassistant/components/yamaha/const.py
+++ b/homeassistant/components/yamaha/const.py
@@ -1,3 +1,4 @@
 """Constants for the Yamaha component."""
 DOMAIN = "yamaha"
 SERVICE_ENABLE_OUTPUT = "enable_output"
+SERVICE_SELECT_SCENE = "select_scene"

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -22,7 +22,6 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
 )
 from homeassistant.const import (
-    ATTR_ENTITY_ID,
     CONF_HOST,
     CONF_NAME,
     STATE_IDLE,
@@ -30,14 +29,16 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PLAYING,
 )
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_platform
 
-from .const import DOMAIN, SERVICE_ENABLE_OUTPUT
+from .const import SERVICE_ENABLE_OUTPUT, SERVICE_SELECT_SCENE
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ENABLED = "enabled"
 ATTR_PORT = "port"
+
+ATTR_SCENE = "scene"
 
 CONF_SOURCE_IGNORE = "source_ignore"
 CONF_SOURCE_NAMES = "source_names"
@@ -46,12 +47,6 @@ CONF_ZONE_NAMES = "zone_names"
 
 DATA_YAMAHA = "yamaha_known_receivers"
 DEFAULT_NAME = "Yamaha Receiver"
-
-MEDIA_PLAYER_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.comp_entity_ids})
-
-ENABLE_OUTPUT_SCHEMA = MEDIA_PLAYER_SCHEMA.extend(
-    {vol.Required(ATTR_ENABLED): cv.boolean, vol.Required(ATTR_PORT): cv.string}
-)
 
 SUPPORT_YAMAHA = (
     SUPPORT_VOLUME_SET
@@ -79,78 +74,94 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Yamaha platform."""
+class YamahaConfigInfo:
+    """Configuration Info for Yamaha Receivers."""
 
-    # Keep track of configured receivers so that we don't end up
-    # discovering a receiver dynamically that we have static config
-    # for. Map each device from its zone_id to an instance since
-    # YamahaDevice is not hashable (thus not possible to add to a set).
-    if hass.data.get(DATA_YAMAHA) is None:
-        hass.data[DATA_YAMAHA] = {}
+    def __init__(self, config: None, discovery_info: None):
+        """Initialize the Configuration Info for Yamaha Receiver."""
+        self.name = config.get(CONF_NAME)
+        self.host = config.get(CONF_HOST)
+        self.ctrl_url = f"http://{self.host}:80/YamahaRemoteControl/ctrl"
+        self.source_ignore = config.get(CONF_SOURCE_IGNORE)
+        self.source_names = config.get(CONF_SOURCE_NAMES)
+        self.zone_ignore = config.get(CONF_ZONE_IGNORE)
+        self.zone_names = config.get(CONF_ZONE_NAMES)
+        self.from_discovery = False
+        if discovery_info is not None:
+            self.name = discovery_info.get("name")
+            self.model = discovery_info.get("model_name")
+            self.ctrl_url = discovery_info.get("control_url")
+            self.desc_url = discovery_info.get("description_url")
+            self.zone_ignore = []
+            self.from_discovery = True
 
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    source_ignore = config.get(CONF_SOURCE_IGNORE)
-    source_names = config.get(CONF_SOURCE_NAMES)
-    zone_ignore = config.get(CONF_ZONE_IGNORE)
-    zone_names = config.get(CONF_ZONE_NAMES)
 
-    if discovery_info is not None:
-        name = discovery_info.get("name")
-        model = discovery_info.get("model_name")
-        ctrl_url = discovery_info.get("control_url")
-        desc_url = discovery_info.get("description_url")
+def _discovery(config_info):
+    """Discover receivers from configuration in the network."""
+    if config_info.from_discovery:
         receivers = rxv.RXV(
-            ctrl_url, model_name=model, friendly_name=name, unit_desc_url=desc_url
+            config_info.ctrl_url,
+            model_name=config_info.model,
+            friendly_name=config_info.name,
+            unit_desc_url=config_info.desc_url,
         ).zone_controllers()
         _LOGGER.debug("Receivers: %s", receivers)
-        # when we are dynamically discovered config is empty
-        zone_ignore = []
-    elif host is None:
+    elif config_info.host is None:
         receivers = []
         for recv in rxv.find():
             receivers.extend(recv.zone_controllers())
     else:
-        ctrl_url = f"http://{host}:80/YamahaRemoteControl/ctrl"
-        receivers = rxv.RXV(ctrl_url, name).zone_controllers()
+        receivers = rxv.RXV(config_info.ctrl_url, config_info.name).zone_controllers()
 
-    devices = []
+    return receivers
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the Yamaha platform."""
+
+    # Keep track of configured receivers so that we don't end up
+    # discovering a receiver dynamically that we have static config
+    # for. Map each device from its zone_id .
+    known_zones = hass.data.setdefault(DATA_YAMAHA, set())
+
+    # Get the Infos for configuration from config (YAML) or Discovery
+    config_info = YamahaConfigInfo(config=config, discovery_info=discovery_info)
+    # Async check if the Receivers are there in the network
+    receivers = await hass.async_add_executor_job(_discovery, config_info)
+
+    entities = []
     for receiver in receivers:
-        if receiver.zone in zone_ignore:
+        if receiver.zone in config_info.zone_ignore:
             continue
 
-        device = YamahaDevice(name, receiver, source_ignore, source_names, zone_names)
+        entity = YamahaDevice(
+            config_info.name,
+            receiver,
+            config_info.source_ignore,
+            config_info.source_names,
+            config_info.zone_names,
+        )
 
         # Only add device if it's not already added
-        if device.zone_id not in hass.data[DATA_YAMAHA]:
-            hass.data[DATA_YAMAHA][device.zone_id] = device
-            devices.append(device)
+        if entity.zone_id not in known_zones:
+            known_zones.add(entity.zone_id)
+            entities.append(entity)
         else:
-            _LOGGER.debug("Ignoring duplicate receiver: %s", name)
+            _LOGGER.debug("Ignoring duplicate receiver: %s", config_info.name)
 
-    def service_handler(service):
-        """Handle for services."""
-        entity_ids = service.data.get(ATTR_ENTITY_ID)
+    async_add_entities(entities)
 
-        devices = [
-            device
-            for device in hass.data[DATA_YAMAHA].values()
-            if not entity_ids or device.entity_id in entity_ids
-        ]
-
-        for device in devices:
-            port = service.data[ATTR_PORT]
-            enabled = service.data[ATTR_ENABLED]
-
-            device.enable_output(port, enabled)
-            device.schedule_update_ha_state(True)
-
-    hass.services.register(
-        DOMAIN, SERVICE_ENABLE_OUTPUT, service_handler, schema=ENABLE_OUTPUT_SCHEMA
+    # Register Service 'select_scene'
+    platform = entity_platform.current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_SELECT_SCENE, {vol.Required(ATTR_SCENE): cv.string}, "set_scene",
     )
-
-    add_entities(devices)
+    # Register Service 'enable_output'
+    platform.async_register_entity_service(
+        SERVICE_ENABLE_OUTPUT,
+        {vol.Required(ATTR_ENABLED): cv.boolean, vol.Required(ATTR_PORT): cv.string},
+        "enable_output",
+    )
 
 
 class YamahaDevice(MediaPlayerEntity):
@@ -350,7 +361,6 @@ class YamahaDevice(MediaPlayerEntity):
         Yamaha to direct play certain kinds of media. media_type is
         treated as the input type that we are setting, and media id is
         specific to it.
-
         For the NET RADIO mediatype the format for ``media_id`` is a
         "path" in your vtuner hierarchy. For instance:
         ``Bookmarks>Internet>Radio Paradise``. The separators are
@@ -358,12 +368,10 @@ class YamahaDevice(MediaPlayerEntity):
         scenes. There is a looping construct built into the yamaha
         library to do this with a fallback timeout if the vtuner
         service is unresponsive.
-
         NOTE: this might take a while, because the only API interface
         for setting the net radio station emulates button pressing and
         navigating through the net radio menu hierarchy. And each sub
         menu must be fetched by the receiver from the vtuner service.
-
         """
         if media_type == "NET RADIO":
             self.receiver.net_radio(media_id)
@@ -371,6 +379,13 @@ class YamahaDevice(MediaPlayerEntity):
     def enable_output(self, port, enabled):
         """Enable or disable an output port.."""
         self.receiver.enable_output(port, enabled)
+
+    def set_scene(self, scene):
+        """Set the current scene."""
+        try:
+            self.receiver.scene = scene
+        except AssertionError:
+            _LOGGER.warning("Scene '%s' does not exist!", scene)
 
     def select_sound_mode(self, sound_mode):
         """Set Sound Mode for Receiver.."""

--- a/homeassistant/components/yamaha/services.yaml
+++ b/homeassistant/components/yamaha/services.yaml
@@ -10,3 +10,12 @@ enable_output:
     enabled:
       description: Boolean indicating if port should be enabled or not.
       example: true
+select_scene:
+  description: "Select a scene on the receiver"
+  fields:
+    entity_id:
+      description: Name(s) of entities to enable/disable port on.
+      example: "media_player.yamaha"
+    scene:
+      description: Name of the scene. Standard for RX-V437 is 'BD/DVD Movie Viewing', 'TV Viewing', 'NET Audio Listening' or 'Radio Listening'
+      example: "TV Viewing"

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -46,6 +46,17 @@ def device_fixture(main_zone):
         yield device
 
 
+async def test_setup_host(hass, device, main_zone):
+    """Test set up integration with host."""
+    assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.yamaha_receiver_main_zone")
+
+    assert state is not None
+    assert state.state == "off"
+
+
 async def test_enable_output(hass, device, main_zone):
     """Test enable output service."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -4,6 +4,7 @@ import pytest
 import homeassistant.components.media_player as mp
 from homeassistant.components.yamaha import media_player as yamaha
 from homeassistant.components.yamaha.const import DOMAIN
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import MagicMock, PropertyMock, call, patch
@@ -64,6 +65,25 @@ async def test_setup_no_host(hass, device, main_zone):
             hass, mp.DOMAIN, {"media_player": {"platform": "yamaha"}}
         )
         await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.yamaha_receiver_main_zone")
+
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_setup_discovery(hass, device, main_zone):
+    """Test set up integration via discovery."""
+    discovery_info = {
+        "name": "Yamaha Receiver",
+        "model_name": "Yamaha",
+        "control_url": "http://receiver",
+        "description_url": "http://receiver/description",
+    }
+    await async_load_platform(
+        hass, mp.DOMAIN, "yamaha", discovery_info, {mp.DOMAIN: {}}
+    )
+    await hass.async_block_till_done()
 
     state = hass.states.get("media_player.yamaha_receiver_main_zone")
 

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -57,6 +57,20 @@ async def test_setup_host(hass, device, main_zone):
     assert state.state == "off"
 
 
+async def test_setup_no_host(hass, device, main_zone):
+    """Test set up integration without host."""
+    with patch("rxv.find", return_value=[device]):
+        assert await async_setup_component(
+            hass, mp.DOMAIN, {"media_player": {"platform": "yamaha"}}
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.yamaha_receiver_main_zone")
+
+    assert state is not None
+    assert state.state == "off"
+
+
 async def test_enable_output(hass, device, main_zone):
     """Test enable output service."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -91,6 +91,26 @@ async def test_setup_discovery(hass, device, main_zone):
     assert state.state == "off"
 
 
+async def test_setup_zone_ignore(hass, device, main_zone):
+    """Test set up integration without host."""
+    assert await async_setup_component(
+        hass,
+        mp.DOMAIN,
+        {
+            "media_player": {
+                "platform": "yamaha",
+                "host": "127.0.0.1",
+                "zone_ignore": "Main zone",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.yamaha_receiver_main_zone")
+
+    assert state is None
+
+
 async def test_enable_output(hass, device, main_zone):
     """Test enable output service."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -3,6 +3,7 @@ import unittest
 
 import homeassistant.components.media_player as mp
 from homeassistant.components.yamaha import media_player as yamaha
+from homeassistant.components.yamaha.const import DOMAIN
 from homeassistant.setup import setup_component
 
 from tests.async_mock import MagicMock, patch
@@ -53,7 +54,16 @@ class TestYamahaMediaPlayer(unittest.TestCase):
             "enabled": enabled,
         }
 
-        self.hass.services.call(yamaha.DOMAIN, yamaha.SERVICE_ENABLE_OUTPUT, data, True)
+        self.hass.services.call(DOMAIN, yamaha.SERVICE_ENABLE_OUTPUT, data, True)
+
+    def select_scene(self, scene):
+        """Select Scene."""
+        data = {
+            "entity_id": "media_player.yamaha_receiver_main_zone",
+            "scene": scene,
+        }
+
+        self.hass.services.call(DOMAIN, yamaha.SERVICE_SELECT_SCENE, data, True)
 
     def create_receiver(self, mock_rxv):
         """Create a mocked receiver."""
@@ -74,3 +84,14 @@ class TestYamahaMediaPlayer(unittest.TestCase):
 
         self.enable_output("hdmi2", False)
         self.main_zone.enable_output.assert_called_with("hdmi2", False)
+
+    @patch("rxv.RXV")
+    def test_select_scene(self, mock_rxv):
+        """Test selecting scenes."""
+        self.create_receiver(mock_rxv)
+
+        self.select_scene("TV Viewing")
+        assert self.main_zone.scene == "TV Viewing"
+
+        self.select_scene("BD/DVD Movie Viewing")
+        assert self.main_zone.scene == "BD/DVD Movie Viewing"

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -1,15 +1,12 @@
 """The tests for the Yamaha Media player platform."""
-import unittest
-
 import pytest
 
 import homeassistant.components.media_player as mp
 from homeassistant.components.yamaha import media_player as yamaha
 from homeassistant.components.yamaha.const import DOMAIN
-from homeassistant.setup import async_setup_component, setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import MagicMock, call, patch
-from tests.common import get_test_home_assistant
 
 CONFIG = {"media_player": {"platform": "yamaha", "host": "127.0.0.1"}}
 
@@ -49,61 +46,6 @@ def device_fixture(main_zone):
         yield device
 
 
-class TestYamahaMediaPlayer(unittest.TestCase):
-    """Test the Yamaha media player."""
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.main_zone = _create_zone_mock("Main zone", "http://main")
-        self.device = FakeYamahaDevice(
-            "http://receiver", "Receiver", zones=[self.main_zone]
-        )
-
-    def tearDown(self):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def enable_output(self, port, enabled):
-        """Enable output on a specific port."""
-        data = {
-            "entity_id": "media_player.yamaha_receiver_main_zone",
-            "port": port,
-            "enabled": enabled,
-        }
-
-        self.hass.services.call(DOMAIN, yamaha.SERVICE_ENABLE_OUTPUT, data, True)
-
-    def select_scene(self, scene):
-        """Select Scene."""
-        data = {
-            "entity_id": "media_player.yamaha_receiver_main_zone",
-            "scene": scene,
-        }
-
-        self.hass.services.call(DOMAIN, yamaha.SERVICE_SELECT_SCENE, data, True)
-
-    def create_receiver(self, mock_rxv):
-        """Create a mocked receiver."""
-        mock_rxv.return_value = self.device
-
-        config = {"media_player": {"platform": "yamaha", "host": "127.0.0.1"}}
-
-        assert setup_component(self.hass, mp.DOMAIN, config)
-        self.hass.block_till_done()
-
-    @patch("rxv.RXV")
-    def test_select_scene(self, mock_rxv):
-        """Test selecting scenes."""
-        self.create_receiver(mock_rxv)
-
-        self.select_scene("TV Viewing")
-        assert self.main_zone.scene == "TV Viewing"
-
-        self.select_scene("BD/DVD Movie Viewing")
-        assert self.main_zone.scene == "BD/DVD Movie Viewing"
-
-
 async def test_enable_output(hass, device, main_zone):
     """Test enable output service."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
@@ -121,3 +63,26 @@ async def test_enable_output(hass, device, main_zone):
 
     assert main_zone.enable_output.call_count == 1
     assert main_zone.enable_output.call_args == call(port, enabled)
+
+
+async def test_select_scene(hass, device, main_zone):
+    """Test select scene service."""
+    assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+    scene = "TV Viewing"
+    data = {
+        "entity_id": "media_player.yamaha_receiver_main_zone",
+        "scene": scene,
+    }
+
+    await hass.services.async_call(DOMAIN, yamaha.SERVICE_SELECT_SCENE, data, True)
+
+    assert main_zone.scene == scene
+
+    scene = "BD/DVD Movie Viewing"
+    data["scene"] = scene
+
+    await hass.services.async_call(DOMAIN, yamaha.SERVICE_SELECT_SCENE, data, True)
+
+    assert main_zone.scene == scene


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Yamaha receivers do support the selecting of scenes. Now this can be done via a service call, as the underlying rxv lib already supports this.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13673

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
