### PR TITLE
Use past tense in messages for already invalidated deprecated configs

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -659,7 +659,7 @@ def deprecated(
         warning = (
             "The '{key}' option is deprecated,"
             " please replace it with '{replacement_key}'."
-            " This option will become invalid in version"
+            " This option {invalidation_status} invalid in version"
             " {invalidation_version}"
         )
     elif replacement_key:
@@ -671,7 +671,7 @@ def deprecated(
         warning = (
             "The '{key}' option is deprecated,"
             " please remove it from your configuration."
-            " This option will become invalid in version"
+            " This option {invalidation_status} invalid in version"
             " {invalidation_version}"
         )
     else:
@@ -690,6 +690,7 @@ def deprecated(
                 warning.format(
                     key=key,
                     replacement_key=replacement_key,
+                    invalidation_status="became",
                     invalidation_version=invalidation_version,
                 )
             )
@@ -702,6 +703,7 @@ def deprecated(
                 warning,
                 key=key,
                 replacement_key=replacement_key,
+                invalidation_status="will become",
                 invalidation_version=invalidation_version,
             )
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -642,8 +642,8 @@ def test_deprecated_with_invalidation_version(caplog, schema, version):
         invalidated_schema(test_data)
     assert str(exc_info.value) == (
         "The 'mars' option is deprecated, "
-        "please remove it from your configuration. This option will "
-        "become invalid in version 0.1.0"
+        "please remove it from your configuration. This option became "
+        "invalid in version 0.1.0"
     )
 
 
@@ -702,7 +702,7 @@ def test_deprecated_with_replacement_key_and_invalidation_version(
         invalidated_schema(test_data)
     assert str(exc_info.value) == (
         "The 'mars' option is deprecated, "
-        "please replace it with 'jupiter'. This option will become "
+        "please replace it with 'jupiter'. This option became "
         "invalid in version 0.1.0"
     )
 
@@ -851,7 +851,7 @@ def test_deprecated_with_replacement_key_invalidation_version_default(
         invalidated_schema(test_data)
     assert str(exc_info.value) == (
         "The 'mars' option is deprecated, "
-        "please replace it with 'jupiter'. This option will become "
+        "please replace it with 'jupiter'. This option became "
         "invalid in version 0.1.0"
     )
 


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix to say "became invalid" if a deprecated option already did, instead of "will become".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
