### PR TITLE
Improve db performance of state change events and reduce overall db size

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -242,6 +242,7 @@ class Recorder(threading.Thread):
 
         self._timechanges_seen = 0
         self._keepalive_count = 0
+        self._old_state_ids = {}
         self.event_session = None
         self.get_session = None
 
@@ -383,6 +384,8 @@ class Recorder(threading.Thread):
 
             try:
                 dbevent = Events.from_event(event)
+                if event.event_type == EVENT_STATE_CHANGED:
+                    dbevent.event_data = "{}"
                 self.event_session.add(dbevent)
                 self.event_session.flush()
             except (TypeError, ValueError):
@@ -394,8 +397,10 @@ class Recorder(threading.Thread):
             if dbevent and event.event_type == EVENT_STATE_CHANGED:
                 try:
                     dbstate = States.from_event(event)
+                    dbstate.old_state_id = self._get_old_state_id(dbstate.entity_id)
                     dbstate.event_id = dbevent.event_id
                     self.event_session.add(dbstate)
+                    self.event_session.flush()
                 except (TypeError, ValueError):
                     _LOGGER.warning(
                         "State is not JSON serializable: %s",
@@ -405,12 +410,32 @@ class Recorder(threading.Thread):
                     # Must catch the exception to prevent the loop from collapsing
                     _LOGGER.exception("Error adding state change: %s", err)
 
+                if "new_state" in event.data:
+                    self._old_state_ids[dbstate.entity_id] = dbstate.state_id
+                elif dbstate.entity_id in self._old_state_ids:
+                    del self._old_state_ids[dbstate.entity_id]
+
             # If they do not have a commit interval
             # than we commit right away
             if not self.commit_interval:
                 self._commit_event_session_or_retry()
 
             self.queue.task_done()
+
+    def _get_old_state_id(self, entity_id):
+        """Find the last state_id for an entity_id in memory cache or the database."""
+        if entity_id in self._old_state_ids:
+            return self._old_state_ids[entity_id]
+        query = (
+            self.event_session.query(States.state_id)
+            .filter(States.entity_id == entity_id)
+            .order_by(States.last_updated.desc())
+            .limit(1)
+        )
+        old_db_state = query.one_or_none()
+        if old_db_state:
+            return old_db_state.state_id
+        return None
 
     def _send_keep_alive(self):
         try:

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -249,14 +249,11 @@ def _apply_update(engine, new_version, old_version):
     elif new_version == 7:
         _create_index(engine, "states", "ix_states_entity_id")
     elif new_version == 8:
-        # Pending migration, want to group a few.
-        pass
-        # _add_columns(engine, "events", [
-        #     'context_parent_id CHARACTER(36)',
-        # ])
-        # _add_columns(engine, "states", [
-        #     'context_parent_id CHARACTER(36)',
-        # ])
+        _add_columns(engine, "events", ["context_parent_id CHARACTER(36)"])
+        _add_columns(engine, "states", ["context_parent_id CHARACTER(36)"])
+        _add_columns(engine, "states", ["old_state_id INTEGER"])
+        _create_index(engine, "states", "ix_states_context_parent_id")
+        _create_index(engine, "events", "ix_events_context_parent_id")
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -24,7 +24,7 @@ import homeassistant.util.dt as dt_util
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class Events(Base):  # type: ignore
     created = Column(DateTime(timezone=True), default=dt_util.utcnow)
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
-    # context_parent_id = Column(String(36), index=True)
+    context_parent_id = Column(String(36), index=True)
 
     @staticmethod
     def from_event(event):
@@ -55,7 +55,7 @@ class Events(Base):  # type: ignore
             time_fired=event.time_fired,
             context_id=event.context.id,
             context_user_id=event.context.user_id,
-            # context_parent_id=event.context.parent_id,
+            context_parent_id=event.context.parent_id,
         )
 
     def to_native(self):
@@ -90,7 +90,8 @@ class States(Base):  # type: ignore
     created = Column(DateTime(timezone=True), default=dt_util.utcnow)
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
-    # context_parent_id = Column(String(36), index=True)
+    context_parent_id = Column(String(36), index=True)
+    old_state_id = Column(Integer)
 
     __table_args__ = (
         # Used for fetching the state of entities at a specific time
@@ -108,7 +109,7 @@ class States(Base):  # type: ignore
             entity_id=entity_id,
             context_id=event.context.id,
             context_user_id=event.context.user_id,
-            # context_parent_id=event.context.parent_id,
+            context_parent_id=event.context.parent_id,
         )
 
         # State got deleted

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1215,10 +1215,10 @@ class TestComponentLogbook(unittest.TestCase):
         self, entity_id, event_time_fired, old_state, new_state
     ):
         """Create a state changed event from a old and new state."""
-        event_data_json = json.dumps(
-            {"entity_id": entity_id, "old_state": old_state, "new_state": new_state},
-            cls=JSONEncoder,
-        )
+        attributes = {}
+        if new_state is not None:
+            attributes = new_state.get("attributes")
+        attributes_json = json.dumps(attributes, cls=JSONEncoder)
         row = collections.namedtuple(
             "Row",
             [
@@ -1230,18 +1230,23 @@ class TestComponentLogbook(unittest.TestCase):
                 "state"
                 "entity_id"
                 "domain"
+                "attributes"
+                "state_id",
+                "old_state_id",
             ],
         )
 
         row.event_type = EVENT_STATE_CHANGED
-        row.event_data = event_data_json
+        row.event_data = "{}"
+        row.attributes = attributes_json
         row.time_fired = event_time_fired
         row.state = new_state and new_state.get("state")
         row.entity_id = entity_id
         row.domain = entity_id and ha.split_entity_id(entity_id)[0]
         row.context_id = None
         row.context_user_id = None
-
+        row.old_state_id = old_state and 1
+        row.state_id = new_state and 1
         return logbook.LazyEventPartialState(row)
 
 


### PR DESCRIPTION
Most of the overhead of logbook is selecting the json data in the database.  

Shown below is a performance graph of MariaDB overhead of a logbook query:
<img width="858" alt="Screen Shot 2020-06-17 at 2 16 56 PM" src="https://user-images.githubusercontent.com/663432/84941303-cdadca80-b0a6-11ea-9c57-2de26756ebfc.png">

As the data is already stored in the states table, we can now find the old state by adding an `old_state_id` to the `states` table and avoid the need to duplicate the data in the events table.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Remove old/new state data from state change event data since it can now be found by a join of the `states` table.  This change avoids duplicate storage of the state in the `events` table.  

Examples showing how to find the old and new state have been provided in the States (https://data.home-assistant.io/docs/states) and Events (https://data.home-assistant.io/docs/events) documentation.

https://github.com/home-assistant/data.home-assistant/pull/63

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add old_state_id to states as well as the parent_context_ids to events and states.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/data.home-assistant/pull/63 https://github.com/home-assistant/home-assistant.io/pull/13784

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
