### PR TITLE
Add new calendar event options, delete and update services

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -69,11 +69,18 @@ def normalize_event(event):
     normalized_event["end"] = end
 
     # cleanup the string so we don't have a bunch of double+ spaces
+    normalized_event["event_id"] = event.get("id", "")
+    normalized_event["status"] = event.get("status", "")
+    normalized_event["created"] = event.get("created", "")
+    normalized_event["updated"] = event.get("updated", "")
     summary = event.get("summary", "")
     normalized_event["message"] = re.sub("  +", "", summary).strip()
     normalized_event["location"] = event.get("location", "")
     normalized_event["description"] = event.get("description", "")
     normalized_event["all_day"] = "date" in event["start"]
+    normalized_event["reminders"] = event.get("reminders", "")
+    normalized_event["transparency"] = event.get("transparency", "")
+    normalized_event["visibility"] = event.get("visibility", "")
 
     return normalized_event
 
@@ -132,12 +139,19 @@ class CalendarEventDevice(Entity):
 
         event = normalize_event(event)
         return {
+            "event_id": event["event_id"],
+            "status": event["status"],
+            "created": event["created"],
+            "updated": event["updated"],
             "message": event["message"],
             "all_day": event["all_day"],
             "start_time": event["start"],
             "end_time": event["end"],
             "location": event["location"],
             "description": event["description"],
+            "reminders": event["reminders"],
+            "transparency": event["transparency"],
+            "visibility": event["visibility"],
         }
 
     @property

--- a/homeassistant/components/google/services.yaml
+++ b/homeassistant/components/google/services.yaml
@@ -8,6 +8,9 @@ add_event:
     calendar_id:
       description: The id of the calendar you want.
       example: "Your email"
+    sendupdates:
+      description: 'Acceptable values are: "all": Notifications are sent to all guests. "externalOnly": Notifications are sent to non-Google Calendar guests only. "none": No notifications are sent.'
+      example: "all"
     summary:
       description: Acts as the title of the event.
       example: "Bowling"
@@ -20,6 +23,12 @@ add_event:
     end_date_time:
       description: The date and time the event should end.
       example: "2019-03-22 22:00:00"
+    location:
+      description: The location the event will be.
+      example: "89 E 42nd St"
+    recurrence:
+      description: "List of RRULE, EXRULE, RDATE and EXDATE lines for a recurring event, as specified in RFC5545."
+      example: "[RRULE:FREQ=DAILY;INTERVAL=1]"
     start_date:
       description: The date the whole day event should start.
       example: "2019-03-10"
@@ -29,3 +38,90 @@ add_event:
     in:
       description: Days or weeks that you want to create the event in.
       example: '"days": 2 or "weeks": 2'
+    status:
+      description: 'Status of the event. Possible values are: "confirmed", "tentative", "cancelled"'
+      example: "confirmed"
+    transparency:
+      description: 'Whether the event blocks time on the calendar. "opaque": The event does block time on the calendar. "transparent": The event does not block time on the calendar.'
+      example: "opaque"
+    visibility:
+      description: 'Visibility of the event. Possible values are: "default", "public", "private", and "confidential" This value is provided for compatibility reasons.'
+      example: "default"
+    reminders_usedefault:
+      description: Whether the default reminders of the calendar apply to the event. Default is false. This does nothing if method and minutes are not specified, event will have a default reminder of 10 minutes.
+      example: "boolean"
+    reminders_overrides_method:
+      description: 'The method used by this reminder. Possible values are: "email" - Reminders are sent via email. "popup" - Reminders are sent via a UI popup.'
+      example: "popup"
+    reminders_overrides_minutes:
+      description: "Number of minutes before the start of the event when the reminder should trigger. Valid values are between 0 and 40320 (4 weeks in minutes)."
+      example: "integer"
+delete_event:
+  description: Delete an event from a calendar.
+  fields:
+    calendar_id:
+      description: The id of the calendar you want.
+      example: "Your email"
+    event_id:
+      description: The id of the event you want.
+      example: "string"
+    sendupdates:
+      description: 'Acceptable values are: "all": Notifications are sent to all guests. "externalOnly": Notifications are sent to non-Google Calendar guests only. "none": No notifications are sent.'
+      example: "all"
+update_event:
+  description: Add a new calendar event.
+  fields:
+    calendar_id:
+      description: The id of the calendar you want.
+      example: "Your email"
+    event_id:
+      description: The id of the event you want.
+      example: "string"
+    sendupdates:
+      description: 'Acceptable values are: "all": Notifications are sent to all guests. "externalOnly": Notifications are sent to non-Google Calendar guests only. "none": No notifications are sent.'
+      example: "all"
+    summary:
+      description: Acts as the title of the event.
+      example: "Bowling"
+    description:
+      description: The description of the event. Optional.
+      example: "Birthday bowling"
+    start_date_time:
+      description: The date and time the event should start.
+      example: "2019-03-22 20:00:00"
+    end_date_time:
+      description: The date and time the event should end.
+      example: "2019-03-22 22:00:00"
+    location:
+      description: The location the event will be.
+      example: "89 E 42nd St"
+    recurrence:
+      description: "List of RRULE, EXRULE, RDATE and EXDATE lines for a recurring event, as specified in RFC5545."
+      example: "[RRULE:FREQ=DAILY;INTERVAL=1]"
+    start_date:
+      description: The date the whole day event should start.
+      example: "2019-03-10"
+    end_date:
+      description: The date the whole day event should end.
+      example: "2019-03-11"
+    in:
+      description: Days or weeks that you want to create the event in.
+      example: '"days": 2 or "weeks": 2'
+    status:
+      description: 'Status of the event. Possible values are: "confirmed", "tentative", "cancelled"'
+      example: "confirmed"
+    transparency:
+      description: 'Whether the event blocks time on the calendar. "opaque": The event does block time on the calendar. "transparent": The event does not block time on the calendar.'
+      example: "opaque"
+    visibility:
+      description: 'Visibility of the event. Possible values are: "default", "public", "private", and "confidential" This value is provided for compatibility reasons.'
+      example: "default"
+    reminders_usedefault:
+      description: Whether the default reminders of the calendar apply to the event. Default is false. This does nothing if method and minutes are not specified, event will have a default reminder of 10 minutes.
+      example: "boolean"
+    reminders_overrides_method:
+      description: 'The method used by this reminder. Possible values are: "email" - Reminders are sent via email. "popup" - Reminders are sent via a UI popup.'
+      example: "popup"
+    reminders_overrides_minutes:
+      description: "Number of minutes before the start of the event when the reminder should trigger. Valid values are between 0 and 40320 (4 weeks in minutes)."
+      example: "integer"

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -350,6 +350,13 @@ async def test_ongoing_event(mock_now, hass, calendar):
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -371,6 +378,13 @@ async def test_just_ended_event(mock_now, hass, calendar):
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -392,6 +406,13 @@ async def test_ongoing_event_different_tz(mock_now, hass, calendar):
         "description": "Sunny day",
         "end_time": "2017-11-27 17:30:00",
         "location": "San Francisco",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -415,6 +436,13 @@ async def test_ongoing_floating_event_returned(mock_now, hass, calendar):
         "end_time": "2017-11-27 20:00:00",
         "location": "Hamburg",
         "description": "What a day",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -436,6 +464,13 @@ async def test_ongoing_event_with_offset(mock_now, hass, calendar):
         "end_time": "2017-11-27 11:00:00",
         "location": "Hamburg",
         "description": "Surprisingly shiny",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -462,6 +497,13 @@ async def test_matching_filter(mock_now, hass, calendar):
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -488,6 +530,13 @@ async def test_matching_filter_real_regexp(mock_now, hass, calendar):
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -550,6 +599,13 @@ async def test_all_day_event_returned(mock_now, hass, calendar):
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
         "description": "What a beautiful day",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -571,6 +627,13 @@ async def test_event_rrule(mock_now, hass, calendar):
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
         "description": "Every day for a while",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -592,6 +655,13 @@ async def test_event_rrule_ongoing(mock_now, hass, calendar):
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
         "description": "Every day for a while",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -613,6 +683,13 @@ async def test_event_rrule_duration(mock_now, hass, calendar):
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
         "description": "Every day for a while as well",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -634,6 +711,13 @@ async def test_event_rrule_duration_ongoing(mock_now, hass, calendar):
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
         "description": "Every day for a while as well",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -655,6 +739,13 @@ async def test_event_rrule_endless(mock_now, hass, calendar):
         "end_time": "2017-11-27 23:59:59",
         "location": "Hamburg",
         "description": "Every day forever",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -684,6 +775,13 @@ async def test_event_rrule_all_day(mock_now, hass, calendar):
         "end_time": "2016-12-02 00:00:00",
         "location": "Hamburg",
         "description": "Groundhog Day",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -708,6 +806,13 @@ async def test_event_rrule_hourly_on_first(mock_now, hass, calendar):
         "end_time": "2015-11-27 00:30:00",
         "location": "Hamburg",
         "description": "The bell tolls for thee",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 
@@ -732,6 +837,13 @@ async def test_event_rrule_hourly_on_last(mock_now, hass, calendar):
         "end_time": "2015-11-27 11:30:00",
         "location": "Hamburg",
         "description": "The bell tolls for thee",
+        "event_id": "0123456789012345678901234567890123456789012345678901234567",
+        "status": "confirmed",
+        "created": "2017-11-26 16:30:00",
+        "updated": "2017-11-26 16:30:00",
+        "reminders": {"useDefault": True},
+        "transparency": "opaque",
+        "visibility": "private",
     }
 
 


### PR DESCRIPTION
## Proposed change

This PR will add support for more options when creating a google calendar event, such as: status, send updates to guests on event creation, deletion, or update, date when the event was created, date when the event was last updated, location, transparency, visibility, event recurrence, and reminders. It also adds support to have the above mentioned attributes included in the state for each calendar entity. The event id for the lastest event will now also be displayed. 

A new update service has been added. This is useful to change, among other things, the status of an event between confirmed, tentative, and cancelled (which is the same as deleted). Flipping a cancelled (deleted) event to confirmed or tentative undeletes it.

Next, is the delete service which only requires the calendar id and the event id. I am currently only able to get the event id from the state attributes. It would be nice to find other event ids either with a list service or some regex search. Achieving this is currently beyond my knowledge. 

My initial motivation for creating this was to have the reminder minutes exposed so that I can use that instead of offset_reached. The minor downside to offset_reached is it being read when I use google tts. My idea is to eventually have reminder minutes replace offset in the summary. If whoever reviews this feels the same way, great!

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Having a service to either list events or return from a regex is still something I'm wishing to achieve. Currently, the list function from google works but it does not return anything to Node-RED. It seems that only states return data to the message body. I'm looking to get results returned from a service to Node-RED or from a separate entity state, whichever is more appropriate. Anyone here who is able to make it happen, thank you. 

The update event service does to same thing as the delete event service does when the event status is set to cancelled. I included the delete event service to make it easier for others to just simply delete an event.

One other thing, my PR only supports one event reminder. The google api supports 5 but I don't know how that can be coded in the service schema to get HA to accept the required indentations in the yaml.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum