### PR TITLE
Upgrade ptvsd to 4.3.2

### DIFF
--- a/homeassistant/components/ptvsd/manifest.json
+++ b/homeassistant/components/ptvsd/manifest.json
@@ -2,6 +2,6 @@
   "domain": "ptvsd",
   "name": "PTVSD - Python Tools for Visual Studio Debug Server",
   "documentation": "https://www.home-assistant.io/integrations/ptvsd",
-  "requirements": ["ptvsd==4.2.8"],
+  "requirements": ["ptvsd==4.3.2"],
   "codeowners": ["@swamp-ig"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1128,7 +1128,7 @@ proxmoxer==1.1.0
 psutil==5.7.0
 
 # homeassistant.components.ptvsd
-ptvsd==4.2.8
+ptvsd==4.3.2
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -491,7 +491,7 @@ prayer_times_calculator==0.0.3
 prometheus_client==0.7.1
 
 # homeassistant.components.ptvsd
-ptvsd==4.2.8
+ptvsd==4.3.2
 
 # homeassistant.components.androidtv
 pure-python-adb==0.2.2.dev0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Upgrades ptvsd from 4.2.8 to 4.3.2.

Release notes:
- **4.3.2**: <https://github.com/microsoft/ptvsd/releases/tag/v4.3.2>
- **4.3.1**: <https://github.com/microsoft/ptvsd/releases/tag/v4.3.1>
- **4.3.0**: <https://github.com/microsoft/ptvsd/releases/tag/v4.3.0>
- **4.2.9**: <https://github.com/microsoft/ptvsd/releases/tag/v4.2.9>

GitHub Compare: <https://github.com/microsoft/ptvsd/compare/v4.2.8...v4.3.2>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
ptvsd:
  wait: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
