### PR TITLE
Set Plex media_player discovery source as an attribute

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -15,6 +15,7 @@ DEBOUNCE_TIMEOUT = 1
 DISPATCHERS = "dispatchers"
 PLATFORMS = frozenset(["media_player", "sensor"])
 PLATFORMS_COMPLETED = "platforms_completed"
+PLAYER_SOURCE = "player_source"
 SERVERS = "servers"
 WEBSOCKETS = "websockets"
 

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -88,11 +88,12 @@ def _async_add_entities(
 class PlexMediaPlayer(MediaPlayerEntity):
     """Representation of a Plex device."""
 
-    def __init__(self, plex_server, device, session=None):
+    def __init__(self, plex_server, device, player_source, session=None):
         """Initialize the Plex device."""
         self.plex_server = plex_server
         self.device = device
         self.session = session
+        self.player_source = player_source
         self._app_name = ""
         self._available = False
         self._device_protocol_capabilities = None
@@ -585,6 +586,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             "session_username": self.username,
             "media_library_name": self._app_name,
             "summary": self.media_summary,
+            "player_source": self.player_source,
         }
 
         return attr

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -32,6 +32,7 @@ from .const import (
     DEBOUNCE_TIMEOUT,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    PLAYER_SOURCE,
     PLEX_NEW_MP_SIGNAL,
     PLEX_UPDATE_MEDIA_PLAYER_SIGNAL,
     PLEX_UPDATE_SENSOR_SIGNAL,
@@ -257,6 +258,9 @@ class PlexServer:
         def process_device(source, device):
             self._known_idle.discard(device.machineIdentifier)
             available_clients.setdefault(device.machineIdentifier, {"device": device})
+            available_clients[device.machineIdentifier].setdefault(
+                PLAYER_SOURCE, source
+            )
 
             if device.machineIdentifier not in ignored_clients:
                 if self.option_ignore_plexweb_clients and device.product == "Plex Web":
@@ -275,11 +279,14 @@ class PlexServer:
             ):
                 new_clients.add(device.machineIdentifier)
                 _LOGGER.debug(
-                    "New %s %s: %s", device.product, source, device.machineIdentifier
+                    "New %s from %s: %s",
+                    device.product,
+                    source,
+                    device.machineIdentifier,
                 )
 
         for device in devices:
-            process_device("device", device)
+            process_device("PMS", device)
 
         def connect_to_resource(resource):
             """Connect to a plex.tv resource and return a Plex client."""
@@ -303,7 +310,7 @@ class PlexServer:
                     connect_to_resource, plextv_client
                 )
                 if device:
-                    process_device("resource", device)
+                    process_device("plex.tv", device)
 
         for session in sessions:
             if session.TYPE == "photo":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Now that there are more than two ways for a Plex client to be discovered (#36857) it would be helpful to have this discovery source readily available as a state attribute.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
