### PR TITLE
Tahoma zwave light support

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -68,7 +68,7 @@ TAHOMA_TYPES = {
     "rts:VenetianBlindRTSComponent": "cover",
     "somfythermostat:SomfyThermostatTemperatureSensor": "sensor",
     "somfythermostat:SomfyThermostatHumiditySensor": "sensor",
-	"zwave:OnOffLightZWaveComponent": "switch",
+    "zwave:OnOffLightZWaveComponent": "switch",
 }
 
 

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -68,6 +68,7 @@ TAHOMA_TYPES = {
     "rts:VenetianBlindRTSComponent": "cover",
     "somfythermostat:SomfyThermostatTemperatureSensor": "sensor",
     "somfythermostat:SomfyThermostatHumiditySensor": "sensor",
+	"zwave:OnOffLightZWaveComponent": "switch",
 }
 
 

--- a/homeassistant/components/tahoma/switch.py
+++ b/homeassistant/components/tahoma/switch.py
@@ -52,10 +52,10 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
                 self._state = STATE_ON
             else:
                 self._state = STATE_OFF
-				
+
         # A RTS power socket doesn't have a feedback channel,
         # so we must assume the socket is available.
-        if self.tahoma_device.type in ("rts:OnOffRTSComponent","zwave:OnOffLightZWaveComponent"):
+        if self.tahoma_device.type in ("rts:OnOffRTSComponent", "zwave:OnOffLightZWaveComponent"):
             self._available = True
         else:
             self._available = bool(

--- a/homeassistant/components/tahoma/switch.py
+++ b/homeassistant/components/tahoma/switch.py
@@ -57,7 +57,7 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
         # so we must assume the socket is available.
         if self.tahoma_device.type == "rts:OnOffRTSComponent":
             self._available = True
-        elif  self.tahoma_device.type == "zwave:OnOffLightZWaveComponent":   
+        elif self.tahoma_device.type == "zwave:OnOffLightZWaveComponent":
             self._available = True
         else:
             self._available = bool(

--- a/homeassistant/components/tahoma/switch.py
+++ b/homeassistant/components/tahoma/switch.py
@@ -55,7 +55,7 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
 
         # A RTS power socket doesn't have a feedback channel,
         # so we must assume the socket is available.
-        if self.tahoma_device.type in ("rts:OnOffRTSComponent", "zwave:OnOffLightZWaveComponent"):
+        if self.tahoma_device.type in ["rts:OnOffRTSComponent", "zwave:OnOffLightZWaveComponent"]:
             self._available = True
         else:
             self._available = bool(

--- a/homeassistant/components/tahoma/switch.py
+++ b/homeassistant/components/tahoma/switch.py
@@ -47,9 +47,15 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
             else:
                 self._state = STATE_OFF
 
+        if self.tahoma_device.type == "zwave:OnOffLightZWaveComponent":
+            if self.tahoma_device.active_states.get("core:OnOffState") == "on":
+                self._state = STATE_ON
+            else:
+                self._state = STATE_OFF
+				
         # A RTS power socket doesn't have a feedback channel,
         # so we must assume the socket is available.
-        if self.tahoma_device.type == "rts:OnOffRTSComponent":
+        if self.tahoma_device.type in ("rts:OnOffRTSComponent","zwave:OnOffLightZWaveComponent"):
             self._available = True
         else:
             self._available = bool(

--- a/homeassistant/components/tahoma/switch.py
+++ b/homeassistant/components/tahoma/switch.py
@@ -55,7 +55,9 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
 
         # A RTS power socket doesn't have a feedback channel,
         # so we must assume the socket is available.
-        if self.tahoma_device.type in ["rts:OnOffRTSComponent", "zwave:OnOffLightZWaveComponent"]:
+        if self.tahoma_device.type == "rts:OnOffRTSComponent":
+            self._available = True
+        elif  self.tahoma_device.type == "zwave:OnOffLightZWaveComponent":   
             self._available = True
         else:
             self._available = bool(


### PR DESCRIPTION
Add a support of Somfy Tahoma zwave in-wall on/off light module (sku: 1822487) connected to Tahoma box throw zwave dungle (sku: 1822492)

Light can be managed from HA or by wall switch in any combinations

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
