### PR TITLE
Allow activity change on start of switching activity

### DIFF
--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, HARMONY_OPTIONS_UPDATE, PLATFORMS
+from .const import ATTR_ACTIVITY_NOTIFY, DOMAIN, HARMONY_OPTIONS_UPDATE, PLATFORMS
 from .remote import HarmonyRemote
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,11 +38,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     name = entry.data[CONF_NAME]
     activity = entry.options.get(ATTR_ACTIVITY)
     delay_secs = entry.options.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
+    activity_notify = entry.options.get(ATTR_ACTIVITY_NOTIFY, False)
 
     harmony_conf_file = hass.config.path(f"harmony_{entry.unique_id}.conf")
     try:
         device = HarmonyRemote(
-            name, entry.unique_id, address, activity, harmony_conf_file, delay_secs
+            name,
+            entry.unique_id,
+            address,
+            activity,
+            harmony_conf_file,
+            delay_secs,
+            activity_notify,
         )
         connected_ok = await device.connect()
     except (asyncio.TimeoutError, ValueError, AttributeError):
@@ -67,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 def _async_import_options_from_data_if_missing(hass: HomeAssistant, entry: ConfigEntry):
     options = dict(entry.options)
     modified = 0
-    for importable_option in [ATTR_ACTIVITY, ATTR_DELAY_SECS]:
+    for importable_option in [ATTR_ACTIVITY, ATTR_DELAY_SECS, ATTR_ACTIVITY_NOTIFY]:
         if importable_option not in entry.options and importable_option in entry.data:
             options[importable_option] = entry.data[importable_option]
             modified = 1

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 def _async_import_options_from_data_if_missing(hass: HomeAssistant, entry: ConfigEntry):
     options = dict(entry.options)
     modified = 0
-    for importable_option in [ATTR_ACTIVITY, ATTR_DELAY_SECS, ATTR_ACTIVITY_NOTIFY]:
+    for importable_option in [ATTR_ACTIVITY, ATTR_DELAY_SECS]:
         if importable_option not in entry.options and importable_option in entry.data:
             options[importable_option] = entry.data[importable_option]
             modified = 1

--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.components.remote import (
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import callback
 
-from .const import DOMAIN, UNIQUE_ID
+from .const import ATTR_ACTIVITY_NOTIFY, DOMAIN, UNIQUE_ID
 from .util import (
     find_best_name_for_remote,
     find_unique_id_for_remote,
@@ -162,6 +162,8 @@ def _options_from_user_input(user_input):
         options[ATTR_ACTIVITY] = user_input[ATTR_ACTIVITY]
     if ATTR_DELAY_SECS in user_input:
         options[ATTR_DELAY_SECS] = user_input[ATTR_DELAY_SECS]
+    if ATTR_ACTIVITY_NOTIFY in user_input:
+        options[ATTR_ACTIVITY_NOTIFY] = user_input[ATTR_ACTIVITY_NOTIFY]
     return options
 
 
@@ -190,6 +192,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     ATTR_ACTIVITY, default=self.config_entry.options.get(ATTR_ACTIVITY),
                 ): vol.In(remote.activity_names),
+                vol.Optional(
+                    ATTR_ACTIVITY_NOTIFY,
+                    default=self.config_entry.options.get(ATTR_ACTIVITY_NOTIFY, False),
+                ): vol.Coerce(bool),
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -6,3 +6,4 @@ PLATFORMS = ["remote"]
 UNIQUE_ID = "unique_id"
 ACTIVITY_POWER_OFF = "PowerOff"
 HARMONY_OPTIONS_UPDATE = "harmony_options_update"
+ATTR_ACTIVITY_NOTIFY = "activity_notify"

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -2,7 +2,7 @@
   "domain": "harmony",
   "name": "Logitech Harmony Hub",
   "documentation": "https://www.home-assistant.io/integrations/harmony",
-  "requirements": ["aioharmony==0.2.4"],
+  "requirements": ["aioharmony==0.2.5"],
   "codeowners": ["@ehendrix23", "@bramkragten", "@bdraco"],
   "ssdp": [
     {

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -170,6 +170,8 @@ class HarmonyRemote(remote.RemoteEntity):
             "config_updated": self.new_config,
             "connect": self.got_connected,
             "disconnect": self.got_disconnected,
+            "new_activity_starting": None,
+            "new_activity": None,
         }
         if self._activity_notify:
             callbacks["new_activity_starting"] = self.new_activity

--- a/homeassistant/components/harmony/strings.json
+++ b/homeassistant/components/harmony/strings.json
@@ -28,7 +28,8 @@
         "description": "Adjust Harmony Hub Options",
         "data": {
           "activity": "The default activity to execute when none is specified.",
-          "delay_secs": "The delay between sending commands."
+          "delay_secs": "The delay between sending commands.",
+          "activity_notify": "Update current activity on start of activity switch."
         }
       }
     }

--- a/homeassistant/components/harmony/translations/en.json
+++ b/homeassistant/components/harmony/translations/en.json
@@ -27,7 +27,8 @@
             "init": {
                 "data": {
                     "activity": "The default activity to execute when none is specified.",
-                    "delay_secs": "The delay between sending commands."
+                    "delay_secs": "The delay between sending commands.",
+                    "activity_notify": "Update current activity on start of activity switch."
                 },
                 "description": "Adjust Harmony Hub Options"
             }

--- a/homeassistant/components/harmony/translations/nl.json
+++ b/homeassistant/components/harmony/translations/nl.json
@@ -27,8 +27,7 @@
             "init": {
                 "data": {
                     "activity": "De standaardactiviteit die moet worden uitgevoerd wanneer er geen is opgegeven.",
-                    "delay_secs": "De vertraging tussen het verzenden van opdrachten.",
-                    "activity_notify": "Verander de activiteit bij het starten van de activiteits verandering."
+                    "delay_secs": "De vertraging tussen het verzenden van opdrachten."
                 },
                 "description": "Pas de Harmony Hub-opties aan"
             }

--- a/homeassistant/components/harmony/translations/nl.json
+++ b/homeassistant/components/harmony/translations/nl.json
@@ -27,7 +27,8 @@
             "init": {
                 "data": {
                     "activity": "De standaardactiviteit die moet worden uitgevoerd wanneer er geen is opgegeven.",
-                    "delay_secs": "De vertraging tussen het verzenden van opdrachten."
+                    "delay_secs": "De vertraging tussen het verzenden van opdrachten.",
+                    "activity_notify": "Verander de activiteit bij het starten van de activiteits verandering."
                 },
                 "description": "Pas de Harmony Hub-opties aan"
             }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -178,7 +178,7 @@ aioftp==0.12.0
 aioguardian==0.2.3
 
 # homeassistant.components.harmony
-aioharmony==0.2.4
+aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
 aiohomekit[IP]==0.2.38

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -85,7 +85,7 @@ aiofreepybox==0.0.8
 aioguardian==0.2.3
 
 # homeassistant.components.harmony
-aioharmony==0.2.4
+aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
 aiohomekit[IP]==0.2.38

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -66,6 +66,7 @@ async def test_form_import(hass):
                 "name": "friend",
                 "activity": "Watch TV",
                 "delay_secs": 0.9,
+                "activity_notify": True,
                 "unique_id": "555234534543",
             },
         )
@@ -78,6 +79,7 @@ async def test_form_import(hass):
         "name": "friend",
         "activity": "Watch TV",
         "delay_secs": 0.9,
+        "activity_notify": True,
     }
     # It is not possible to import options at this time
     # so they end up in the config entry data and are
@@ -148,6 +150,7 @@ async def test_form_cannot_connect(hass):
                 "name": "friend",
                 "activity": "Watch TV",
                 "delay_secs": 0.2,
+                "activity_notify": True,
             },
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Provide user with the option to update current activity when the switch to a new activity is initiated instead of when the switch is completed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #307111
- This PR is related to issue: 
- Link to documentation pull request: TBD

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
