### PR TITLE
Enable storage sensors for proxmox integration

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -26,6 +26,7 @@ CONF_NODE = "node"
 CONF_NODES = "nodes"
 CONF_VMS = "vms"
 CONF_CONTAINERS = "containers"
+CONF_STORAGE = "storage"
 
 DEFAULT_PORT = 8006
 DEFAULT_REALM = "pam"
@@ -57,6 +58,9 @@ CONFIG_SCHEMA = vol.Schema(
                                         ],
                                         vol.Optional(CONF_CONTAINERS, default=[]): [
                                             cv.positive_int
+                                        ],
+                                        vol.Optional(CONF_STORAGE, default=[]): [
+                                            cv.string
                                         ],
                                     }
                                 )
@@ -107,6 +111,9 @@ def setup(hass, config):
         hass.helpers.discovery.load_platform(
             "binary_sensor", DOMAIN, {"entries": config[DOMAIN]}, config
         )
+        hass.helpers.discovery.load_platform(
+            "sensor", DOMAIN, {"entries": config[DOMAIN]}, config
+        )
         return True
 
     return False
@@ -117,6 +124,7 @@ class ProxmoxItemType(Enum):
 
     qemu = 0
     lxc = 1
+    storage = 2
 
 
 class ProxmoxClient:

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -1,0 +1,113 @@
+"""Sensor to read Proxmox VE data."""
+import logging
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_HOST, CONF_PORT
+
+from . import CONF_CONTAINERS, CONF_NODES, CONF_STORAGE, PROXMOX_CLIENTS, ProxmoxItemType
+
+ATTRIBUTION = "Data provided by Proxmox VE"
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+
+    sensors = []
+
+    for entry in discovery_info["entries"]:
+        port = entry[CONF_PORT]
+
+        for node in entry[CONF_NODES]:
+            for storage in node[CONF_STORAGE]:
+                sensors.append(
+                    ProxmoxSensor(
+                        hass.data[PROXMOX_CLIENTS][f"{entry[CONF_HOST]}:{port}"],
+                        node["node"],
+                        ProxmoxItemType.storage,
+                        storage,
+                    )
+                )
+
+    add_entities(sensors, True)
+
+
+class ProxmoxSensor(Entity):
+    """A binary sensor for reading Proxmox VE data."""
+
+    def __init__(self, proxmox_client, item_node, item_type, item_name):
+        """Initialize the binary sensor."""
+        self._proxmox_client = proxmox_client
+        self._item_node = item_node
+        self._item_type = item_type
+        self._storagename = item_name
+
+        self._name = None
+        self._maxdisk = None
+        self._usedisk = None
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return '%'
+
+    @property
+    def state(self):
+        """Return percent of storage used if storage is available."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return device attributes of the entity."""
+        return {
+            "node": self._item_node,
+            "storagename": self._storagename,
+            "type": self._item_type.name,
+            "gb_total": self._total,
+            "gb_used": self._used,
+            "gb_avail": self._avail,
+            "content": self._content,
+            "type": self._type,
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+        }
+
+    def update(self):
+        """Check if the storage exists."""
+        item = self.poll_item()
+
+        if item is None:
+            _LOGGER.warning("Failed to poll storage %s", self._storagename)
+            return
+
+        self._state = round( item["used_fraction"] * 100, 1)
+        self._total = round( item["total"] / 1024/1024/1024, 1)
+        self._used = round( item["used"] / 1024/1024/1024, 1)
+        self._avail = round( item["avail"] / 1024/1024/1024, 1)
+        self._content = item["content"]
+        self._type = item["type"]
+
+    def poll_item(self):
+        """Find the storage with the set name."""
+        items = (
+            self._proxmox_client.get_api_client()
+            .nodes(self._item_node)
+            .get(self._item_type.name)
+        )
+        item = next(
+            (item for item in items if item["storage"] == str(self._storagename)), None
+        )
+
+        if item is None:
+            _LOGGER.warning("Couldn't find storage with the name %s", self._storagename)
+            return None
+
+        if self._name is None:
+            self._name = f"{self._item_node} storage {self._storagename}"
+
+        return item

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_HOST, CONF_PORT
 
-from . import CONF_CONTAINERS, CONF_NODES, CONF_STORAGE, PROXMOX_CLIENTS, ProxmoxItemType
+from . import CONF_NODES, CONF_STORAGE, PROXMOX_CLIENTS, ProxmoxItemType
 
 ATTRIBUTION = "Data provided by Proxmox VE"
 _LOGGER = logging.getLogger(__name__)
@@ -68,12 +68,11 @@ class ProxmoxSensor(Entity):
         return {
             "node": self._item_node,
             "storagename": self._storagename,
-            "type": self._item_type.name,
+            "type": self._type,
             "gb_total": self._total,
             "gb_used": self._used,
             "gb_avail": self._avail,
             "content": self._content,
-            "type": self._type,
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 
@@ -85,10 +84,10 @@ class ProxmoxSensor(Entity):
             _LOGGER.warning("Failed to poll storage %s", self._storagename)
             return
 
-        self._state = round( item["used_fraction"] * 100, 1)
-        self._total = round( item["total"] / 1024/1024/1024, 1)
-        self._used = round( item["used"] / 1024/1024/1024, 1)
-        self._avail = round( item["avail"] / 1024/1024/1024, 1)
+        self._state = round(item["used_fraction"] * 100, 1)
+        self._total = round(item["total"] / 1024 / 1024 / 1024, 1)
+        self._used = round(item["used"] / 1024 / 1024 / 1024, 1)
+        self._avail = round(item["avail"] / 1024 / 1024 / 1024, 1)
         self._content = item["content"]
         self._type = item["type"]
 

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -46,6 +46,11 @@ class ProxmoxSensor(Entity):
         self._maxdisk = None
         self._usedisk = None
         self._state = None
+        self._total = None
+        self._used = None
+        self._avail = None
+        self._content = None
+        self._type = None
 
     @property
     def name(self):

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -12,7 +12,6 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
-
     sensors = []
 
     for entry in discovery_info["entries"]:

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -1,8 +1,8 @@
 """Sensor to read Proxmox VE data."""
 import logging
 
-from homeassistant.helpers.entity import Entity
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_HOST, CONF_PORT
+from homeassistant.helpers.entity import Entity
 
 from . import CONF_NODES, CONF_STORAGE, PROXMOX_CLIENTS, ProxmoxItemType
 
@@ -59,7 +59,7 @@ class ProxmoxSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
-        return '%'
+        return "%"
 
     @property
     def state(self):

--- a/test.md
+++ b/test.md
@@ -1,0 +1,1 @@
+This is a test.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Enables sensors for storage on proxmox hosts. Sensor reports percent used, with attributes for total, free, and available space, storage type, and content.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
proxmoxve_dev:
  - host: 192.168.1.50
    verify_ssl: false
    username: username
    password: password
    realm: pve
    nodes:
      - node: !secret proxmox_node
        vms:
          - 100
          - 101
        containers:
          - 102
          - 103
        storage:
          - local
          - local-lvm
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13802

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
