### PR TITLE
Handle Mobile App registrations for device names containing of only emoji

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -86,9 +86,12 @@ async def async_setup_entry(hass, entry):
     elif emoji.emoji_count(registration[ATTR_DEVICE_NAME]):
         # If otherwise empty string contains emoji
         # use descriptive name of the first emoji
-        registration[ATTR_DEVICE_NAME] = emoji.demojize(
-            emoji.emoji_lis(registration[ATTR_DEVICE_NAME])[0]["emoji"]
-        ).replace(":", "")
+        registration[ATTR_DEVICE_NAME] = (
+            emoji.demojize(emoji.emoji_lis(registration[ATTR_DEVICE_NAME])[0]["emoji"])
+            .replace(":", "")
+            .replace("_", " ")
+            .title()
+        )
     else:
         # Fallback to DEVICE_ID
         registration[ATTR_DEVICE_NAME] = registration[ATTR_DEVICE_ID]

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -1,6 +1,8 @@
 """Integrates Native Apps to Home Assistant."""
 import asyncio
 
+import emoji
+
 from homeassistant.components import cloud
 from homeassistant.components.webhook import (
     async_register as webhook_register,
@@ -9,6 +11,7 @@ from homeassistant.components.webhook import (
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.helpers import device_registry as dr, discovery
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.util import slugify
 
 from .const import (
     ATTR_DEVICE_ID,
@@ -75,6 +78,20 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 async def async_setup_entry(hass, entry):
     """Set up a mobile_app entry."""
     registration = entry.data
+
+    if slugify(registration[ATTR_DEVICE_NAME], separator=""):
+        # if slug is not empty and would not only be underscores
+        # use DEVICE_NAME
+        pass
+    elif emoji.emoji_count(registration[ATTR_DEVICE_NAME]):
+        # If otherwise empty string contains emoji
+        # use descriptive name of the first emoji
+        registration[ATTR_DEVICE_NAME] = emoji.demojize(
+            emoji.emoji_lis(registration[ATTR_DEVICE_NAME])[0]["emoji"]
+        ).replace(":", "")
+    else:
+        # Fallback to DEVICE_ID
+        registration[ATTR_DEVICE_NAME] = registration[ATTR_DEVICE_ID]
 
     webhook_id = registration[CONF_WEBHOOK_ID]
 

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -1,8 +1,6 @@
 """Integrates Native Apps to Home Assistant."""
 import asyncio
 
-import emoji
-
 from homeassistant.components import cloud
 from homeassistant.components.webhook import (
     async_register as webhook_register,
@@ -11,7 +9,6 @@ from homeassistant.components.webhook import (
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.helpers import device_registry as dr, discovery
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-from homeassistant.util import slugify
 
 from .const import (
     ATTR_DEVICE_ID,
@@ -78,23 +75,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 async def async_setup_entry(hass, entry):
     """Set up a mobile_app entry."""
     registration = entry.data
-
-    if slugify(registration[ATTR_DEVICE_NAME], separator=""):
-        # if slug is not empty and would not only be underscores
-        # use DEVICE_NAME
-        pass
-    elif emoji.emoji_count(registration[ATTR_DEVICE_NAME]):
-        # If otherwise empty string contains emoji
-        # use descriptive name of the first emoji
-        registration[ATTR_DEVICE_NAME] = (
-            emoji.demojize(emoji.emoji_lis(registration[ATTR_DEVICE_NAME])[0]["emoji"])
-            .replace(":", "")
-            .replace("_", " ")
-            .title()
-        )
-    else:
-        # Fallback to DEVICE_ID
-        registration[ATTR_DEVICE_NAME] = registration[ATTR_DEVICE_ID]
 
     webhook_id = registration[CONF_WEBHOOK_ID]
 

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -3,6 +3,7 @@ import secrets
 from typing import Dict
 
 from aiohttp.web import Request, Response
+import emoji
 from nacl.secret import SecretBox
 import voluptuous as vol
 
@@ -10,6 +11,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.const import CONF_WEBHOOK_ID, HTTP_CREATED
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util import slugify
 
 from .const import (
     ATTR_APP_DATA,
@@ -74,6 +76,18 @@ class RegistrationsView(HomeAssistantView):
             data[CONF_SECRET] = secrets.token_hex(SecretBox.KEY_SIZE)
 
         data[CONF_USER_ID] = request["hass_user"].id
+
+        if slugify(data[ATTR_DEVICE_NAME], separator=""):
+            # if slug is not empty and would not only be underscores
+            # use DEVICE_NAME
+            pass
+        elif slugify(emoji.demojize(data[ATTR_DEVICE_NAME]), separator=""):
+            # If we can decode emoji to get non-empty DEVICE_NAME
+            # use descriptive emoji name
+            data[ATTR_DEVICE_NAME] = emoji.demojize(data[ATTR_DEVICE_NAME])
+        else:
+            # Fallback to DEVICE_ID
+            data[ATTR_DEVICE_NAME] = data[ATTR_DEVICE_ID]
 
         await hass.async_create_task(
             hass.config_entries.flow.async_init(

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_REMOTE_UI_URL,
     CONF_SECRET,
     CONF_USER_ID,
+    DOMAIN,
 )
 from .helpers import supports_encryption
 
@@ -73,6 +74,12 @@ class RegistrationsView(HomeAssistantView):
             data[CONF_SECRET] = secrets.token_hex(SecretBox.KEY_SIZE)
 
         data[CONF_USER_ID] = request["hass_user"].id
+
+        await hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, data=data, context={"source": "registration"}
+            )
+        )
 
         remote_ui_url = None
         try:

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -3,7 +3,6 @@ import secrets
 from typing import Dict
 
 from aiohttp.web import Request, Response
-import emoji
 from nacl.secret import SecretBox
 import voluptuous as vol
 
@@ -11,7 +10,6 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.const import CONF_WEBHOOK_ID, HTTP_CREATED
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import slugify
 
 from .const import (
     ATTR_APP_DATA,
@@ -29,7 +27,6 @@ from .const import (
     CONF_REMOTE_UI_URL,
     CONF_SECRET,
     CONF_USER_ID,
-    DOMAIN,
 )
 from .helpers import supports_encryption
 
@@ -76,26 +73,6 @@ class RegistrationsView(HomeAssistantView):
             data[CONF_SECRET] = secrets.token_hex(SecretBox.KEY_SIZE)
 
         data[CONF_USER_ID] = request["hass_user"].id
-
-        if slugify(data[ATTR_DEVICE_NAME], separator=""):
-            # if slug is not empty and would not only be underscores
-            # use DEVICE_NAME
-            pass
-        elif emoji.emoji_count(data[ATTR_DEVICE_NAME]):
-            # If otherwise empty string contains emoji
-            # use descriptive name of the first emoji
-            data[ATTR_DEVICE_NAME] = emoji.demojize(
-                emoji.emoji_lis(data[ATTR_DEVICE_NAME])[0]["emoji"]
-            ).replace(":", "")
-        else:
-            # Fallback to DEVICE_ID
-            data[ATTR_DEVICE_NAME] = data[ATTR_DEVICE_ID]
-
-        await hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN, data=data, context={"source": "registration"}
-            )
-        )
 
         remote_ui_url = None
         try:

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -81,10 +81,12 @@ class RegistrationsView(HomeAssistantView):
             # if slug is not empty and would not only be underscores
             # use DEVICE_NAME
             pass
-        elif slugify(emoji.demojize(data[ATTR_DEVICE_NAME]), separator=""):
-            # If we can decode emoji to get non-empty DEVICE_NAME
-            # use descriptive emoji name
-            data[ATTR_DEVICE_NAME] = emoji.demojize(data[ATTR_DEVICE_NAME])
+        elif emoji.emoji_count(data[ATTR_DEVICE_NAME]):
+            # If otherwise empty string contains emoji
+            # use descriptive name of the first emoji
+            data[ATTR_DEVICE_NAME] = emoji.demojize(
+                emoji.emoji_lis(data[ATTR_DEVICE_NAME])[0]["emoji"]
+            ).replace(":", "")
         else:
             # Fallback to DEVICE_ID
             data[ATTR_DEVICE_NAME] = data[ATTR_DEVICE_ID]

--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mobile App",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
-  "requirements": ["PyNaCl==1.3.0"],
+  "requirements": ["PyNaCl==1.3.0", "emoji==0.5.4"],
   "dependencies": ["http", "webhook", "person"],
   "after_dependencies": ["cloud", "camera"],
   "codeowners": ["@robbiet480"],

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,6 +11,7 @@ ciso8601==2.1.3
 cryptography==2.9.2
 defusedxml==0.6.0
 distro==1.5.0
+emoji==0.5.4
 hass-nabucasa==0.34.6
 home-assistant-frontend==20200617.0
 importlib-metadata==1.6.0;python_version<'3.8'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -528,6 +528,9 @@ eliqonline==1.2.2
 # homeassistant.components.elkm1
 elkm1-lib==0.7.18
 
+# homeassistant.components.mobile_app
+emoji==0.5.4
+
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -244,6 +244,9 @@ elgato==0.2.0
 # homeassistant.components.elkm1
 elkm1-lib==0.7.18
 
+# homeassistant.components.mobile_app
+emoji==0.5.4
+
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

iOS (and maybe Android) allows users to set their device's name to contain solely emoji. When these devices try to set up the companion apps, the onboarding fails with a `400 unacceptable` error code because these are appearing as empty strings.

These changes address this by checking the device name at registration and attempting to find an acceptable solution. Logic is:
- If Slugify will return a none empty string with `separator = ""` (avoid underscores only) then just proceed as normal
- If an otherwise empty name contains emoji, decode and use the descriptive name of first emoji (avoid long names). I.e. 🤦‍♂️🙅‍♂️ becomes "person_facepalming". Use this for the entity prefixes but leave the Device Register name (not ID) as the user's preferred emoji sequence.
- If both those cases would return empty strings, the device name must solely consist of special characters, fallback to using the device ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/ios#479
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
