### PR TITLE
Reduce state conversion overhead in history by lazy loading properties

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -605,7 +605,7 @@ class LazyState(State):
         "_context",
     ]
 
-    def __init__(self, row):
+    def __init__(self, row):  # pylint: disable=super-init-not-called
         """Init the lazy state."""
         self._row = row
         self.entity_id = self._row.entity_id

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -2,6 +2,7 @@
 from collections import defaultdict
 from datetime import timedelta
 from itertools import groupby
+import json
 import logging
 import time
 from typing import Optional, cast
@@ -22,7 +23,7 @@ from homeassistant.const import (
     CONF_INCLUDE,
     HTTP_BAD_REQUEST,
 )
-from homeassistant.core import split_entity_id
+from homeassistant.core import Context, State, split_entity_id
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
@@ -268,9 +269,7 @@ def _get_states_with_session(
 
     return [
         state
-        for state in (
-            States.to_native(row, validate_entity_id=False) for row in execute(query)
-        )
+        for state in (LazyState(row) for row in execute(query))
         if not state.attributes.get(ATTR_HIDDEN, False)
     ]
 
@@ -329,10 +328,7 @@ def _sorted_states_to_json(
             ent_results.extend(
                 [
                     native_state
-                    for native_state in (
-                        States.to_native(db_state, validate_entity_id=False)
-                        for db_state in group
-                    )
+                    for native_state in (LazyState(db_state) for db_state in group)
                     if (
                         domain != SCRIPT_DOMAIN
                         or native_state.attributes.get(ATTR_CAN_CANCEL)
@@ -347,15 +343,15 @@ def _sorted_states_to_json(
         # in-between only provide the "state" and the
         # "last_changed".
         if not ent_results:
-            ent_results.append(States.to_native(next(group), validate_entity_id=False))
+            ent_results.append(LazyState(next(group)))
 
         initial_state = ent_results[-1]
         prev_state = ent_results[-1]
         initial_state_count = len(ent_results)
 
         for db_state in group:
-            if ATTR_HIDDEN in db_state.attributes and States.to_native(
-                db_state, validate_entity_id=False
+            if ATTR_HIDDEN in db_state.attributes and LazyState(
+                db_state
             ).attributes.get(ATTR_HIDDEN, False):
                 continue
 
@@ -382,7 +378,7 @@ def _sorted_states_to_json(
             # There was at least one state change
             # replace the last minimal state with
             # a full state
-            ent_results[-1] = States.to_native(prev_state, validate_entity_id=False)
+            ent_results[-1] = LazyState(prev_state)
 
     # Filter out the empty lists if some states had 0 results.
     return {key: val for key, val in result.items() if val}
@@ -594,3 +590,82 @@ class Filters:
         if self.excluded_entities:
             query = query.filter(~States.entity_id.in_(self.excluded_entities))
         return query
+
+
+class LazyState(State):
+    """A lazy version of core State."""
+
+    __slots__ = [
+        "_row",
+        "entity_id",
+        "state",
+        "_attributes",
+        "_last_changed",
+        "_last_updated",
+        "_context",
+    ]
+
+    def __init__(self, row):
+        """Init the lazy state."""
+        self._row = row
+        self.entity_id = self._row.entity_id
+        self.state = self._row.state
+        self._attributes = None
+        self._last_changed = None
+        self._last_updated = None
+        self._context = None
+
+    @property
+    def attributes(self):
+        """State attributes."""
+        if not self._attributes:
+            try:
+                self._attributes = json.loads(self._row.attributes)
+            except ValueError:
+                # When json.loads fails
+                _LOGGER.exception("Error converting row to state: %s", self)
+                self._attributes = {}
+        return self._attributes
+
+    @property
+    def context(self):
+        """State context."""
+        if not self._context:
+            self._context = Context(
+                id=self._row.context_id, user_id=self._row.context_user_id
+            )
+        return self._context
+
+    @property  # type: ignore
+    def last_changed(self):
+        """Last changed datetime."""
+        if not self._last_changed:
+            self._last_changed = process_timestamp(self._row.last_changed)
+        return self._last_changed
+
+    @last_changed.setter
+    def last_changed(self, value):
+        """Set last changed datetime."""
+        self._last_changed = value
+
+    @property  # type: ignore
+    def last_updated(self):
+        """Last updated datetime."""
+        if not self._last_updated:
+            self._last_updated = process_timestamp(self._row.last_updated)
+        return self._last_updated
+
+    @last_updated.setter
+    def last_updated(self, value):
+        """Set last updated datetime."""
+        self._last_updated = value
+
+    def __eq__(self, other):
+        """Return the comparison."""
+        return (
+            other.__class__ in [self.__class__, State]
+            and self.entity_id == other.entity_id
+            and self.state == other.state
+            and self.attributes == other.attributes
+            and self.context == other.context
+        )


### PR DESCRIPTION
Builds on https://github.com/home-assistant/core/pull/36938

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce state conversion overhead in history by lazy loading properties.  ~13% decrease in execution time with minimal responses. ~47% decrease in execution time for domains that require full responses. Additionally, single entity history api calls are about 14% faster.

Use case testing: The mini graph card no longer has a perceptible loading delay after this change https://github.com/kalkih/mini-graph-card

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
