### PR TITLE
Cope with attribute errors being converted in prometheus

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -167,7 +167,7 @@ class PrometheusMetrics:
             try:
                 value = float(value)
                 metric.labels(**self._labels(state)).set(value)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
 
     def _metric(self, metric, factory, documentation, extra_labels=None):


### PR DESCRIPTION
## Proposed change
This merge request stops incorrectly behaving entity attributes from filling the logs with python tracebacks.

If we don't want to lose the error we can also change the `pass` line to `_LOGGER.warning("Could not convert %s to float", state)`, but as we currently ignore ValueError's it was figured we also don't want these


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- Currently seeing this with the [ShellyForHASS](https://github.com/StyraHem/ShellyForHASS) custom integration mainly, but I have seen others also cause this.
- example attribute that can't be converted to a float: `<state switch.light=off; shelly_type=Shelly 1, shelly_id=XXX, ip_address=192.168.1.2, protocols=['CoAP-discovery', 'CoAP-msg', 'poll', 'mDns'], has_firmware_update=False, mqtt_connected=False, cloud_status=connected, switch=False, friendly_name=Star, icon=mdi:switch @ 2020-06-18T16:20:21.162404+01:00>`

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
 - Can't see how to update the existing tests for this...

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
