### PR TITLE
Fix logbook filtering by entity id

### DIFF
--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -12,9 +12,12 @@ import voluptuous as vol
 
 from homeassistant.components import logbook, recorder, sun
 from homeassistant.components.alexa.smart_home import EVENT_ALEXA_SMART_HOME
+from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_HIDDEN,
+    ATTR_NAME,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
     EVENT_STATE_CHANGED,
@@ -354,7 +357,10 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_INCLUDE: {logbook.CONF_ENTITIES: [entity_id2]}
+                    logbook.CONF_INCLUDE: {
+                        logbook.CONF_DOMAINS: ["homeassistant"],
+                        logbook.CONF_ENTITIES: [entity_id2],
+                    }
                 },
             }
         )
@@ -399,7 +405,9 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_INCLUDE: {logbook.CONF_DOMAINS: ["sensor", "alexa"]}
+                    logbook.CONF_INCLUDE: {
+                        logbook.CONF_DOMAINS: ["homeassistant", "sensor", "alexa"]
+                    }
                 },
             }
         )
@@ -445,7 +453,7 @@ class TestComponentLogbook(unittest.TestCase):
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
                     logbook.CONF_INCLUDE: {
-                        logbook.CONF_DOMAINS: ["sensor"],
+                        logbook.CONF_DOMAINS: ["sensor", "homeassistant"],
                         logbook.CONF_ENTITIES: ["switch.bla"],
                     },
                     logbook.CONF_EXCLUDE: {
@@ -1541,6 +1549,86 @@ async def test_logbook_view_end_time_entity(hass, hass_client):
     json = await response.json()
     assert len(json) == 1
     assert json[0]["entity_id"] == entity_id_test
+
+
+async def test_logbook_entity_filter_with_automations(hass, hass_client):
+    """Test the logbook view with end_time and entity with automations and scripts."""
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, "automation", {})
+    await async_setup_component(hass, "script", {})
+
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    entity_id_test = "alarm_control_panel.area_001"
+    hass.states.async_set(entity_id_test, STATE_OFF)
+    hass.states.async_set(entity_id_test, STATE_ON)
+    entity_id_second = "alarm_control_panel.area_002"
+    hass.states.async_set(entity_id_second, STATE_OFF)
+    hass.states.async_set(entity_id_second, STATE_ON)
+
+    hass.bus.async_fire(
+        EVENT_AUTOMATION_TRIGGERED,
+        {ATTR_NAME: "Mock automation", ATTR_ENTITY_ID: "automation.mock_automation"},
+    )
+    hass.bus.async_fire(
+        EVENT_SCRIPT_STARTED,
+        {ATTR_NAME: "Mock script", ATTR_ENTITY_ID: "script.mock_script"},
+    )
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    await hass.async_add_job(partial(trigger_db_commit, hass))
+    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    client = await hass_client()
+
+    # Today time 00:00:00
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day)
+
+    # Test today entries with filter by end_time
+    end_time = start + timedelta(hours=24)
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}"
+    )
+    assert response.status == 200
+    json_dict = await response.json()
+
+    import pprint
+
+    pprint.pprint(json_dict)
+
+    assert len(json_dict) == 5
+    assert json_dict[0]["entity_id"] == entity_id_test
+    assert json_dict[1]["entity_id"] == entity_id_second
+    assert json_dict[2]["entity_id"] == "automation.mock_automation"
+    assert json_dict[3]["entity_id"] == "script.mock_script"
+    assert json_dict[4]["domain"] == "homeassistant"
+
+    # Test entries for 3 days with filter by entity_id
+    end_time = start + timedelta(hours=72)
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=alarm_control_panel.area_001"
+    )
+    assert response.status == 200
+    json_dict = await response.json()
+    assert len(json_dict) == 1
+    assert json_dict[0]["entity_id"] == entity_id_test
+
+    # Tomorrow time 00:00:00
+    start = dt_util.utcnow()
+    start_date = datetime(start.year, start.month, start.day)
+
+    # Test entries from today to 3 days with filter by entity_id
+    end_time = start_date + timedelta(hours=72)
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}&entity=alarm_control_panel.area_002"
+    )
+    assert response.status == 200
+    json_dict = await response.json()
+    assert len(json_dict) == 1
+    assert json_dict[0]["entity_id"] == entity_id_second
 
 
 class MockLazyEventPartialState(ha.Event):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1595,10 +1595,6 @@ async def test_logbook_entity_filter_with_automations(hass, hass_client):
     assert response.status == 200
     json_dict = await response.json()
 
-    import pprint
-
-    pprint.pprint(json_dict)
-
     assert len(json_dict) == 5
     assert json_dict[0]["entity_id"] == entity_id_test
     assert json_dict[1]["entity_id"] == entity_id_second


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Log book filtering was unexpectedly including start/stop/described events when filtering by entity_id.

The tests didn't catch this because the integrations that describe events were not loaded in the tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32575
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
