### PR TITLE
Drop ZHA sensor for Analog/Multistate input clusters

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -3,6 +3,8 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import zigpy.zcl.clusters.closures
+
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -280,9 +282,10 @@ class ChannelPool:
             # incorrectly.
             if (
                 hasattr(cluster, "ep_attribute")
+                and cluster_id == zigpy.zcl.clusters.closures.DoorLock.cluster_id
                 and cluster.ep_attribute == "multistate_input"
             ):
-                channel_class = base.ZigbeeChannel
+                channel_class = general.MultistateInput
             # end of ugly hack
             channel = channel_class(cluster, self)
             if channel.name == const.CHANNEL_POWER_CONFIGURATION:

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -25,11 +25,9 @@ from homeassistant.util.temperature import fahrenheit_to_celsius
 
 from .core import discovery
 from .core.const import (
-    CHANNEL_ANALOG_INPUT,
     CHANNEL_ELECTRICAL_MEASUREMENT,
     CHANNEL_HUMIDITY,
     CHANNEL_ILLUMINANCE,
-    CHANNEL_MULTISTATE_INPUT,
     CHANNEL_POWER_CONFIGURATION,
     CHANNEL_PRESSURE,
     CHANNEL_SMARTENERGY_METERING,
@@ -153,13 +151,6 @@ class Sensor(ZhaEntity):
         return round(float(value * self._multiplier) / self._divisor)
 
 
-@STRICT_MATCH(channel_names=CHANNEL_ANALOG_INPUT)
-class AnalogInput(Sensor):
-    """Sensor that displays analog input values."""
-
-    SENSOR_ATTR = "present_value"
-
-
 @STRICT_MATCH(channel_names=CHANNEL_POWER_CONFIGURATION)
 class Battery(Sensor):
     """Battery sensor of power configuration cluster."""
@@ -218,18 +209,6 @@ class ElectricalMeasurement(Sensor):
         if value < 100 and self._channel.divisor > 1:
             return round(value, self._decimals)
         return round(value)
-
-
-@STRICT_MATCH(channel_names=CHANNEL_MULTISTATE_INPUT)
-class Text(Sensor):
-    """Sensor that displays string values."""
-
-    _device_class = None
-    _unit = None
-
-    def formatter(self, value) -> str:
-        """Return string value."""
-        return value
 
 
 @STRICT_MATCH(generic_ids=CHANNEL_ST_HUMIDITY_CLUSTER)

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -1372,8 +1372,6 @@ DEVICES = [
             },
         },
         "entities": [
-            "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
-            "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement",
             "switch.lumi_lumi_plug_maus01_77665544_on_off",
         ],
@@ -1387,16 +1385,6 @@ DEVICES = [
                 "channels": ["electrical_measurement"],
                 "entity_class": "ElectricalMeasurement",
                 "entity_id": "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-2-12"): {
-                "channels": ["analog_input"],
-                "entity_class": "AnalogInput",
-                "entity_id": "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-3-12"): {
-                "channels": ["analog_input"],
-                "entity_class": "AnalogInput",
-                "entity_id": "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
             },
         },
         "event_channels": ["1:0x0019"],
@@ -1426,7 +1414,6 @@ DEVICES = [
         "entities": [
             "light.lumi_lumi_relay_c2acn01_77665544_on_off",
             "light.lumi_lumi_relay_c2acn01_77665544_on_off_2",
-            "sensor.lumi_lumi_relay_c2acn01_77665544_analog_input",
             "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement",
         ],
         "entity_map": {
@@ -1434,11 +1421,6 @@ DEVICES = [
                 "channels": ["on_off"],
                 "entity_class": "Light",
                 "entity_id": "light.lumi_lumi_relay_c2acn01_77665544_on_off",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-12"): {
-                "channels": ["analog_input"],
-                "entity_class": "AnalogInput",
-                "entity_id": "sensor.lumi_lumi_relay_c2acn01_77665544_analog_input",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 "channels": ["electrical_measurement"],
@@ -1482,32 +1464,12 @@ DEVICES = [
                 "profile_id": 260,
             },
         },
-        "entities": [
-            "sensor.lumi_lumi_remote_b186acn01_77665544_multistate_input",
-            "sensor.lumi_lumi_remote_b186acn01_77665544_multistate_input_2",
-            "sensor.lumi_lumi_remote_b186acn01_77665544_multistate_input_3",
-            "sensor.lumi_lumi_remote_b186acn01_77665544_power",
-        ],
+        "entities": ["sensor.lumi_lumi_remote_b186acn01_77665544_power"],
         "entity_map": {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],
                 "entity_class": "Battery",
                 "entity_id": "sensor.lumi_lumi_remote_b186acn01_77665544_power",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_remote_b186acn01_77665544_multistate_input_2",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-2-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_remote_b186acn01_77665544_multistate_input_3",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-3-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_remote_b186acn01_77665544_multistate_input",
             },
         },
         "event_channels": ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
@@ -1541,32 +1503,12 @@ DEVICES = [
                 "profile_id": 260,
             },
         },
-        "entities": [
-            "sensor.lumi_lumi_remote_b286acn01_77665544_multistate_input",
-            "sensor.lumi_lumi_remote_b286acn01_77665544_multistate_input_2",
-            "sensor.lumi_lumi_remote_b286acn01_77665544_multistate_input_3",
-            "sensor.lumi_lumi_remote_b286acn01_77665544_power",
-        ],
+        "entities": ["sensor.lumi_lumi_remote_b286acn01_77665544_power"],
         "entity_map": {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],
                 "entity_class": "Battery",
                 "entity_id": "sensor.lumi_lumi_remote_b286acn01_77665544_power",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_remote_b286acn01_77665544_multistate_input_3",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-2-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_remote_b286acn01_77665544_multistate_input_2",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-3-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_remote_b286acn01_77665544_multistate_input",
             },
         },
         "event_channels": ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
@@ -1897,32 +1839,12 @@ DEVICES = [
                 "profile_id": 260,
             },
         },
-        "entities": [
-            "sensor.lumi_lumi_sensor_86sw1_77665544_multistate_input",
-            "sensor.lumi_lumi_sensor_86sw1_77665544_multistate_input_2",
-            "sensor.lumi_lumi_sensor_86sw1_77665544_multistate_input_3",
-            "sensor.lumi_lumi_sensor_86sw1_77665544_power",
-        ],
+        "entities": ["sensor.lumi_lumi_sensor_86sw1_77665544_power"],
         "entity_map": {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],
                 "entity_class": "Battery",
                 "entity_id": "sensor.lumi_lumi_sensor_86sw1_77665544_power",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_sensor_86sw1_77665544_multistate_input_3",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-2-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_sensor_86sw1_77665544_multistate_input_2",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-3-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_sensor_86sw1_77665544_multistate_input",
             },
         },
         "event_channels": ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
@@ -1956,26 +1878,12 @@ DEVICES = [
                 "profile_id": 260,
             },
         },
-        "entities": [
-            "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_analog_input",
-            "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_multistate_input",
-            "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power",
-        ],
+        "entities": ["sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power"],
         "entity_map": {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],
                 "entity_class": "Battery",
                 "entity_id": "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-2-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_multistate_input",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-3-12"): {
-                "channels": ["analog_input"],
-                "entity_class": "AnalogInput",
-                "entity_id": "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_analog_input",
             },
         },
         "event_channels": ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
@@ -2161,8 +2069,6 @@ DEVICES = [
         },
         "entities": [
             "binary_sensor.lumi_lumi_sensor_smoke_77665544_ias_zone",
-            "sensor.lumi_lumi_sensor_smoke_77665544_analog_input",
-            "sensor.lumi_lumi_sensor_smoke_77665544_multistate_input",
             "sensor.lumi_lumi_sensor_smoke_77665544_power",
         ],
         "entity_map": {
@@ -2170,16 +2076,6 @@ DEVICES = [
                 "channels": ["power"],
                 "entity_class": "Battery",
                 "entity_id": "sensor.lumi_lumi_sensor_smoke_77665544_power",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-12"): {
-                "channels": ["analog_input"],
-                "entity_class": "AnalogInput",
-                "entity_id": "sensor.lumi_lumi_sensor_smoke_77665544_analog_input",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_sensor_smoke_77665544_multistate_input",
             },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 "channels": ["ias_zone"],
@@ -2254,20 +2150,12 @@ DEVICES = [
                 "profile_id": 260,
             }
         },
-        "entities": [
-            "sensor.lumi_lumi_sensor_switch_aq3_77665544_multistate_input",
-            "sensor.lumi_lumi_sensor_switch_aq3_77665544_power",
-        ],
+        "entities": ["sensor.lumi_lumi_sensor_switch_aq3_77665544_power"],
         "entity_map": {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 "channels": ["power"],
                 "entity_class": "Battery",
                 "entity_id": "sensor.lumi_lumi_sensor_switch_aq3_77665544_power",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-18"): {
-                "channels": ["multistate_input"],
-                "entity_class": "Text",
-                "entity_id": "sensor.lumi_lumi_sensor_switch_aq3_77665544_multistate_input",
             },
         },
         "event_channels": ["1:0x0006"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Yes. Drop ZHA sensors corresponding to `AnalogInput` and `MultistateInput` Zigbee clusters. Mostly seen in aqara vibration/cube devices which are pretty much stateless. So remove entities and rely on `zha_events` instead. 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop ZHA sensors corresponding to `AnalogInput` and `MultistateInput` Zigbee clusters. The way they are used right now is stateless and `zha_events` is a better way of handling it.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zigpy/zha-device-handlers/issues/372
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
