### PR TITLE
Optimize recorder MySQL tables when repacking

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -39,10 +39,9 @@ def purge_old_data(instance, purge_days, repack):
                 _LOGGER.debug("Vacuuming SQL DB to free space")
                 instance.engine.execute("VACUUM")
             # Optimize mysql / mariadb tables to free up space on disk
-            elif instance.engine.driver in ("mysqldb"):
+            elif instance.engine.driver == "mysqldb":
                 _LOGGER.debug("Optimizing SQL DB to free space")
-                instance.engine.execute("OPTIMIZE TABLE states")
-                instance.engine.execute("OPTIMIZE TABLE events")
+                instance.engine.execute("OPTIMIZE TABLE states, events")
 
     except SQLAlchemyError as err:
         _LOGGER.warning("Error purging history: %s.", err)

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -33,10 +33,16 @@ def purge_old_data(instance, purge_days, repack):
             )
             _LOGGER.debug("Deleted %s events", deleted_rows)
 
-        # Execute sqlite vacuum command to free up space on disk
-        if repack and instance.engine.driver in ("pysqlite", "postgresql"):
-            _LOGGER.debug("Vacuuming SQL DB to free space")
-            instance.engine.execute("VACUUM")
+        if repack:
+            # Execute sqlite or postgresql vacuum command to free up space on disk
+            if instance.engine.driver in ("pysqlite", "postgresql"):
+                _LOGGER.debug("Vacuuming SQL DB to free space")
+                instance.engine.execute("VACUUM")
+            # Optimize mysql / mariadb tables to free up space on disk
+            elif instance.engine.driver in ("mysqldb"):
+                _LOGGER.debug("Optimizing SQL DB to free space")
+                instance.engine.execute("OPTIMIZE TABLE states")
+                instance.engine.execute("OPTIMIZE TABLE events")
 
     except SQLAlchemyError as err:
         _LOGGER.warning("Error purging history: %s.", err)


### PR DESCRIPTION
## Proposed change

Adds repack support for the MySQL / MariaDB database engines. When using MySQL or MariaDB for recorder, the database files on disk will only grow. Repacking those files will reclaim this disk space. Essentially this is the same functionality that is currently implemented for SQLite and PostgreSQL.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#13746

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
