### PR TITLE
Set MQTT sensor to state unavailable when value expires

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -181,7 +181,7 @@ class MqttBinarySensor(
                 expiration_at = dt_util.utcnow() + timedelta(seconds=expire_after)
 
                 self._expiration_trigger = async_track_point_in_utc_time(
-                    self.hass, self.value_is_expired, expiration_at
+                    self.hass, self._value_is_expired, expiration_at
                 )
 
             value_template = self._config.get(CONF_VALUE_TEMPLATE)
@@ -250,7 +250,7 @@ class MqttBinarySensor(
         await MqttDiscoveryUpdate.async_will_remove_from_hass(self)
 
     @callback
-    def value_is_expired(self, *_):
+    def _value_is_expired(self, *_):
         """Triggered when value is expired."""
 
         self._expiration_trigger = None

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -274,14 +274,6 @@ class MqttBinarySensor(
         return self._state
 
     @property
-    def state(self):
-        """Return the state of the binary sensor."""
-        if self._expired:
-            return None
-
-        return super().state
-
-    @property
     def device_class(self):
         """Return the class of this sensor."""
         return self._config.get(CONF_DEVICE_CLASS)
@@ -295,3 +287,12 @@ class MqttBinarySensor(
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
+
+    @property
+    def available(self) -> bool:
+        """Return true if the device is available and value has not expired."""
+        expire_after = self._config.get(CONF_EXPIRE_AFTER)
+        # pylint: disable=no-member
+        return MqttAvailability.available.fget(self) and (
+            expire_after is None or not self._expired
+        )

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -274,6 +274,14 @@ class MqttBinarySensor(
         return self._state
 
     @property
+    def state(self):
+        """Return the state of the binary sensor."""
+        if self._expired:
+            return None
+
+        return super().state
+
+    @property
     def device_class(self):
         """Return the class of this sensor."""
         return self._config.get(CONF_DEVICE_CLASS)
@@ -287,12 +295,3 @@ class MqttBinarySensor(
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    @property
-    def available(self) -> bool:
-        """Return true if the device is available and value has not expired."""
-        expire_after = self._config.get(CONF_EXPIRE_AFTER)
-        # pylint: disable=no-member
-        return MqttAvailability.available.fget(self) and (
-            expire_after is None or not self._expired
-        )

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -78,9 +77,9 @@ async def test_setting_sensor_value_expires_availability_topic(
 
     async_fire_mqtt_message(hass, "availability-topic", "online")
 
-    # State should be unknown since expire_after is defined and > 0
+    # State should be unavailable since expire_after is defined and > 0
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_UNAVAILABLE
 
     await expires_helper(hass, mqtt_mock, caplog)
 
@@ -104,9 +103,9 @@ async def test_setting_sensor_value_expires(
     )
     await hass.async_block_till_done()
 
-    # State should be unknown since expire_after is defined and > 0
+    # State should be unavailable since expire_after is defined and > 0
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_UNAVAILABLE
 
     await expires_helper(hass, mqtt_mock, caplog)
 
@@ -158,7 +157,7 @@ async def expires_helper(hass, mqtt_mock, caplog):
 
     # Value is expired now
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
@@ -619,9 +618,9 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
         )
         await hass.async_block_till_done()
 
-    # Test that binary_sensor state is unknown
+    # Test that binary_sensor is not available
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_UNAVAILABLE
 
     # Publish state message
     with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
@@ -662,7 +661,7 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
 
     # Test that binary_sensor has expired
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_UNAVAILABLE
 
     # Resend config message to update discovery
     with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
@@ -673,7 +672,7 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
 
     # Test that binary_sensor is still expired
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_UNAVAILABLE
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -77,9 +78,9 @@ async def test_setting_sensor_value_expires_availability_topic(
 
     async_fire_mqtt_message(hass, "availability-topic", "online")
 
-    # State should be unavailable since expire_after is defined and > 0
+    # State should be unknown since expire_after is defined and > 0
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
     await expires_helper(hass, mqtt_mock, caplog)
 
@@ -103,9 +104,9 @@ async def test_setting_sensor_value_expires(
     )
     await hass.async_block_till_done()
 
-    # State should be unavailable since expire_after is defined and > 0
+    # State should be unknown since expire_after is defined and > 0
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
     await expires_helper(hass, mqtt_mock, caplog)
 
@@ -157,7 +158,7 @@ async def expires_helper(hass, mqtt_mock, caplog):
 
     # Value is expired now
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
@@ -618,9 +619,9 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
         )
         await hass.async_block_till_done()
 
-    # Test that binary_sensor is not available
+    # Test that binary_sensor state is unknown
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
     # Publish state message
     with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
@@ -661,7 +662,7 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
 
     # Test that binary_sensor has expired
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
     # Resend config message to update discovery
     with patch(("homeassistant.helpers.event.dt_util.utcnow"), return_value=now):
@@ -672,7 +673,7 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
 
     # Test that binary_sensor is still expired
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.no_fail_on_log_exception


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`mqtt.sensor` will be set to STATE_UNAVAILABLE instead of STATE_UNKNOWN when value expires.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set MQTT sensor to state STATE_UNAVAILABLE when value expires.

Background:
PR #26058 introduced `expire_after` for `mqtt.binary_sensor` similar to the functionality already available in `mqtt.sensor`.

The difference is that MQTT  binary_sensor reports state `STATE_UNAVAILABLE` while the sensor reports `STATE_UNKNOWN`.
This PR aligns the behavior to also set MQTT sensor to state `STATE_UNAVAILABLE` when the value expires.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
