### PR TITLE
Add icon_type as configuration variable

### DIFF
--- a/homeassistant/components/lametric/notify.py
+++ b/homeassistant/components/lametric/notify.py
@@ -134,7 +134,7 @@ class LaMetricNotificationService(BaseNotificationService):
                 try:
                     lmn.set_device(dev)
                     lmn.send_notification(
-                        model, lifetime=self._lifetime, priority=priority, icon_type=icon_type,
+                        model, lifetime=self._lifetime, priority=priority, icon_type=icon_type
                     )
                     _LOGGER.debug("Sent notification to LaMetric %s", dev["name"])
                 except OSError:

--- a/homeassistant/components/lametric/notify.py
+++ b/homeassistant/components/lametric/notify.py
@@ -54,7 +54,9 @@ def get_service(hass, config, discovery_info=None):
 class LaMetricNotificationService(BaseNotificationService):
     """Implement the notification service for LaMetric."""
 
-    def __init__(self, hasslametricmanager, icon, lifetime, cycles, priority, icon_type):
+    def __init__(
+        self, hasslametricmanager, icon, lifetime, cycles, priority, icon_type
+    ):
         """Initialize the service."""
         self.hasslametricmanager = hasslametricmanager
         self._icon = icon
@@ -134,7 +136,10 @@ class LaMetricNotificationService(BaseNotificationService):
                 try:
                     lmn.set_device(dev)
                     lmn.send_notification(
-                        model, lifetime=self._lifetime, priority=priority, icon_type=icon_type
+                        model,
+                        lifetime=self._lifetime,
+                        priority=priority,
+                        icon_type=icon_type,
                     )
                     _LOGGER.debug("Sent notification to LaMetric %s", dev["name"])
                 except OSError:

--- a/homeassistant/components/lametric/notify.py
+++ b/homeassistant/components/lametric/notify.py
@@ -20,10 +20,12 @@ from . import DOMAIN as LAMETRIC_DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 AVAILABLE_PRIORITIES = ["info", "warning", "critical"]
+AVAILABLE_ICON_TYPES = ["none", "info", "alert"]
 
 CONF_CYCLES = "cycles"
 CONF_LIFETIME = "lifetime"
 CONF_PRIORITY = "priority"
+CONF_ICON_TYPE = "icon_type"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -31,6 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_LIFETIME, default=10): cv.positive_int,
         vol.Optional(CONF_CYCLES, default=1): cv.positive_int,
         vol.Optional(CONF_PRIORITY, default="warning"): vol.In(AVAILABLE_PRIORITIES),
+        vol.Optional(CONF_ICON_TYPE, default="info"): vol.In(AVAILABLE_ICON_TYPES),
     }
 )
 
@@ -44,19 +47,21 @@ def get_service(hass, config, discovery_info=None):
         config[CONF_LIFETIME] * 1000,
         config[CONF_CYCLES],
         config[CONF_PRIORITY],
+        config[CONF_ICON_TYPE],
     )
 
 
 class LaMetricNotificationService(BaseNotificationService):
     """Implement the notification service for LaMetric."""
 
-    def __init__(self, hasslametricmanager, icon, lifetime, cycles, priority):
+    def __init__(self, hasslametricmanager, icon, lifetime, cycles, priority, icon_type):
         """Initialize the service."""
         self.hasslametricmanager = hasslametricmanager
         self._icon = icon
         self._lifetime = lifetime
         self._cycles = cycles
         self._priority = priority
+        self._icon_type = icon_type
         self._devices = []
 
     def send_message(self, message="", **kwargs):
@@ -69,6 +74,7 @@ class LaMetricNotificationService(BaseNotificationService):
         cycles = self._cycles
         sound = None
         priority = self._priority
+        icon_type = self._icon_type
 
         # Additional data?
         if data is not None:
@@ -82,6 +88,15 @@ class LaMetricNotificationService(BaseNotificationService):
                     _LOGGER.error("Sound ID %s unknown, ignoring", data["sound"])
             if "cycles" in data:
                 cycles = int(data["cycles"])
+            if "icon_type" in data:
+                if data["icon_type"] in AVAILABLE_ICON_TYPES:
+                    icon_type = data["icon_type"]
+                else:
+                    _LOGGER.warning(
+                        "Priority %s invalid, using default %s",
+                        data["priority"],
+                        priority,
+                    )
             if "priority" in data:
                 if data["priority"] in AVAILABLE_PRIORITIES:
                     priority = data["priority"]
@@ -91,7 +106,6 @@ class LaMetricNotificationService(BaseNotificationService):
                         data["priority"],
                         priority,
                     )
-
         text_frame = SimpleFrame(icon, message)
         _LOGGER.debug(
             "Icon/Message/Cycles/Lifetime: %s, %s, %d, %d",
@@ -120,7 +134,7 @@ class LaMetricNotificationService(BaseNotificationService):
                 try:
                     lmn.set_device(dev)
                     lmn.send_notification(
-                        model, lifetime=self._lifetime, priority=priority
+                        model, lifetime=self._lifetime, priority=priority, icon_type=icon_type,
                     )
                     _LOGGER.debug("Sent notification to LaMetric %s", dev["name"])
                 except OSError:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

LaMetric notifications display an icon representing the nature of notification before announcing the intended message. This changes adds the ability to modify the icon using `icon_type` to "info" or "alert" or disable it entirely. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
notify:
  name: NOTIFIER_NAME
  platform: lametric
  lifetime: 20
  icon: a7956
  cycles: 3
  priority: info
  icon_type: none
```
You can also use `icon_type` via service data

```yaml
- alias: "Send notification on arrival at school"
  trigger:
    platform: state
    entity_id: device_tracker.son_mobile
    from: 'not_home'
    to: 'school'
  action:
    service: notify.lametric
    data:
      message: "Son has arrived at school!"
      data:
        sound: 'notification'
        icon: 'i51'
        cycles: 0
        priority: 'critical'
        icon_type: none
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36570
- This PR is related to issue: https://community.home-assistant.io/t/lametric-missing-configuration-icon-type/203123
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
