### PR TITLE
Improve after_dependencies handling

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -1,6 +1,7 @@
 """Provide methods to bootstrap a Home Assistant instance."""
 import asyncio
 import contextlib
+from datetime import datetime
 import logging
 import logging.handlers
 import os
@@ -42,6 +43,8 @@ LOG_SLOW_STARTUP_INTERVAL = 60
 DEBUGGER_INTEGRATIONS = {"ptvsd"}
 CORE_INTEGRATIONS = ("homeassistant", "persistent_notification")
 LOGGING_INTEGRATIONS = {"logger", "system_log", "sentry"}
+# These integrations are set up before other integrations
+# Note, stage 1 after dependencies are not respected.
 STAGE_1_INTEGRATIONS = {
     # To record data
     "recorder",
@@ -335,95 +338,97 @@ def _get_domains(hass: core.HomeAssistant, config: Dict[str, Any]) -> Set[str]:
     return domains
 
 
+async def _async_log_pending_setups(
+    domains: Set[str], setup_started: Dict[str, datetime]
+) -> None:
+    """Periodic log of setups that are pending for longer than LOG_SLOW_STARTUP_INTERVAL."""
+    while True:
+        await asyncio.sleep(LOG_SLOW_STARTUP_INTERVAL)
+        remaining = [domain for domain in domains if domain in setup_started]
+
+        if remaining:
+            _LOGGER.info(
+                "Waiting on integrations to complete setup: %s", ", ".join(remaining),
+            )
+
+
+async def async_setup_multi_components(
+    hass: core.HomeAssistant,
+    domains: Set[str],
+    config: Dict[str, Any],
+    setup_started: Dict[str, datetime],
+) -> None:
+    """Set up multiple domains. Log on failure."""
+    futures = {
+        domain: hass.async_create_task(async_setup_component(hass, domain, config))
+        for domain in domains
+    }
+    log_task = asyncio.create_task(_async_log_pending_setups(domains, setup_started))
+    await asyncio.wait(futures.values())
+    log_task.cancel()
+    errors = [domain for domain in domains if futures[domain].exception()]
+    for domain in errors:
+        exception = futures[domain].exception()
+        assert exception is not None
+        _LOGGER.error(
+            "Error setting up integration %s - received exception",
+            domain,
+            exc_info=(type(exception), exception, exception.__traceback__),
+        )
+
+
 async def _async_set_up_integrations(
     hass: core.HomeAssistant, config: Dict[str, Any]
 ) -> None:
     """Set up all the integrations."""
-
     setup_started = hass.data[DATA_SETUP_STARTED] = {}
-
-    async def async_setup_multi_components(domains: Set[str]) -> None:
-        """Set up multiple domains. Log on failure."""
-
-        async def _async_log_pending_setups() -> None:
-            """Periodic log of setups that are pending for longer than LOG_SLOW_STARTUP_INTERVAL."""
-            while True:
-                await asyncio.sleep(LOG_SLOW_STARTUP_INTERVAL)
-                remaining = [domain for domain in domains if domain in setup_started]
-
-                if remaining:
-                    _LOGGER.info(
-                        "Waiting on integrations to complete setup: %s",
-                        ", ".join(remaining),
-                    )
-
-        futures = {
-            domain: hass.async_create_task(async_setup_component(hass, domain, config))
-            for domain in domains
-        }
-        log_task = asyncio.create_task(_async_log_pending_setups())
-        await asyncio.wait(futures.values())
-        log_task.cancel()
-        errors = [domain for domain in domains if futures[domain].exception()]
-        for domain in errors:
-            exception = futures[domain].exception()
-            assert exception is not None
-            _LOGGER.error(
-                "Error setting up integration %s - received exception",
-                domain,
-                exc_info=(type(exception), exception, exception.__traceback__),
-            )
-
     domains = _get_domains(hass, config)
-    async_set_domains_to_be_loaded(hass, domains)
 
-    # Start up debuggers. Start these first in case they want to wait.
-    debuggers = domains & DEBUGGER_INTEGRATIONS
-    if debuggers:
-        _LOGGER.debug("Starting up debuggers %s", debuggers)
-        await async_setup_multi_components(debuggers)
-        domains -= DEBUGGER_INTEGRATIONS
+    # Resolve all dependencies so we know all integrations that will be loaded
+    integrations_to_process = []
 
-    # Resolve all dependencies of all components so we can find the logging
-    # and integrations that need faster initialization.
-    resolved_domains_task = asyncio.gather(
-        *(loader.async_component_dependencies(hass, domain) for domain in domains),
-        return_exceptions=True,
-    )
-
-    # Finish resolving domains
-    for dep_domains in await resolved_domains_task:
-        # Result is either a set or an exception. We ignore exceptions
-        # It will be properly handled during setup of the domain.
-        if isinstance(dep_domains, set):
-            domains.update(dep_domains)
-
-    # setup components
-    logging_domains = domains & LOGGING_INTEGRATIONS
-    stage_1_domains = domains & STAGE_1_INTEGRATIONS
-
-    # Load all stage 1 domains and add their after_deps to stage 1
     for int_or_exc in await asyncio.gather(
-        *(loader.async_get_integration(hass, domain) for domain in stage_1_domains),
+        *(loader.async_get_integration(hass, domain) for domain in domains),
         return_exceptions=True,
     ):
         # Exceptions are handled in async_setup_component.
         if (
             not isinstance(int_or_exc, loader.Integration)
-            or not int_or_exc.after_dependencies
+            or int_or_exc.all_dependencies_resolved
         ):
             continue
 
-        for domain in int_or_exc.after_dependencies:
-            if domain in domains:
-                stage_1_domains.add(domain)
+        integrations_to_process.append(int_or_exc)
 
+    to_resolve = [
+        itg.resolve_dependencies()
+        for itg in integrations_to_process
+        if not itg.all_dependencies_resolved
+    ]
+    if to_resolve:
+        await asyncio.gather(*to_resolve)
+
+    for itg in integrations_to_process:
+        domains.update(itg.dependencies)
+
+    # Start up debuggers. Start these first in case they want to wait.
+    debuggers = domains & DEBUGGER_INTEGRATIONS
+    if debuggers:
+        _LOGGER.debug("Starting up debuggers %s", debuggers)
+        await async_setup_multi_components(hass, debuggers, config, setup_started)
+        domains -= DEBUGGER_INTEGRATIONS
+
+    # setup components
+    logging_domains = domains & LOGGING_INTEGRATIONS
+    stage_1_domains = domains & STAGE_1_INTEGRATIONS
+
+    # Calculate stage 2
     stage_2_domains = domains - logging_domains - stage_1_domains
 
+    # Start setup
     if logging_domains:
         _LOGGER.info("Setting up %s", logging_domains)
-
-        await async_setup_multi_components(logging_domains)
+        await async_setup_multi_components(hass, logging_domains, config, setup_started)
 
     # Kick off loading the registries. They don't need to be awaited.
     asyncio.gather(
@@ -435,10 +440,11 @@ async def _async_set_up_integrations(
     if stage_1_domains:
         _LOGGER.info("Setting up %s", stage_1_domains)
 
-        await async_setup_multi_components(stage_1_domains)
+        await async_setup_multi_components(hass, stage_1_domains, config, setup_started)
 
     if stage_2_domains:
-        await async_setup_multi_components(stage_2_domains)
+        async_set_domains_to_be_loaded(hass, stage_2_domains)
+        await async_setup_multi_components(hass, stage_2_domains, config, setup_started)
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -464,7 +464,6 @@ async def _async_set_up_integrations(
                 continue
 
             deps_promotion.update(dep_itg.all_dependencies)
-            deps_promotion.update(dep_itg.after_dependencies)
 
     stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
 
@@ -476,11 +475,12 @@ async def _async_set_up_integrations(
     )
 
     # Start setup
-    async_set_domains_to_be_loaded(hass, stage_1_domains | stage_2_domains)
-
     if stage_1_domains:
         _LOGGER.info("Setting up stage 1: %s", stage_1_domains)
         await async_setup_multi_components(hass, stage_1_domains, config, setup_started)
+
+    # Enables after dependencies
+    async_set_domains_to_be_loaded(hass, stage_1_domains | stage_2_domains)
 
     if stage_2_domains:
         _LOGGER.info("Setting up stage 2: %s", stage_2_domains)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -387,7 +387,6 @@ async def _async_set_up_integrations(
     """Set up all the integrations."""
     setup_started = hass.data[DATA_SETUP_STARTED] = {}
     domains_to_setup = _get_domains(hass, config)
-    logging_domains = domains_to_setup & LOGGING_INTEGRATIONS
 
     # Resolve all dependencies so we know all integrations
     # that will have to be loaded and start rightaway
@@ -428,6 +427,8 @@ async def _async_set_up_integrations(
                 to_resolve.add(dep)
 
     _LOGGER.info("Domains to be set up: %s", domains_to_setup)
+
+    logging_domains = domains_to_setup & LOGGING_INTEGRATIONS
 
     # Load logging as soon as possible
     if logging_domains:

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -20,7 +20,12 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.setup import DATA_SETUP, DATA_SETUP_STARTED, async_setup_component
+from homeassistant.setup import (
+    DATA_SETUP,
+    DATA_SETUP_STARTED,
+    async_set_domains_to_be_loaded,
+    async_setup_component,
+)
 from homeassistant.util.logging import async_activate_log_queue_handler
 from homeassistant.util.package import async_get_user_site, is_virtual_env
 from homeassistant.util.yaml import clear_secret_cache
@@ -370,6 +375,7 @@ async def _async_set_up_integrations(
             )
 
     domains = _get_domains(hass, config)
+    async_set_domains_to_be_loaded(hass, domains)
 
     # Start up debuggers. Start these first in case they want to wait.
     debuggers = domains & DEBUGGER_INTEGRATIONS
@@ -395,6 +401,23 @@ async def _async_set_up_integrations(
     # setup components
     logging_domains = domains & LOGGING_INTEGRATIONS
     stage_1_domains = domains & STAGE_1_INTEGRATIONS
+
+    # Load all stage 1 domains and add their after_deps to stage 1
+    for int_or_exc in await asyncio.gather(
+        *(loader.async_get_integration(hass, domain) for domain in stage_1_domains),
+        return_exceptions=True,
+    ):
+        # Exceptions are handled in async_setup_component.
+        if (
+            not isinstance(int_or_exc, loader.Integration)
+            or not int_or_exc.after_dependencies
+        ):
+            continue
+
+        for domain in int_or_exc.after_dependencies:
+            if domain in domains:
+                stage_1_domains.add(domain)
+
     stage_2_domains = domains - logging_domains - stage_1_domains
 
     if logging_domains:
@@ -414,43 +437,7 @@ async def _async_set_up_integrations(
 
         await async_setup_multi_components(stage_1_domains)
 
-    # Load all integrations
-    after_dependencies: Dict[str, Set[str]] = {}
-
-    for int_or_exc in await asyncio.gather(
-        *(loader.async_get_integration(hass, domain) for domain in stage_2_domains),
-        return_exceptions=True,
-    ):
-        # Exceptions are handled in async_setup_component.
-        if isinstance(int_or_exc, loader.Integration) and int_or_exc.after_dependencies:
-            after_dependencies[int_or_exc.domain] = set(int_or_exc.after_dependencies)
-
-    last_load = None
-    while stage_2_domains:
-        domains_to_load = set()
-
-        for domain in stage_2_domains:
-            after_deps = after_dependencies.get(domain)
-            # Load if integration has no after_dependencies or they are
-            # all loaded
-            if not after_deps or not after_deps - hass.config.components:
-                domains_to_load.add(domain)
-
-        if not domains_to_load or domains_to_load == last_load:
-            break
-
-        _LOGGER.debug("Setting up %s", domains_to_load)
-
-        await async_setup_multi_components(domains_to_load)
-
-        last_load = domains_to_load
-        stage_2_domains -= domains_to_load
-
-    # These are stage 2 domains that never have their after_dependencies
-    # satisfied.
     if stage_2_domains:
-        _LOGGER.debug("Final set up: %s", stage_2_domains)
-
         await async_setup_multi_components(stage_2_domains)
 
     # Wrap up startup

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -445,8 +445,8 @@ async def _async_set_up_integrations(
     # calculate what components to setup in what stage
     stage_1_domains = set()
 
-    # Find all (after) dependencies of any dependency of any stage 1 integration
-    # that we plan on loading and promote them to stage 1 to avoid deadlocks
+    # Find all dependencies of any dependency of any stage 1 integration that
+    # we plan on loading and promote them to stage 1
     deps_promotion = STAGE_1_INTEGRATIONS
     while deps_promotion:
         old_deps_promotion = deps_promotion

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -385,21 +385,20 @@ async def _async_set_up_integrations(
     domains = _get_domains(hass, config)
 
     # Resolve all dependencies so we know all integrations that will be loaded
-    integrations_to_process = []
-
-    for int_or_exc in await asyncio.gather(
-        *(loader.async_get_integration(hass, domain) for domain in domains),
-        return_exceptions=True,
-    ):
-        # Exceptions are handled in async_setup_component.
-        if isinstance(int_or_exc, loader.Integration):
-            integrations_to_process.append(int_or_exc)
-
+    integrations_to_process = [
+        int_or_exc
+        for int_or_exc in await asyncio.gather(
+            *(loader.async_get_integration(hass, domain) for domain in domains),
+            return_exceptions=True,
+        )
+        if isinstance(int_or_exc, loader.Integration)
+    ]
     to_resolve = [
         itg.resolve_dependencies()
         for itg in integrations_to_process
         if not itg.all_dependencies_resolved
     ]
+
     if to_resolve:
         await asyncio.gather(*to_resolve)
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -42,12 +42,16 @@ LOG_SLOW_STARTUP_INTERVAL = 60
 
 DEBUGGER_INTEGRATIONS = {"ptvsd"}
 CORE_INTEGRATIONS = ("homeassistant", "persistent_notification")
-LOGGING_INTEGRATIONS = {"logger", "system_log", "sentry"}
-# These integrations are set up before other integrations
-# Note, stage 1 after dependencies are not respected.
-STAGE_1_INTEGRATIONS = {
+LOGGING_INTEGRATIONS = {
+    # Set log levels
+    "logger",
+    # Error logging
+    "system_log",
+    "sentry",
     # To record data
     "recorder",
+}
+STAGE_1_INTEGRATIONS = {
     # To make sure we forward data to other instances
     "mqtt_eventstream",
     # To provide account link implementations
@@ -383,8 +387,24 @@ async def _async_set_up_integrations(
     """Set up all the integrations."""
     setup_started = hass.data[DATA_SETUP_STARTED] = {}
     domains = _get_domains(hass, config)
+    logging_domains = domains & LOGGING_INTEGRATIONS
 
-    # Resolve all dependencies so we know all integrations that will be loaded
+    # Load logging as soon as possible
+    if logging_domains:
+        _LOGGER.info("Setting up logging: %s", logging_domains)
+        await async_setup_multi_components(hass, logging_domains, config, setup_started)
+
+    _LOGGER.info("Domains to be set up: %s", domains)
+
+    # Start up debuggers. Start these first in case they want to wait.
+    debuggers = domains & DEBUGGER_INTEGRATIONS
+
+    if debuggers:
+        _LOGGER.debug("Setting up debuggers: %s", debuggers)
+        await async_setup_multi_components(hass, debuggers, config, setup_started)
+
+    # Resolve all dependencies so we know all integrations
+    # that will have to be loaded and start rightaway
     integrations_to_process = [
         int_or_exc
         for int_or_exc in await asyncio.gather(
@@ -405,22 +425,36 @@ async def _async_set_up_integrations(
     for itg in integrations_to_process:
         domains.update(itg.dependencies)
 
-    # Start up debuggers. Start these first in case they want to wait.
-    debuggers = domains & DEBUGGER_INTEGRATIONS
-    if debuggers:
-        _LOGGER.debug("Starting up debuggers %s", debuggers)
-        await async_setup_multi_components(hass, debuggers, config, setup_started)
-        domains -= DEBUGGER_INTEGRATIONS
-
-    # setup components
-    logging_domains = domains & LOGGING_INTEGRATIONS
+    # calculate what components to setup in what stage
     stage_1_domains = domains & STAGE_1_INTEGRATIONS
-    stage_2_domains = domains - logging_domains - stage_1_domains
 
-    # Start setup
-    if logging_domains:
-        _LOGGER.info("Setting up %s", logging_domains)
-        await async_setup_multi_components(hass, logging_domains, config, setup_started)
+    # Find all after dependencies of any dependency of any stage 1 integration
+    # that we plan on loading and promote them to stage 1
+    integration_cache = {itg.domain: itg for itg in integrations_to_process}
+
+    for itg in integrations_to_process:
+        if itg.domain not in stage_1_domains:
+            continue
+
+        # Promote all after dependencies of anything that
+        # will be loaded during stage 1 to stage 1
+        stage_1_domains.update(itg.all_dependencies)
+        stage_1_domains.update(
+            domain for domain in itg.after_dependencies if domain in domains
+        )
+
+        # And do that too for all of its dependencies
+        for dep_domain in itg.all_dependencies:
+            dep_itg = integration_cache.get(dep_domain)
+            if dep_itg is None:
+                dep_itg = await loader.async_get_integration(hass, dep_domain)
+                integration_cache[dep_itg.domain] = dep_itg
+
+            stage_1_domains.update(
+                domain for domain in dep_itg.after_dependencies if domain in domains
+            )
+
+    stage_2_domains = domains - logging_domains - debuggers - stage_1_domains
 
     # Kick off loading the registries. They don't need to be awaited.
     asyncio.gather(
@@ -429,13 +463,15 @@ async def _async_set_up_integrations(
         hass.helpers.area_registry.async_get_registry(),
     )
 
+    # Start setup
+    async_set_domains_to_be_loaded(hass, stage_1_domains | stage_2_domains)
+
     if stage_1_domains:
-        _LOGGER.info("Setting up %s", stage_1_domains)
+        _LOGGER.info("Setting up stage 1: %s", stage_1_domains)
         await async_setup_multi_components(hass, stage_1_domains, config, setup_started)
 
     if stage_2_domains:
-        # This will manage after_dependencies
-        async_set_domains_to_be_loaded(hass, stage_2_domains)
+        _LOGGER.info("Setting up stage 2: %s", stage_2_domains)
         await async_setup_multi_components(hass, stage_2_domains, config, setup_started)
 
     # Wrap up startup

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -392,13 +392,8 @@ async def _async_set_up_integrations(
         return_exceptions=True,
     ):
         # Exceptions are handled in async_setup_component.
-        if (
-            not isinstance(int_or_exc, loader.Integration)
-            or int_or_exc.all_dependencies_resolved
-        ):
-            continue
-
-        integrations_to_process.append(int_or_exc)
+        if isinstance(int_or_exc, loader.Integration):
+            integrations_to_process.append(int_or_exc)
 
     to_resolve = [
         itg.resolve_dependencies()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -415,8 +415,6 @@ async def _async_set_up_integrations(
     # setup components
     logging_domains = domains & LOGGING_INTEGRATIONS
     stage_1_domains = domains & STAGE_1_INTEGRATIONS
-
-    # Calculate stage 2
     stage_2_domains = domains - logging_domains - stage_1_domains
 
     # Start setup
@@ -433,10 +431,10 @@ async def _async_set_up_integrations(
 
     if stage_1_domains:
         _LOGGER.info("Setting up %s", stage_1_domains)
-
         await async_setup_multi_components(hass, stage_1_domains, config, setup_started)
 
     if stage_2_domains:
+        # This will manage after_dependencies
         async_set_domains_to_be_loaded(hass, stage_2_domains)
         await async_setup_multi_components(hass, stage_2_domains, config, setup_started)
 

--- a/homeassistant/components/auth/manifest.json
+++ b/homeassistant/components/auth/manifest.json
@@ -3,7 +3,6 @@
   "name": "Auth",
   "documentation": "https://www.home-assistant.io/integrations/auth",
   "dependencies": ["http"],
-  "after_dependencies": ["onboarding"],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/onboarding/manifest.json
+++ b/homeassistant/components/onboarding/manifest.json
@@ -2,7 +2,7 @@
   "domain": "onboarding",
   "name": "Home Assistant Onboarding",
   "documentation": "https://www.home-assistant.io/integrations/onboarding",
-  "dependencies": ["auth", "http", "person"],
+  "dependencies": ["http", "person"],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/onboarding/manifest.json
+++ b/homeassistant/components/onboarding/manifest.json
@@ -2,7 +2,7 @@
   "domain": "onboarding",
   "name": "Home Assistant Onboarding",
   "documentation": "https://www.home-assistant.io/integrations/onboarding",
-  "dependencies": ["http", "person"],
+  "dependencies": ["auth", "http", "person"],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -569,16 +569,12 @@ async def _async_component_dependencies(
         if start_domain in dep_integration.after_dependencies:
             raise CircularDependency(start_domain, dependency_domain)
 
-        # If this integration is already fully resolved, use that info
-        if dep_integration.all_dependencies_resolved:
-            loaded.update(dep_integration.all_dependencies)
-            continue
+        if dep_integration.dependencies:
+            dep_loaded = await _async_component_dependencies(
+                hass, start_domain, dep_integration, loaded, loading
+            )
 
-        dep_loaded = await _async_component_dependencies(
-            hass, start_domain, dep_integration, loaded, loading
-        )
-
-        loaded.update(dep_loaded)
+            loaded.update(dep_loaded)
 
     loaded.add(domain)
     loading.remove(domain)

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -3,7 +3,7 @@ import asyncio
 import logging.handlers
 from timeit import default_timer as timer
 from types import ModuleType
-from typing import Awaitable, Callable, List, Optional
+from typing import Awaitable, Callable, Optional, Set
 
 from homeassistant import config as conf_util, core, loader, requirements
 from homeassistant.config import async_notify_setup_error
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_COMPONENT = "component"
 
+DATA_SETUP_DONE = "setup_done"
 DATA_SETUP_STARTED = "setup_started"
 DATA_SETUP = "setup_tasks"
 DATA_DEPS_REQS = "deps_reqs_processed"
@@ -24,6 +25,15 @@ SLOW_SETUP_WARNING = 10
 # Since a pip install can run, we wait
 # 30 minutes to timeout
 SLOW_SETUP_MAX_WAIT = 1800
+
+
+@core.callback
+def async_set_domains_to_be_loaded(hass: core.HomeAssistant, domains: Set[str]) -> None:
+    """Set domains that are going to be loaded from the config.
+
+    This will allow us to properly handle after_dependencies.
+    """
+    hass.data[DATA_SETUP_DONE] = {domain: asyncio.Event() for domain in domains}
 
 
 def setup_component(hass: core.HomeAssistant, domain: str, config: ConfigType) -> bool:
@@ -52,26 +62,41 @@ async def async_setup_component(
         _async_setup_component(hass, domain, config)
     )
 
-    return await task  # type: ignore
+    try:
+        return await task  # type: ignore
+    finally:
+        if domain in hass.data.get(DATA_SETUP_DONE, {}):
+            hass.data[DATA_SETUP_DONE].pop(domain).set()
 
 
 async def _async_process_dependencies(
-    hass: core.HomeAssistant, config: ConfigType, name: str, dependencies: List[str]
+    hass: core.HomeAssistant, config: ConfigType, integration: loader.Integration
 ) -> bool:
     """Ensure all dependencies are set up."""
-    tasks = [async_setup_component(hass, dep, config) for dep in dependencies]
+    tasks = [
+        async_setup_component(hass, dep, config) for dep in integration.dependencies
+    ]
+
+    to_be_loaded = hass.data.get(DATA_SETUP_DONE, {})
+    for dep in integration.after_dependencies:
+        if dep in to_be_loaded:
+            tasks.append(to_be_loaded[dep].wait())
 
     if not tasks:
         return True
 
     results = await asyncio.gather(*tasks)
 
-    failed = [dependencies[idx] for idx, res in enumerate(results) if not res]
+    failed = [
+        domain
+        for idx, domain in enumerate(integration.dependencies)
+        if not results[idx]
+    ]
 
     if failed:
         _LOGGER.error(
             "Unable to set up dependencies of %s. Setup failed for dependencies: %s",
-            name,
+            integration.domain,
             ", ".join(failed),
         )
 
@@ -301,9 +326,7 @@ async def async_process_deps_reqs(
     elif integration.domain in processed:
         return
 
-    if integration.dependencies and not await _async_process_dependencies(
-        hass, config, integration.domain, integration.dependencies
-    ):
+    if not await _async_process_dependencies(hass, config, integration):
         raise HomeAssistantError("Could not set up all dependencies.")
 
     if not hass.config.skip_pip and integration.requirements:

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -254,7 +254,14 @@ def validate(integrations: Dict[str, Integration], config):
             continue
 
         # check that all referenced dependencies exist
+        after_deps = integration.manifest.get("after_dependencies", [])
         for dep in integration.manifest.get("dependencies", []):
+            if dep in after_deps:
+                integration.add_error(
+                    "dependencies",
+                    f"Dependency {dep} is both in dependencies and after_dependencies",
+                )
+
             if dep not in integrations:
                 integration.add_error(
                     "dependencies", f"Dependency {dep} does not exist"

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -90,6 +90,7 @@ class ImportCollector(ast.NodeVisitor):
 
 ALLOWED_USED_COMPONENTS = {
     # Internal integrations
+    "auth",
     "alert",
     "automation",
     "conversation",

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -90,7 +90,6 @@ class ImportCollector(ast.NodeVisitor):
 
 ALLOWED_USED_COMPONENTS = {
     # Internal integrations
-    "auth",
     "alert",
     "automation",
     "conversation",
@@ -104,6 +103,7 @@ ALLOWED_USED_COMPONENTS = {
     "input_number",
     "input_select",
     "input_text",
+    "onboarding",
     "persistent_notification",
     "person",
     "script",

--- a/tests/common.py
+++ b/tests/common.py
@@ -991,6 +991,8 @@ def mock_integration(hass, module):
     hass.data.setdefault(loader.DATA_INTEGRATIONS, {})[module.DOMAIN] = integration
     hass.data.setdefault(loader.DATA_COMPONENTS, {})[module.DOMAIN] = module
 
+    return integration
+
 
 def mock_entity_platform(hass, platform_path, module):
     """Mock a entity platform.

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -136,8 +136,8 @@ async def test_setup_after_deps_all_present(hass):
     assert order == ["logger", "root", "first_dep", "second_dep"]
 
 
-async def test_setup_after_deps_in_stage_1(hass):
-    """Test after_dependencies set up via platform."""
+async def test_setup_after_deps_in_stage_1_ignored(hass):
+    """Test after_dependencies are ignored in stage 1."""
     # This test relies on this
     assert "cloud" in bootstrap.STAGE_1_INTEGRATIONS
     order = []
@@ -178,7 +178,7 @@ async def test_setup_after_deps_in_stage_1(hass):
 
     assert "normal_integration" in hass.config.components
     assert "cloud" in hass.config.components
-    assert order == ["an_after_dep", "normal_integration", "cloud"]
+    assert order == ["cloud", "an_after_dep", "normal_integration"]
 
 
 async def test_setup_after_deps_via_platform(hass):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from homeassistant import bootstrap
+from homeassistant import bootstrap, core
 import homeassistant.config as config_util
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
@@ -16,9 +16,11 @@ from tests.async_mock import patch
 from tests.common import (
     MockConfigEntry,
     MockModule,
+    MockPlatform,
     flush_store,
     get_test_config_dir,
     mock_coro,
+    mock_entity_platform,
     mock_integration,
 )
 
@@ -132,9 +134,95 @@ async def test_setup_after_deps_all_present(hass, caplog):
     assert order == ["root", "first_dep", "second_dep"]
 
 
-async def test_setup_after_deps_not_trigger_load(hass, caplog):
+async def test_setup_after_deps_in_stage_1(hass):
+    """Test after_dependencies set up via platform."""
+    # This test relies on this
+    assert "frontend" in bootstrap.STAGE_1_INTEGRATIONS
+    order = []
+
+    def gen_domain_setup(domain):
+        async def async_setup(hass, config):
+            order.append(domain)
+            return True
+
+        return async_setup
+
+    mock_integration(
+        hass,
+        MockModule(
+            domain="normal_integration",
+            async_setup=gen_domain_setup("normal_integration"),
+        ),
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            domain="frontend",
+            async_setup=gen_domain_setup("frontend"),
+            partial_manifest={"after_dependencies": ["normal_integration"]},
+        ),
+    )
+
+    await bootstrap._async_set_up_integrations(
+        hass, {"frontend": {}, "normal_integration": {}}
+    )
+
+    assert "normal_integration" in hass.config.components
+    assert "frontend" in hass.config.components
+    assert order == ["normal_integration", "frontend"]
+
+
+async def test_setup_after_deps_via_platform(hass):
+    """Test after_dependencies set up via platform."""
+    order = []
+    after_dep_event = asyncio.Event()
+
+    def gen_domain_setup(domain):
+        async def async_setup(hass, config):
+            if domain == "after_dep_of_platform_int":
+                await after_dep_event.wait()
+
+            order.append(domain)
+            return True
+
+        return async_setup
+
+    mock_integration(
+        hass,
+        MockModule(
+            domain="after_dep_of_platform_int",
+            async_setup=gen_domain_setup("after_dep_of_platform_int"),
+        ),
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            domain="platform_int",
+            async_setup=gen_domain_setup("platform_int"),
+            partial_manifest={"after_dependencies": ["after_dep_of_platform_int"]},
+        ),
+    )
+    mock_entity_platform(hass, "light.platform_int", MockPlatform())
+
+    @core.callback
+    def continue_loading(_):
+        """When light component loaded, continue other loading."""
+        after_dep_event.set()
+
+    hass.bus.async_listen_once("component_loaded", continue_loading)
+
+    await bootstrap._async_set_up_integrations(
+        hass, {"light": {"platform": "platform_int"}, "after_dep_of_platform_int": {}}
+    )
+
+    assert "light" in hass.config.components
+    assert "after_dep_of_platform_int" in hass.config.components
+    assert "platform_int" in hass.config.components
+    assert order == ["after_dep_of_platform_int", "platform_int"]
+
+
+async def test_setup_after_deps_not_trigger_load(hass):
     """Test after_dependencies does not trigger loading it."""
-    caplog.set_level(logging.DEBUG)
     order = []
 
     def gen_domain_setup(domain):
@@ -169,12 +257,10 @@ async def test_setup_after_deps_not_trigger_load(hass, caplog):
     assert "root" in hass.config.components
     assert "first_dep" not in hass.config.components
     assert "second_dep" in hass.config.components
-    assert order == ["root", "second_dep"]
 
 
-async def test_setup_after_deps_not_present(hass, caplog):
+async def test_setup_after_deps_not_present(hass):
     """Test after_dependencies when referenced integration doesn't exist."""
-    caplog.set_level(logging.DEBUG)
     order = []
 
     def gen_domain_setup(domain):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -123,14 +123,17 @@ async def test_setup_after_deps_all_present(hass):
         ),
     )
 
-    await bootstrap._async_set_up_integrations(
-        hass, {"root": {}, "first_dep": {}, "second_dep": {}}
-    )
+    with patch(
+        "homeassistant.components.logger.async_setup", gen_domain_setup("logger")
+    ):
+        await bootstrap._async_set_up_integrations(
+            hass, {"root": {}, "first_dep": {}, "second_dep": {}, "logger": {}}
+        )
 
     assert "root" in hass.config.components
     assert "first_dep" in hass.config.components
     assert "second_dep" in hass.config.components
-    assert order == ["root", "first_dep", "second_dep"]
+    assert order == ["logger", "root", "first_dep", "second_dep"]
 
 
 async def test_setup_after_deps_via_platform(hass):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -83,7 +83,7 @@ async def test_core_failure_loads_safe_mode(hass, caplog):
     assert "group" not in hass.config.components
 
 
-async def test_setting_up_config(hass, caplog):
+async def test_setting_up_config(hass):
     """Test we set up domains in config."""
     await bootstrap._async_set_up_integrations(
         hass, {"group hello": {}, "homeassistant": {}}
@@ -92,9 +92,8 @@ async def test_setting_up_config(hass, caplog):
     assert "group" in hass.config.components
 
 
-async def test_setup_after_deps_all_present(hass, caplog):
+async def test_setup_after_deps_all_present(hass):
     """Test after_dependencies when all present."""
-    caplog.set_level(logging.DEBUG)
     order = []
 
     def gen_domain_setup(domain):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -134,44 +134,6 @@ async def test_setup_after_deps_all_present(hass, caplog):
     assert order == ["root", "first_dep", "second_dep"]
 
 
-async def test_setup_after_deps_in_stage_1(hass):
-    """Test after_dependencies set up via platform."""
-    # This test relies on this
-    assert "frontend" in bootstrap.STAGE_1_INTEGRATIONS
-    order = []
-
-    def gen_domain_setup(domain):
-        async def async_setup(hass, config):
-            order.append(domain)
-            return True
-
-        return async_setup
-
-    mock_integration(
-        hass,
-        MockModule(
-            domain="normal_integration",
-            async_setup=gen_domain_setup("normal_integration"),
-        ),
-    )
-    mock_integration(
-        hass,
-        MockModule(
-            domain="frontend",
-            async_setup=gen_domain_setup("frontend"),
-            partial_manifest={"after_dependencies": ["normal_integration"]},
-        ),
-    )
-
-    await bootstrap._async_set_up_integrations(
-        hass, {"frontend": {}, "normal_integration": {}}
-    )
-
-    assert "normal_integration" in hass.config.components
-    assert "frontend" in hass.config.components
-    assert order == ["normal_integration", "frontend"]
-
-
 async def test_setup_after_deps_via_platform(hass):
     """Test after_dependencies set up via platform."""
     order = []

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -13,31 +13,23 @@ async def test_component_dependencies(hass):
     """Test if we can get the proper load order of components."""
     mock_integration(hass, MockModule("mod1"))
     mock_integration(hass, MockModule("mod2", ["mod1"]))
-    mock_integration(hass, MockModule("mod3", ["mod2"]))
+    mod_3 = mock_integration(hass, MockModule("mod3", ["mod2"]))
 
     assert {"mod1", "mod2", "mod3"} == await loader._async_component_dependencies(
-        hass, "mod3", set(), set()
+        hass, mod_3, set(), set()
     )
 
     # Create circular dependency
     mock_integration(hass, MockModule("mod1", ["mod3"]))
 
     with pytest.raises(loader.CircularDependency):
-        print(await loader._async_component_dependencies(hass, "mod3", set(), set()))
+        print(await loader._async_component_dependencies(hass, mod_3, set(), set()))
 
     # Depend on non-existing component
-    mock_integration(hass, MockModule("mod1", ["nonexisting"]))
+    mod_1 = mock_integration(hass, MockModule("mod1", ["nonexisting"]))
 
     with pytest.raises(loader.IntegrationNotFound):
-        print(await loader._async_component_dependencies(hass, "mod1", set(), set()))
-
-    # Try to get dependencies for non-existing component
-    with pytest.raises(loader.IntegrationNotFound):
-        print(
-            await loader._async_component_dependencies(
-                hass, "nonexisting", set(), set()
-            )
-        )
+        print(await loader._async_component_dependencies(hass, mod_1, set(), set()))
 
 
 def test_component_loader(hass):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -16,20 +16,40 @@ async def test_component_dependencies(hass):
     mod_3 = mock_integration(hass, MockModule("mod3", ["mod2"]))
 
     assert {"mod1", "mod2", "mod3"} == await loader._async_component_dependencies(
-        hass, mod_3, set(), set()
+        hass, "mod_3", mod_3, set(), set()
     )
 
     # Create circular dependency
     mock_integration(hass, MockModule("mod1", ["mod3"]))
 
     with pytest.raises(loader.CircularDependency):
-        print(await loader._async_component_dependencies(hass, mod_3, set(), set()))
+        print(
+            await loader._async_component_dependencies(
+                hass, "mod_3", mod_3, set(), set()
+            )
+        )
 
     # Depend on non-existing component
     mod_1 = mock_integration(hass, MockModule("mod1", ["nonexisting"]))
 
     with pytest.raises(loader.IntegrationNotFound):
-        print(await loader._async_component_dependencies(hass, mod_1, set(), set()))
+        print(
+            await loader._async_component_dependencies(
+                hass, "mod_1", mod_1, set(), set()
+            )
+        )
+
+    # Having an after dependency 2 deps down that is circular
+    mod_1 = mock_integration(
+        hass, MockModule("mod1", partial_manifest={"after_dependencies": ["mod_3"]})
+    )
+
+    with pytest.raises(loader.CircularDependency):
+        print(
+            await loader._async_component_dependencies(
+                hass, "mod_3", mod_3, set(), set()
+            )
+        )
 
 
 def test_component_loader(hass):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -15,25 +15,29 @@ async def test_component_dependencies(hass):
     mock_integration(hass, MockModule("mod2", ["mod1"]))
     mock_integration(hass, MockModule("mod3", ["mod2"]))
 
-    assert {"mod1", "mod2", "mod3"} == await loader.async_component_dependencies(
-        hass, "mod3"
+    assert {"mod1", "mod2", "mod3"} == await loader._async_component_dependencies(
+        hass, "mod3", set(), set()
     )
 
     # Create circular dependency
     mock_integration(hass, MockModule("mod1", ["mod3"]))
 
     with pytest.raises(loader.CircularDependency):
-        print(await loader.async_component_dependencies(hass, "mod3"))
+        print(await loader._async_component_dependencies(hass, "mod3", set(), set()))
 
     # Depend on non-existing component
     mock_integration(hass, MockModule("mod1", ["nonexisting"]))
 
     with pytest.raises(loader.IntegrationNotFound):
-        print(await loader.async_component_dependencies(hass, "mod1"))
+        print(await loader._async_component_dependencies(hass, "mod1", set(), set()))
 
     # Try to get dependencies for non-existing component
     with pytest.raises(loader.IntegrationNotFound):
-        print(await loader.async_component_dependencies(hass, "nonexisting"))
+        print(
+            await loader._async_component_dependencies(
+                hass, "nonexisting", set(), set()
+            )
+        )
 
 
 def test_component_loader(hass):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -480,12 +480,6 @@ class TestSetup:
         assert call_order == [1, 1, 2]
 
 
-async def test_component_cannot_depend_config(hass):
-    """Test config is not allowed to be a dependency."""
-    result = await setup._async_process_dependencies(hass, None, "test", ["config"])
-    assert not result
-
-
 async def test_component_warn_slow_setup(hass):
     """Warn we log when a component setup takes a long time."""
     mock_integration(hass, MockModule("test_component1"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`after_dependencies` were not honored for integrations that were loaded because a platform was being setup. This is fixed now. 

This now handles `after_dependencies` as we do `dependencies`. We schedule all setups of stage 2 integrations at once, and let asyncio events ping when setup can proceed.

This should also make startup faster again :) Want to run a test @bdraco ?

Fixes #36786

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
