### PR TITLE
Lutron component overhaul and improvements

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -136,8 +136,7 @@ async def async_setup_entry(hass, entry):
         # connections={(dr.CONNECTION_NETWORK_MAC, config.mac)},
         identifiers={(DOMAIN, hass_data[LUTRON_CONTROLLER].guid)},
         manufacturer="Lutron",
-        # TODO: Use a getter once pylutron is updated
-        name=hass_data[LUTRON_CONTROLLER]._name,
+        name=hass_data[LUTRON_CONTROLLER].name,
         # model=config.modelid,
         # sw_version=config.swversion,
     )

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -126,7 +126,7 @@ async def async_setup_entry(hass, entry):
                 hass_button = LutronButton(hass, hass_area, keypad, button)
                 _LOGGER.debug("Adding Button %s", hass_button.id)
                 hass_data[LUTRON_BUTTONS][hass_button.id] = hass_button
-        if area.occupancy_group is not None:
+        if area.occupancy_group is not None and area.sensors:
             hass_data[LUTRON_DEVICES]["binary_sensor"].append(
                 (hass_area, area.occupancy_group)
             )

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -209,6 +209,8 @@ class LutronDevice(Entity):
     @property
     def name(self):
         """Return the name of the device."""
+        if self._area.id:
+            return self._lutron_device.name
         return f"{self._area.name} {self._lutron_device.name}"
 
     @property

--- a/homeassistant/components/lutron/binary_sensor.py
+++ b/homeassistant/components/lutron/binary_sensor.py
@@ -7,18 +7,19 @@ from homeassistant.components.binary_sensor import (
 )
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+from .const import DOMAIN
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Lutron occupancy sensors."""
-    if discovery_info is None:
-        return
-    devs = []
-    for (area_name, device) in hass.data[LUTRON_DEVICES]["binary_sensor"]:
-        dev = LutronOccupancySensor(area_name, device, hass.data[LUTRON_CONTROLLER])
-        devs.append(dev)
-
-    add_entities(devs)
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up occupancy sensors for a Lutron deployment."""
+    async_add_entities(
+        LutronOccupancySensor(
+            area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
+        )
+        for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES][
+            "binary_sensor"
+        ]
+    )
 
 
 class LutronOccupancySensor(LutronDevice, BinarySensorEntity):
@@ -46,7 +47,7 @@ class LutronOccupancySensor(LutronDevice, BinarySensorEntity):
         # The default LutronDevice naming would create 'Kitchen Occ Kitchen',
         # but since there can only be one OccupancyGroup per area we go
         # with something shorter.
-        return f"{self._area_name} Occupancy"
+        return f"{self._area.name} Occupancy"
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron/config_flow.py
+++ b/homeassistant/components/lutron/config_flow.py
@@ -1,0 +1,88 @@
+"""Config flow for Lutron integration."""
+
+import logging
+from typing import Any, Dict, Optional
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, ConfigFlow, OptionsFlow
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (  # pylint:disable=unused-import
+    CONF_ENABLE_AREAS,
+    DEFAULT_ENABLE_AREAS,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LutronConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow for Lutron RadioRA 2."""
+
+    VERSION = 1
+    CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_import(
+        self, user_input: Optional[ConfigType] = None
+    ) -> Dict[str, Any]:
+        """Handle a flow initiated by configuration file."""
+        return await self.async_step_user(user_input)
+
+    async def async_step_user(
+        self, user_input: Optional[ConfigType] = None
+    ) -> Dict[str, Any]:
+        """Handle a flow initiated by the user."""
+        if user_input is None:
+            return self._show_setup_form()
+
+        await self.async_set_unique_id(user_input[CONF_HOST])
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
+
+    def _show_setup_form(self, errors: Optional[Dict] = None) -> Dict[str, Any]:
+        """Show the setup form to the user."""
+        data_schema = {
+            vol.Required(CONF_HOST): str,
+            vol.Required(CONF_USERNAME): str,
+            vol.Required(CONF_PASSWORD): str,
+        }
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors or {},
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(OptionsFlow):
+    """Handle a option flow for Harmony."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Handle options flow."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_ENABLE_AREAS,
+                    default=self.config_entry.options.get(
+                        CONF_ENABLE_AREAS, DEFAULT_ENABLE_AREAS
+                    ),
+                ): bool,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/lutron/const.py
+++ b/homeassistant/components/lutron/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Lutron component."""
+
+DOMAIN = "lutron"
+
+CONF_ENABLE_AREAS = "enable_areas"
+DEFAULT_ENABLE_AREAS = False

--- a/homeassistant/components/lutron/cover.py
+++ b/homeassistant/components/lutron/cover.py
@@ -10,19 +10,17 @@ from homeassistant.components.cover import (
 )
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Lutron shades."""
-    devs = []
-    for (area_name, device) in hass.data[LUTRON_DEVICES]["cover"]:
-        dev = LutronCover(area_name, device, hass.data[LUTRON_CONTROLLER])
-        devs.append(dev)
-
-    add_entities(devs, True)
-    return True
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up covers for a single Lutron deployment."""
+    async_add_entities(
+        LutronCover(area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],)
+        for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES]["cover"]
+    )
 
 
 class LutronCover(LutronDevice, CoverEntity):

--- a/homeassistant/components/lutron/cover.py
+++ b/homeassistant/components/lutron/cover.py
@@ -18,8 +18,15 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up covers for a single Lutron deployment."""
     async_add_entities(
-        LutronCover(area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],)
-        for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES]["cover"]
+        (
+            LutronCover(
+                area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
+            )
+            for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES][
+                "cover"
+            ]
+        ),
+        True,
     )
 
 

--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -16,8 +16,15 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up lights for a Lutron deployment."""
     async_add_entities(
-        LutronLight(area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],)
-        for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES]["light"]
+        (
+            LutronLight(
+                area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
+            )
+            for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES][
+                "light"
+            ]
+        ),
+        True,
     )
 
 

--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -8,18 +8,17 @@ from homeassistant.components.light import (
 )
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Lutron lights."""
-    devs = []
-    for (area_name, device) in hass.data[LUTRON_DEVICES]["light"]:
-        dev = LutronLight(area_name, device, hass.data[LUTRON_CONTROLLER])
-        devs.append(dev)
-
-    add_entities(devs, True)
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up lights for a Lutron deployment."""
+    async_add_entities(
+        LutronLight(area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],)
+        for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES]["light"]
+    )
 
 
 def to_lutron_level(level):
@@ -35,10 +34,10 @@ def to_hass_level(level):
 class LutronLight(LutronDevice, LightEntity):
     """Representation of a Lutron Light, including dimmable."""
 
-    def __init__(self, area_name, lutron_device, controller):
+    def __init__(self, area, lutron_device, controller):
         """Initialize the light."""
         self._prev_brightness = None
-        super().__init__(area_name, lutron_device, controller)
+        super().__init__(area, lutron_device, controller)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -3,6 +3,6 @@
   "name": "Lutron",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lutron",
-  "requirements": ["pylutron==0.2.6"],
+  "requirements": ["pylutron==0.2.7"],
   "codeowners": ["@JonGilmore"]
 }

--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "lutron",
   "name": "Lutron",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lutron",
   "requirements": ["pylutron==0.2.6"],
   "codeowners": ["@JonGilmore"]

--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -2,6 +2,6 @@
   "domain": "lutron",
   "name": "Lutron",
   "documentation": "https://www.home-assistant.io/integrations/lutron",
-  "requirements": ["pylutron==0.2.5"],
+  "requirements": ["pylutron==0.2.6"],
   "codeowners": ["@JonGilmore"]
 }

--- a/homeassistant/components/lutron/scene.py
+++ b/homeassistant/components/lutron/scene.py
@@ -5,31 +5,36 @@ from typing import Any
 from homeassistant.components.scene import Scene
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Lutron scenes."""
-    devs = []
-    for scene_data in hass.data[LUTRON_DEVICES]["scene"]:
-        (area_name, keypad_name, device, led) = scene_data
-        dev = LutronScene(
-            area_name, keypad_name, device, led, hass.data[LUTRON_CONTROLLER]
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up scenes for a Lutron Deployment."""
+    async_add_entities(
+        LutronScene(
+            area,
+            keypad,
+            device,
+            led,
+            hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
         )
-        devs.append(dev)
-
-    add_entities(devs, True)
+        for (area, keypad, device, led) in hass.data[DOMAIN][entry.entry_id][
+            LUTRON_DEVICES
+        ]["scene"]
+    )
 
 
 class LutronScene(LutronDevice, Scene):
     """Representation of a Lutron Scene."""
 
-    def __init__(self, area_name, keypad_name, lutron_device, lutron_led, controller):
+    def __init__(self, area, keypad, lutron_device, lutron_led, controller):
         """Initialize the scene/button."""
-        super().__init__(area_name, lutron_device, controller)
-        self._keypad_name = keypad_name
+        super().__init__(area, lutron_device, controller)
+        self._keypad = keypad
         self._led = lutron_led
+        self._keypad_unique_id = f"{self._controller.guid}_{self._keypad.uuid}"
 
     def activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
@@ -38,4 +43,23 @@ class LutronScene(LutronDevice, Scene):
     @property
     def name(self):
         """Return the name of the device."""
-        return f"{self._area_name} {self._keypad_name}: {self._lutron_device.name}"
+        return f"{self._area.name} {self._keypad.name}: {self._lutron_device.name}"
+
+    @property
+    def device_info(self):
+        """Return key device information."""
+        device_info = {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self._keypad_unique_id)
+            },
+            "name": f"{self._area.name} {self._keypad.name}",
+            "manufacturer": "Lutron",
+            "model": self._keypad.type,
+            # "sw_version": self.light.swversion,
+            "via_device": (DOMAIN, self._lutron_device._lutron.guid),
+            "area_id": self._area.id,
+        }
+        if self._area.id:
+            device_info["area_id"] = self._area.id
+        return device_info

--- a/homeassistant/components/lutron/scene.py
+++ b/homeassistant/components/lutron/scene.py
@@ -13,16 +13,19 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up scenes for a Lutron Deployment."""
     async_add_entities(
-        LutronScene(
-            area,
-            keypad,
-            device,
-            led,
-            hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
-        )
-        for (area, keypad, device, led) in hass.data[DOMAIN][entry.entry_id][
-            LUTRON_DEVICES
-        ]["scene"]
+        (
+            LutronScene(
+                area,
+                keypad,
+                device,
+                led,
+                hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
+            )
+            for (area, keypad, device, led) in hass.data[DOMAIN][entry.entry_id][
+                LUTRON_DEVICES
+            ]["scene"]
+        ),
+        True,
     )
 
 
@@ -31,9 +34,9 @@ class LutronScene(LutronDevice, Scene):
 
     def __init__(self, area, keypad, lutron_device, lutron_led, controller):
         """Initialize the scene/button."""
-        super().__init__(area, lutron_device, controller)
         self._keypad = keypad
         self._led = lutron_led
+        super().__init__(area, lutron_device, controller)
         self._keypad_unique_id = f"{self._controller.guid}_{self._keypad.uuid}"
 
     def activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/lutron/scene.py
+++ b/homeassistant/components/lutron/scene.py
@@ -46,6 +46,8 @@ class LutronScene(LutronDevice, Scene):
     @property
     def name(self):
         """Return the name of the device."""
+        if self._area.id:
+            return f"{self._keypad.name}: {self._lutron_device.name}"
         return f"{self._area.name} {self._keypad.name}: {self._lutron_device.name}"
 
     @property

--- a/homeassistant/components/lutron/services.yaml
+++ b/homeassistant/components/lutron/services.yaml
@@ -1,0 +1,19 @@
+press_button:
+  description: Press (and hold) a button on a keypad
+  fields:
+    button:
+      description: The button ID
+      example: stairs.family_room
+release_button:
+  description: Release a button on a keypad
+  fields:
+    button:
+      description: The button ID
+      example: stairs.family_room
+tap_button:
+  description: Press and Release a button on a keypad
+  fields:
+    button:
+      description: The button ID
+      example: stairs.family_room
+

--- a/homeassistant/components/lutron/strings.json
+++ b/homeassistant/components/lutron/strings.json
@@ -1,0 +1,34 @@
+{
+  "title": "Lutron",
+  "config": {
+    "flow_title": "Lutron: {name}",
+    "step": {
+      "user": {
+        "title": "Connect to Lutron",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Adjust Lutron Options",
+        "data": {
+          "enable_areas": "Allow Lutron to define and assign devices to areas. (Requires Restart)"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -35,7 +35,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 ]["scene"]
                 if led
             ),
-        )
+        ),
+        True,
     )
 
 

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -1,41 +1,51 @@
 """Support for Lutron switches."""
+from itertools import chain
 import logging
 
 from homeassistant.components.switch import SwitchEntity
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Lutron switches."""
-    devs = []
-
-    # Add Lutron Switches
-    for (area_name, device) in hass.data[LUTRON_DEVICES]["switch"]:
-        dev = LutronSwitch(area_name, device, hass.data[LUTRON_CONTROLLER])
-        devs.append(dev)
-
-    # Add the indicator LEDs for scenes (keypad buttons)
-    for scene_data in hass.data[LUTRON_DEVICES]["scene"]:
-        (area_name, keypad_name, scene, led) = scene_data
-        if led is not None:
-            led = LutronLed(
-                area_name, keypad_name, scene, led, hass.data[LUTRON_CONTROLLER]
-            )
-            devs.append(led)
-
-    add_entities(devs, True)
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up switches and leds for a Lutron deployment."""
+    async_add_entities(
+        chain(
+            (
+                LutronSwitch(
+                    area, device, hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
+                )
+                for (area, device) in hass.data[DOMAIN][entry.entry_id][LUTRON_DEVICES][
+                    "switch"
+                ]
+            ),
+            (
+                LutronLed(
+                    area,
+                    keypad,
+                    device,
+                    led,
+                    hass.data[DOMAIN][entry.entry_id][LUTRON_CONTROLLER],
+                )
+                for (area, keypad, device, led) in hass.data[DOMAIN][entry.entry_id][
+                    LUTRON_DEVICES
+                ]["scene"]
+                if led
+            ),
+        )
+    )
 
 
 class LutronSwitch(LutronDevice, SwitchEntity):
     """Representation of a Lutron Switch."""
 
-    def __init__(self, area_name, lutron_device, controller):
+    def __init__(self, area, lutron_device, controller):
         """Initialize the switch."""
         self._prev_state = None
-        super().__init__(area_name, lutron_device, controller)
+        super().__init__(area, lutron_device, controller)
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
@@ -66,11 +76,12 @@ class LutronSwitch(LutronDevice, SwitchEntity):
 class LutronLed(LutronDevice, SwitchEntity):
     """Representation of a Lutron Keypad LED."""
 
-    def __init__(self, area_name, keypad_name, scene_device, led_device, controller):
+    def __init__(self, area, keypad, scene_device, led_device, controller):
         """Initialize the switch."""
-        self._keypad_name = keypad_name
+        self._keypad = keypad
         self._scene_name = scene_device.name
-        super().__init__(area_name, led_device, controller)
+        self._keypad_unique_id = f"{led_device._lutron.guid}_{keypad.uuid}"
+        super().__init__(area, led_device, controller)
 
     def turn_on(self, **kwargs):
         """Turn the LED on."""
@@ -84,7 +95,7 @@ class LutronLed(LutronDevice, SwitchEntity):
     def device_state_attributes(self):
         """Return the state attributes."""
         attr = {
-            "keypad": self._keypad_name,
+            "keypad": self._keypad.name,
             "scene": self._scene_name,
             "led": self._lutron_device.name,
         }
@@ -98,7 +109,7 @@ class LutronLed(LutronDevice, SwitchEntity):
     @property
     def name(self):
         """Return the name of the LED."""
-        return f"{self._area_name} {self._keypad_name}: {self._scene_name} LED"
+        return f"{self._area.name} {self._keypad.name}: {self._scene_name} LED"
 
     def update(self):
         """Call when forcing a refresh of the device."""
@@ -107,3 +118,22 @@ class LutronLed(LutronDevice, SwitchEntity):
 
         # The following property getter actually triggers an update in Lutron
         self._lutron_device.state  # pylint: disable=pointless-statement
+
+    @property
+    def device_info(self):
+        """Return key device information."""
+        device_info = {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self._keypad_unique_id)
+            },
+            "name": f"{self._area.name} {self._keypad.name}",
+            "manufacturer": "Lutron",
+            "model": self._keypad.type,
+            # "sw_version": self.light.swversion,
+            "via_device": (DOMAIN, self._controller.guid),
+            "area_id": self._area.id,
+        }
+        if self._area.id:
+            device_info["area_id"] = self._area.id
+        return device_info

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -91,6 +91,7 @@ FLOWS = [
     "locative",
     "logi_circle",
     "luftdaten",
+    "lutron",
     "mailgun",
     "melcloud",
     "met",

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -49,6 +49,18 @@ class AreaRegistry:
         return self.areas.values()
 
     @callback
+    def async_get_or_create(self, name: str) -> AreaEntry:
+        """Get an area.  Create if it doesn't exist."""
+        if not name:
+            raise ValueError("Cannot have unnamed Areas")
+
+        area = self._async_is_registered(name)
+        if area:
+            return area
+
+        return self.async_create(name)
+
+    @callback
     def async_create(self, name: str) -> AreaEntry:
         """Create a new area."""
         if self._async_is_registered(name):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -150,6 +150,7 @@ class DeviceRegistry:
         sw_version=_UNDEF,
         entry_type=_UNDEF,
         via_device=None,
+        area_id=_UNDEF,
     ):
         """Get device. Create if it doesn't exist."""
         if not identifiers and not connections:
@@ -194,6 +195,7 @@ class DeviceRegistry:
             name=name,
             sw_version=sw_version,
             entry_type=entry_type,
+            area_id=area_id,
         )
 
     @callback

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -354,6 +354,7 @@ class EntityPlatform:
                     "sw_version",
                     "entry_type",
                     "via_device",
+                    "area_id",
                 ):
                     if key in device_info:
                         processed_dev_info[key] = device_info[key]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1448,7 +1448,7 @@ pyloopenergy==0.1.3
 pylutron-caseta==0.6.1
 
 # homeassistant.components.lutron
-pylutron==0.2.6
+pylutron==0.2.7
 
 # homeassistant.components.mailgun
 pymailgunner==1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1448,7 +1448,7 @@ pyloopenergy==0.1.3
 pylutron-caseta==0.6.1
 
 # homeassistant.components.lutron
-pylutron==0.2.5
+pylutron==0.2.6
 
 # homeassistant.components.mailgun
 pymailgunner==1.4

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -53,6 +53,33 @@ async def test_create_area(hass, registry, update_events):
     assert update_events[0]["area_id"] == area.id
 
 
+async def test_get_or_create_area(hass, registry, update_events):
+    """Make sure that we can get or create an area."""
+    area1 = registry.async_get_or_create("mock")
+
+    assert area1.name == "mock"
+    assert len(registry.areas) == 1
+
+    area2 = registry.async_get_or_create("mock")
+
+    await hass.async_block_till_done()
+    assert area1 == area2
+    assert len(registry.areas) == 1
+
+    assert len(update_events) == 1
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["area_id"] == area1.id
+
+
+async def test_get_or_create_area_with_empty_name(hass, registry, update_events):
+    """Make sure that we can't get or create an unnamed area."""
+    with pytest.raises(ValueError) as e_info:
+        _ = registry.async_get_or_create("")
+        assert e_info == "Cannot have unnamed Areas"
+
+    assert len(update_events) == 0
+
+
 async def test_create_area_with_name_already_in_use(hass, registry, update_events):
     """Make sure that we can't create an area with a name already in use."""
     area1 = registry.async_create("mock")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
- Upgrade pylutron to 0.2.7
- Add support for configuring via the integrations UI
- Bring in new unique IDs from pylutron
- Properly define devices vs. entities
  - Keypads, Switches, Main Repeater, and Remotes are all devices
- Add support for importing Area names and assignments from Lutron
  - Users can enable this to import areas and then turn it off to
    override specific devices.
- Add services for press-and-hold, release, and tapping of buttons
  - This allows for the use of the alarm button where holding the
    holding the button is required to keep the alarm state active.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/13962

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
