### PR TITLE
Update sun and moon, to user Astral 2.2

### DIFF
--- a/homeassistant/components/moon/sensor.py
+++ b/homeassistant/components/moon/sensor.py
@@ -1,7 +1,7 @@
 """Support for tracking the moon phases."""
 import logging
 
-from astral import Astral
+from astral import moon
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -91,4 +91,4 @@ class MoonSensor(Entity):
     async def async_update(self):
         """Get the time and updates the states."""
         today = dt_util.as_local(dt_util.utcnow()).date()
-        self._state = Astral().moon_phase(today)
+        self._state = moon.phase(today)

--- a/homeassistant/helpers/sun.py
+++ b/homeassistant/helpers/sun.py
@@ -1,6 +1,6 @@
 """Helpers for sun events."""
 import datetime
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
 from homeassistant.core import callback
@@ -14,28 +14,33 @@ if TYPE_CHECKING:
 
 DATA_LOCATION_CACHE = "astral_location_cache"
 
+ELEVATION_AGNOSTIC_EVENTS = ("noon", "midnight")
+
 
 @callback
 @bind_hass
-def get_astral_location(hass: HomeAssistantType) -> "astral.Location":
+def get_astral_location(
+    hass: HomeAssistantType,
+) -> Tuple["astral.location.Location", "astral.Elevation"]:
     """Get an astral location for the current Home Assistant configuration."""
 
-    from astral import Location  # pylint: disable=import-outside-toplevel
+    from astral import LocationInfo  # pylint: disable=import-outside-toplevel
+    from astral.location import Location  # pylint: disable=import-outside-toplevel
 
+    timezone = str(hass.config.time_zone)
     latitude = hass.config.latitude
     longitude = hass.config.longitude
-    timezone = str(hass.config.time_zone)
     elevation = hass.config.elevation
-    info = ("", "", latitude, longitude, timezone, elevation)
+    info = ("", "", timezone, latitude, longitude)
 
     # Cache astral locations so they aren't recreated with the same args
     if DATA_LOCATION_CACHE not in hass.data:
         hass.data[DATA_LOCATION_CACHE] = {}
 
     if info not in hass.data[DATA_LOCATION_CACHE]:
-        hass.data[DATA_LOCATION_CACHE][info] = Location(info)
+        hass.data[DATA_LOCATION_CACHE][info] = Location(LocationInfo(*info))
 
-    return hass.data[DATA_LOCATION_CACHE][info]
+    return hass.data[DATA_LOCATION_CACHE][info], elevation
 
 
 @callback
@@ -47,25 +52,30 @@ def get_astral_event_next(
     offset: Optional[datetime.timedelta] = None,
 ) -> datetime.datetime:
     """Calculate the next specified solar event."""
-    location = get_astral_location(hass)
-    return get_location_astral_event_next(location, event, utc_point_in_time, offset)
+    location, elevation = get_astral_location(hass)
+    return get_location_astral_event_next(
+        location, elevation, event, utc_point_in_time, offset
+    )
 
 
 @callback
 def get_location_astral_event_next(
-    location: "astral.Location",
+    location: "astral.location.Location",
+    elevation: "astral.Elevation",
     event: str,
     utc_point_in_time: Optional[datetime.datetime] = None,
     offset: Optional[datetime.timedelta] = None,
 ) -> datetime.datetime:
     """Calculate the next specified solar event."""
-    from astral import AstralError  # pylint: disable=import-outside-toplevel
-
     if offset is None:
         offset = datetime.timedelta()
 
     if utc_point_in_time is None:
         utc_point_in_time = dt_util.utcnow()
+
+    kwargs = {"local": False}
+    if event not in ELEVATION_AGNOSTIC_EVENTS:
+        kwargs["observer_elevation"] = elevation
 
     mod = -1
     while True:
@@ -74,13 +84,13 @@ def get_location_astral_event_next(
                 getattr(location, event)(
                     dt_util.as_local(utc_point_in_time).date()
                     + datetime.timedelta(days=mod),
-                    local=False,
+                    **kwargs,
                 )
                 + offset
             )
             if next_dt > utc_point_in_time:
                 return next_dt
-        except AstralError:
+        except ValueError:
             pass
         mod += 1
 
@@ -93,9 +103,7 @@ def get_astral_event_date(
     date: Union[datetime.date, datetime.datetime, None] = None,
 ) -> Optional[datetime.datetime]:
     """Calculate the astral event time for the specified date."""
-    from astral import AstralError  # pylint: disable=import-outside-toplevel
-
-    location = get_astral_location(hass)
+    location, elevation = get_astral_location(hass)
 
     if date is None:
         date = dt_util.now().date()
@@ -103,9 +111,13 @@ def get_astral_event_date(
     if isinstance(date, datetime.datetime):
         date = dt_util.as_local(date).date()
 
+    kwargs = {"local": False}
+    if event not in ELEVATION_AGNOSTIC_EVENTS:
+        kwargs["observer_elevation"] = elevation
+
     try:
-        return getattr(location, event)(date, local=False)  # type: ignore
-    except AstralError:
+        return getattr(location, event)(date, **kwargs)  # type: ignore
+    except ValueError:
         # Event never occurs for specified date.
         return None
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -2,7 +2,7 @@ PyJWT==1.7.1
 PyNaCl==1.3.0
 aiohttp==3.6.1
 aiohttp_cors==0.7.0
-astral==1.10.1
+astral==2.2
 async_timeout==3.0.1
 attrs==19.3.0
 bcrypt==3.1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,6 +1,6 @@
 # Home Assistant core
 aiohttp==3.6.1
-astral==1.10.1
+astral==2.2
 async_timeout==3.0.1
 attrs==19.3.0
 bcrypt==3.1.7

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ PACKAGES = find_packages(exclude=["tests", "tests.*"])
 
 REQUIRES = [
     "aiohttp==3.6.1",
-    "astral==1.10.1",
+    "astral==2.2",
     "async_timeout==3.0.1",
     "attrs==19.3.0",
     "bcrypt==3.1.7",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change updates the sun and moon components to use the new python-astral 2.x api. This also updates the corresponding requirements, to reflect these changes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sun:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36636
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
