### PR TITLE
Update MQTT tests to not create duplicated config entries

### DIFF
--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -41,11 +41,7 @@ from .test_common import (
 )
 
 from tests.async_mock import patch
-from tests.common import (
-    MockConfigEntry,
-    async_fire_mqtt_message,
-    async_fire_time_changed,
-)
+from tests.common import async_fire_mqtt_message, async_fire_time_changed
 
 DEFAULT_CONFIG = {
     binary_sensor.DOMAIN: {
@@ -527,7 +523,7 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
     hass, mqtt_mock, caplog
 ):
     """Test that binary_sensor with expire_after set behaves correctly on discovery and discovery update."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
     config = {

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -30,11 +30,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-from tests.common import (
-    MockConfigEntry,
-    async_fire_mqtt_message,
-    async_mock_mqtt_component,
-)
+from tests.common import async_fire_mqtt_message, async_mock_mqtt_component
 
 DEFAULT_CONFIG = {
     camera.DOMAIN: {"platform": "mqtt", "name": "test", "topic": "test_topic"}
@@ -155,7 +151,7 @@ async def test_discovery_removal_camera(hass, mqtt_mock, caplog):
 
 async def test_discovery_update_camera(hass, mqtt_mock, caplog):
     """Test update of discovered camera."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
     data1 = '{ "name": "Beer",' '  "topic": "test_topic"}'
@@ -169,7 +165,7 @@ async def test_discovery_update_camera(hass, mqtt_mock, caplog):
 @pytest.mark.no_fail_on_log_exception
 async def test_discovery_broken(hass, mqtt_mock, caplog):
     """Test handling of bad discovery message."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
     data1 = '{ "name": "Beer" }'

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from tests.async_mock import ANY
 from tests.common import (
-    MockConfigEntry,
     async_fire_mqtt_message,
     async_mock_mqtt_component,
     async_setup_component,
@@ -250,7 +249,7 @@ async def help_test_discovery_update_attr(hass, mqtt_mock, caplog, domain, confi
     data1 = json.dumps(config1[domain])
     data2 = json.dumps(config2[domain])
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data1)
     await hass.async_block_till_done()
@@ -286,7 +285,7 @@ async def help_test_discovery_removal(hass, mqtt_mock, caplog, domain, data):
 
     This is a test helper for the MqttDiscoveryUpdate mixin.
     """
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -308,7 +307,7 @@ async def help_test_discovery_update(hass, mqtt_mock, caplog, domain, data1, dat
 
     This is a test helper for the MqttDiscoveryUpdate mixin.
     """
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data1)
@@ -331,7 +330,7 @@ async def help_test_discovery_update(hass, mqtt_mock, caplog, domain, data1, dat
 
 async def help_test_discovery_broken(hass, mqtt_mock, caplog, domain, data1, data2):
     """Test handling of bad discovery message."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data1)
@@ -360,8 +359,7 @@ async def help_test_entity_device_info_with_identifier(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -388,8 +386,7 @@ async def help_test_entity_device_info_with_connection(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_MAC)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -413,8 +410,7 @@ async def help_test_entity_device_info_remove(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     dev_registry = await hass.helpers.device_registry.async_get_registry()
     ent_registry = await hass.helpers.entity_registry.async_get_registry()
@@ -445,8 +441,7 @@ async def help_test_entity_device_info_update(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -519,8 +514,7 @@ async def help_test_entity_id_update_discovery_update(
         config[domain]["availability_topic"] = "avty-topic"
         topic = "avty-topic"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     ent_registry = mock_registry(hass, {})
 
@@ -560,8 +554,7 @@ async def help_test_entity_debug_info(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -596,8 +589,7 @@ async def help_test_entity_debug_info_max_messages(hass, mqtt_mock, domain, conf
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -661,8 +653,7 @@ async def help_test_entity_debug_info_message(
     if payload is None:
         payload = "ON"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -710,8 +701,7 @@ async def help_test_entity_debug_info_remove(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -756,8 +746,7 @@ async def help_test_entity_debug_info_update_entity_id(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     dev_registry = await hass.helpers.device_registry.async_get_registry()
     ent_registry = mock_registry(hass, {})

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -10,7 +10,6 @@ from homeassistant.components.mqtt.discovery import async_start
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
-    MockConfigEntry,
     assert_lists_same,
     async_fire_mqtt_message,
     async_get_device_automations,
@@ -41,8 +40,7 @@ def calls(hass):
 
 async def test_get_triggers(hass, device_reg, entity_reg, mqtt_mock):
     """Test we get the expected triggers from a discovered mqtt device."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -73,8 +71,7 @@ async def test_get_triggers(hass, device_reg, entity_reg, mqtt_mock):
 
 async def test_get_unknown_triggers(hass, device_reg, entity_reg, mqtt_mock):
     """Test we don't get unknown triggers."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     # Discover a sensor (without device triggers)
@@ -117,8 +114,7 @@ async def test_get_unknown_triggers(hass, device_reg, entity_reg, mqtt_mock):
 
 async def test_get_non_existing_triggers(hass, device_reg, entity_reg, mqtt_mock):
     """Test getting non existing triggers."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     # Discover a sensor (without device triggers)
@@ -138,8 +134,7 @@ async def test_get_non_existing_triggers(hass, device_reg, entity_reg, mqtt_mock
 @pytest.mark.no_fail_on_log_exception
 async def test_discover_bad_triggers(hass, device_reg, entity_reg, mqtt_mock):
     """Test bad discovery message."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     # Test sending bad data
@@ -184,8 +179,7 @@ async def test_discover_bad_triggers(hass, device_reg, entity_reg, mqtt_mock):
 
 async def test_update_remove_triggers(hass, device_reg, entity_reg, mqtt_mock):
     """Test triggers can be updated and removed."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -241,8 +235,7 @@ async def test_update_remove_triggers(hass, device_reg, entity_reg, mqtt_mock):
 
 async def test_if_fires_on_mqtt_message(hass, device_reg, calls, mqtt_mock):
     """Test triggers firing."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -320,8 +313,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
     hass, device_reg, calls, mqtt_mock
 ):
     """Test triggers firing of MQTT device triggers discovered after setup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data0 = (
@@ -407,8 +399,7 @@ async def test_if_fires_on_mqtt_message_after_update(
     hass, device_reg, calls, mqtt_mock
 ):
     """Test triggers firing after update."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -485,8 +476,7 @@ async def test_if_fires_on_mqtt_message_after_update(
 async def test_no_resubscribe_same_topic(hass, device_reg, mqtt_mock):
     """Test subscription to topics without change."""
     mock_mqtt = await async_mock_mqtt_component(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -533,8 +523,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     hass, device_reg, calls, mqtt_mock
 ):
     """Test triggers not firing after removal."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -597,8 +586,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     hass, device_reg, calls, mqtt_mock
 ):
     """Test triggers not firing after removal."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -651,8 +639,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
 async def test_attach_remove(hass, device_reg, mqtt_mock):
     """Test attach and removal of trigger."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data1 = (
@@ -704,8 +691,7 @@ async def test_attach_remove(hass, device_reg, mqtt_mock):
 
 async def test_attach_remove_late(hass, device_reg, mqtt_mock):
     """Test attach and removal of trigger ."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data0 = (
@@ -765,8 +751,7 @@ async def test_attach_remove_late(hass, device_reg, mqtt_mock):
 
 async def test_attach_remove_late2(hass, device_reg, mqtt_mock):
     """Test attach and removal of trigger ."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data0 = (
@@ -820,8 +805,7 @@ async def test_attach_remove_late2(hass, device_reg, mqtt_mock):
 
 async def test_entity_device_info_with_connection(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -854,8 +838,7 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock):
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -888,8 +871,7 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
 
 async def test_entity_device_info_update(hass, mqtt_mock):
     """Test device registry update."""
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -928,8 +910,7 @@ async def test_entity_device_info_update(hass, mqtt_mock):
 
 async def test_cleanup_trigger(hass, device_reg, entity_reg, mqtt_mock):
     """Test trigger discovery topic is cleaned when device is removed from registry."""
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     config = {
@@ -967,8 +948,7 @@ async def test_cleanup_trigger(hass, device_reg, entity_reg, mqtt_mock):
 
 async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
     """Test removal from device registry when trigger is removed."""
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     config = {
@@ -1000,8 +980,7 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
 
 async def test_cleanup_device_several_triggers(hass, device_reg, entity_reg, mqtt_mock):
     """Test removal from device registry when the last trigger is removed."""
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     config1 = {
@@ -1060,8 +1039,7 @@ async def test_cleanup_device_with_entity1(hass, device_reg, entity_reg, mqtt_mo
 
     Trigger removed first, then entity.
     """
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     config1 = {
@@ -1116,8 +1094,7 @@ async def test_cleanup_device_with_entity2(hass, device_reg, entity_reg, mqtt_mo
 
     Entity removed first, then trigger.
     """
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     config1 = {
@@ -1172,8 +1149,7 @@ async def test_trigger_debug_info(hass, mqtt_mock):
 
     This is a test helper for MQTT debug_info.
     """
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -13,12 +13,7 @@ from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED, async_st
 from homeassistant.const import STATE_OFF, STATE_ON
 
 from tests.async_mock import AsyncMock, patch
-from tests.common import (
-    MockConfigEntry,
-    async_fire_mqtt_message,
-    mock_device_registry,
-    mock_registry,
-)
+from tests.common import async_fire_mqtt_message, mock_device_registry, mock_registry
 
 
 @pytest.fixture
@@ -35,7 +30,7 @@ def entity_reg(hass):
 
 async def test_subscribing_config_topic(hass, mqtt_mock):
     """Test setting up discovery."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     discovery_topic = "homeassistant"
     await async_start(hass, discovery_topic, entry)
@@ -51,9 +46,7 @@ async def test_invalid_topic(hass, mqtt_mock):
     with patch(
         "homeassistant.components.mqtt.discovery.async_dispatcher_send"
     ) as mock_dispatcher_send:
-        entry = MockConfigEntry(
-            domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"}
-        )
+        entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
         mock_dispatcher_send = AsyncMock(return_value=None)
         await async_start(hass, "homeassistant", entry)
@@ -70,9 +63,7 @@ async def test_invalid_json(hass, mqtt_mock, caplog):
     with patch(
         "homeassistant.components.mqtt.discovery.async_dispatcher_send"
     ) as mock_dispatcher_send:
-        entry = MockConfigEntry(
-            domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"}
-        )
+        entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
         mock_dispatcher_send = AsyncMock(return_value=None)
         await async_start(hass, "homeassistant", entry)
@@ -90,7 +81,7 @@ async def test_only_valid_components(hass, mqtt_mock, caplog):
     with patch(
         "homeassistant.components.mqtt.discovery.async_dispatcher_send"
     ) as mock_dispatcher_send:
-        entry = MockConfigEntry(domain=mqtt.DOMAIN)
+        entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
         invalid_component = "timer"
 
@@ -110,7 +101,7 @@ async def test_only_valid_components(hass, mqtt_mock, caplog):
 
 async def test_correct_config_discovery(hass, mqtt_mock, caplog):
     """Test sending in correct JSON."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -130,7 +121,7 @@ async def test_correct_config_discovery(hass, mqtt_mock, caplog):
 
 async def test_discover_fan(hass, mqtt_mock, caplog):
     """Test discovering an MQTT fan."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -150,7 +141,7 @@ async def test_discover_fan(hass, mqtt_mock, caplog):
 
 async def test_discover_climate(hass, mqtt_mock, caplog):
     """Test discovering an MQTT climate component."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -172,7 +163,7 @@ async def test_discover_climate(hass, mqtt_mock, caplog):
 
 async def test_discover_alarm_control_panel(hass, mqtt_mock, caplog):
     """Test discovering an MQTT alarm control panel component."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -194,7 +185,7 @@ async def test_discover_alarm_control_panel(hass, mqtt_mock, caplog):
 
 async def test_discovery_incl_nodeid(hass, mqtt_mock, caplog):
     """Test sending in correct JSON with optional node_id included."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -214,7 +205,7 @@ async def test_discovery_incl_nodeid(hass, mqtt_mock, caplog):
 
 async def test_non_duplicate_discovery(hass, mqtt_mock, caplog):
     """Test for a non duplicate component."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -241,7 +232,7 @@ async def test_non_duplicate_discovery(hass, mqtt_mock, caplog):
 
 async def test_removal(hass, mqtt_mock, caplog):
     """Test removal of component through empty discovery message."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -262,7 +253,7 @@ async def test_removal(hass, mqtt_mock, caplog):
 
 async def test_rediscover(hass, mqtt_mock, caplog):
     """Test rediscover of removed component."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -292,7 +283,7 @@ async def test_rediscover(hass, mqtt_mock, caplog):
 
 async def test_duplicate_removal(hass, mqtt_mock, caplog):
     """Test for a non duplicate component."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -314,8 +305,7 @@ async def test_duplicate_removal(hass, mqtt_mock, caplog):
 
 async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
     """Test discvered device is cleaned up when removed from registry."""
-    config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data = (
@@ -357,7 +347,7 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
 
 async def test_discovery_expansion(hass, mqtt_mock, caplog):
     """Test expansion of abbreviated discovery payload."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -447,7 +437,7 @@ async def test_missing_discover_abbreviations(hass, mqtt_mock, caplog):
 
 async def test_no_implicit_state_topic_switch(hass, mqtt_mock, caplog):
     """Test no implicit state topic for switch."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "homeassistant", entry)
 
@@ -472,7 +462,7 @@ async def test_no_implicit_state_topic_switch(hass, mqtt_mock, caplog):
 
 async def test_complex_discovery_topic_prefix(hass, mqtt_mock, caplog):
     """Tests handling of discovery topic prefix with multiple slashes."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     await async_start(hass, "my_home/homeassistant/register", entry)
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -895,8 +895,7 @@ async def test_mqtt_ws_remove_discovered_device(
     hass, device_reg, entity_reg, hass_ws_client, mqtt_mock
 ):
     """Test MQTT websocket device removal."""
-    config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data = (
@@ -928,8 +927,7 @@ async def test_mqtt_ws_remove_discovered_device_twice(
     hass, device_reg, hass_ws_client, mqtt_mock
 ):
     """Test MQTT websocket device removal."""
-    config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data = (
@@ -963,8 +961,7 @@ async def test_mqtt_ws_remove_discovered_device_same_topic(
     hass, device_reg, hass_ws_client, mqtt_mock
 ):
     """Test MQTT websocket device removal."""
-    config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     data = (
@@ -1021,8 +1018,7 @@ async def test_mqtt_ws_get_device_debug_info(
     hass, device_reg, hass_ws_client, mqtt_mock
 ):
     """Test MQTT websocket device debug info."""
-    config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    config_entry.add_to_hass(hass)
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", config_entry)
 
     config = {
@@ -1107,8 +1103,7 @@ async def test_debug_info_multiple_devices(hass, mqtt_mock):
         },
     ]
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -1189,8 +1184,7 @@ async def test_debug_info_multiple_entities_triggers(hass, mqtt_mock):
         },
     ]
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -1267,8 +1261,7 @@ async def test_debug_info_wildcard(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -1316,8 +1309,7 @@ async def test_debug_info_filter_same(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -1378,8 +1370,7 @@ async def test_debug_info_same_topic(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 
@@ -1432,8 +1423,7 @@ async def test_debug_info_qos_retain(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     registry = await hass.helpers.device_registry.async_get_registry()
 

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -185,11 +185,7 @@ from .test_common import (
 )
 
 from tests.async_mock import call, patch
-from tests.common import (
-    MockConfigEntry,
-    assert_setup_component,
-    async_fire_mqtt_message,
-)
+from tests.common import assert_setup_component, async_fire_mqtt_message
 from tests.components.light import common
 
 DEFAULT_CONFIG = {
@@ -1425,7 +1421,7 @@ async def test_discovery_removal_light(hass, mqtt_mock, caplog):
 
 async def test_discovery_deprecated(hass, mqtt_mock, caplog):
     """Test discovery of mqtt light with deprecated platform option."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
     data = (
         '{ "name": "Beer",' '  "platform": "mqtt",' '  "command_topic": "test_topic"}'

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -40,11 +40,7 @@ from .test_common import (
 )
 
 from tests.async_mock import patch
-from tests.common import (
-    MockConfigEntry,
-    async_fire_mqtt_message,
-    async_fire_time_changed,
-)
+from tests.common import async_fire_mqtt_message, async_fire_time_changed
 
 DEFAULT_CONFIG = {
     sensor.DOMAIN: {"platform": "mqtt", "name": "test", "state_topic": "test-topic"}
@@ -431,8 +427,7 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock):
 
 async def test_entity_device_info_with_hub(hass, mqtt_mock):
     """Test MQTT sensor device registry integration."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    entry.add_to_hass(hass)
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
     registry = await hass.helpers.device_registry.async_get_registry()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update MQTT tests to not create duplicated config entries when the `mqtt_mock` test fixture is used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
