### PR TITLE
Add vizio service to update a device setting

### DIFF
--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -27,6 +27,19 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
+SERVICE_UPDATE_SETTING = "update_setting"
+
+ATTR_SETTING_TYPE = "setting_type"
+ATTR_SETTING_TYPES = f"{ATTR_SETTING_TYPE}s"
+ATTR_SETTING_NAME = "setting_name"
+ATTR_NEW_VALUE = "new_value"
+
+UPDATE_SETTING_SCHEMA = {
+    vol.Required(ATTR_SETTING_TYPE): cv.string,
+    vol.Required(ATTR_SETTING_NAME): cv.string,
+    vol.Required(ATTR_NEW_VALUE): vol.Or(vol.Coerce(int), cv.string),
+}
+
 CONF_ADDITIONAL_CONFIGS = "additional_configs"
 CONF_APP_ID = "APP_ID"
 CONF_APPS = "apps"
@@ -66,6 +79,8 @@ SUPPORTED_COMMANDS = {
 VIZIO_SOUND_MODE = "eq"
 VIZIO_AUDIO_SETTINGS = "audio"
 VIZIO_MUTE_ON = "on"
+VIZIO_VOLUME = "volume"
+VIZIO_MUTE = "mute"
 
 # Since Vizio component relies on device class, this dict will ensure that changes to
 # the values of DEVICE_CLASS_SPEAKER or DEVICE_CLASS_TV don't require changes to pyvizio.

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -30,7 +30,6 @@ import homeassistant.helpers.config_validation as cv
 SERVICE_UPDATE_SETTING = "update_setting"
 
 ATTR_SETTING_TYPE = "setting_type"
-ATTR_SETTING_TYPES = f"{ATTR_SETTING_TYPE}s"
 ATTR_SETTING_NAME = "setting_name"
 ATTR_NEW_VALUE = "new_value"
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -56,7 +56,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=30)
 PARALLEL_UPDATES = 0
 
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -214,8 +214,8 @@ class VizioDevice(MediaPlayerEntity):
         self._state = STATE_ON
 
         if not self._setting_types:
-            self._setting_types = await self._device.get_setting_types_list(
-                log_api_exception=False
+            self._setting_types = sorted(
+                await self._device.get_setting_types_list(log_api_exception=False)
             )
 
         for setting_type in self._setting_types:

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -223,7 +223,7 @@ class VizioDevice(MediaPlayerEntity):
                 setting_type, log_api_exception=False
             )
 
-        if self._all_settings[VIZIO_AUDIO_SETTINGS]:
+        if self._all_settings.get(VIZIO_AUDIO_SETTINGS):
             self._volume_level = (
                 float(self._all_settings[VIZIO_AUDIO_SETTINGS][VIZIO_VOLUME])
                 / self._max_volume

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -223,7 +223,7 @@ class VizioDevice(MediaPlayerEntity):
                 setting_type, log_api_exception=False
             )
 
-        if self._all_settings.get(VIZIO_AUDIO_SETTINGS):
+        if VIZIO_AUDIO_SETTINGS in self._all_settings:
             self._volume_level = (
                 float(self._all_settings[VIZIO_AUDIO_SETTINGS][VIZIO_VOLUME])
                 / self._max_volume

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -290,7 +290,9 @@ class VizioDevice(MediaPlayerEntity):
         self, setting_type: str, setting_name: str, new_value: Union[int, str]
     ) -> None:
         """Update a setting when update_setting service is called."""
-        await self._device.set_setting(setting_type, setting_name, new_value)
+        await self._device.set_setting(
+            setting_type.lower(), setting_name.lower(), new_value
+        )
 
     async def async_added_to_hass(self):
         """Register callbacks when entity is added."""

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -291,7 +291,9 @@ class VizioDevice(MediaPlayerEntity):
     ) -> None:
         """Update a setting when update_setting service is called."""
         await self._device.set_setting(
-            setting_type.lower(), setting_name.lower(), new_value
+            setting_type.lower().replace(" ", "_"),
+            setting_name.lower().replace(" ", "_"),
+            new_value,
         )
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/vizio/services.yaml
+++ b/homeassistant/components/vizio/services.yaml
@@ -1,0 +1,15 @@
+update_setting:
+  description: Update the value of a setting on a particular Vizio media player device.
+  fields:
+    entity_id:
+      description: Name of an entity to send command.
+      example: "media_player.vizio_smartcast"
+    setting_type:
+      description: The type of setting to be changed. Available types are listed in the `setting_types` property.
+      example: "audio"
+    setting_name:
+      description: The name of the setting to be changed. Available settings for a given setting_type are listed in the `<setting_type>_settings` property.
+      example: "eq"
+    new_value:
+      description: The new value for the setting
+      example: "Music"

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -146,6 +146,9 @@ def vizio_update_fixture():
             "mute": "Off",
         },
     ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_setting_types_list",
+        return_value=["audio"],
+    ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_setting_options",
         return_value=EQ_LIST,
     ), patch(

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -146,9 +146,6 @@ def vizio_update_fixture():
             "mute": "Off",
         },
     ), patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.get_setting_types_list",
-        return_value=["audio"],
-    ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_setting_options",
         return_value=EQ_LIST,
     ), patch(

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -41,6 +41,7 @@ from homeassistant.components.vizio.const import (
     CONF_APPS,
     CONF_VOLUME_STEP,
     DOMAIN,
+    SERVICE_UPDATE_SETTING,
     VIZIO_SCHEMA,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
@@ -129,6 +130,9 @@ async def _cm_for_test_setup_without_apps(
         "homeassistant.components.vizio.media_player.VizioAsync.get_all_settings",
         return_value=all_settings,
     ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_setting_types_list",
+        return_value=["audio"],
+    ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_setting_options",
         return_value=EQ_LIST,
     ), patch(
@@ -174,13 +178,14 @@ async def _test_setup_speaker(
         unique_id=UNIQUE_ID,
     )
 
+    audio_settings = {
+        "volume": int(MAX_VOLUME[VIZIO_DEVICE_CLASS_SPEAKER] / 2),
+        "mute": "Off",
+        "eq": CURRENT_EQ,
+    }
+
     async with _cm_for_test_setup_without_apps(
-        {
-            "volume": int(MAX_VOLUME[VIZIO_DEVICE_CLASS_SPEAKER] / 2),
-            "mute": "Off",
-            "eq": CURRENT_EQ,
-        },
-        vizio_power_state,
+        audio_settings, vizio_power_state,
     ):
         with patch(
             "homeassistant.components.vizio.media_player.VizioAsync.get_current_app_config",
@@ -194,6 +199,8 @@ async def _test_setup_speaker(
                 _assert_sources_and_volume(attr, VIZIO_DEVICE_CLASS_SPEAKER)
                 assert not service_call.called
                 assert "sound_mode" in attr
+                assert attr["audio_settings"] == audio_settings
+                assert attr["setting_types"] == ["audio"]
 
 
 @asynccontextmanager
@@ -248,6 +255,7 @@ async def _test_setup_failure(hass: HomeAssistantType, config: str) -> None:
 
 async def _test_service(
     hass: HomeAssistantType,
+    domain: str,
     vizio_func_name: str,
     ha_service_name: str,
     additional_service_data: Optional[Dict[str, Any]],
@@ -263,7 +271,7 @@ async def _test_service(
         f"homeassistant.components.vizio.media_player.VizioAsync.{vizio_func_name}"
     ) as service_call:
         await hass.services.async_call(
-            MP_DOMAIN, ha_service_name, service_data=service_data, blocking=True,
+            domain, ha_service_name, service_data=service_data, blocking=True,
         )
         assert service_call.called
 
@@ -347,29 +355,49 @@ async def test_services(
     """Test all Vizio media player entity services."""
     await _test_setup_tv(hass, True)
 
-    await _test_service(hass, "pow_on", SERVICE_TURN_ON, None)
-    await _test_service(hass, "pow_off", SERVICE_TURN_OFF, None)
+    await _test_service(hass, MP_DOMAIN, "pow_on", SERVICE_TURN_ON, None)
+    await _test_service(hass, MP_DOMAIN, "pow_off", SERVICE_TURN_OFF, None)
     await _test_service(
-        hass, "mute_on", SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: True}
+        hass, MP_DOMAIN, "mute_on", SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: True}
     )
     await _test_service(
-        hass, "mute_off", SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: False}
+        hass,
+        MP_DOMAIN,
+        "mute_off",
+        SERVICE_VOLUME_MUTE,
+        {ATTR_MEDIA_VOLUME_MUTED: False},
     )
     await _test_service(
-        hass, "set_input", SERVICE_SELECT_SOURCE, {ATTR_INPUT_SOURCE: "USB"}, "USB"
+        hass,
+        MP_DOMAIN,
+        "set_input",
+        SERVICE_SELECT_SOURCE,
+        {ATTR_INPUT_SOURCE: "USB"},
+        "USB",
     )
-    await _test_service(hass, "vol_up", SERVICE_VOLUME_UP, None)
-    await _test_service(hass, "vol_down", SERVICE_VOLUME_DOWN, None)
+    await _test_service(hass, MP_DOMAIN, "vol_up", SERVICE_VOLUME_UP, None)
+    await _test_service(hass, MP_DOMAIN, "vol_down", SERVICE_VOLUME_DOWN, None)
     await _test_service(
-        hass, "vol_up", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 1}
+        hass, MP_DOMAIN, "vol_up", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 1}
     )
     await _test_service(
-        hass, "vol_down", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 0}
+        hass, MP_DOMAIN, "vol_down", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 0}
     )
-    await _test_service(hass, "ch_up", SERVICE_MEDIA_NEXT_TRACK, None)
-    await _test_service(hass, "ch_down", SERVICE_MEDIA_PREVIOUS_TRACK, None)
+    await _test_service(hass, MP_DOMAIN, "ch_up", SERVICE_MEDIA_NEXT_TRACK, None)
+    await _test_service(hass, MP_DOMAIN, "ch_down", SERVICE_MEDIA_PREVIOUS_TRACK, None)
     await _test_service(
-        hass, "set_setting", SERVICE_SELECT_SOUND_MODE, {ATTR_SOUND_MODE: "Music"}
+        hass,
+        MP_DOMAIN,
+        "set_setting",
+        SERVICE_SELECT_SOUND_MODE,
+        {ATTR_SOUND_MODE: "Music"},
+    )
+    await _test_service(
+        hass,
+        DOMAIN,
+        "set_setting",
+        SERVICE_UPDATE_SETTING,
+        {"setting_type": "audio", "setting_name": "eq", "new_value": "Music"},
     )
 
 
@@ -389,7 +417,9 @@ async def test_options_update(
         entry=config_entry, options=new_options,
     )
     assert config_entry.options == updated_options
-    await _test_service(hass, "vol_up", SERVICE_VOLUME_UP, None, num=VOLUME_STEP)
+    await _test_service(
+        hass, MP_DOMAIN, "vol_up", SERVICE_VOLUME_UP, None, num=VOLUME_STEP
+    )
 
 
 async def _test_update_availability_switch(
@@ -474,6 +504,7 @@ async def test_setup_with_apps(
 
     await _test_service(
         hass,
+        MP_DOMAIN,
         "launch_app",
         SERVICE_SELECT_SOURCE,
         {ATTR_INPUT_SOURCE: CURRENT_APP},
@@ -550,6 +581,7 @@ async def test_setup_with_apps_additional_apps_config(
 
     await _test_service(
         hass,
+        MP_DOMAIN,
         "launch_app",
         SERVICE_SELECT_SOURCE,
         {ATTR_INPUT_SOURCE: "Netflix"},
@@ -557,6 +589,7 @@ async def test_setup_with_apps_additional_apps_config(
     )
     await _test_service(
         hass,
+        MP_DOMAIN,
         "launch_app_config",
         SERVICE_SELECT_SOURCE,
         {ATTR_INPUT_SOURCE: CURRENT_APP},

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -392,7 +392,7 @@ async def test_services(
         DOMAIN,
         "set_setting",
         SERVICE_UPDATE_SETTING,
-        {"setting_type": "audio", "setting_name": "eq", "new_value": "Music"},
+        {"setting_type": "Audio", "setting_name": "EQ", "new_value": "Music"},
     )
 
 

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -130,9 +130,6 @@ async def _cm_for_test_setup_without_apps(
         "homeassistant.components.vizio.media_player.VizioAsync.get_all_settings",
         return_value=all_settings,
     ), patch(
-        "homeassistant.components.vizio.media_player.VizioAsync.get_setting_types_list",
-        return_value=["audio"],
-    ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_setting_options",
         return_value=EQ_LIST,
     ), patch(
@@ -199,8 +196,6 @@ async def _test_setup_speaker(
                 _assert_sources_and_volume(attr, VIZIO_DEVICE_CLASS_SPEAKER)
                 assert not service_call.called
                 assert "sound_mode" in attr
-                assert attr["audio_settings"] == audio_settings
-                assert attr["setting_types"] == ["audio"]
 
 
 @asynccontextmanager


### PR DESCRIPTION
## Proposed change
Added a service to update a particular device setting. This was requested via Discord.

Separately, I've noticed that the web server running on my Vizio device becomes unresponsive after some time due to some recent changes. I think it's because I have increased the number of API calls given the update interval (these calls can take > 1 second each). Given that this has further increased the number of API calls being made, I have increased the update interval to hopefully reduce the chances of this happening.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: home-assistant/home-assistant.io#13736

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
