### PR TITLE
Set default pjlink timeout 

### DIFF
--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -98,7 +98,9 @@ class PjLinkDevice(MediaPlayerEntity):
     def projector(self):
         """Create PJLink Projector instance."""
 
-        projector = Projector.from_address(self._host, self._port, self._encoding, self._timeout)
+        projector = Projector.from_address(
+            self._host, self._port, self._encoding, self._timeout
+        )
         projector.authenticate(self._password)
         return projector
 

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
-    CONF_TIMEOUT,
     STATE_OFF,
     STATE_ON,
 )
@@ -38,7 +37,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     }
 )
 
@@ -54,7 +52,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
     encoding = config.get(CONF_ENCODING)
     password = config.get(CONF_PASSWORD)
-    timeout = config.get(CONF_TIMEOUT)
 
     if "pjlink" not in hass.data:
         hass.data["pjlink"] = {}
@@ -64,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if device_label in hass_data:
         return
 
-    device = PjLinkDevice(host, port, name, encoding, password, timeout)
+    device = PjLinkDevice(host, port, name, encoding, password)
     hass_data[device_label] = device
     add_entities([device], True)
 
@@ -77,14 +74,13 @@ def format_input_source(input_source_name, input_source_number):
 class PjLinkDevice(MediaPlayerEntity):
     """Representation of a PJLink device."""
 
-    def __init__(self, host, port, name, encoding, password, timeout):
+    def __init__(self, host, port, name, encoding, password):
         """Iinitialize the PJLink device."""
         self._host = host
         self._port = port
         self._name = name
         self._password = password
         self._encoding = encoding
-        self._timeout = timeout
         self._muted = False
         self._pwstate = STATE_OFF
         self._current_source = None
@@ -99,7 +95,7 @@ class PjLinkDevice(MediaPlayerEntity):
         """Create PJLink Projector instance."""
 
         projector = Projector.from_address(
-            self._host, self._port, self._encoding, self._timeout
+            self._host, self._port, self._encoding, DEFAULT_TIMEOUT
         )
         projector.authenticate(self._password)
         return projector

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_TIMEOUT,
     STATE_OFF,
     STATE_ON,
 )
@@ -28,6 +29,7 @@ CONF_ENCODING = "encoding"
 
 DEFAULT_PORT = 4352
 DEFAULT_ENCODING = "utf-8"
+DEFAULT_TIMEOUT = 10
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -36,6 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     }
 )
 
@@ -51,6 +54,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
     encoding = config.get(CONF_ENCODING)
     password = config.get(CONF_PASSWORD)
+    timeout = config.get(CONF_TIMEOUT)
 
     if "pjlink" not in hass.data:
         hass.data["pjlink"] = {}
@@ -60,7 +64,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if device_label in hass_data:
         return
 
-    device = PjLinkDevice(host, port, name, encoding, password)
+    device = PjLinkDevice(host, port, name, encoding, password, timeout)
     hass_data[device_label] = device
     add_entities([device], True)
 
@@ -73,13 +77,14 @@ def format_input_source(input_source_name, input_source_number):
 class PjLinkDevice(MediaPlayerEntity):
     """Representation of a PJLink device."""
 
-    def __init__(self, host, port, name, encoding, password):
+    def __init__(self, host, port, name, encoding, password, timeout):
         """Iinitialize the PJLink device."""
         self._host = host
         self._port = port
         self._name = name
         self._password = password
         self._encoding = encoding
+        self._timeout = timeout
         self._muted = False
         self._pwstate = STATE_OFF
         self._current_source = None
@@ -93,7 +98,7 @@ class PjLinkDevice(MediaPlayerEntity):
     def projector(self):
         """Create PJLink Projector instance."""
 
-        projector = Projector.from_address(self._host, self._port, self._encoding)
+        projector = Projector.from_address(self._host, self._port, self._encoding, self._timeout)
         projector.authenticate(self._password)
         return projector
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add timeout configuration to PJLink component.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
media_player:
  - platform: pjlink
    host: 192.168.1.2
    timeout: 10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13749

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
