### PR TITLE
Make recorder execute avoid native conversion by default

### DIFF
--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -311,7 +311,7 @@ class Plant(Entity):
                 )
                 .order_by(States.last_updated.asc())
             )
-            states = execute(query)
+            states = execute(query, to_native=True, validate_entity_ids=False)
 
             for state in states:
                 # filter out all None, NaN and "unknown" states

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -128,7 +128,7 @@ class States(Base):  # type: ignore
 
         return dbstate
 
-    def to_native(self):
+    def to_native(self, validate_entity_id=True):
         """Convert to an HA state object."""
         context = Context(id=self.context_id, user_id=self.context_user_id)
         try:
@@ -139,9 +139,7 @@ class States(Base):  # type: ignore
                 process_timestamp(self.last_changed),
                 process_timestamp(self.last_updated),
                 context=context,
-                # Temp, because database can still store invalid entity IDs
-                # Remove with 1.0 or in 2020.
-                temp_invalid_id_bypass=True,
+                validate_entity_id=validate_entity_id,
             )
         except ValueError:
             # When json.loads fails

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -54,7 +54,7 @@ def commit(session, work):
     return False
 
 
-def execute(qry, to_native=True):
+def execute(qry, to_native=False, validate_entity_ids=True):
     """Query the database and convert the objects to HA native form.
 
     This method also retries a few times in the case of stale connections.
@@ -64,7 +64,12 @@ def execute(qry, to_native=True):
             timer_start = time.perf_counter()
             if to_native:
                 result = [
-                    row for row in (row.to_native() for row in qry) if row is not None
+                    row
+                    for row in (
+                        row.to_native(validate_entity_id=validate_entity_ids)
+                        for row in qry
+                    )
+                    if row is not None
                 ]
             else:
                 result = list(qry)

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -332,7 +332,7 @@ class StatisticsSensor(Entity):
             query = query.order_by(States.last_updated.desc()).limit(
                 self._sampling_size
             )
-            states = execute(query)
+            states = execute(query, to_native=True, validate_entity_ids=False)
 
         for state in reversed(states):
             self._add_state_to_queue(state)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -739,14 +739,12 @@ class State:
         last_changed: Optional[datetime.datetime] = None,
         last_updated: Optional[datetime.datetime] = None,
         context: Optional[Context] = None,
-        # Temp, because database can still store invalid entity IDs
-        # Remove with 1.0 or in 2020.
-        temp_invalid_id_bypass: Optional[bool] = False,
+        validate_entity_id: Optional[bool] = True,
     ) -> None:
         """Initialize a new state."""
         state = str(state)
 
-        if not valid_entity_id(entity_id) and not temp_invalid_id_bypass:
+        if validate_entity_id and not valid_entity_id(entity_id):
             raise InvalidEntityFormatError(
                 f"Invalid entity id encountered: {entity_id}. "
                 "Format should be <domain>.<object_id>"

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -2,12 +2,14 @@
 from datetime import datetime
 import unittest
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from homeassistant.components.recorder.models import Base, Events, RecorderRuns, States
 from homeassistant.const import EVENT_STATE_CHANGED
 import homeassistant.core as ha
+from homeassistant.exceptions import InvalidEntityFormatError
 from homeassistant.util import dt
 
 ENGINE = None
@@ -155,8 +157,11 @@ class TestRecorderRuns(unittest.TestCase):
 
 def test_states_from_native_invalid_entity_id():
     """Test loading a state from an invalid entity ID."""
-    event = States()
-    event.entity_id = "test.invalid__id"
-    event.attributes = "{}"
-    state = event.to_native()
+    state = States()
+    state.entity_id = "test.invalid__id"
+    state.attributes = "{}"
+    with pytest.raises(InvalidEntityFormatError):
+        state = state.to_native()
+
+    state = state.to_native(validate_entity_id=False)
     assert state.entity_id == "test.invalid__id"

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -47,7 +47,7 @@ def test_recorder_bad_execute(hass_recorder):
 
     hass_recorder()
 
-    def to_native():
+    def to_native(validate_entity_id=True):
         """Rasie exception."""
         raise SQLAlchemyError()
 
@@ -57,6 +57,6 @@ def test_recorder_bad_execute(hass_recorder):
     with pytest.raises(SQLAlchemyError), patch(
         "homeassistant.components.recorder.time.sleep"
     ) as e_mock:
-        util.execute((mck1,))
+        util.execute((mck1,), to_native=True)
 
     assert e_mock.call_count == 2

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -3,8 +3,6 @@ from datetime import datetime, timedelta
 import statistics
 import unittest
 
-import pytest
-
 from homeassistant.components import recorder
 from homeassistant.components.statistics.sensor import StatisticsSensor
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS
@@ -17,6 +15,7 @@ from tests.common import (
     get_test_home_assistant,
     init_recorder_component,
 )
+from tests.components.recorder.common import wait_recording_done
 
 
 class TestStatisticsSensor(unittest.TestCase):
@@ -321,11 +320,12 @@ class TestStatisticsSensor(unittest.TestCase):
         ) == state.attributes.get("max_age")
         assert self.change_rate == state.attributes.get("change_rate")
 
-    @pytest.mark.skip("Flaky in CI")
     def test_initialize_from_database(self):
         """Test initializing the statistics from the database."""
         # enable the recorder
         init_recorder_component(self.hass)
+        self.hass.block_till_done()
+        self.hass.data[recorder.DATA_INSTANCE].block_till_done()
         # store some values
         for value in self.values:
             self.hass.states.set(
@@ -333,7 +333,7 @@ class TestStatisticsSensor(unittest.TestCase):
             )
             self.hass.block_till_done()
         # wait for the recorder to really store the data
-        self.hass.data[recorder.DATA_INSTANCE].block_till_done()
+        wait_recording_done(self.hass)
         # only now create the statistics component, so that it must read the
         # data from the database
         assert setup_component(
@@ -357,7 +357,6 @@ class TestStatisticsSensor(unittest.TestCase):
         state = self.hass.states.get("sensor.test")
         assert str(self.mean) == state.state
 
-    @pytest.mark.skip("Flaky in CI")
     def test_initialize_from_database_with_maxage(self):
         """Test initializing the statistics from the database."""
         mock_data = {
@@ -381,6 +380,8 @@ class TestStatisticsSensor(unittest.TestCase):
 
         # enable the recorder
         init_recorder_component(self.hass)
+        self.hass.block_till_done()
+        self.hass.data[recorder.DATA_INSTANCE].block_till_done()
 
         with patch(
             "homeassistant.components.statistics.sensor.dt_util.utcnow", new=mock_now
@@ -397,7 +398,7 @@ class TestStatisticsSensor(unittest.TestCase):
                 mock_data["return_time"] += timedelta(hours=1)
 
             # wait for the recorder to really store the data
-            self.hass.data[recorder.DATA_INSTANCE].block_till_done()
+            wait_recording_done(self.hass)
             # only now create the statistics component, so that it must read
             # the data from the database
             assert setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Recorder `execute` calls now return database rows instead of native objects by default unless `to_native=True` is passed.  Converting to native object is expensives and can be done later for rows the caller is interested in that could not be filtered by SQL.

Entity_id validation now default to on when converting states to native.  To disable validation when converting states to native, pass `validate_entity_id=False` to `to_native` or when using `execute` with `to_native=True`, pass `validate_entity_ids=False`


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
