### PR TITLE
Retry failed Amcrest commands that change settings

### DIFF
--- a/homeassistant/components/amcrest/helpers.py
+++ b/homeassistant/components/amcrest/helpers.py
@@ -1,4 +1,6 @@
 """Helpers for amcrest component."""
+import logging
+
 from .const import DOMAIN
 
 
@@ -7,9 +9,10 @@ def service_signal(service, *args):
     return "_".join([DOMAIN, service, *args])
 
 
-def log_update_error(logger, action, name, entity_type, error):
+def log_update_error(logger, action, name, entity_type, error, level=logging.ERROR):
     """Log an update error."""
-    logger.error(
+    logger.log(
+        level,
         "Could not %s %s %s due to error: %s",
         action,
         name,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It appears that sometimes a command to change a setting (e.g., enable video, turn off motion detection, etc.) will be sent to the camera successfully (i.e., without failing due to communication or any other immediate error from the camera), yet will still not take effect. Previously these commands were considered "optimistic" and the corresponding entity attribute would be changed anyway as if it had worked. This can lead to not recording when it should, or possibly even worse, leaving the video or audio stream enabled when it should have been turned off.

This change enhances these operations such that after sending the command the setting is retrieved from the camera to make sure it actually changed. If not, or if there were any other errors, the operation is repeated, up to three times, before giving up and logging an error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
