### PR TITLE
Handle Plex Live TV sessions

### DIFF
--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -87,14 +87,19 @@ class PlexSensor(Entity):
                 # "Supernatural (2005) - s01e13 - Route 666"
 
                 def sync_io_attributes(session):
-                    return (session.show(), session.seasonEpisode)
+                    year = None
+                    try:
+                        year = session.show().year
+                    except TypeError:
+                        pass
+                    return (year, session.seasonEpisode)
 
-                show, season_episode = await self.hass.async_add_executor_job(
+                year, season_episode = await self.hass.async_add_executor_job(
                     sync_io_attributes, sess
                 )
                 season_title = sess.grandparentTitle
-                if show.year is not None:
-                    season_title += f" ({show.year!s})"
+                if year is not None:
+                    season_title += f" ({year!s})"
                 episode_title = sess.title
                 now_playing_title = (
                     f"{season_title} - {season_episode} - {episode_title}"

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -250,6 +250,11 @@ class MockPlexSession:
         return 10000000
 
     @property
+    def librarySectionID(self):
+        """Mock the librarySectionID attribute."""
+        return 1
+
+    @property
     def ratingKey(self):
         """Mock the ratingKey attribute."""
         return 123


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some assumptions about the session fields cause issues when a Plex client is watching live TV through a tuner hooked up to the server. This PR fixes all the issues I've found in my own testing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33570
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
