### PR TITLE
Xiaomi Miio gateway: add ip to zeroconf discovery title

### DIFF
--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -67,7 +67,9 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
             # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-            self.context.update({"title_placeholders": {"name": f"Gateway {self.host}"}})
+            self.context.update(
+                {"title_placeholders": {"name": f"Gateway {self.host}"}}
+            )
 
             return await self.async_step_gateway()
 

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -66,6 +66,9 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
+            # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
+            self.context.update({"title_placeholders": {"name": self.host}})
+
             return await self.async_step_gateway()
 
         # Discovered device is not yet supported

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -67,7 +67,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
             # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-            self.context.update({"title_placeholders": {"name": self.host}})
+            self.context.update({"title_placeholders": {"name": f"Gateway {self.host}"}})
 
             return await self.async_step_gateway()
 

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Xiaomi Miio: {name}",
     "step": {
       "user": {
         "title": "Xiaomi Miio",

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -11,7 +11,7 @@
       },
       "gateway": {
         "title": "Connect to a Xiaomi Gateway",
-        "description": "You will need the API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions.",
+        "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Note that this token is diffrent from the key used by the xiaomi_aqara integration",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]",
           "token": "API Token",

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -11,7 +11,7 @@
       },
       "gateway": {
         "title": "Connect to a Xiaomi Gateway",
-        "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Note that this token is diffrent from the key used by the xiaomi_aqara integration",
+        "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Please note, that this token is different from the key used by the Xiaomi Aqara integration.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]",
           "token": "API Token",

--- a/homeassistant/components/xiaomi_miio/translations/en.json
+++ b/homeassistant/components/xiaomi_miio/translations/en.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "flow_title": "Xiaomi Miio: {name}",
         "abort": {
             "already_configured": "Device is already configured",
             "already_in_progress": "Config flow for this Xiaomi Miio device is already in progress."

--- a/homeassistant/components/xiaomi_miio/translations/en.json
+++ b/homeassistant/components/xiaomi_miio/translations/en.json
@@ -16,7 +16,7 @@
                     "name": "Name of the Gateway",
                     "token": "API Token"
                 },
-                "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Note that this token is diffrent from the key used by the xiaomi_aqara integration",
+                "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Please note, that this token is different from the key used by the Xiaomi Aqara integration.",
                 "title": "Connect to a Xiaomi Gateway"
             },
             "user": {

--- a/homeassistant/components/xiaomi_miio/translations/en.json
+++ b/homeassistant/components/xiaomi_miio/translations/en.json
@@ -16,7 +16,7 @@
                     "name": "Name of the Gateway",
                     "token": "API Token"
                 },
-                "description": "You will need the API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions.",
+                "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Note that this token is diffrent from the key used by the xiaomi_aqara integration",
                 "title": "Connect to a Xiaomi Gateway"
             },
             "user": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This adds the IP to the zeroconf discovery title of the xiaomi miio integration when discovering an xiaomi aqara gateway.
This is needed for users that have multiple gateways to identify which gateway needs which token.

It also clearifys the config flow gateway step: the token is a 32 char token and is diffrent from the xiaomi_aqara integration, after getting lots of "issues" about people that were confused by the key of the xiaomi_aqara integration.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Config Flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/36630 & https://github.com/home-assistant/core/issues/36601
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
