### PR TITLE
highlight Dockerfile.dev as Dockerfile in github ui

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 *.png binary
 *.zip binary
 *.mp3 binary
+
+Dockerfile.dev linguist-language=Dockerfile


### PR DESCRIPTION
## Proposed change
Use Dockerfile syntax highlighter for Dockerfile.dev file.


## Type of change
- [X] Code quality improvements to existing code or addition of tests

More info at
https://github.com/github/linguist#overrides


I have merged this PR into my fork's dev branch, check it here https://github.com/adaamz/core/blob/dev/Dockerfile.dev