### PR TITLE
mobile_app: Camera Stream Webhook

### DIFF
--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -72,3 +72,5 @@ ATTR_SENSOR_UOM = "unit_of_measurement"
 
 SIGNAL_SENSOR_UPDATE = f"{DOMAIN}_sensor_update"
 SIGNAL_LOCATION_UPDATE = DOMAIN + "_location_update_{}"
+
+ATTR_CAMERA_ENTITY_ID = "camera_entity_id"

--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
   "requirements": ["PyNaCl==1.3.0"],
   "dependencies": ["http", "webhook", "person"],
-  "after_dependencies": ["cloud"],
+  "after_dependencies": ["cloud", "camera"],
   "codeowners": ["@robbiet480"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES as BINARY_SENSOR_CLASSES,
 )
+from homeassistant.components.camera import SUPPORT_STREAM as CAMERA_SUPPORT_STREAM
 from homeassistant.components.device_tracker import (
     ATTR_BATTERY,
     ATTR_GPS,
@@ -29,7 +30,7 @@ from homeassistant.const import (
     HTTP_CREATED,
 )
 from homeassistant.core import EventOrigin
-from homeassistant.exceptions import ServiceNotFound, TemplateError
+from homeassistant.exceptions import HomeAssistantError, ServiceNotFound, TemplateError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.template import attach
@@ -40,6 +41,7 @@ from .const import (
     ATTR_ALTITUDE,
     ATTR_APP_DATA,
     ATTR_APP_VERSION,
+    ATTR_CAMERA_ENTITY_ID,
     ATTR_COURSE,
     ATTR_DEVICE_ID,
     ATTR_DEVICE_NAME,
@@ -238,6 +240,32 @@ async def webhook_fire_event(hass, config_entry, data):
         context=registration_context(config_entry.data),
     )
     return empty_okay_response()
+
+
+@WEBHOOK_COMMANDS.register("stream_camera")
+@validate_schema({vol.Required(ATTR_CAMERA_ENTITY_ID): cv.string})
+async def webhook_stream_camera(hass, config_entry, data):
+    """Handle a request to HLS-stream a camera."""
+    camera = hass.states.get(data[ATTR_CAMERA_ENTITY_ID])
+
+    if camera is None:
+        return webhook_response(
+            {"success": False}, registration=config_entry.data, status=HTTP_BAD_REQUEST,
+        )
+
+    resp = {"mjpeg_path": "/api/camera_proxy_stream/%s" % (camera.entity_id)}
+
+    if camera.attributes["supported_features"] & CAMERA_SUPPORT_STREAM:
+        try:
+            resp["hls_path"] = await hass.components.camera.async_request_stream(
+                camera.entity_id, "hls"
+            )
+        except HomeAssistantError:
+            resp["hls_path"] = None
+    else:
+        resp["hls_path"] = None
+
+    return webhook_response(resp, registration=config_entry.data)
 
 
 @WEBHOOK_COMMANDS.register("render_template")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Adds a webhook called `camera_stream` to get paths to stream a camera, rather than hard-coding them. Additionally introduces the ability to get the HLS stream address if available.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue: home-assistant/iOS#649
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
