### PR TITLE
Fix logbook filtering for described events

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -340,7 +340,7 @@ def _get_related_entity_ids(session, entity_filter):
 
     query = session.query(States).with_entities(States.entity_id).distinct()
 
-    for tryno in range(0, RETRIES):
+    for tryno in range(RETRIES):
         try:
             result = [row.entity_id for row in query if entity_filter(row.entity_id)]
 
@@ -419,11 +419,12 @@ def _get_events(hass, config, start_day, end_day, entity_id=None):
 
 
 def _keep_event(hass, event, entities_filter):
-    domain, entity_id = None, None
+    domain = event.data.get(ATTR_DOMAIN)
+    entity_id = event.data.get("entity_id")
+    if entity_id:
+        domain = split_entity_id(entity_id)[0]
 
     if event.event_type == EVENT_STATE_CHANGED:
-        entity_id = event.data.get("entity_id")
-
         if entity_id is None:
             return False
 
@@ -441,7 +442,6 @@ def _keep_event(hass, event, entities_filter):
         if new_state.get("state") == old_state.get("state"):
             return False
 
-        domain = split_entity_id(entity_id)[0]
         attributes = new_state.get("attributes", {})
 
         # Also filter auto groups.
@@ -455,13 +455,11 @@ def _keep_event(hass, event, entities_filter):
 
     elif event.event_type == EVENT_LOGBOOK_ENTRY:
         domain = event.data.get(ATTR_DOMAIN)
-        entity_id = event.data.get(ATTR_ENTITY_ID)
 
     elif event.event_type == EVENT_SCRIPT_STARTED:
         domain = "script"
-        entity_id = event.data.get(ATTR_ENTITY_ID)
 
-    elif event.event_type in hass.data.get(DOMAIN, {}):
+    elif not entity_id and event.event_type in hass.data.get(DOMAIN, {}):
         domain = hass.data[DOMAIN][event.event_type][0]
 
     if not entity_id and domain:

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -460,6 +460,8 @@ def _keep_event(hass, event, entities_filter):
         domain = "script"
 
     elif not entity_id and event.event_type in hass.data.get(DOMAIN, {}):
+        # If the entity_id isn't described, use the domain that describes
+        # the event for filtering.
         domain = hass.data[DOMAIN][event.event_type][0]
 
     if not entity_id and domain:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes logbook filtering for described logbook events.

If the described event contains an `entity_id`, it will be used for filtering (including the entity domain). If the described event has no `entity_id`, the originating domain is used for filtering.

Exempted from this is the `EVENT_LOGBOOK_ENTRY`, as this has always been the case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36576
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
