### PR TITLE
Fix TTS key by hashing options values too

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -1,6 +1,5 @@
 """Provide functionality for TTS."""
 import asyncio
-import ctypes
 import functools as ft
 import hashlib
 import io
@@ -8,7 +7,7 @@ import logging
 import mimetypes
 import os
 import re
-from typing import Optional
+from typing import Dict, Optional
 
 from aiohttp import web
 import mutagen
@@ -212,6 +211,16 @@ async def async_setup(hass, config):
     return True
 
 
+def _hash_options(options: Dict) -> str:
+    """Hashes an options dictionary."""
+    opts_hash = hashlib.blake2s(digest_size=5)
+    for key, value in sorted(options.items()):
+        opts_hash.update(str(key).encode())
+        opts_hash.update(str(value).encode())
+
+    return opts_hash.hexdigest()
+
+
 class SpeechManager:
     """Representation of a speech store."""
 
@@ -304,7 +313,7 @@ class SpeechManager:
             ]
             if invalid_opts:
                 raise HomeAssistantError(f"Invalid options found: {invalid_opts}")
-            options_key = ctypes.c_size_t(hash(frozenset(options))).value
+            options_key = _hash_options(options)
         else:
             options_key = "-"
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1,6 +1,4 @@
 """The tests for the TTS component."""
-import ctypes
-
 import pytest
 import yarl
 
@@ -265,11 +263,11 @@ async def test_setup_component_and_test_service_with_service_options(
             "entity_id": "media_player.something",
             tts.ATTR_MESSAGE: "There is someone at the door.",
             tts.ATTR_LANGUAGE: "de",
-            tts.ATTR_OPTIONS: {"voice": "alex"},
+            tts.ATTR_OPTIONS: {"voice": "alex", "age": 5},
         },
         blocking=True,
     )
-    opt_hash = ctypes.c_size_t(hash(frozenset({"voice": "alex"}))).value
+    opt_hash = tts._hash_options({"voice": "alex", "age": 5})
 
     assert len(calls) == 1
     assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
@@ -306,7 +304,7 @@ async def test_setup_component_and_test_with_service_options_def(hass, empty_cac
             },
             blocking=True,
         )
-        opt_hash = ctypes.c_size_t(hash(frozenset({"voice": "alex"}))).value
+        opt_hash = tts._hash_options({"voice": "alex"})
 
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
@@ -343,7 +341,7 @@ async def test_setup_component_and_test_service_with_service_options_wrong(
         },
         blocking=True,
     )
-    opt_hash = ctypes.c_size_t(hash(frozenset({"speed": 1}))).value
+    opt_hash = tts._hash_options({"speed": 1})
 
     assert len(calls) == 0
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The generated hash of the TTS options was only looking at the keys, not the values. This caused incorrect cache hits.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
