### PR TITLE
Improve isoformat timestamp performance

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -13,7 +13,11 @@ import voluptuous as vol
 
 from homeassistant.components import recorder
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.recorder.models import States, process_timestamp
+from homeassistant.components.recorder.models import (
+    States,
+    process_timestamp,
+    process_timestamp_to_utc_isoformat,
+)
 from homeassistant.components.recorder.util import execute, session_scope
 from homeassistant.const import (
     ATTR_HIDDEN,
@@ -318,7 +322,7 @@ def _sorted_states_to_json(
 
     # Called in a tight loop so cache the function
     # here
-    _process_timestamp = process_timestamp
+    _process_timestamp_to_utc_isoformat = process_timestamp_to_utc_isoformat
 
     # Append all changes to it
     for ent_id, group in groupby(states, lambda state: state.entity_id):
@@ -362,9 +366,9 @@ def _sorted_states_to_json(
             ent_results.append(
                 {
                     STATE_KEY: db_state.state,
-                    LAST_CHANGED_KEY: _process_timestamp(
+                    LAST_CHANGED_KEY: _process_timestamp_to_utc_isoformat(
                         db_state.last_changed
-                    ).isoformat(),
+                    ),
                 }
             )
             prev_state = db_state

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.components import recorder
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.recorder.models import (
     States,
-    process_timestamp,
     process_timestamp_to_utc_isoformat,
 )
 from homeassistant.components.recorder.util import execute, session_scope

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.components import recorder
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.recorder.models import (
     States,
+    process_timestamp,
     process_timestamp_to_utc_isoformat,
 )
 from homeassistant.components.recorder.util import execute, session_scope

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -28,7 +28,7 @@ SCHEMA_VERSION = 8
 
 _LOGGER = logging.getLogger(__name__)
 
-DB_TIMEZONE = "Z"
+DB_TIMEZONE = "+00:00"
 
 
 class Events(Base):  # type: ignore
@@ -202,3 +202,13 @@ def process_timestamp(ts):
         return ts.replace(tzinfo=dt_util.UTC)
 
     return dt_util.as_utc(ts)
+
+
+def process_timestamp_to_utc_isoformat(ts):
+    """Process a timestamp into UTC isotime."""
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return f"{ts.isoformat()}{DB_TIMEZONE}"
+
+    return dt_util.as_utc(ts).isoformat()

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 from homeassistant.components import logbook, recorder, sun
 from homeassistant.components.alexa.smart_home import EVENT_ALEXA_SMART_HOME
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.components.recorder.models import process_timestamp_to_utc_isoformat
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -1230,7 +1231,7 @@ class TestComponentLogbook(unittest.TestCase):
     ):
         """Assert an entry is what is expected."""
         if when:
-            assert when == entry["when"]
+            assert when.isoformat() == entry["when"]
 
         if name:
             assert name == entry["name"]
@@ -1639,3 +1640,8 @@ class MockLazyEventPartialState(ha.Event):
     def context_user_id(self):
         """Context user id of event."""
         return self.context.user_id
+
+    @property
+    def time_fired_isoformat(self):
+        """Time event was fired in utc isoformat."""
+        return process_timestamp_to_utc_isoformat(self.time_fired)

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -3,10 +3,18 @@ from datetime import datetime
 import unittest
 
 import pytest
+import pytz
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from homeassistant.components.recorder.models import Base, Events, RecorderRuns, States
+from homeassistant.components.recorder.models import (
+    Base,
+    Events,
+    RecorderRuns,
+    States,
+    process_timestamp,
+    process_timestamp_to_utc_isoformat,
+)
 from homeassistant.const import EVENT_STATE_CHANGED
 import homeassistant.core as ha
 from homeassistant.exceptions import InvalidEntityFormatError
@@ -165,3 +173,66 @@ def test_states_from_native_invalid_entity_id():
 
     state = state.to_native(validate_entity_id=False)
     assert state.entity_id == "test.invalid__id"
+
+
+async def test_process_timestamp():
+    """Test processing time stamp to UTC."""
+    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
+    datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
+    est = pytz.timezone("US/Eastern")
+    datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)
+    nst = pytz.timezone("Canada/Newfoundland")
+    datetime_nst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=nst)
+    hst = pytz.timezone("US/Hawaii")
+    datetime_hst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=hst)
+
+    assert process_timestamp(datetime_with_tzinfo) == datetime(
+        2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC
+    )
+    assert process_timestamp(datetime_without_tzinfo) == datetime(
+        2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC
+    )
+    assert process_timestamp(datetime_est_timezone) == datetime(
+        2016, 7, 9, 15, 56, tzinfo=dt.UTC
+    )
+    assert process_timestamp(datetime_nst_timezone) == datetime(
+        2016, 7, 9, 14, 31, tzinfo=dt.UTC
+    )
+    assert process_timestamp(datetime_hst_timezone) == datetime(
+        2016, 7, 9, 21, 31, tzinfo=dt.UTC
+    )
+
+
+async def test_process_timestamp_to_utc_isoformat():
+    """Test processing time stamp to UTC isoformat."""
+    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
+    datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
+    est = pytz.timezone("US/Eastern")
+    datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)
+    est = pytz.timezone("US/Eastern")
+    datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)
+    nst = pytz.timezone("Canada/Newfoundland")
+    datetime_nst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=nst)
+    hst = pytz.timezone("US/Hawaii")
+    datetime_hst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=hst)
+
+    assert (
+        process_timestamp_to_utc_isoformat(datetime_with_tzinfo)
+        == "2016-07-09T11:00:00+00:00"
+    )
+    assert (
+        process_timestamp_to_utc_isoformat(datetime_without_tzinfo)
+        == "2016-07-09T11:00:00+00:00"
+    )
+    assert (
+        process_timestamp_to_utc_isoformat(datetime_est_timezone)
+        == "2016-07-09T15:56:00+00:00"
+    )
+    assert (
+        process_timestamp_to_utc_isoformat(datetime_nst_timezone)
+        == "2016-07-09T14:31:00+00:00"
+    )
+    assert (
+        process_timestamp_to_utc_isoformat(datetime_hst_timezone)
+        == "2016-07-09T21:31:00+00:00"
+    )

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -201,6 +201,7 @@ async def test_process_timestamp():
     assert process_timestamp(datetime_hst_timezone) == datetime(
         2016, 7, 9, 21, 31, tzinfo=dt.UTC
     )
+    assert process_timestamp(None) is None
 
 
 async def test_process_timestamp_to_utc_isoformat():
@@ -236,3 +237,4 @@ async def test_process_timestamp_to_utc_isoformat():
         process_timestamp_to_utc_isoformat(datetime_hst_timezone)
         == "2016-07-09T21:31:00+00:00"
     )
+    assert process_timestamp_to_utc_isoformat(None) is None


### PR DESCRIPTION
When I fixed the performance graphs with #36769, I went with an unoptimized solution in order to make sure everything worked.  Now that I've had more time to research this, a better performing solution is available.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Converting timestamps is ~23% of the history api time.  This change reduces the timestamp conversion to 11% of the history api time by avoiding having to call the `datetime.replace` method which recreates the datetime object.

logbook is slightly faster as well but only about ~3%.
```
# hass --script benchmark logbook_filtering_attributes
Using event loop: asyncio.unix_events
Benchmark logbook_filtering_attributes done in 0.24250392918474972s
Benchmark logbook_filtering_attributes done in 0.24464374710805714s
Benchmark logbook_filtering_attributes done in 0.24994343100115657s
Benchmark logbook_filtering_attributes done in 0.24100427702069283s
Benchmark logbook_filtering_attributes done in 0.24424397386610508s
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
