### PR TITLE
Mark config dependency of frontend

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -50,7 +50,6 @@ STAGE_1_INTEGRATIONS = {
     # as possible so problem integrations can
     # be removed
     "frontend",
-    "config",
 }
 
 

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -5,7 +5,6 @@
   "dependencies": [
     "automation",
     "cloud",
-    "config",
     "frontend",
     "history",
     "logbook",

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -6,6 +6,7 @@
   "dependencies": [
     "api",
     "auth",
+    "config",
     "device_automation",
     "http",
     "lovelace",

--- a/homeassistant/components/safe_mode/manifest.json
+++ b/homeassistant/components/safe_mode/manifest.json
@@ -3,6 +3,6 @@
   "name": "Safe Mode",
   "config_flow": false,
   "documentation": "https://www.home-assistant.io/integrations/safe_mode",
-  "dependencies": ["frontend", "config", "persistent_notification", "cloud"],
+  "dependencies": ["frontend", "persistent_notification", "cloud"],
   "codeowners": ["@home-assistant/core"]
 }

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -9,9 +9,8 @@ from typing import Any, Callable, Collection, Dict, Optional, Union
 
 from homeassistant import core, setup
 from homeassistant.const import ATTR_DISCOVERED, ATTR_SERVICE, EVENT_PLATFORM_DISCOVERED
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.loader import DEPENDENCY_BLACKLIST, bind_hass
+from homeassistant.loader import bind_hass
 from homeassistant.util.async_ import run_callback_threadsafe
 
 EVENT_LOAD_PLATFORM = "load_platform.{}"
@@ -79,9 +78,6 @@ async def async_discover(
     hass_config: ConfigType,
 ) -> None:
     """Fire discovery event. Can ensure a component is loaded."""
-    if component in DEPENDENCY_BLACKLIST:
-        raise HomeAssistantError(f"Cannot discover the {component} component.")
-
     if component is not None and component not in hass.config.components:
         await setup.async_setup_component(hass, component, hass_config)
 
@@ -180,9 +176,6 @@ async def async_load_platform(
     This method is a coroutine.
     """
     assert hass_config, "You need to pass in the real hass config"
-
-    if component in DEPENDENCY_BLACKLIST:
-        raise HomeAssistantError(f"Cannot discover the {component} component.")
 
     setup_success = True
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
 
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)  # pylint: disable=invalid-name
 
-DEPENDENCY_BLACKLIST = {"config"}
-
 _LOGGER = logging.getLogger(__name__)
 
 DATA_COMPONENTS = "components"

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -59,17 +59,6 @@ async def _async_process_dependencies(
     hass: core.HomeAssistant, config: ConfigType, name: str, dependencies: List[str]
 ) -> bool:
     """Ensure all dependencies are set up."""
-    blacklisted = [dep for dep in dependencies if dep in loader.DEPENDENCY_BLACKLIST]
-
-    if blacklisted and name not in ("default_config", "safe_mode"):
-        _LOGGER.error(
-            "Unable to set up dependencies of %s: "
-            "found blacklisted dependencies: %s",
-            name,
-            ", ".join(blacklisted),
-        )
-        return False
-
     tasks = [async_setup_component(hass, dep, config) for dep in dependencies]
 
     if not tasks:

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -1,11 +1,8 @@
 """Test discovery helpers."""
 from unittest.mock import patch
 
-import pytest
-
 from homeassistant import setup
 from homeassistant.core import callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 
 from tests.common import (
@@ -216,15 +213,3 @@ class TestHelpersDiscovery:
 
         # test_component will only be setup once
         assert len(component_calls) == 1
-
-
-async def test_load_platform_forbids_config():
-    """Test you cannot setup config component with load_platform."""
-    with pytest.raises(HomeAssistantError):
-        await discovery.async_load_platform(None, "config", "zwave", {}, {"config": {}})
-
-
-async def test_discover_forbids_config():
-    """Test you cannot setup config component with load_platform."""
-    with pytest.raises(HomeAssistantError):
-        await discovery.async_discover(None, None, None, "config", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The config integration will always be loaded if you load the frontend integration. The config panel can no longer be disabled.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Before we had an authentication system, all admin tasks were done via the `config` integration. So as a way of securing your installation, you could disable those APIs. Nowadays this is no longer necessary as we check for admin access. This means that we can mark the `config` integration a dependency of the frontend integration plus clean up the feature that prevented `config` from being marked a dependency.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
