### PR TITLE
Add support for multiple entity_ids in conditions

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -844,7 +844,7 @@ NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_CONDITION): "numeric_state",
-            vol.Required(CONF_ENTITY_ID): entity_id,
+            vol.Required(CONF_ENTITY_ID): entity_ids,
             CONF_BELOW: vol.Coerce(float),
             CONF_ABOVE: vol.Coerce(float),
             vol.Optional(CONF_VALUE_TEMPLATE): template,
@@ -857,7 +857,7 @@ STATE_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_CONDITION): "state",
-            vol.Required(CONF_ENTITY_ID): entity_id,
+            vol.Required(CONF_ENTITY_ID): entity_ids,
             vol.Required(CONF_STATE): str,
             vol.Optional(CONF_FOR): vol.All(time_period, positive_timedelta),
             # To support use_trigger_value in automation
@@ -905,7 +905,7 @@ TIME_CONDITION_SCHEMA = vol.All(
 ZONE_CONDITION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_CONDITION): "zone",
-        vol.Required(CONF_ENTITY_ID): entity_id,
+        vol.Required(CONF_ENTITY_ID): entity_ids,
         "zone": entity_id,
         # To support use_trigger_value in automation
         # Deprecated 2016/04/25

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -266,6 +266,123 @@ async def test_if_numeric_state_not_raise_on_unavailable(hass):
         assert len(logwarn.mock_calls) == 0
 
 
+async def test_state_multiple_entities(hass):
+    """Test with multiple entities in condition."""
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "state",
+                    "entity_id": ["sensor.temperature_1", "sensor.temperature_2"],
+                    "state": "100",
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set("sensor.temperature_1", 100)
+    hass.states.async_set("sensor.temperature_2", 100)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature_1", 101)
+    hass.states.async_set("sensor.temperature_2", 100)
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature_1", 100)
+    hass.states.async_set("sensor.temperature_2", 101)
+    assert not test(hass)
+
+
+async def test_numeric_state_multiple_entities(hass):
+    """Test with multiple entities in condition."""
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "numeric_state",
+                    "entity_id": ["sensor.temperature_1", "sensor.temperature_2"],
+                    "below": 50,
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set("sensor.temperature_1", 49)
+    hass.states.async_set("sensor.temperature_2", 49)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature_1", 50)
+    hass.states.async_set("sensor.temperature_2", 49)
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature_1", 49)
+    hass.states.async_set("sensor.temperature_2", 50)
+    assert not test(hass)
+
+
+async def test_zone_multiple_entities(hass):
+    """Test with multiple entities in condition."""
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "zone",
+                    "entity_id": ["device_tracker.person_1", "device_tracker.person_2"],
+                    "zone": "zone.home",
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set(
+        "zone.home",
+        "zoning",
+        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
+    )
+
+    hass.states.async_set(
+        "device_tracker.person_1",
+        "home",
+        {"friendly_name": "person_1", "latitude": 2.1, "longitude": 1.1},
+    )
+    hass.states.async_set(
+        "device_tracker.person_2",
+        "home",
+        {"friendly_name": "person_2", "latitude": 2.1, "longitude": 1.1},
+    )
+    assert test(hass)
+
+    hass.states.async_set(
+        "device_tracker.person_1",
+        "home",
+        {"friendly_name": "person_1", "latitude": 20.1, "longitude": 10.1},
+    )
+    hass.states.async_set(
+        "device_tracker.person_2",
+        "home",
+        {"friendly_name": "person_2", "latitude": 2.1, "longitude": 1.1},
+    )
+    assert not test(hass)
+
+    hass.states.async_set(
+        "device_tracker.person_1",
+        "home",
+        {"friendly_name": "person_1", "latitude": 2.1, "longitude": 1.1},
+    )
+    hass.states.async_set(
+        "device_tracker.person_2",
+        "home",
+        {"friendly_name": "person_2", "latitude": 20.1, "longitude": 10.1},
+    )
+    assert not test(hass)
+
+
 async def test_extract_entities():
     """Test extracting entities."""
     assert condition.async_extract_entities(
@@ -312,6 +429,16 @@ async def test_extract_entities():
                         },
                     ],
                 },
+                {
+                    "condition": "state",
+                    "entity_id": ["sensor.temperature_7", "sensor.temperature_8"],
+                    "state": "100",
+                },
+                {
+                    "condition": "numeric_state",
+                    "entity_id": ["sensor.temperature_9", "sensor.temperature_10"],
+                    "below": 110,
+                },
             ],
         }
     ) == {
@@ -321,6 +448,10 @@ async def test_extract_entities():
         "sensor.temperature_4",
         "sensor.temperature_5",
         "sensor.temperature_6",
+        "sensor.temperature_7",
+        "sensor.temperature_8",
+        "sensor.temperature_9",
+        "sensor.temperature_10",
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for using a list of entities in a condition statement.
This is more in line with the trigger syntax and allows for reducing the amount of code needed in automations.

Example before:

```yaml
condition:
  - platform: state
    entity_id: light.kitchen
    state: 'on'
  - platform: state
    entity_id: light.living_room
    state: 'on'
  - platform: state
    entity_id: light.office
    state: 'on'
```

Example after:

```yaml
condition:
  - platform: state
    entity_id:
      - light.kitchen
      - light.living_room
      - light.office
    state: 'on'
```

The same has been applied to other conditions that support entities: numeric_state and zone:

```yaml
condition:
  - platform: numeric_state
    entity_id:
      - sensor.kitchen_temperature
      - sensor.living_room_temperature
      - sensor.office_temperature
    below: 18
```

```yaml
condition:
  - platform: zone
    entity_id:
      - device_tracker.frenck
      - device_tracker.daphne
    zone: zone.home
````

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

See proposal.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13761

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
