### PR TITLE
Support default transition in light profiles

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -146,7 +146,8 @@ def preprocess_turn_on_alternatives(params):
     if profile is not None:
         params.setdefault(ATTR_XY_COLOR, profile[:2])
         params.setdefault(ATTR_BRIGHTNESS, profile[2])
-        params.setdefault(ATTR_TRANSITION, profile[3] if len(profile) > 3 else 0)
+        if len(profile) > 3:
+            params.setdefault(ATTR_TRANSITION, profile[3])
 
     color_name = params.pop(ATTR_COLOR_NAME, None)
     if color_name is not None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -123,7 +123,12 @@ LIGHT_TURN_ON_SCHEMA = {
 
 
 PROFILE_SCHEMA = vol.Schema(
-    vol.ExactSequence((str, cv.small_float, cv.small_float, cv.byte))
+    vol.Any(
+        vol.ExactSequence((str, cv.small_float, cv.small_float, cv.byte)),
+        vol.ExactSequence(
+            (str, cv.small_float, cv.small_float, cv.byte, cv.positive_int)
+        ),
+    )
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -141,6 +146,7 @@ def preprocess_turn_on_alternatives(params):
     if profile is not None:
         params.setdefault(ATTR_XY_COLOR, profile[:2])
         params.setdefault(ATTR_BRIGHTNESS, profile[2])
+        params.setdefault(ATTR_TRANSITION, profile[3] if len(profile) > 3 else 0)
 
     color_name = params.pop(ATTR_COLOR_NAME, None)
     if color_name is not None:
@@ -313,8 +319,22 @@ class Profiles:
 
                     try:
                         for rec in reader:
-                            profile, color_x, color_y, brightness = PROFILE_SCHEMA(rec)
-                            profiles[profile] = (color_x, color_y, brightness)
+                            (
+                                profile,
+                                color_x,
+                                color_y,
+                                brightness,
+                                *transition,
+                            ) = PROFILE_SCHEMA(rec)
+
+                            transition = transition[0] if transition else 0
+
+                            profiles[profile] = (
+                                color_x,
+                                color_y,
+                                brightness,
+                                transition,
+                            )
                     except vol.MultipleInvalid as ex:
                         _LOGGER.error(
                             "Error parsing light profile from %s: %s", profile_path, ex

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -258,7 +258,7 @@ class TestLight(unittest.TestCase):
         assert {
             light.ATTR_BRIGHTNESS: prof_bri,
             light.ATTR_HS_COLOR: (prof_h, prof_s),
-            light.ATTR_TRANSITION: (prof_t),
+            light.ATTR_TRANSITION: prof_t,
         } == data
 
         _, data = ent2.last_call("turn_on")

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -243,12 +243,14 @@ class TestLight(unittest.TestCase):
         assert {} == data
 
         # One of the light profiles
-        prof_name, prof_h, prof_s, prof_bri = "relax", 35.932, 69.412, 144
+        prof_name, prof_h, prof_s, prof_bri, prof_t = "relax", 35.932, 69.412, 144, 0
 
         # Test light profiles
         common.turn_on(self.hass, ent1.entity_id, profile=prof_name)
         # Specify a profile and a brightness attribute to overwrite it
-        common.turn_on(self.hass, ent2.entity_id, profile=prof_name, brightness=100)
+        common.turn_on(
+            self.hass, ent2.entity_id, profile=prof_name, brightness=100, transition=1
+        )
 
         self.hass.block_till_done()
 
@@ -256,12 +258,14 @@ class TestLight(unittest.TestCase):
         assert {
             light.ATTR_BRIGHTNESS: prof_bri,
             light.ATTR_HS_COLOR: (prof_h, prof_s),
+            light.ATTR_TRANSITION: (prof_t),
         } == data
 
         _, data = ent2.last_call("turn_on")
         assert {
             light.ATTR_BRIGHTNESS: 100,
             light.ATTR_HS_COLOR: (prof_h, prof_s),
+            light.ATTR_TRANSITION: 1,
         } == data
 
         # Test toggle with parameters
@@ -271,6 +275,7 @@ class TestLight(unittest.TestCase):
         assert {
             light.ATTR_BRIGHTNESS: 255,
             light.ATTR_HS_COLOR: (prof_h, prof_s),
+            light.ATTR_TRANSITION: prof_t,
         } == data
 
         # Test bad data
@@ -314,8 +319,8 @@ class TestLight(unittest.TestCase):
 
         # Setup a wrong light file
         with open(user_light_file, "w") as user_file:
-            user_file.write("id,x,y,brightness\n")
-            user_file.write("I,WILL,NOT,WORK\n")
+            user_file.write("id,x,y,brightness,transition\n")
+            user_file.write("I,WILL,NOT,WORK,EVER\n")
 
         assert not setup_component(
             self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -347,7 +352,11 @@ class TestLight(unittest.TestCase):
         _, data = ent1.last_call("turn_on")
 
         assert light.is_on(self.hass, ent1.entity_id)
-        assert {light.ATTR_HS_COLOR: (71.059, 100), light.ATTR_BRIGHTNESS: 100} == data
+        assert {
+            light.ATTR_HS_COLOR: (71.059, 100),
+            light.ATTR_BRIGHTNESS: 100,
+            light.ATTR_TRANSITION: 0,
+        } == data
 
         common.turn_on(self.hass, ent1.entity_id, profile="test_off")
 
@@ -356,7 +365,48 @@ class TestLight(unittest.TestCase):
         _, data = ent1.last_call("turn_off")
 
         assert not light.is_on(self.hass, ent1.entity_id)
-        assert {} == data
+        assert {light.ATTR_TRANSITION: 0} == data
+
+    def test_light_profiles_with_transition(self):
+        """Test light profiles with transition."""
+        platform = getattr(self.hass.components, "test.light")
+        platform.init()
+
+        user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)
+
+        with open(user_light_file, "w") as user_file:
+            user_file.write("id,x,y,brightness,transition\n")
+            user_file.write("test,.4,.6,100,2\n")
+            user_file.write("test_off,0,0,0,0\n")
+
+        assert setup_component(
+            self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
+        )
+        self.hass.block_till_done()
+
+        ent1, _, _ = platform.ENTITIES
+
+        common.turn_on(self.hass, ent1.entity_id, profile="test")
+
+        self.hass.block_till_done()
+
+        _, data = ent1.last_call("turn_on")
+
+        assert light.is_on(self.hass, ent1.entity_id)
+        assert {
+            light.ATTR_HS_COLOR: (71.059, 100),
+            light.ATTR_BRIGHTNESS: 100,
+            light.ATTR_TRANSITION: 2,
+        } == data
+
+        common.turn_on(self.hass, ent1.entity_id, profile="test_off")
+
+        self.hass.block_till_done()
+
+        _, data = ent1.last_call("turn_off")
+
+        assert not light.is_on(self.hass, ent1.entity_id)
+        assert {light.ATTR_TRANSITION: 0} == data
 
     def test_default_profiles_group(self):
         """Test default turn-on light profile for all lights."""
@@ -377,7 +427,9 @@ class TestLight(unittest.TestCase):
                 return StringIO(profile_data)
             return real_open(path, *args, **kwargs)
 
-        profile_data = "id,x,y,brightness\ngroup.all_lights.default,.4,.6,99\n"
+        profile_data = (
+            "id,x,y,brightness,transition\ngroup.all_lights.default,.4,.6,99,2\n"
+        )
         with mock.patch("os.path.isfile", side_effect=_mock_isfile), mock.patch(
             "builtins.open", side_effect=_mock_open
         ), mock_storage():
@@ -390,7 +442,11 @@ class TestLight(unittest.TestCase):
         common.turn_on(self.hass, ent.entity_id)
         self.hass.block_till_done()
         _, data = ent.last_call("turn_on")
-        assert {light.ATTR_HS_COLOR: (71.059, 100), light.ATTR_BRIGHTNESS: 99} == data
+        assert {
+            light.ATTR_HS_COLOR: (71.059, 100),
+            light.ATTR_BRIGHTNESS: 99,
+            light.ATTR_TRANSITION: 2,
+        } == data
 
     def test_default_profiles_light(self):
         """Test default turn-on light profile for a specific light."""
@@ -412,9 +468,9 @@ class TestLight(unittest.TestCase):
             return real_open(path, *args, **kwargs)
 
         profile_data = (
-            "id,x,y,brightness\n"
-            + "group.all_lights.default,.3,.5,200\n"
-            + "light.ceiling_2.default,.6,.6,100\n"
+            "id,x,y,brightness,transition\n"
+            + "group.all_lights.default,.3,.5,200,0\n"
+            + "light.ceiling_2.default,.6,.6,100,3\n"
         )
         with mock.patch("os.path.isfile", side_effect=_mock_isfile), mock.patch(
             "builtins.open", side_effect=_mock_open
@@ -430,7 +486,11 @@ class TestLight(unittest.TestCase):
         common.turn_on(self.hass, dev.entity_id)
         self.hass.block_till_done()
         _, data = dev.last_call("turn_on")
-        assert {light.ATTR_HS_COLOR: (50.353, 100), light.ATTR_BRIGHTNESS: 100} == data
+        assert {
+            light.ATTR_HS_COLOR: (50.353, 100),
+            light.ATTR_BRIGHTNESS: 100,
+            light.ATTR_TRANSITION: 3,
+        } == data
 
 
 async def test_light_context(hass, hass_admin_user):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allows users to specify a default "transition" value for individual (or all) lights by expanding on the existing [default turn-on values/profiles](https://www.home-assistant.io/integrations/light/#default-turn-on-values) mechanism. 

E.g. `light.patio.default,0.5119,0.4147,144` --> `light.patio.default,0.5119,0.4147,144,2`

This change is backwards-compatible, allowing light_profiles.csv to be in either 4-column (no transition) or 5-column (with transition) format.

Currently, the only way to set a default transition for individual lights is by making a template light that calls a script that calls "light.turn_on" on the light you care about with a transition parameter, doing that for each light you care about, then finding a way to obscure the original light, so that all light interactions happen through the template light.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml
light:
  - platform: switch
    name: Christmas Tree Lights
    profile: slowblue
    entity_id: switch.christmas_tree_lights
```

```csv
# Example light_profiles.csv
id,x,y,brightness,transition
relax,0.5119,0.4147,144,0
concentrate,0.5119,0.4147,219,0
energize,0.368,0.3686,203,0
reading,0.4448,0.4066,240,0
slowblue,0.193, 0.129,255,5
group.all_lights.default,0.5119,0.4147,144,2
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/13738

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

https://github.com/home-assistant/home-assistant.io/pull/13738

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
