### PR TITLE
Bump Netdisco to 2.7.1

### DIFF
--- a/homeassistant/components/discovery/manifest.json
+++ b/homeassistant/components/discovery/manifest.json
@@ -2,7 +2,7 @@
   "domain": "discovery",
   "name": "Discovery",
   "documentation": "https://www.home-assistant.io/integrations/discovery",
-  "requirements": ["netdisco==2.7.0"],
+  "requirements": ["netdisco==2.7.1"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],
   "quality_scale": "internal"

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["defusedxml==0.6.0", "netdisco==2.7.0"],
+  "requirements": ["defusedxml==0.6.0", "netdisco==2.7.1"],
   "after_dependencies": ["zeroconf"],
   "codeowners": []
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,7 +15,7 @@ hass-nabucasa==0.34.6
 home-assistant-frontend==20200617.0
 importlib-metadata==1.6.0;python_version<'3.8'
 jinja2>=2.11.1
-netdisco==2.7.0
+netdisco==2.7.1
 pip>=8.0.3
 python-slugify==4.0.0
 pytz>=2020.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -950,7 +950,7 @@ netdata==0.1.2
 
 # homeassistant.components.discovery
 # homeassistant.components.ssdp
-netdisco==2.7.0
+netdisco==2.7.1
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -412,7 +412,7 @@ nessclient==0.9.15
 
 # homeassistant.components.discovery
 # homeassistant.components.ssdp
-netdisco==2.7.0
+netdisco==2.7.1
 
 # homeassistant.components.nexia
 nexia==0.9.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes a warning in newer zeroconf versions.

```
home-assistant/home-assistant/venv/lib/python3.7/site-packages/zeroconf/__init__.py:1541: FutureWarning: <netdisco.discoverables.spotify_connect.Discoverable object at 0x7f0034194290> has no update_service method. Provide one (it can be empty if you don't care about the updates), it'll become mandatory.
  FutureWarning,
```

https://github.com/home-assistant/netdisco/releases/tag/2.7.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
