### PR TITLE
Fix nightlight support detection

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -239,11 +239,12 @@ class YeelightDevice:
 
     @property
     def is_nightlight_supported(self) -> bool:
-        """Return true / false if nightlight is supported."""
-        if self.model:
-            return self.bulb.get_model_specs().get("night_light", False)
+        """
+        Return true / false if nightlight is supported.
 
-        # It should support both ceiling and other lights
+        Uses brightness as it appears to be supported in both ceiling and other lights.
+        """
+
         return self._nightlight_brightness is not None
 
     @property
@@ -333,6 +334,12 @@ class YeelightDevice:
         """Request device capabilities."""
         try:
             self.bulb.get_capabilities()
+            _LOGGER.debug(
+                "Device %s, %s capabilities: %s",
+                self.ipaddr,
+                self.name,
+                self.bulb.capabilities,
+            )
         except BulbException as ex:
             _LOGGER.error(
                 "Unable to get device capabilities %s, %s: %s",


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Skip check from model specs, for nightlight support. It was added previously, to add offline devices correctly ( if configured model type supported nightlight, it was added ). Now after supporting unique_id we don't have to do that, and we should fall back to query device about its properties.

It would be good to include it in 0.111.1 , as it fixes regression from 0.111.0 in some cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Before using device capabilities, if model was not set, removed if was false, as model was not set. Now model is always set, because of get_capabilities call, populating device model ( https://gitlab.com/stavros/python-yeelight/-/blob/master/yeelight/main.py#L344 ). So if model was not described here: https://gitlab.com/stavros/python-yeelight/-/blob/master/yeelight/main.py#L29 , for supporting night light, it was assumed to not support nightlight, even when model was not set by hand.

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/36652
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
