### PR TITLE
Use chip id in Konnected pro boards

### DIFF
--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -185,7 +185,7 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.data[CONF_PORT] = port
         try:
             status = await get_status(self.hass, host, port)
-            self.data[CONF_ID] = status.get("chipId") or status["mac"].replace(":", "")
+            self.data[CONF_ID] = status.get("chipId", status["mac"].replace(":", ""))
         except (CannotConnect, KeyError):
             raise CannotConnect
         else:
@@ -293,8 +293,8 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             else:
-                self.data[CONF_ID] = status.get("chipId") or status["mac"].replace(
-                    ":", ""
+                self.data[CONF_ID] = status.get(
+                    "chipId", status["mac"].replace(":", "")
                 )
                 self.data[CONF_MODEL] = status.get("model", KONN_MODEL)
 

--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -185,7 +185,7 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.data[CONF_PORT] = port
         try:
             status = await get_status(self.hass, host, port)
-            self.data[CONF_ID] = status["mac"].replace(":", "")
+            self.data[CONF_ID] = status.get("chipId") or status["mac"].replace(":", "")
         except (CannotConnect, KeyError):
             raise CannotConnect
         else:
@@ -293,7 +293,9 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             else:
-                self.data[CONF_ID] = status["mac"].replace(":", "")
+                self.data[CONF_ID] = status.get("chipId") or status["mac"].replace(
+                    ":", ""
+                )
                 self.data[CONF_MODEL] = status.get("model", KONN_MODEL)
 
                 # save off our discovered host info

--- a/homeassistant/components/konnected/panel.py
+++ b/homeassistant/components/konnected/panel.py
@@ -76,7 +76,7 @@ class AlarmPanel:
 
     @property
     def device_id(self):
-        """Device id is the MAC address as string with punctuation removed."""
+        """Device id is the chipId (pro) or MAC address as string with punctuation removed."""
         return self.config.get(CONF_ID)
 
     @property

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -69,7 +69,9 @@ async def test_pro_flow_works(hass, mock_panel):
     assert result["type"] == "form"
     assert result["step_id"] == "user"
 
+    # pro uses chipId instead of MAC as unique id
     mock_panel.get_status.return_value = {
+        "chipId": "1234567",
         "mac": "11:22:33:44:55:66",
         "model": "Konnected Pro",
     }
@@ -80,7 +82,7 @@ async def test_pro_flow_works(hass, mock_panel):
     assert result["step_id"] == "confirm"
     assert result["description_placeholders"] == {
         "model": "Konnected Alarm Panel Pro",
-        "id": "112233445566",
+        "id": "1234567",
         "host": "1.2.3.4",
         "port": 1234,
     }
@@ -192,8 +194,9 @@ async def test_import_no_host_user_finish(hass, mock_panel):
 
 
 async def test_import_ssdp_host_user_finish(hass, mock_panel):
-    """Test importing a panel with no host info which ssdp discovers."""
+    """Test importing a pro panel with no host info which ssdp discovers."""
     mock_panel.get_status.return_value = {
+        "chipId": "somechipid",
         "mac": "11:22:33:44:55:66",
         "model": "Konnected Pro",
     }
@@ -224,12 +227,12 @@ async def test_import_ssdp_host_user_finish(hass, mock_panel):
                     "out1": "Disabled",
                 },
             },
-            "id": "112233445566",
+            "id": "somechipid",
         },
     )
     assert result["type"] == "form"
     assert result["step_id"] == "import_confirm"
-    assert result["description_placeholders"]["id"] == "112233445566"
+    assert result["description_placeholders"]["id"] == "somechipid"
 
     # discover the panel via ssdp
     ssdp_result = await hass.config_entries.flow.async_init(
@@ -251,7 +254,7 @@ async def test_import_ssdp_host_user_finish(hass, mock_panel):
     assert result["step_id"] == "confirm"
     assert result["description_placeholders"] == {
         "model": "Konnected Alarm Panel Pro",
-        "id": "112233445566",
+        "id": "somechipid",
         "host": "0.0.0.0",
         "port": 1234,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The Konnected Pro Panels have multiple network interfaces (wifi/ethernet).  Using the MAC as the unique id for the device can cause problems is the interface used switches after the device is initially setup. 

To address this the Pro Panels now use the "chipId" as the identifier which is constant regardless of the network interface.

To maintain backward compatibility we fall back to MAC if the chipId isn't present.  All non pro panels do no include the chipId field so this should be a non-breaking change.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13794

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
