### PR TITLE
Improve history api performance part 4

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -55,6 +55,18 @@ NEED_ATTRIBUTE_DOMAINS = {"climate", "water_heater", "thermostat", "script"}
 SCRIPT_DOMAIN = "script"
 ATTR_CAN_CANCEL = "can_cancel"
 
+QUERY_STATES = [
+    States.domain,
+    States.entity_id,
+    States.state,
+    States.attributes,
+    States.last_changed,
+    States.last_updated,
+    States.created,
+    States.context_id,
+    States.context_user_id,
+]
+
 
 def get_significant_states(hass, *args, **kwargs):
     """Wrap _get_significant_states with a sql session."""
@@ -83,7 +95,7 @@ def _get_significant_states(
     timer_start = time.perf_counter()
 
     if significant_changes_only:
-        query = session.query(States).filter(
+        query = session.query(*QUERY_STATES).filter(
             (
                 States.domain.in_(SIGNIFICANT_DOMAINS)
                 | (States.last_changed == States.last_updated)
@@ -91,7 +103,7 @@ def _get_significant_states(
             & (States.last_updated > start_time)
         )
     else:
-        query = session.query(States).filter(States.last_updated > start_time)
+        query = session.query(*QUERY_STATES).filter(States.last_updated > start_time)
 
     if filters:
         query = filters.apply(query, entity_ids)
@@ -123,7 +135,7 @@ def state_changes_during_period(hass, start_time, end_time=None, entity_id=None)
     """Return states changes during UTC period start_time - end_time."""
 
     with session_scope(hass=hass) as session:
-        query = session.query(States).filter(
+        query = session.query(*QUERY_STATES).filter(
             (States.last_changed == States.last_updated)
             & (States.last_updated > start_time)
         )
@@ -149,7 +161,9 @@ def get_last_state_changes(hass, number_of_states, entity_id):
     start_time = dt_util.utcnow()
 
     with session_scope(hass=hass) as session:
-        query = session.query(States).filter(States.last_changed == States.last_updated)
+        query = session.query(*QUERY_STATES).filter(
+            States.last_changed == States.last_updated
+        )
 
         if entity_id is not None:
             query = query.filter_by(entity_id=entity_id.lower())
@@ -200,7 +214,7 @@ def _get_states_with_session(
         if run is None:
             return []
 
-    query = session.query(States)
+    query = session.query(*QUERY_STATES)
 
     if entity_ids and len(entity_ids) == 1:
         # Use an entirely different (and extremely fast) query if we only
@@ -261,7 +275,7 @@ def _get_states_with_session(
 
     return [
         state
-        for state in execute(query)
+        for state in (States.to_native(row) for row in execute(query, to_native=False))
         if not state.attributes.get(ATTR_HIDDEN, False)
     ]
 
@@ -320,7 +334,9 @@ def _sorted_states_to_json(
             ent_results.extend(
                 [
                     native_state
-                    for native_state in (db_state.to_native() for db_state in group)
+                    for native_state in (
+                        States.to_native(db_state) for db_state in group
+                    )
                     if (
                         domain != SCRIPT_DOMAIN
                         or native_state.attributes.get(ATTR_CAN_CANCEL)
@@ -335,16 +351,16 @@ def _sorted_states_to_json(
         # in-between only provide the "state" and the
         # "last_changed".
         if not ent_results:
-            ent_results.append(next(group).to_native())
+            ent_results.append(States.to_native(next(group)))
 
         initial_state = ent_results[-1]
         prev_state = ent_results[-1]
         initial_state_count = len(ent_results)
 
         for db_state in group:
-            if ATTR_HIDDEN in db_state.attributes and db_state.to_native().attributes.get(
-                ATTR_HIDDEN, False
-            ):
+            if ATTR_HIDDEN in db_state.attributes and States.to_native(
+                db_state
+            ).attributes.get(ATTR_HIDDEN, False):
                 continue
 
             # With minimal response we do not care about attribute
@@ -368,7 +384,7 @@ def _sorted_states_to_json(
             # There was at least one state change
             # replace the last minimal state with
             # a full state
-            ent_results[-1] = prev_state.to_native()
+            ent_results[-1] = States.to_native(prev_state)
 
     # Filter out the empty lists if some states had 0 results.
     return {key: val for key, val in result.items() if val}


### PR DESCRIPTION
This builds on #35822


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Minimize the amount of data selected from
the database

Testing:

History API Response time for 1 day
Average of 10 runs with minimal_response

Before: 9.47s
After: 4.43s

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
