### PR TITLE
Fix mobile_app registering/update sensor values with an unknown state

### DIFF
--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -352,7 +352,7 @@ async def webhook_enable_encryption(hass, config_entry, data):
         vol.Required(ATTR_SENSOR_TYPE): vol.In(SENSOR_TYPES),
         vol.Required(ATTR_SENSOR_UNIQUE_ID): cv.string,
         vol.Optional(ATTR_SENSOR_UOM): cv.string,
-        vol.Required(ATTR_SENSOR_STATE): vol.Any(bool, str, int, float),
+        vol.Required(ATTR_SENSOR_STATE): vol.Any(None, bool, str, int, float),
         vol.Optional(ATTR_SENSOR_ICON, default="mdi:cellphone"): cv.icon,
     }
 )
@@ -414,7 +414,7 @@ async def webhook_update_sensor_states(hass, config_entry, data):
         {
             vol.Optional(ATTR_SENSOR_ATTRIBUTES, default={}): dict,
             vol.Optional(ATTR_SENSOR_ICON, default="mdi:cellphone"): cv.icon,
-            vol.Required(ATTR_SENSOR_STATE): vol.Any(bool, str, int, float),
+            vol.Required(ATTR_SENSOR_STATE): vol.Any(None, bool, str, int, float),
             vol.Required(ATTR_SENSOR_TYPE): vol.In(SENSOR_TYPES),
             vol.Required(ATTR_SENSOR_UNIQUE_ID): cv.string,
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes these errors reported in several places:

```
2020-06-07 14:47:33 ERROR (MainThread) [homeassistant.components.mobile_app.webhook] Received invalid webhook payload: required key not provided @ data['state']. Got None
```

In Home Assistant, a None value on an entity state is actually valid, however, register and update schema in the mobile_app integration didn't allow for it.

Currently, in the Mobile app, null values are handled on most places, like in this PR:

<https://github.com/home-assistant/iOS/commit/16e2d11900eed1587a07e46773877c5bff29ca76>
```
carrierSensor.State = carrier.carrierName ?? "N/A"
```

However, handling is not correct. If a sensor is unavailable / has no value, the None value should be sent, not `N/A`. (CC @robbiet480)

This PR adjusts the schema to allow for None values in sensor states during registration and update.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33279 
- This PR is related to issue: #36455 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
