### PR TITLE
User defined profile name for Withings

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -81,8 +81,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     config_updates = {}
 
     # Add a unique id if it's an older config entry.
-    if entry.unique_id != entry.data["token"]["userid"]:
-        config_updates["unique_id"] = entry.data["token"]["userid"]
+    if entry.unique_id != entry.data["token"]["userid"] or not isinstance(
+        entry.unique_id, str
+    ):
+        config_updates["unique_id"] = str(entry.data["token"]["userid"])
 
     # Add the webhook configuration.
     if CONF_WEBHOOK_ID not in entry.data:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -39,17 +39,20 @@ DOMAIN = const.DOMAIN
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.All(
-            cv.deprecated(const.CONF_PROFILES, invalidation_version="0.114"),
-            vol.Schema(
-                {
-                    vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),
-                    vol.Required(CONF_CLIENT_SECRET): vol.All(
-                        cv.string, vol.Length(min=1)
-                    ),
-                    vol.Optional(const.CONF_USE_WEBHOOK, default=False): cv.boolean,
-                }
-            ),
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),
+                vol.Required(CONF_CLIENT_SECRET): vol.All(cv.string, vol.Length(min=1)),
+                vol.Optional(const.CONF_USE_WEBHOOK, default=False): cv.boolean,
+                cv.deprecated(
+                    const.CONF_PROFILES, invalidation_version="0.114"
+                ): vol.All(
+                    cv.ensure_list,
+                    vol.Unique(),
+                    vol.Length(min=1),
+                    [vol.All(cv.string, vol.Length(min=1))],
+                ),
+            }
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -44,12 +44,6 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),
                 vol.Required(CONF_CLIENT_SECRET): vol.All(cv.string, vol.Length(min=1)),
                 vol.Optional(const.CONF_USE_WEBHOOK, default=False): cv.boolean,
-                vol.Required(const.CONF_PROFILES): vol.All(
-                    cv.ensure_list,
-                    vol.Unique(),
-                    vol.Length(min=1),
-                    [vol.All(cv.string, vol.Length(min=1))],
-                ),
             }
         )
     },

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -39,12 +39,17 @@ DOMAIN = const.DOMAIN
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),
-                vol.Required(CONF_CLIENT_SECRET): vol.All(cv.string, vol.Length(min=1)),
-                vol.Optional(const.CONF_USE_WEBHOOK, default=False): cv.boolean,
-            }
+        DOMAIN: vol.All(
+            cv.deprecated(const.CONF_PROFILES),
+            vol.Schema(
+                {
+                    vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),
+                    vol.Required(CONF_CLIENT_SECRET): vol.All(
+                        cv.string, vol.Length(min=1)
+                    ),
+                    vol.Optional(const.CONF_USE_WEBHOOK, default=False): cv.boolean,
+                }
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -40,7 +40,7 @@ DOMAIN = const.DOMAIN
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
-            cv.deprecated(const.CONF_PROFILES),
+            cv.deprecated(const.CONF_PROFILES, invalidation_version="0.114"),
             vol.Schema(
                 {
                     vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -39,20 +39,23 @@ DOMAIN = const.DOMAIN
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),
-                vol.Required(CONF_CLIENT_SECRET): vol.All(cv.string, vol.Length(min=1)),
-                vol.Optional(const.CONF_USE_WEBHOOK, default=False): cv.boolean,
-                cv.deprecated(
-                    const.CONF_PROFILES, invalidation_version="0.114"
-                ): vol.All(
-                    cv.ensure_list,
-                    vol.Unique(),
-                    vol.Length(min=1),
-                    [vol.All(cv.string, vol.Length(min=1))],
-                ),
-            }
+        DOMAIN: vol.All(
+            cv.deprecated(const.CONF_PROFILES, invalidation_version="0.114"),
+            vol.Schema(
+                {
+                    vol.Required(CONF_CLIENT_ID): vol.All(cv.string, vol.Length(min=1)),
+                    vol.Required(CONF_CLIENT_SECRET): vol.All(
+                        cv.string, vol.Length(min=1)
+                    ),
+                    vol.Optional(const.CONF_USE_WEBHOOK, default=False): cv.boolean,
+                    vol.Optional(const.CONF_PROFILES): vol.All(
+                        cv.ensure_list,
+                        vol.Unique(),
+                        vol.Length(min=1),
+                        [vol.All(cv.string, vol.Length(min=1))],
+                    ),
+                }
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/withings/config_flow.py
+++ b/homeassistant/components/withings/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Withings."""
 import logging
+from typing import Dict, Optional
 
 import voluptuous as vol
 from withings_api.common import AuthScope
@@ -7,6 +8,7 @@ from withings_api.common import AuthScope
 from homeassistant import config_entries
 from homeassistant.components.withings import const
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,32 +48,60 @@ class WithingsFlowHandler(
 
     async def async_step_profile(self, data: dict) -> dict:
         """Prompt the user to select a user profile."""
-        profile = data.get(const.PROFILE)
+        errors = {}
+        # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
+        context_profile = self.context.get(const.PROFILE)
+        profile = data.get(const.PROFILE) or context_profile
 
         if profile:
-            new_data = {**self._current_data, **{const.PROFILE: profile}}
-            self._current_data = None
-            return await self.async_step_finish(new_data)
+            existing_entry = next(
+                iter(
+                    config_entry
+                    for config_entry in self.hass.config_entries.async_entries(
+                        const.DOMAIN
+                    )
+                    if slugify(config_entry.data.get(const.PROFILE)) == slugify(profile)
+                ),
+                None,
+            )
+
+            if context_profile or not existing_entry:
+                new_data = {**self._current_data, **{const.PROFILE: profile}}
+                self._current_data = None
+                return await self.async_step_finish(new_data)
+
+            errors["base"] = "profile_exists"
 
         return self.async_show_form(
             step_id="profile",
             data_schema=vol.Schema({vol.Required(const.PROFILE): str}),
+            errors=errors,
         )
 
-    async def async_step_reauth(self, data: dict) -> dict:
+    async def async_step_reauth(self, data: Optional[Dict]) -> dict:
         """Prompt user to re-authenticate."""
         if data is not None:
             return await self.async_step_user()
 
+        # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
+        placeholders = {"profile": self.context["profile"]}
+
+        self.context.update({"title_placeholders": placeholders})
+
         return self.async_show_form(
             step_id="reauth",
             # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-            description_placeholders={"profile": self.context["profile"]},
+            description_placeholders=placeholders,
         )
 
     async def async_step_finish(self, data: dict) -> dict:
         """Finish the flow."""
         self._current_data = None
 
-        await self.async_set_unique_id(data["token"]["userid"], raise_on_progress=False)
+        config_entry = await self.async_set_unique_id(
+            str(data["token"]["userid"]), raise_on_progress=False
+        )
+        if config_entry:
+            await self.hass.config_entries.async_remove(config_entry.entry_id)
+
         return self.async_create_entry(title=data[const.PROFILE], data=data)

--- a/homeassistant/components/withings/config_flow.py
+++ b/homeassistant/components/withings/config_flow.py
@@ -53,10 +53,9 @@ class WithingsFlowHandler(
             self._current_data = None
             return await self.async_step_finish(new_data)
 
-        profiles = self.hass.data[const.DOMAIN][const.CONFIG][const.CONF_PROFILES]
         return self.async_show_form(
             step_id="profile",
-            data_schema=vol.Schema({vol.Required(const.PROFILE): vol.In(profiles)}),
+            data_schema=vol.Schema({vol.Required(const.PROFILE): str}),
         )
 
     async def async_step_reauth(self, data: dict) -> dict:

--- a/homeassistant/components/withings/config_flow.py
+++ b/homeassistant/components/withings/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Withings."""
 import logging
+from typing import Dict, Union
 
 import voluptuous as vol
 from withings_api.common import AuthScope
@@ -19,7 +20,8 @@ class WithingsFlowHandler(
 
     DOMAIN = const.DOMAIN
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
-    _current_data: dict = {}
+    # Temporarily holds authorization data during the profile step.
+    _current_data: Dict[str, Union[None, str, int]] = {}
 
     @property
     def logger(self) -> logging.Logger:

--- a/homeassistant/components/withings/strings.json
+++ b/homeassistant/components/withings/strings.json
@@ -18,7 +18,8 @@
     },
     "abort": {
       "authorize_url_timeout": "Timeout generating authorize url.",
-      "missing_configuration": "The Withings integration is not configured. Please follow the documentation."
+      "missing_configuration": "The Withings integration is not configured. Please follow the documentation.",
+      "already_configured": "Configuration updated for profile."
     },
     "create_entry": { "default": "Successfully authenticated with Withings." }
   }

--- a/homeassistant/components/withings/strings.json
+++ b/homeassistant/components/withings/strings.json
@@ -4,14 +4,17 @@
     "step": {
       "profile": {
         "title": "User Profile.",
-        "description": "Provide a unique profile name for this data. Typically this is the name of profile you selected in the previous step. Note: It's important the name is unique across all Withings integrations, otherwise data will be mis-labeled and you will have to recreate the integration.",
+        "description": "Provide a unique profile name for this data. Typically this is the name of the profile you selected in the previous step.",
         "data": { "profile": "Profile Name" }
       },
       "pick_implementation": { "title": "Pick Authentication Method" },
       "reauth": {
-        "title": "Re-authenticate {profile}",
+        "title": "Re-authenticate Profile",
         "description": "The \"{profile}\" profile needs to be re-authenticated in order to continue receiving Withings data."
       }
+    },
+    "error": {
+      "profile_exists": "User profile is already configured. Please provide a unique profile name."
     },
     "abort": {
       "authorize_url_timeout": "Timeout generating authorize url.",

--- a/homeassistant/components/withings/strings.json
+++ b/homeassistant/components/withings/strings.json
@@ -4,8 +4,8 @@
     "step": {
       "profile": {
         "title": "User Profile.",
-        "description": "Which profile did you select on the Withings website? It's important the profiles match, otherwise data will be mis-labeled.",
-        "data": { "profile": "Profile" }
+        "description": "Provide a unique profile name for this data. Typically this is the name of profile you selected in the previous step. Note: It's important the name is unique across all Withings integrations, otherwise data will be mis-labeled and you will have to recreate the integration.",
+        "data": { "profile": "Profile Name" }
       },
       "pick_implementation": { "title": "Pick Authentication Method" },
       "reauth": {

--- a/tests/components/withings/common.py
+++ b/tests/components/withings/common.py
@@ -141,9 +141,6 @@ class ComponentFactory:
                 CONF_CLIENT_ID: self._client_id,
                 CONF_CLIENT_SECRET: self._client_secret,
                 const.CONF_USE_WEBHOOK: True,
-                const.CONF_PROFILES: [
-                    profile_config.profile for profile_config in self._profile_configs
-                ],
             },
         }
 
@@ -233,11 +230,9 @@ class ComponentFactory:
         result = await self._hass.config_entries.flow.async_configure(result["flow_id"])
         assert result.get("type") == "form"
         assert result.get("step_id") == "profile"
-        assert result.get("data_schema").schema["profile"].container == [
-            profile.profile for profile in self._profile_configs
-        ]
+        assert "profile" in result.get("data_schema").schema
 
-        # Select the user profile.
+        # Provide the user profile.
         result = await self._hass.config_entries.flow.async_configure(
             result["flow_id"], {const.PROFILE: profile_config.profile}
         )

--- a/tests/components/withings/test_config_flow.py
+++ b/tests/components/withings/test_config_flow.py
@@ -1,0 +1,45 @@
+"""Tests for config flow."""
+
+from homeassistant.components.withings import const
+from homeassistant.components.withings.config_flow import WithingsFlowHandler
+from homeassistant.core import HomeAssistant
+
+from tests.components.withings.common import ComponentFactory, new_profile_config
+
+
+async def test_config_non_unique_profile(
+    hass: HomeAssistant, component_factory: ComponentFactory
+) -> None:
+    """Test setup a non-unique profile."""
+    person0 = new_profile_config("person0", 0)
+
+    await component_factory.configure_component(profile_configs=(person0,))
+    await component_factory.setup_profile(person0.user_id)
+
+    flow_handler = WithingsFlowHandler()
+    flow_handler.hass = hass
+    flow_handler.context = {}
+    result = await flow_handler.async_oauth_create_entry({"profile": person0.profile})
+    assert result
+    assert result["errors"]["base"] == "profile_exists"
+
+
+async def test_config_reauth_profile(
+    hass: HomeAssistant, component_factory: ComponentFactory
+) -> None:
+    """Test reauth an existing profile re-creates the config entry."""
+    person0 = new_profile_config("person0", 0)
+
+    await component_factory.configure_component(profile_configs=(person0,))
+    await component_factory.setup_profile(person0.user_id)
+
+    flow_handler = WithingsFlowHandler()
+    flow_handler.hass = hass
+    flow_handler.context = {"profile": person0.profile}
+    result = await flow_handler.async_oauth_create_entry(
+        {"token": {"userid": 0}, "profile": person0.profile}
+    )
+    assert result
+    assert result["type"] == "create_entry"
+    assert flow_handler.unique_id == "0"
+    assert not hass.config_entries.async_entries(const.DOMAIN)

--- a/tests/components/withings/test_config_flow.py
+++ b/tests/components/withings/test_config_flow.py
@@ -1,45 +1,100 @@
 """Tests for config flow."""
+from aiohttp.test_utils import TestClient
 
+from homeassistant.components import webhook
 from homeassistant.components.withings import const
-from homeassistant.components.withings.config_flow import WithingsFlowHandler
-from homeassistant.core import HomeAssistant
+from homeassistant.config import async_process_ha_core_config
+from homeassistant.const import (
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_EXTERNAL_URL,
+    CONF_UNIT_SYSTEM,
+    CONF_UNIT_SYSTEM_METRIC,
+)
+from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.config_entry_oauth2_flow import AUTH_CALLBACK_PATH
+from homeassistant.setup import async_setup_component
 
-from tests.components.withings.common import ComponentFactory, new_profile_config
+from tests.common import MockConfigEntry
 
 
-async def test_config_non_unique_profile(
-    hass: HomeAssistant, component_factory: ComponentFactory
-) -> None:
+async def test_config_non_unique_profile(hass: HomeAssistant) -> None:
     """Test setup a non-unique profile."""
-    person0 = new_profile_config("person0", 0)
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN, data={const.PROFILE: "person0"}, unique_id="0"
+    )
+    config_entry.add_to_hass(hass)
 
-    await component_factory.configure_component(profile_configs=(person0,))
-    await component_factory.setup_profile(person0.user_id)
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN, context={"source": "profile"}, data={const.PROFILE: "person0"}
+    )
 
-    flow_handler = WithingsFlowHandler()
-    flow_handler.hass = hass
-    flow_handler.context = {}
-    result = await flow_handler.async_oauth_create_entry({"profile": person0.profile})
     assert result
     assert result["errors"]["base"] == "profile_exists"
 
 
 async def test_config_reauth_profile(
-    hass: HomeAssistant, component_factory: ComponentFactory
+    hass: HomeAssistant, aiohttp_client, aioclient_mock
 ) -> None:
     """Test reauth an existing profile re-creates the config entry."""
-    person0 = new_profile_config("person0", 0)
+    hass_config = {
+        HA_DOMAIN: {
+            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
+            CONF_EXTERNAL_URL: "http://127.0.0.1:8080/",
+        },
+        const.DOMAIN: {
+            CONF_CLIENT_ID: "my_client_id",
+            CONF_CLIENT_SECRET: "my_client_secret",
+            const.CONF_USE_WEBHOOK: False,
+        },
+    }
+    await async_process_ha_core_config(hass, hass_config.get(HA_DOMAIN))
+    assert await async_setup_component(hass, HA_DOMAIN, {})
+    assert await async_setup_component(hass, webhook.DOMAIN, hass_config)
+    assert await async_setup_component(hass, const.DOMAIN, hass_config)
+    await hass.async_block_till_done()
 
-    await component_factory.configure_component(profile_configs=(person0,))
-    await component_factory.setup_profile(person0.user_id)
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN, data={const.PROFILE: "person0"}, unique_id="0"
+    )
+    config_entry.add_to_hass(hass)
 
-    flow_handler = WithingsFlowHandler()
-    flow_handler.hass = hass
-    flow_handler.context = {"profile": person0.profile}
-    result = await flow_handler.async_oauth_create_entry(
-        {"token": {"userid": 0}, "profile": person0.profile}
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN, context={"source": "reauth", "profile": "person0"}
     )
     assert result
-    assert result["type"] == "create_entry"
-    assert flow_handler.unique_id == "0"
-    assert not hass.config_entries.async_entries(const.DOMAIN)
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth"
+    assert result["description_placeholders"] == {const.PROFILE: "person0"}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {},)
+
+    # pylint: disable=protected-access
+    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
+
+    client: TestClient = await aiohttp_client(hass.http.app)
+    resp = await client.get(f"{AUTH_CALLBACK_PATH}?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        "https://account.withings.com/oauth2/token",
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+            "userid": "0",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+    entries = hass.config_entries.async_entries(const.DOMAIN)
+    assert entries
+    assert entries[0].data["token"]["refresh_token"] == "mock-refresh-token"

--- a/tests/components/withings/test_config_flow.py
+++ b/tests/components/withings/test_config_flow.py
@@ -1,7 +1,6 @@
 """Tests for config flow."""
 from aiohttp.test_utils import TestClient
 
-from homeassistant.components import webhook
 from homeassistant.components.withings import const
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import (
@@ -50,8 +49,6 @@ async def test_config_reauth_profile(
         },
     }
     await async_process_ha_core_config(hass, hass_config.get(HA_DOMAIN))
-    assert await async_setup_component(hass, HA_DOMAIN, {})
-    assert await async_setup_component(hass, webhook.DOMAIN, hass_config)
     assert await async_setup_component(hass, const.DOMAIN, hass_config)
     await hass.async_block_till_done()
 

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -177,3 +177,28 @@ async def test_set_config_unique_id(
 
         await hass.config_entries.async_setup(config_entry.entry_id)
         assert config_entry.unique_id == "my_user_id"
+
+
+async def test_set_convert_unique_id_to_string(
+    hass: HomeAssistant, component_factory: ComponentFactory
+) -> None:
+    """Test upgrading configs to use a unique id."""
+    person0 = new_profile_config("person0", 0)
+
+    await component_factory.configure_component(profile_configs=(person0,))
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={"token": {"userid": 1234}, "profile": person0.profile},
+    )
+
+    with patch("homeassistant.components.withings.async_get_data_manager") as mock:
+        data_manager: DataManager = MagicMock(spec=DataManager)
+        data_manager.poll_data_update_coordinator = MagicMock(
+            spec=DataUpdateCoordinator
+        )
+        data_manager.poll_data_update_coordinator.last_update_success = True
+        mock.return_value = data_manager
+        config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        assert config_entry.unique_id == "1234"

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -43,71 +43,40 @@ def test_config_schema_basic_config() -> None:
             CONF_CLIENT_ID: "my_client_id",
             CONF_CLIENT_SECRET: "my_client_secret",
             const.CONF_USE_WEBHOOK: True,
-            const.CONF_PROFILES: ["Person 1", "Person 2"],
         }
     )
 
 
 def test_config_schema_client_id() -> None:
     """Test schema."""
+    config_schema_assert_fail({CONF_CLIENT_SECRET: "my_client_secret"})
     config_schema_assert_fail(
-        {
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: ["Person 1", "Person 2"],
-        }
-    )
-    config_schema_assert_fail(
-        {
-            CONF_CLIENT_SECRET: "my_client_secret",
-            CONF_CLIENT_ID: "",
-            const.CONF_PROFILES: ["Person 1"],
-        }
+        {CONF_CLIENT_SECRET: "my_client_secret", CONF_CLIENT_ID: ""}
     )
     config_schema_validate(
-        {
-            CONF_CLIENT_SECRET: "my_client_secret",
-            CONF_CLIENT_ID: "my_client_id",
-            const.CONF_PROFILES: ["Person 1"],
-        }
+        {CONF_CLIENT_SECRET: "my_client_secret", CONF_CLIENT_ID: "my_client_id"}
     )
 
 
 def test_config_schema_client_secret() -> None:
     """Test schema."""
-    config_schema_assert_fail(
-        {CONF_CLIENT_ID: "my_client_id", const.CONF_PROFILES: ["Person 1"]}
-    )
-    config_schema_assert_fail(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "",
-            const.CONF_PROFILES: ["Person 1"],
-        }
-    )
+    config_schema_assert_fail({CONF_CLIENT_ID: "my_client_id"})
+    config_schema_assert_fail({CONF_CLIENT_ID: "my_client_id", CONF_CLIENT_SECRET: ""})
     config_schema_validate(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: ["Person 1"],
-        }
+        {CONF_CLIENT_ID: "my_client_id", CONF_CLIENT_SECRET: "my_client_secret"}
     )
 
 
 def test_config_schema_use_webhook() -> None:
     """Test schema."""
     config_schema_validate(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: ["Person 1"],
-        }
+        {CONF_CLIENT_ID: "my_client_id", CONF_CLIENT_SECRET: "my_client_secret"}
     )
     config = config_schema_validate(
         {
             CONF_CLIENT_ID: "my_client_id",
             CONF_CLIENT_SECRET: "my_client_secret",
             const.CONF_USE_WEBHOOK: True,
-            const.CONF_PROFILES: ["Person 1"],
         }
     )
     assert config[const.DOMAIN][const.CONF_USE_WEBHOOK] is True
@@ -116,7 +85,6 @@ def test_config_schema_use_webhook() -> None:
             CONF_CLIENT_ID: "my_client_id",
             CONF_CLIENT_SECRET: "my_client_secret",
             const.CONF_USE_WEBHOOK: False,
-            const.CONF_PROFILES: ["Person 1"],
         }
     )
     assert config[const.DOMAIN][const.CONF_USE_WEBHOOK] is False
@@ -125,49 +93,6 @@ def test_config_schema_use_webhook() -> None:
             CONF_CLIENT_ID: "my_client_id",
             CONF_CLIENT_SECRET: "my_client_secret",
             const.CONF_USE_WEBHOOK: "A",
-            const.CONF_PROFILES: ["Person 1"],
-        }
-    )
-
-
-def test_config_schema_profiles() -> None:
-    """Test schema."""
-    config_schema_assert_fail(
-        {CONF_CLIENT_ID: "my_client_id", CONF_CLIENT_SECRET: "my_client_secret"}
-    )
-    config_schema_assert_fail(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: "",
-        }
-    )
-    config_schema_assert_fail(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: [],
-        }
-    )
-    config_schema_assert_fail(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: ["Person 1", "Person 1"],
-        }
-    )
-    config_schema_validate(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: ["Person 1"],
-        }
-    )
-    config_schema_validate(
-        {
-            CONF_CLIENT_ID: "my_client_id",
-            CONF_CLIENT_SECRET: "my_client_secret",
-            const.CONF_PROFILES: ["Person 1", "Person 2"],
         }
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Withings "profiles" yaml configuration is no longer supported and has been moved into ui-based configuration.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Withings "profiles" config attribute is largely unnecessary, confuses users and requires you restart home assistant when you need to add a new person. For these reasons, it has been removed in favor of the user providing their own name at the end of setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
withings:
  client_id: "my_client_id"
  client_secret: "my_secret"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36585
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13779

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
