### PR TITLE
Bump aiokef 0.2.12

### DIFF
--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -3,5 +3,5 @@
   "name": "KEF",
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.2.10", "getmac==0.8.2"]
+  "requirements": ["aiokef==0.2.11", "getmac==0.8.2"]
 }

--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -3,5 +3,5 @@
   "name": "KEF",
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.2.11", "getmac==0.8.2"]
+  "requirements": ["aiokef==0.2.12", "getmac==0.8.2"]
 }

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -133,7 +133,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         supports_on,
         sources,
         speaker_type,
-        ioloop=hass.loop,
+        loop=hass.loop,
         unique_id=unique_id,
     )
 
@@ -191,7 +191,7 @@ class KefMediaPlayer(MediaPlayerEntity):
         supports_on,
         sources,
         speaker_type,
-        ioloop,
+        loop,
         unique_id,
     ):
         """Initialize the media player."""
@@ -204,7 +204,7 @@ class KefMediaPlayer(MediaPlayerEntity):
             maximum_volume,
             standby_time,
             inverse_speaker_mode,
-            ioloop=ioloop,
+            loop=loop,
         )
         self._unique_id = unique_id
         self._supports_on = supports_on

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -197,7 +197,7 @@ aioimaplib==0.7.15
 aiokafka==0.5.1
 
 # homeassistant.components.kef
-aiokef==0.2.10
+aiokef==0.2.11
 
 # homeassistant.components.lifx
 aiolifx==0.6.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -197,7 +197,7 @@ aioimaplib==0.7.15
 aiokafka==0.5.1
 
 # homeassistant.components.kef
-aiokef==0.2.11
+aiokef==0.2.12
 
 # homeassistant.components.lifx
 aiolifx==0.6.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dependency update. Make sure to shield a disconnect task from cancellation.

Relevant commit https://github.com/basnijholt/aiokef/commit/c9276ac7c8b69adc99258b79256360573f59f1ad#diff-b774af83d4e664d3720c99ee853a9a95R312

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
