### PR TITLE
Add Plum Lightpad config flow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -312,7 +312,7 @@ homeassistant/components/plaato/* @JohNan
 homeassistant/components/plant/* @ChristianKuehnel
 homeassistant/components/plex/* @jjlawren
 homeassistant/components/plugwise/* @CoMPaTech @bouwew
-homeassistant/components/plum_lightpad/* @ColinHarrington
+homeassistant/components/plum_lightpad/* @ColinHarrington @prystupa
 homeassistant/components/point/* @fredrike
 homeassistant/components/powerwall/* @bdraco @jrester
 homeassistant/components/prometheus/* @knyar

--- a/homeassistant/components/plum_lightpad/__init__.py
+++ b/homeassistant/components/plum_lightpad/__init__.py
@@ -62,5 +62,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, lambda: plum.cleanup())
+    def cleanup(event):
+        """Clean up resources."""
+        plum.cleanup()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
     return True

--- a/homeassistant/components/plum_lightpad/__init__.py
+++ b/homeassistant/components/plum_lightpad/__init__.py
@@ -48,7 +48,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Plum Lightpad from a config entry."""
-    _LOGGER.info("Setting up config entry with ID = %s", entry.unique_id)
+    _LOGGER.debug("Setting up config entry with ID = %s", entry.unique_id)
 
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)

--- a/homeassistant/components/plum_lightpad/__init__.py
+++ b/homeassistant/components/plum_lightpad/__init__.py
@@ -1,5 +1,4 @@
 """Support for Plum Lightpad devices."""
-from copy import deepcopy
 import logging
 
 import voluptuous as vol
@@ -39,7 +38,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
     _LOGGER.info("Found Plum Lightpad configuration in config, importing...")
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=deepcopy(conf)
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
         )
     )
 

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -45,7 +45,7 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await load_plum(username, password, self.hass)
         except (ContentTypeError, ConnectTimeout, HTTPError) as ex:
-            _LOGGER.error("Unable to connect to Plum cloud: %s", str(ex))
+            _LOGGER.error("Unable to connect/authenticate to Plum cloud: %s", str(ex))
             return self._show_form({"base": "cannot_connect"})
 
         already_registered = await self.async_set_unique_id(username)

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -48,9 +48,8 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.error("Unable to connect/authenticate to Plum cloud: %s", str(ex))
             return self._show_form({"base": "cannot_connect"})
 
-        already_registered = await self.async_set_unique_id(username)
-        if already_registered:
-            return self.async_abort(reason="single_instance_per_username_allowed")
+        await self.async_set_unique_id(username)
+        self._abort_if_unique_id_configured()
 
         return self.async_create_entry(
             title=username, data={CONF_USERNAME: username, CONF_PASSWORD: password}

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import ConfigType
 
-from .const import DOMAIN
+from .const import DOMAIN  # pylint: disable=unused-import
 from .utils import load_plum
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -1,0 +1,58 @@
+"""Config flow for Plum Lightpad."""
+import logging
+from typing import Any, Dict, Optional
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import ConfigType
+
+from .const import DOMAIN
+from .utils import load_plum
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for Plum Lightpad integration."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: Optional[ConfigType]) -> Dict[str, Any]:
+        """Handle a flow initialized by the user or redirected to by import."""
+        if not user_input:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_USERNAME): str,
+                        vol.Required(CONF_PASSWORD): str,
+                    }
+                ),
+            )
+
+        username = user_input[CONF_USERNAME]
+        password = user_input[CONF_PASSWORD]
+
+        # load Plum just so we know username/password work
+        plum = await load_plum(username, password, self.hass)
+        plum.cleanup()
+
+        already_registered = await self.async_set_unique_id(username)
+        if already_registered:
+            _LOGGER.warning(
+                "Config entry with ID = %s is already registered, skipping...",
+                self.unique_id,
+            )
+            return self.async_abort(reason="single_instance_per_username_allowed")
+
+        return self.async_create_entry(
+            title=username, data={CONF_USERNAME: username, CONF_PASSWORD: password}
+        )
+
+    async def async_step_import(
+        self, import_config: Optional[ConfigType]
+    ) -> Dict[str, Any]:
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -36,8 +36,7 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         password = user_input[CONF_PASSWORD]
 
         # load Plum just so we know username/password work
-        plum = await load_plum(username, password, self.hass)
-        plum.cleanup()
+        await load_plum(username, password, self.hass)
 
         already_registered = await self.async_set_unique_id(username)
         if already_registered:

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -19,7 +19,9 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: Optional[ConfigType]) -> Dict[str, Any]:
+    async def async_step_user(
+        self, user_input: Optional[ConfigType] = None
+    ) -> Dict[str, Any]:
         """Handle a flow initialized by the user or redirected to by import."""
         if not user_input:
             return self.async_show_form(

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -42,7 +42,8 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         already_registered = await self.async_set_unique_id(username)
         if already_registered:
             _LOGGER.warning(
-                "Config entry with ID = %s is already registered, skipping...",
+                "Config entry with Domain/ID = %s/%s is already registered, skipping...",
+                DOMAIN,
                 self.unique_id,
             )
             return self.async_abort(reason="single_instance_per_username_allowed")

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -1,5 +1,4 @@
 """Config flow for Plum Lightpad."""
-import logging
 from typing import Any, Dict, Optional
 
 import voluptuous as vol
@@ -10,8 +9,6 @@ from homeassistant.helpers import ConfigType
 
 from .const import DOMAIN
 from .utils import load_plum
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -42,11 +39,6 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         already_registered = await self.async_set_unique_id(username)
         if already_registered:
-            _LOGGER.warning(
-                "Config entry with Domain/ID = %s/%s is already registered, skipping...",
-                DOMAIN,
-                self.unique_id,
-            )
             return self.async_abort(reason="single_instance_per_username_allowed")
 
         return self.async_create_entry(

--- a/homeassistant/components/plum_lightpad/light.py
+++ b/homeassistant/components/plum_lightpad/light.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
         setup_entities(device)
 
     device_web_session = async_get_clientsession(hass, verify_ssl=False)
-    hass.async_create_task(
+    hass.loop.create_task(
         plum.discover(
             hass.loop,
             loadListener=new_load,

--- a/homeassistant/components/plum_lightpad/light.py
+++ b/homeassistant/components/plum_lightpad/light.py
@@ -1,4 +1,9 @@
 """Support for Plum Lightpad lights."""
+import logging
+from typing import Callable, List
+
+from plumlightpad import Plum
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
@@ -6,30 +11,55 @@ from homeassistant.components.light import (
     SUPPORT_COLOR,
     LightEntity,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import Entity
 import homeassistant.util.color as color_util
 
 from .const import DOMAIN
 
+_LOGGER = logging.getLogger(__name__)
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Initialize the Plum Lightpad Light and GlowRing."""
-    if discovery_info is None:
-        return
 
-    plum = hass.data[DOMAIN]
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity]], None],
+) -> None:
+    """Set up Plum Lightpad dimmer lights and glow rings."""
 
-    entities = []
+    plum: Plum = hass.data[DOMAIN][entry.entry_id]
 
-    if "lpid" in discovery_info:
-        lightpad = plum.get_lightpad(discovery_info["lpid"])
-        entities.append(GlowRing(lightpad=lightpad))
+    def setup_entities(device) -> None:
+        entities = []
 
-    if "llid" in discovery_info:
-        logical_load = plum.get_load(discovery_info["llid"])
-        entities.append(PlumLight(load=logical_load))
+        if "lpid" in device:
+            lightpad = plum.get_lightpad(device["lpid"])
+            entities.append(GlowRing(lightpad=lightpad))
 
-    if entities:
-        async_add_entities(entities)
+        if "llid" in device:
+            logical_load = plum.get_load(device["llid"])
+            entities.append(PlumLight(load=logical_load))
+
+        if entities:
+            async_add_entities(entities)
+
+    async def new_load(device):
+        setup_entities(device)
+
+    async def new_lightpad(device):
+        setup_entities(device)
+
+    device_web_session = async_get_clientsession(hass, verify_ssl=False)
+    hass.async_create_task(
+        plum.discover(
+            hass.loop,
+            loadListener=new_load,
+            lightpadListener=new_lightpad,
+            websession=device_web_session,
+        )
+    )
 
 
 class PlumLight(LightEntity):
@@ -63,6 +93,16 @@ class PlumLight(LightEntity):
     def name(self):
         """Return the name of the switch if any."""
         return self._load.name
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "name": self.name,
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "model": "Dimmer",
+            "manufacturer": "Plum",
+        }
 
     @property
     def brightness(self) -> int:
@@ -144,6 +184,16 @@ class GlowRing(LightEntity):
     def name(self):
         """Return the name of the switch if any."""
         return self._name
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "name": self.name,
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "model": "Glow Ring",
+            "manufacturer": "Plum",
+        }
 
     @property
     def brightness(self) -> int:

--- a/homeassistant/components/plum_lightpad/manifest.json
+++ b/homeassistant/components/plum_lightpad/manifest.json
@@ -2,6 +2,12 @@
   "domain": "plum_lightpad",
   "name": "Plum Lightpad",
   "documentation": "https://www.home-assistant.io/integrations/plum_lightpad",
-  "requirements": ["plumlightpad==0.0.11"],
-  "codeowners": ["@ColinHarrington"]
+  "requirements": [
+    "plumlightpad==0.0.11"
+  ],
+  "codeowners": [
+    "@ColinHarrington",
+    "@prystupa"
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/plum_lightpad/strings.json
+++ b/homeassistant/components/plum_lightpad/strings.json
@@ -2,7 +2,6 @@
   "config": {
     "step": {
       "user": {
-        "title": "Fill in your Plum Cloud login information",
         "data": {
           "username": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/components/plum_lightpad/strings.json
+++ b/homeassistant/components/plum_lightpad/strings.json
@@ -11,7 +11,7 @@
       }
     },
     "abort": {
-      "single_instance_per_username_allowed": "Only one config entry per unique username is supported"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   }
 }

--- a/homeassistant/components/plum_lightpad/strings.json
+++ b/homeassistant/components/plum_lightpad/strings.json
@@ -8,6 +8,9 @@
         }
       }
     },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }

--- a/homeassistant/components/plum_lightpad/strings.json
+++ b/homeassistant/components/plum_lightpad/strings.json
@@ -1,0 +1,17 @@
+{
+  "title": "Plum Lightpad",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Fill in your Plum Cloud login information",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_per_username_allowed": "Only one config entry per unique username is supported"
+    }
+  }
+}

--- a/homeassistant/components/plum_lightpad/strings.json
+++ b/homeassistant/components/plum_lightpad/strings.json
@@ -5,8 +5,8 @@
       "user": {
         "title": "Fill in your Plum Cloud login information",
         "data": {
-          "username": "Email",
-          "password": "Password"
+          "username": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },

--- a/homeassistant/components/plum_lightpad/strings.json
+++ b/homeassistant/components/plum_lightpad/strings.json
@@ -1,5 +1,4 @@
 {
-  "title": "Plum Lightpad",
   "config": {
     "step": {
       "user": {

--- a/homeassistant/components/plum_lightpad/translations/en.json
+++ b/homeassistant/components/plum_lightpad/translations/en.json
@@ -1,0 +1,17 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_per_username_allowed": "Only one config entry per unique username is supported"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "password": "Password",
+                    "username": "Email"
+                },
+                "title": "Fill in your Plum Cloud login information"
+            }
+        }
+    },
+    "title": "Plum Lightpad"
+}

--- a/homeassistant/components/plum_lightpad/translations/en.json
+++ b/homeassistant/components/plum_lightpad/translations/en.json
@@ -3,6 +3,9 @@
         "abort": {
             "single_instance_per_username_allowed": "Only one config entry per unique username is supported"
         },
+        "error": {
+            "cannot_connect": "Unable to connect to Plum Cloud."
+        },
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/plum_lightpad/utils.py
+++ b/homeassistant/components/plum_lightpad/utils.py
@@ -1,0 +1,14 @@
+"""Reusable utilities for the Plum Lightpad component."""
+
+from plumlightpad import Plum
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+
+async def load_plum(username: str, password: str, hass: HomeAssistant) -> Plum:
+    """Initialize Plum Lightpad API and load metadata stored in the cloud."""
+    plum = Plum(username, password)
+    cloud_web_session = async_get_clientsession(hass, verify_ssl=True)
+    await plum.loadCloudData(cloud_web_session)
+    return plum

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -118,6 +118,7 @@ FLOWS = [
     "plaato",
     "plex",
     "plugwise",
+    "plum_lightpad",
     "point",
     "powerwall",
     "ps4",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -470,9 +470,6 @@ plexauth==0.0.5
 # homeassistant.components.plex
 plexwebsocket==0.0.10
 
-# homeassistant.components.plum_lightpad
-plumlightpad==0.0.11
-
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm
 pmsensor==0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -470,6 +470,9 @@ plexauth==0.0.5
 # homeassistant.components.plex
 plexwebsocket==0.0.10
 
+# homeassistant.components.plum_lightpad
+plumlightpad==0.0.11
+
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm
 pmsensor==0.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR makes it possible for Plum Lightpad integration to be configured via config flow from UI and/or from existing configuration in configuration.yaml.
This PR also exposes Plum dimmers and glow rings as devices, so that they can be manipulated in automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
