### PR TITLE
Abort other config flows on import

### DIFF
--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -59,6 +59,9 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
             for flow in in_progress:
                 self.hass.config_entries.flow.async_abort(flow["flow_id"])
 
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
         return self.async_create_entry(title=self._title, data={})
 
     async def async_step_discovery(self, discovery_info):
@@ -76,8 +79,13 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_import(self, _):
         """Handle a flow initialized by import."""
-        if self._async_in_progress() or self._async_current_entries():
+        if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
+
+        # Cancel other flows.
+        in_progress = self._async_in_progress()
+        for flow in in_progress:
+            self.hass.config_entries.flow.async_abort(flow["flow_id"])
 
         return self.async_create_entry(title=self._title, data={})
 

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -149,6 +149,27 @@ async def test_only_one_in_progress(hass, discovery_flow_conf):
     assert len(hass.config_entries.flow.async_progress()) == 0
 
 
+async def test_import_abort_discovery(hass, discovery_flow_conf):
+    """Test import will finish and cancel discovered one."""
+    mock_entity_platform(hass, "config_flow.test", None)
+
+    # Discovery starts flow
+    result = await hass.config_entries.flow.async_init(
+        "test", context={"source": config_entries.SOURCE_DISCOVERY}, data={}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    # Start import flow
+    result = await hass.config_entries.flow.async_init(
+        "test", context={"source": config_entries.SOURCE_IMPORT}, data={}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    # Discovery flow has been aborted
+    assert len(hass.config_entries.flow.async_progress()) == 0
+
+
 async def test_import_no_confirmation(hass, discovery_flow_conf):
     """Test import requires no confirmation to set up."""
     flow = config_entries.HANDLERS["test"]()


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't block import of config entry from `configuration.yaml` if devices have already been discovered, instead abort the discovery flow.

Change proposed by @bdraco https://github.com/home-assistant/core/issues/35735#issuecomment-640269281

Symptom described here: https://github.com/home-assistant/core/issues/35735#issuecomment-640118471

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
