### PR TITLE
Remove powerwall attributes no longer present in latest firmware

### DIFF
--- a/homeassistant/components/powerwall/binary_sensor.py
+++ b/homeassistant/components/powerwall/binary_sensor.py
@@ -11,9 +11,6 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import DEVICE_CLASS_POWER
 
 from .const import (
-    ATTR_GRID_CODE,
-    ATTR_NOMINAL_SYSTEM_POWER,
-    ATTR_REGION,
     DOMAIN,
     POWERWALL_API_DEVICE_TYPE,
     POWERWALL_API_GRID_STATUS,
@@ -78,15 +75,6 @@ class PowerWallRunningSensor(PowerWallEntity, BinarySensorEntity):
     def is_on(self):
         """Get the powerwall running state."""
         return self._coordinator.data[POWERWALL_API_SITEMASTER].running
-
-    @property
-    def device_state_attributes(self):
-        """Return the device specific state attributes."""
-        return {
-            ATTR_REGION: self._site_info.region,
-            ATTR_GRID_CODE: self._site_info.grid_code,
-            ATTR_NOMINAL_SYSTEM_POWER: self._site_info.nominal_system_power_kW,
-        }
 
 
 class PowerWallConnectedSensor(PowerWallEntity, BinarySensorEntity):

--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -8,13 +8,10 @@ POWERWALL_API_CHANGED = "api_changed"
 
 UPDATE_INTERVAL = 30
 
-ATTR_REGION = "region"
-ATTR_GRID_CODE = "grid_code"
 ATTR_FREQUENCY = "frequency"
 ATTR_ENERGY_EXPORTED = "energy_exported_(in_kW)"
 ATTR_ENERGY_IMPORTED = "energy_imported_(in_kW)"
 ATTR_INSTANT_AVERAGE_VOLTAGE = "instant_average_voltage"
-ATTR_NOMINAL_SYSTEM_POWER = "nominal_system_power_kW"
 ATTR_IS_ACTIVE = "is_active"
 
 STATUS_VERSION = "version"

--- a/tests/components/powerwall/test_binary_sensor.py
+++ b/tests/components/powerwall/test_binary_sensor.py
@@ -33,9 +33,6 @@ async def test_sensors(hass):
     state = hass.states.get("binary_sensor.powerwall_status")
     assert state.state == STATE_ON
     expected_attributes = {
-        "region": "IEEE1547a:2014",
-        "grid_code": "60Hz_240V_s_IEEE1547a_2014",
-        "nominal_system_power_kW": 25,
         "friendly_name": "Powerwall Status",
         "device_class": "power",
     }


### PR DESCRIPTION
Currently the integration fails to setup on 1.47 US systems

Tesla removed these attributes on some 1.47 systems which broke everything for the US region after update.  These were nice to haves that are not strictly needed so we can remove them.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove powerwall attributes no longer present in latest firmware
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
