### PR TITLE
Add new Remote Python Debugger integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -153,7 +153,6 @@ omit =
     homeassistant/components/danfoss_air/*
     homeassistant/components/darksky/weather.py
     homeassistant/components/ddwrt/device_tracker.py
-    homeassistant/components/debugpy/__init__.py
     homeassistant/components/decora/light.py
     homeassistant/components/decora_wifi/light.py
     homeassistant/components/delijn/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -153,6 +153,7 @@ omit =
     homeassistant/components/danfoss_air/*
     homeassistant/components/darksky/weather.py
     homeassistant/components/ddwrt/device_tracker.py
+    homeassistant/components/debugpy/__init__.py
     homeassistant/components/decora/light.py
     homeassistant/components/decora_wifi/light.py
     homeassistant/components/delijn/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -86,6 +86,7 @@ homeassistant/components/cpuspeed/* @fabaff
 homeassistant/components/cups/* @fabaff
 homeassistant/components/daikin/* @fredrike
 homeassistant/components/darksky/* @fabaff
+homeassistant/components/debugpy/* @frenck
 homeassistant/components/deconz/* @Kane610
 homeassistant/components/delijn/* @bollewolle @Emilv2
 homeassistant/components/demo/* @home-assistant/core

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -40,7 +40,7 @@ DATA_LOGGING = "logging"
 
 LOG_SLOW_STARTUP_INTERVAL = 60
 
-DEBUGGER_INTEGRATIONS = {"ptvsd"}
+DEBUGGER_INTEGRATIONS = {"debugpy", "ptvsd"}
 CORE_INTEGRATIONS = ("homeassistant", "persistent_notification")
 LOGGING_INTEGRATIONS = {
     # Set log levels

--- a/homeassistant/components/debugpy/__init__.py
+++ b/homeassistant/components/debugpy/__init__.py
@@ -1,0 +1,83 @@
+"""The Remote Python Debugger integration."""
+from asyncio import Event
+import logging
+from threading import Thread
+from typing import Optional
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant, ServiceCall
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.helpers.typing import ConfigType
+
+DOMAIN = "debugpy"
+CONF_WAIT = "wait"
+CONF_START = "start"
+SERVICE_START = "start"
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(CONF_HOST, default="0.0.0.0"): cv.string,
+                vol.Optional(CONF_PORT, default=5678): cv.port,
+                vol.Optional(CONF_START, default=True): cv.boolean,
+                vol.Optional(CONF_WAIT, default=False): cv.boolean,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Remote Python Debugger component."""
+    conf = config[DOMAIN]
+
+    async def debug_start(
+        call: Optional[ServiceCall] = None, *, wait: bool = True
+    ) -> None:
+        """Start the debugger."""
+        # This is a local import, since importing this at the top, will cause
+        # ptvsd to hook into `sys.settrace`. So does `coverage` to generate
+        # coverage, resulting in a battle and incomplete code test coverage.
+        import debugpy  # pylint: disable=import-outside-toplevel
+
+        debugpy.listen((conf[CONF_HOST], conf[CONF_PORT]))
+
+        wait = conf[CONF_WAIT]
+        if wait:
+            _LOGGER.warning(
+                "Waiting for remote debug connection on %s:%s",
+                conf[CONF_HOST],
+                conf[CONF_PORT],
+            )
+            ready = Event()
+
+            def waitfor():
+                debugpy.wait_for_client()
+                hass.loop.call_soon_threadsafe(ready.set)
+
+            Thread(target=waitfor).start()
+
+            await ready.wait()
+        else:
+            _LOGGER.warning(
+                "Listening for remote debug connection on %s:%s",
+                conf[CONF_HOST],
+                conf[CONF_PORT],
+            )
+
+    async_register_admin_service(
+        hass, DOMAIN, SERVICE_START, debug_start, schema=vol.Schema({})
+    )
+
+    # If set to start the debugger on startup, do so
+    if conf[CONF_START]:
+        await debug_start(wait=conf[CONF_WAIT])
+
+    return True

--- a/homeassistant/components/debugpy/__init__.py
+++ b/homeassistant/components/debugpy/__init__.py
@@ -4,6 +4,7 @@ import logging
 from threading import Thread
 from typing import Optional
 
+import debugpy
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -42,11 +43,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         call: Optional[ServiceCall] = None, *, wait: bool = True
     ) -> None:
         """Start the debugger."""
-        # This is a local import, since importing this at the top, will cause
-        # ptvsd to hook into `sys.settrace`. So does `coverage` to generate
-        # coverage, resulting in a battle and incomplete code test coverage.
-        import debugpy  # pylint: disable=import-outside-toplevel
-
         debugpy.listen((conf[CONF_HOST], conf[CONF_PORT]))
 
         wait = conf[CONF_WAIT]

--- a/homeassistant/components/debugpy/manifest.json
+++ b/homeassistant/components/debugpy/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "debugpy",
+  "name": "Remote Python Debugger",
+  "documentation": "https://www.home-assistant.io/integrations/debugpy",
+  "requirements": ["debugpy==1.0.0b11"],
+  "codeowners": ["@frenck"],
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/debugpy/services.yaml
+++ b/homeassistant/components/debugpy/services.yaml
@@ -1,0 +1,3 @@
+# Describes the format for available Remote Python Debugger services
+start:
+  description: Start the Remote Python Debugger.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -456,6 +456,9 @@ datadog==0.15.0
 # homeassistant.components.metoffice
 datapoint==0.9.5
 
+# homeassistant.components.debugpy
+debugpy==1.0.0b11
+
 # homeassistant.components.decora
 # decora==0.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -208,6 +208,9 @@ datadog==0.15.0
 # homeassistant.components.metoffice
 datapoint==0.9.5
 
+# homeassistant.components.debugpy
+debugpy==1.0.0b11
+
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns
 # homeassistant.components.ohmconnect

--- a/tests/components/debugpy/__init__.py
+++ b/tests/components/debugpy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Remote Python Debugger integration."""

--- a/tests/components/debugpy/test_init.py
+++ b/tests/components/debugpy/test_init.py
@@ -17,7 +17,7 @@ from tests.async_mock import patch
 
 @pytest.fixture
 def mock_debugpy():
-    """Mock path lib."""
+    """Mock debugpy lib."""
     with patch("homeassistant.components.debugpy.debugpy") as mocked_debugpy:
         yield mocked_debugpy
 
@@ -28,6 +28,7 @@ async def test_default(hass: HomeAssistant, mock_debugpy) -> None:
 
     mock_debugpy.listen.assert_called_once_with(("0.0.0.0", 5678))
     mock_debugpy.wait_for_client.assert_not_called()
+    assert len(mock_debugpy.method_calls) == 1
 
 
 async def test_wait_on_startup(hass: HomeAssistant, mock_debugpy) -> None:
@@ -36,6 +37,7 @@ async def test_wait_on_startup(hass: HomeAssistant, mock_debugpy) -> None:
 
     mock_debugpy.listen.assert_called_once_with(("0.0.0.0", 5678))
     mock_debugpy.wait_for_client.assert_called_once()
+    assert len(mock_debugpy.method_calls) == 2
 
 
 async def test_on_demand(hass: HomeAssistant, mock_debugpy) -> None:
@@ -48,6 +50,7 @@ async def test_on_demand(hass: HomeAssistant, mock_debugpy) -> None:
 
     mock_debugpy.listen.assert_not_called()
     mock_debugpy.wait_for_client.assert_not_called()
+    assert len(mock_debugpy.method_calls) == 0
 
     await hass.services.async_call(
         DOMAIN, SERVICE_START, blocking=True,
@@ -55,3 +58,4 @@ async def test_on_demand(hass: HomeAssistant, mock_debugpy) -> None:
 
     mock_debugpy.listen.assert_called_once_with(("127.0.0.1", 80))
     mock_debugpy.wait_for_client.assert_not_called()
+    assert len(mock_debugpy.method_calls) == 1

--- a/tests/components/debugpy/test_init.py
+++ b/tests/components/debugpy/test_init.py
@@ -32,7 +32,7 @@ async def test_default(hass: HomeAssistant, mock_debugpy) -> None:
 
 
 async def test_wait_on_startup(hass: HomeAssistant, mock_debugpy) -> None:
-    """Test if the default settings work."""
+    """Test if the waiting for client is called."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_WAIT: True}})
 
     mock_debugpy.listen.assert_called_once_with(("0.0.0.0", 5678))
@@ -41,7 +41,7 @@ async def test_wait_on_startup(hass: HomeAssistant, mock_debugpy) -> None:
 
 
 async def test_on_demand(hass: HomeAssistant, mock_debugpy) -> None:
-    """Test if the default settings work."""
+    """Test on-demand debugging using a service call."""
     assert await async_setup_component(
         hass,
         DOMAIN,

--- a/tests/components/debugpy/test_init.py
+++ b/tests/components/debugpy/test_init.py
@@ -1,0 +1,57 @@
+"""Tests for the Remote Python Debugger integration."""
+import pytest
+
+from homeassistant.components.debugpy import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_START,
+    CONF_WAIT,
+    DOMAIN,
+    SERVICE_START,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import patch
+
+
+@pytest.fixture
+def mock_debugpy():
+    """Mock path lib."""
+    with patch("homeassistant.components.debugpy.debugpy") as mocked_debugpy:
+        yield mocked_debugpy
+
+
+async def test_default(hass: HomeAssistant, mock_debugpy) -> None:
+    """Test if the default settings work."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    mock_debugpy.listen.assert_called_once_with(("0.0.0.0", 5678))
+    mock_debugpy.wait_for_client.assert_not_called()
+
+
+async def test_wait_on_startup(hass: HomeAssistant, mock_debugpy) -> None:
+    """Test if the default settings work."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_WAIT: True}})
+
+    mock_debugpy.listen.assert_called_once_with(("0.0.0.0", 5678))
+    mock_debugpy.wait_for_client.assert_called_once()
+
+
+async def test_on_demand(hass: HomeAssistant, mock_debugpy) -> None:
+    """Test if the default settings work."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {CONF_START: False, CONF_HOST: "127.0.0.1", CONF_PORT: 80}},
+    )
+
+    mock_debugpy.listen.assert_not_called()
+    mock_debugpy.wait_for_client.assert_not_called()
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_START, blocking=True,
+    )
+
+    mock_debugpy.listen.assert_called_once_with(("127.0.0.1", 80))
+    mock_debugpy.wait_for_client.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds in the new remote Python debugger by Microsoft: `debugpy`, which 
is a successor of `ptsvd` and now default baked into Visual Studio Code (since March 2020).

`debugpy`: <https://github.com/microsoft/debugpy>

Announcement: <https://devblogs.microsoft.com/python/python-in-visual-studio-code-march-2020-release/>

This integration provides a method to enable the integration in the configuration, without hooking in the debugger into Python yet; and exposes a service to do so instead.

This is useful to allow the debug integration to be present, without affecting the run-time (or any other process debugging), for example on a production machine of a developer. It can be started on demand by calling the `debugpy.start` service (when experiencing that one weird problem all of a sudden).

Example of attaching the debugger to a (production) system by injecting the debugger on-demand:

![2020-06-20 21 36 46](https://user-images.githubusercontent.com/195327/85210414-e8e73700-b33f-11ea-91d9-b23cb7176e13.gif)


```
----------- coverage: platform linux, python 3.7.6-final-0 -----------
Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
homeassistant/components/debugpy/__init__.py      35      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

# Default start on starting Home Assistant
debugpy:

# Block the startup of Home Assistant until the
# remote debugger client is attached.
debugpy:
  wait: true

# Enable the integration without starting it.
# Use the `debugpy.start` service to activate the debugger on runtime.
debugpy:
  start: false
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13800

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
