### PR TITLE
Fix mobile_app sensor re-registration handling

### DIFF
--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -56,7 +56,6 @@ ERR_ENCRYPTION_ALREADY_ENABLED = "encryption_already_enabled"
 ERR_ENCRYPTION_NOT_AVAILABLE = "encryption_not_available"
 ERR_ENCRYPTION_REQUIRED = "encryption_required"
 ERR_SENSOR_NOT_REGISTERED = "not_registered"
-ERR_SENSOR_DUPLICATE_UNIQUE_ID = "duplicate_unique_id"
 ERR_INVALID_FORMAT = "invalid_format"
 
 

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -375,7 +375,7 @@ async def webhook_register_sensor(hass, config_entry, data):
         async_dispatcher_send(hass, SIGNAL_SENSOR_UPDATE, new_state)
 
         return webhook_response(
-            {"success": True}, registration=config_entry.data, status=HTTP_CREATED,
+            {"success": True}, registration=new_state, status=HTTP_CREATED,
         )
 
     data[CONF_WEBHOOK_ID] = config_entry.data[CONF_WEBHOOK_ID]

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -382,11 +382,11 @@ async def webhook_register_sensor(hass, config_entry, data):
         lambda: savable_state(hass), DELAY_SAVE
     )
 
-    if not existing_sensor:
+    if existing_sensor:
+        async_dispatcher_send(hass, SIGNAL_SENSOR_UPDATE, data)
+    else:
         register_signal = f"{DOMAIN}_{data[ATTR_SENSOR_TYPE]}_register"
         async_dispatcher_send(hass, register_signal, data)
-    else:
-        async_dispatcher_send(hass, SIGNAL_SENSOR_UPDATE, data)
 
     return webhook_response(
         {"success": True}, registration=config_entry.data, status=HTTP_CREATED,

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -78,7 +78,6 @@ from .const import (
     ERR_ENCRYPTION_NOT_AVAILABLE,
     ERR_ENCRYPTION_REQUIRED,
     ERR_INVALID_FORMAT,
-    ERR_SENSOR_DUPLICATE_UNIQUE_ID,
     ERR_SENSOR_NOT_REGISTERED,
     SIGNAL_LOCATION_UPDATE,
     SIGNAL_SENSOR_UPDATE,
@@ -364,21 +363,22 @@ async def webhook_enable_encryption(hass, config_entry, data):
 async def webhook_register_sensor(hass, config_entry, data):
     """Handle a register sensor webhook."""
     entity_type = data[ATTR_SENSOR_TYPE]
-
     unique_id = data[ATTR_SENSOR_UNIQUE_ID]
 
     unique_store_key = f"{config_entry.data[CONF_WEBHOOK_ID]}_{unique_id}"
 
+    # If sensor already is registered, dispatch an update instead
     if unique_store_key in hass.data[DOMAIN][entity_type]:
-        _LOGGER.error("Refusing to re-register existing sensor %s!", unique_id)
-        return error_response(
-            ERR_SENSOR_DUPLICATE_UNIQUE_ID,
-            f"{entity_type} {unique_id} already exists!",
-            status=409,
+        _LOGGER.debug("Re-register existing sensor %s", unique_id)
+        entry = hass.data[DOMAIN][entity_type][unique_store_key]
+        new_state = {**entry, **data}
+        async_dispatcher_send(hass, SIGNAL_SENSOR_UPDATE, new_state)
+
+        return webhook_response(
+            {"success": True}, registration=config_entry.data, status=HTTP_CREATED,
         )
 
     data[CONF_WEBHOOK_ID] = config_entry.data[CONF_WEBHOOK_ID]
-
     hass.data[DOMAIN][entity_type][unique_store_key] = data
 
     hass.data[DOMAIN][DATA_STORE].async_delay_save(

--- a/tests/components/mobile_app/test_entity.py
+++ b/tests/components/mobile_app/test_entity.py
@@ -122,6 +122,8 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
     assert reg_json == {"success": True}
     await hass.async_block_till_done()
 
+    assert "Re-register existing sensor" not in caplog.text
+
     entity = hass.states.get("sensor.test_1_battery_state")
     assert entity is not None
 

--- a/tests/components/mobile_app/test_entity.py
+++ b/tests/components/mobile_app/test_entity.py
@@ -95,8 +95,8 @@ async def test_sensor_must_register(hass, create_registrations, webhook_client):
     assert json["battery_state"]["error"]["code"] == "not_registered"
 
 
-async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client):
-    """Test that sensors must have a unique ID."""
+async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, caplog):
+    """Test that a duplicate unique ID in registration updates the sensor."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
 
@@ -120,14 +120,39 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client):
 
     reg_json = await reg_resp.json()
     assert reg_json == {"success": True}
+    await hass.async_block_till_done()
 
+    entity = hass.states.get("sensor.test_1_battery_state")
+    assert entity is not None
+
+    assert entity.attributes["device_class"] == "battery"
+    assert entity.attributes["icon"] == "mdi:battery"
+    assert entity.attributes["unit_of_measurement"] == UNIT_PERCENTAGE
+    assert entity.attributes["foo"] == "bar"
+    assert entity.domain == "sensor"
+    assert entity.name == "Test 1 Battery State"
+    assert entity.state == "100"
+
+    payload["data"]["state"] = 99
     dupe_resp = await webhook_client.post(webhook_url, json=payload)
 
-    assert dupe_resp.status == 409
+    assert dupe_resp.status == 201
+    dupe_reg_json = await dupe_resp.json()
+    assert dupe_reg_json == {"success": True}
+    await hass.async_block_till_done()
 
-    dupe_json = await dupe_resp.json()
-    assert dupe_json["success"] is False
-    assert dupe_json["error"]["code"] == "duplicate_unique_id"
+    assert "Re-register existing sensor" in caplog.text
+
+    entity = hass.states.get("sensor.test_1_battery_state")
+    assert entity is not None
+
+    assert entity.attributes["device_class"] == "battery"
+    assert entity.attributes["icon"] == "mdi:battery"
+    assert entity.attributes["unit_of_measurement"] == UNIT_PERCENTAGE
+    assert entity.attributes["foo"] == "bar"
+    assert entity.domain == "sensor"
+    assert entity.name == "Test 1 Battery State"
+    assert entity.state == "99"
 
 
 async def test_register_sensor_no_state(hass, create_registrations, webhook_client):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A lot of reports of the following errors can be found (example):
```
Refusing to re-register existing sensor battery_level!
```

While this is correct handling, it is annoying. One can argue if it should be an error in the logs, or a debug level log. As a consuming application could recover from this.

This PR takes a different approach. Instead of rejecting the registration, it will take the registration request, and update the sensor instead (based on unique ID of the sensor).

From the application that consumes the API, the (re-registration) is successful, while on the HA side of things, the new values has been processed and no new entities are created.

This can be done safely, as the webhook ID and unique ID of the sensor still have to match (if they didn't a normal registration is triggered as usual).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36455
- This PR is related to issue: home-assistant/iOS#599
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
