### PR TITLE
Remove loading of legacy translations

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -20,12 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 TRANSLATION_LOAD_LOCK = "translation_load_lock"
 TRANSLATION_FLATTEN_CACHE = "translation_flatten_cache"
 
-MOVED_TRANSLATIONS_DIRECTORY_MSG = (
-    "%s: the '.translations' directory has been moved, the new name is 'translations', "
-    "starting with Home Assistant 0.111 your translations will no longer "
-    "load if you do not move/rename this "
-)
-
 
 def recursive_flatten(prefix: Any, data: Dict) -> Dict[str, Any]:
     """Return a flattened representation of dict data."""
@@ -71,12 +65,7 @@ def component_translation_path(
     else:
         filename = f"{language}.json"
 
-    translation_legacy_path = integration.file_path / ".translations"
     translation_path = integration.file_path / "translations"
-
-    if translation_legacy_path.is_dir() and not translation_path.is_dir():
-        _LOGGER.warning(MOVED_TRANSLATIONS_DIRECTORY_MSG, domain)
-        return str(translation_legacy_path / filename)
 
     return str(translation_path / filename)
 

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -32,7 +32,7 @@ REMOVED_TITLE_MSG = (
 
 MOVED_TRANSLATIONS_DIRECTORY_MSG = (
     "The '.translations' directory has been moved, the new name is 'translations', "
-    "starting with Home Assistant 0.111 your translations will no longer "
+    "starting with Home Assistant 0.112 your translations will no longer "
     "load if you do not move/rename this "
 )
 
@@ -47,7 +47,7 @@ def check_translations_directory_name(integration: Integration) -> None:
         return
 
     if legacy_translations.is_dir():
-        integration.add_warning("translations", MOVED_TRANSLATIONS_DIRECTORY_MSG)
+        integration.add_error("translations", MOVED_TRANSLATIONS_DIRECTORY_MSG)
 
 
 def find_references(strings, prefix, found):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

```
This breaking change applies to maintainers and users of custom integrations (custom_components) that have used the `.translations` directory for translations, as previously warned that directory is no longer loaded.
The new name for this directory is `translations` (without the `.` prefix), for Home Assistant to be able to load your files from this directory, simply remove the `.` from the name of it.

If you publish your custom integration to GitHub, you should enable the [`hassfest` action](https://developers.home-assistant.io/blog/2020/04/16/hassfest), this would have warned you about this change for the past 3 releases.
```


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove loading of legacy translations


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
