### PR TITLE
Add Tts enqueue

### DIFF
--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -119,6 +119,9 @@ play_media:
     media_content_type:
       description: The type of the content to play. Must be one of image, music, tvshow, video, episode, channel or playlist
       example: "music"
+    enqueue:
+      description: Add the content to play at the end of the playlist/queue. True/false
+      exemple: true
 
 select_source:
   description: Send the media player the command to change input source.

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
 from homeassistant.components.media_player.const import (
+    ATTR_MEDIA_ENQUEUE,
     MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_PLAYLIST,
     SUPPORT_CLEAR_PLAYLIST,
@@ -344,13 +345,17 @@ class MpdDevice(MediaPlayerEntity):
             else:
                 self._currentplaylist = None
                 _LOGGER.warning("Unknown playlist name %s", media_id)
-            self._client.clear()
+            if not kwargs.get(ATTR_MEDIA_ENQUEUE):
+                self._client.clear()
             self._client.load(media_id)
-            self._client.play()
+            if not kwargs.get(ATTR_MEDIA_ENQUEUE):
+                self._client.play()
         else:
-            self._client.clear()
+            if not kwargs.get(ATTR_MEDIA_ENQUEUE):
+                self._client.clear()
             self._client.add(media_id)
-            self._client.play()
+            if not kwargs.get(ATTR_MEDIA_ENQUEUE):
+                self._client.play()
 
     @property
     def shuffle(self):

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_ENQUEUE,
     DOMAIN as DOMAIN_MP,
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
@@ -56,6 +57,7 @@ CONF_TIME_MEMORY = "time_memory"
 DEFAULT_CACHE = True
 DEFAULT_CACHE_DIR = "tts"
 DEFAULT_TIME_MEMORY = 300
+DEFAULT_ENQUEUE = False
 DOMAIN = "tts"
 
 MEM_CACHE_FILENAME = "filename"
@@ -99,6 +101,7 @@ SCHEMA_SERVICE_SAY = vol.Schema(
         vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
         vol.Optional(ATTR_LANGUAGE): cv.string,
         vol.Optional(ATTR_OPTIONS): dict,
+        vol.Optional(ATTR_MEDIA_ENQUEUE, default=DEFAULT_ENQUEUE): cv.boolean,
     }
 )
 
@@ -159,6 +162,7 @@ async def async_setup(hass, config):
             cache = service.data.get(ATTR_CACHE)
             language = service.data.get(ATTR_LANGUAGE)
             options = service.data.get(ATTR_OPTIONS)
+            enqueue = service.data.get(ATTR_MEDIA_ENQUEUE)
 
             try:
                 url = await tts.async_get_url(
@@ -172,6 +176,7 @@ async def async_setup(hass, config):
                 ATTR_MEDIA_CONTENT_ID: url,
                 ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
                 ATTR_ENTITY_ID: entity_ids,
+                ATTR_MEDIA_ENQUEUE: enqueue,
             }
 
             await hass.services.async_call(

--- a/homeassistant/components/tts/services.yaml
+++ b/homeassistant/components/tts/services.yaml
@@ -18,6 +18,9 @@ say:
     options:
       description: A dictionary containing platform-specific options. Optional depending on the platform.
       example: platform specific
+    enqueue:
+      description: Add the content to play at the end of the playlist/queue of the device. True/false
+      exemple: true
 
 clear_cache:
   description: Remove cache files and RAM cache.

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -6,6 +6,7 @@ from homeassistant.components.demo.tts import DemoProvider
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_ENQUEUE,
     DOMAIN as DOMAIN_MP,
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The goal of this change is to generalize the use of enqueue, an undocumented option of the media_player.play_media service, by allowing it's use in the TTS integration.
This is based on the Feature Request : https://community.home-assistant.io/t/append-media-function-for-media-player-component/168180
I quote : 

> This way you can easily plane something like :
> 
>     Chime > TTS
>     TTS “Welcome home” > TTS “Number of voicemail” > TTS “List of chore” > TTS"
> 
> You get the idea.
> This have multiple benefit :
> 
>     You don’t have to put “guess” sleep or wait for the state of the player to change to tringer the next event
>     Transition are seamless
>     All TTS get generated right at the start, so there is less delay is the sound files isn’t in cache
>     You can make “shorter” TTS, have more of them not changing and cached, and keep API call count lower
>     Because it’s not TTS only, you can request to play the song X after the current song
> 

It also add the enqueue option for the MPD integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Link to documentation pull request: To do if this is validated

This fulfill Feature Requests https://community.home-assistant.io/t/append-media-function-for-media-player-component/168180
Right now, from a quick search in the code, Enqueue is only supported by : 

- sonos
- heos
- squeezebox
- bluesound

This PR add the enqueue capability to MPD
I could not setup a development environment on my system because docker isn't available without some kernel modification (Fedora 32) and Pyenv didn't work.
Test have be done on my production environment (core install)

Test could be developed if the feature require it.

script service call exemple:
```
tts_wake_up_routine:
  sequence:
  - service : media_player.clear_playlist
    entity_id: media_player.bedroom
  - service: media_player.play_media
    data:
      entity_id: media_player.bedroom
      media_content_id: https://home-assistant.local/local/sound/chime.mp3
      media_content_type: music
      enqueue: true
  - service: tts.watson_tts_say
    data:
      entity_id: media_player.bedroom
      message: "Good morning !"
      enqueue: true
  - service: tts.watson_tts_say
    data_template:
      entity_id: media_player.bedroom
      message: "The temperature is {{ state("sensor.outside_temperature") }} °C."
      enqueue: true
 - service: tts.watson_tts_say
    data:
      entity_id: media_player.bedroom
      message: "smooth jazz will be deployed in 3... 2.... 1"
      enqueue: true
  - service: media_player.play_media
    data:
      entity_id: media_player.bedroom
      media_content_id: https://home-assistant.local/local/aperture/offering_by_LarryStephens.mp3
      media_content_type: music
      enqueue: true
 - service: media_player.media_play
      entity_id: media_player.bedroom
```



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
