### PR TITLE
Fix Plugwise schema name display and non_device_class icons

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -122,8 +122,7 @@ class PwThermostat(SmileGateway, ClimateEntity):
         """Return the device specific state attributes."""
         attributes = {}
         if self._schema_names:
-            if len(self._schema_names) > 1:
-                attributes["available_schemas"] = self._schema_names
+            attributes["available_schemas"] = self._schema_names
         if self._selected_schema:
             attributes["selected_schema"] = self._selected_schema
         return attributes

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -317,8 +317,6 @@ class PwAuxDeviceSensor(SmileSensor, Entity):
     @property
     def icon(self):
         """Return the icon to use in the frontend."""
-        if CUSTOM_ICONS.get(self._sensor) is not None:
-            self._icon = CUSTOM_ICONS.get(self._sensor)
         return self._icon
 
     @callback
@@ -335,6 +333,9 @@ class PwAuxDeviceSensor(SmileSensor, Entity):
             self._heating_state = data["heating_state"]
         if data.get("cooling_state") is not None:
             self._cooling_state = data["cooling_state"]
+
+        if CUSTOM_ICONS.get(self._sensor) is not None:
+            self._icon = CUSTOM_ICONS.get(self._sensor)
 
         self._state = "idle"
         self._icon = IDLE_ICON
@@ -380,5 +381,8 @@ class PwPowerSensor(SmileSensor, Entity):
             if self._unit_of_measurement == ENERGY_KILO_WATT_HOUR:
                 measurement = int(measurement / 1000)
             self._state = measurement
+
+        if CUSTOM_ICONS.get(self._sensor) is not None:
+            self._icon = CUSTOM_ICONS.get(self._sensor)
 
         self.async_write_ha_state()

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -157,6 +157,13 @@ INDICATE_ACTIVE_LOCAL_DEVICE = [
     "flame_state",
 ]
 
+CUSTOM_ICONS = {
+    "gas_consumed_interval": "mdi:fire",
+    "gas_consumed_cumulative": "mdi:fire",
+    "modulation_level": "mdi:percent",
+    "valve_position": "mdi:valve",
+}
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Smile sensors from a config entry."""
@@ -310,6 +317,8 @@ class PwAuxDeviceSensor(SmileSensor, Entity):
     @property
     def icon(self):
         """Return the icon to use in the frontend."""
+        if CUSTOM_ICONS.get(self._sensor) is not None:
+            self._icon = CUSTOM_ICONS.get(self._sensor)
         return self._icon
 
     @callback

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -278,6 +278,7 @@ class PwThermostatSensor(SmileSensor, Entity):
         """Set up the Plugwise API."""
         super().__init__(api, coordinator, name, dev_id, sensor)
 
+        self._icon = None
         self._model = sensor_type[SENSOR_MAP_MODEL]
         self._unit_of_measurement = sensor_type[SENSOR_MAP_UOM]
         self._dev_class = sensor_type[SENSOR_MAP_DEVICE_CLASS]
@@ -299,6 +300,7 @@ class PwThermostatSensor(SmileSensor, Entity):
             if self._unit_of_measurement == UNIT_PERCENTAGE:
                 measurement = int(measurement)
             self._state = measurement
+            self._icon = CUSTOM_ICONS.get(self._sensor, self._icon)
 
         self.async_write_ha_state()
 
@@ -343,8 +345,6 @@ class PwAuxDeviceSensor(SmileSensor, Entity):
             self._state = "cooling"
             self._icon = COOL_ICON
 
-        self._icon = CUSTOM_ICONS.get(self._sensor, self._icon)
-
         self.async_write_ha_state()
 
 
@@ -355,6 +355,7 @@ class PwPowerSensor(SmileSensor, Entity):
         """Set up the Plugwise API."""
         super().__init__(api, coordinator, name, dev_id, sensor)
 
+        self._icon = None
         self._model = model
         if model is None:
             self._model = sensor_type[SENSOR_MAP_MODEL]
@@ -380,8 +381,6 @@ class PwPowerSensor(SmileSensor, Entity):
             if self._unit_of_measurement == ENERGY_KILO_WATT_HOUR:
                 measurement = int(measurement / 1000)
             self._state = measurement
-
-        if CUSTOM_ICONS.get(self._sensor) is not None:
-            self._icon = CUSTOM_ICONS.get(self._sensor)
+            self._icon = CUSTOM_ICONS.get(self._sensor, self._icon)
 
         self.async_write_ha_state()

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -343,8 +343,7 @@ class PwAuxDeviceSensor(SmileSensor, Entity):
             self._state = "cooling"
             self._icon = COOL_ICON
 
-        if CUSTOM_ICONS.get(self._sensor) is not None:
-            self._icon = CUSTOM_ICONS.get(self._sensor)
+        self._icon = CUSTOM_ICONS.get(self._sensor, self._icon)
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -334,9 +334,6 @@ class PwAuxDeviceSensor(SmileSensor, Entity):
         if data.get("cooling_state") is not None:
             self._cooling_state = data["cooling_state"]
 
-        if CUSTOM_ICONS.get(self._sensor) is not None:
-            self._icon = CUSTOM_ICONS.get(self._sensor)
-
         self._state = "idle"
         self._icon = IDLE_ICON
         if self._heating_state:
@@ -345,6 +342,9 @@ class PwAuxDeviceSensor(SmileSensor, Entity):
         if self._cooling_state:
             self._state = "cooling"
             self._icon = COOL_ICON
+
+        if CUSTOM_ICONS.get(self._sensor) is not None:
+            self._icon = CUSTOM_ICONS.get(self._sensor)
 
         self.async_write_ha_state()
 


### PR DESCRIPTION
## Proposed change
Small change to always show available schema's even if there is only one and add icons for non `device_class` entities

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes #36669
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

