### PR TITLE
Fix threading issue with mcp23017 platform

### DIFF
--- a/homeassistant/components/mcp23017/__init__.py
+++ b/homeassistant/components/mcp23017/__init__.py
@@ -1,3 +1,45 @@
 """Support for I2C MCP23017 chip."""
 
+import threading
+
 DOMAIN = "mcp23017"
+
+
+class DeviceList:
+    """Lockable device dictionary.
+
+    This class enables thread-safe usage of multiple:
+    - components within one device (unique initialization for each device iso for each component)
+    - devices within a system (WAR: adafruit_bus_device.I3CDevice using thread-unsafe Lockable.try_lock() from adafruit_blinka)
+    """
+
+    def __init__(self):
+        """Initialize the device dictionary and associated lock."""
+        self._lock = threading.Lock()
+        self._instances = {}
+
+    def __enter__(self):
+        """Acquire dictionary lock."""
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        """Release dictionary lock."""
+        self._lock.release()
+
+    def __contains__(self, key):
+        """Handle 'in' operator."""
+        return key in self._instances
+
+    def __getitem__(self, key):
+        """Handle 'object[key]' operation."""
+        if key not in self._instances:
+            return None
+        return self._instances[key]
+
+    def __setitem__(self, key, value):
+        """Handle 'object[key]=value' operation."""
+        self._instances[key] = value
+
+
+DEVICES = DeviceList()

--- a/homeassistant/components/mcp23017/switch.py
+++ b/homeassistant/components/mcp23017/switch.py
@@ -7,6 +7,7 @@ import busio  # pylint: disable=import-error
 import digitalio  # pylint: disable=import-error
 import voluptuous as vol
 
+from homeassistant.components.mcp23017 import DEVICES as mcp23017Dict
 from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
@@ -39,7 +40,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     i2c_address = config.get(CONF_I2C_ADDRESS)
 
     i2c = busio.I2C(board.SCL, board.SDA)
-    mcp = MCP23017(i2c, address=i2c_address)
+
+    with mcp23017Dict:  # Protect global variable access
+        if i2c_address not in mcp23017Dict:
+            mcp23017Dict[i2c_address] = MCP23017(i2c, address=i2c_address)
+
+    mcp = mcp23017Dict[i2c_address]
 
     switches = []
     pins = config.get(CONF_PINS)
@@ -59,8 +65,9 @@ class MCP23017Switch(ToggleEntity):
         self._invert_logic = invert_logic
         self._state = False
 
-        self._pin.direction = digitalio.Direction.OUTPUT
-        self._pin.value = self._invert_logic
+        with mcp23017Dict:  # Protect device HW access
+            self._pin.direction = digitalio.Direction.OUTPUT
+            self._pin.value = self._invert_logic
 
     @property
     def name(self):
@@ -84,12 +91,14 @@ class MCP23017Switch(ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        self._pin.value = not self._invert_logic
+        with mcp23017Dict:  # Protect device HW access
+            self._pin.value = not self._invert_logic
         self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        self._pin.value = self._invert_logic
+        with mcp23017Dict:  # Protect device HW access
+            self._pin.value = self._invert_logic
         self._state = False
         self.schedule_update_ha_state()


### PR DESCRIPTION
Fixing threading issue with mcp23017 platform when:
- multiple integration are instantiated within a single device
- multiple devices are instantiated

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cfr. #31867

Addition of a lockable device dictionnary for mcp23017 components enabling thread-safe usage of multiple:
- components within one device (unique device initialization)
- devices within a system

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Instantiate two MCP23017 (I2C addresses 0x26 and 0x27) each configured as 8 binary_sensor inputs and 8 switch outputs
binary_sensor:
  - platform: mcp23017
    i2c_address: 0x26
    scan_interval: 1
    invert_logic: true
    pins:
      8 : Button_0
      9 : Button_1
      10: Button_2
      11: Button_3
      12: Button_4
      13: Button_5
      14: Button_6
      15: Button_7
  - platform: mcp23017
    i2c_address: 0x27
    scan_interval: 1
    invert_logic: true
    pins:
      8 : Button_10
      9 : Button_11
      10: Button_12
      11: Button_13
      12: Button_14
      13: Button_15
      14: Button_16
      15: Button_17

switch:
  - platform: mcp23017
    i2c_address: 0x26
    pins:
      0 : Output_0
      1 : Output_1
      2 : Output_2
      3 : Output_3
      4 : Output_4
      5 : Output_5
      6 : Output_6
      7 : Output_7
  - platform: mcp23017
    i2c_address: 0x27
    pins:
      0 : Output_10
      1 : Output_11
      2 : Output_12
      3 : Output_13
      4 : Output_14
      5 : Output_15
      6 : Output_16
      7 : Output_17
```
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31867
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] Local tests pass. **Your PR cannot be merged unless tests pass**
Tested with two MCP23017 each configured as a mix of binary_sensor and switch (4 active threads)
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
