### PR TITLE
Add support for multiple states/zones in conditions

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -295,13 +295,11 @@ def state_from_config(
     if config_validation:
         config = cv.STATE_CONDITION_SCHEMA(config)
     entity_ids = config.get(CONF_ENTITY_ID, [])
-    req_states = config.get(CONF_STATE, [])
+    req_states: Union[str, List[str]] = config.get(CONF_STATE, [])
     for_period = config.get("for")
 
     if not isinstance(req_states, list):
         req_states = [req_states]
-
-    req_states = [cast(str, req_state) for req_state in req_states]
 
     def if_state(hass: HomeAssistant, variables: TemplateVarsType = None) -> bool:
         """Test if condition."""

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import functools as ft
 import logging
 import sys
-from typing import Callable, Container, Optional, Set, Union, cast
+from typing import Callable, Container, List, Optional, Set, Union, cast
 
 from homeassistant.components import zone as zone_cmp
 from homeassistant.components.device_automation import (
@@ -263,7 +263,7 @@ def async_numeric_state_from_config(
 def state(
     hass: HomeAssistant,
     entity: Union[None, str, State],
-    req_state: str,
+    req_state: Union[str, List[str]],
     for_period: Optional[timedelta] = None,
 ) -> bool:
     """Test if state matches requirements.
@@ -277,7 +277,10 @@ def state(
         return False
     assert isinstance(entity, State)
 
-    is_state = entity.state == req_state
+    if isinstance(req_state, str):
+        req_state = [req_state]
+
+    is_state = entity.state in req_state
 
     if for_period is None or not is_state:
         return is_state
@@ -292,13 +295,18 @@ def state_from_config(
     if config_validation:
         config = cv.STATE_CONDITION_SCHEMA(config)
     entity_ids = config.get(CONF_ENTITY_ID, [])
-    req_state = cast(str, config.get(CONF_STATE))
+    req_states = config.get(CONF_STATE, [])
     for_period = config.get("for")
+
+    if not isinstance(req_states, list):
+        req_states = [req_states]
+
+    req_states = [cast(str, req_state) for req_state in req_states]
 
     def if_state(hass: HomeAssistant, variables: TemplateVarsType = None) -> bool:
         """Test if condition."""
         return all(
-            state(hass, entity_id, req_state, for_period) for entity_id in entity_ids
+            state(hass, entity_id, req_states, for_period) for entity_id in entity_ids
         )
 
     return if_state
@@ -512,11 +520,17 @@ def zone_from_config(
     if config_validation:
         config = cv.ZONE_CONDITION_SCHEMA(config)
     entity_ids = config.get(CONF_ENTITY_ID, [])
-    zone_entity_id = config.get(CONF_ZONE)
+    zone_entity_ids = config.get(CONF_ZONE, [])
 
     def if_in_zone(hass: HomeAssistant, variables: TemplateVarsType = None) -> bool:
         """Test if condition."""
-        return all(zone(hass, zone_entity_id, entity_id) for entity_id in entity_ids)
+        return all(
+            any(
+                zone(hass, zone_entity_id, entity_id)
+                for zone_entity_id in zone_entity_ids
+            )
+            for entity_id in entity_ids
+        )
 
     return if_in_zone
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -858,7 +858,7 @@ STATE_CONDITION_SCHEMA = vol.All(
         {
             vol.Required(CONF_CONDITION): "state",
             vol.Required(CONF_ENTITY_ID): entity_ids,
-            vol.Required(CONF_STATE): str,
+            vol.Required(CONF_STATE): vol.Any(str, [str]),
             vol.Optional(CONF_FOR): vol.All(time_period, positive_timedelta),
             # To support use_trigger_value in automation
             # Deprecated 2016/04/25
@@ -906,7 +906,7 @@ ZONE_CONDITION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_CONDITION): "zone",
         vol.Required(CONF_ENTITY_ID): entity_ids,
-        "zone": entity_id,
+        "zone": entity_ids,
         # To support use_trigger_value in automation
         # Deprecated 2016/04/25
         vol.Optional("event"): vol.Any("enter", "leave"),

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -295,6 +295,32 @@ async def test_state_multiple_entities(hass):
     assert not test(hass)
 
 
+async def test_multiple_states(hass):
+    """Test with multiple states in condition."""
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "state",
+                    "entity_id": "sensor.temperature",
+                    "state": ["100", "200"],
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set("sensor.temperature", 100)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature", 200)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature", 42)
+    assert not test(hass)
+
+
 async def test_numeric_state_multiple_entities(hass):
     """Test with multiple entities in condition."""
     test = await condition.async_from_config(
@@ -379,6 +405,55 @@ async def test_zone_multiple_entities(hass):
         "device_tracker.person_2",
         "home",
         {"friendly_name": "person_2", "latitude": 20.1, "longitude": 10.1},
+    )
+    assert not test(hass)
+
+
+async def test_multiple_zones(hass):
+    """Test with multiple entities in condition."""
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "zone",
+                    "entity_id": "device_tracker.person",
+                    "zone": ["zone.home", "zone.work"],
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set(
+        "zone.home",
+        "zoning",
+        {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
+    )
+    hass.states.async_set(
+        "zone.work",
+        "zoning",
+        {"name": "work", "latitude": 20.1, "longitude": 10.1, "radius": 10},
+    )
+
+    hass.states.async_set(
+        "device_tracker.person",
+        "home",
+        {"friendly_name": "person", "latitude": 2.1, "longitude": 1.1},
+    )
+    assert test(hass)
+
+    hass.states.async_set(
+        "device_tracker.person",
+        "home",
+        {"friendly_name": "person", "latitude": 20.1, "longitude": 10.1},
+    )
+    assert test(hass)
+
+    hass.states.async_set(
+        "device_tracker.person",
+        "home",
+        {"friendly_name": "person", "latitude": 50.1, "longitude": 20.1},
     )
     assert not test(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for checking against multiple possible states or zones in a state or zone condition.

Example before:

```yaml
condition:
  - condition: or
    conditions: 
      - platform: state
        entity_id: alarm_control_panel.home
        state: armed_home
      - platform: state
        entity_id: alarm_control_panel.home
        state: armed_away
```

Example after:

```yaml
condition:
  - platform: state
    entity_id: alarm_control_pane.home
    state:
      - armed_home
      - armed_away
```

This also works for zones:

```yaml
condition:
  - platform: zone
    entity_id: device_tracker.frenck
    zone:
      - zone.home
      - zone.work
```

This can be combined with the multiple entities introduced in #36817 (for both states and zones)

```yaml
condition:
  - platform: zone
    entity_id:
      - device_tracker.frenck
      - device_tracker.daphne
    zone:
      - zone.home
      - zone.work
```

The above condition would pass if both frenck and daphne are either at home or at work.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

See proposal.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13768

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
