### PR TITLE
Fix LCN cover behavior when using output ports

### DIFF
--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -86,7 +86,6 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        self._is_closed = True
         self._is_opening = False
         self._is_closing = True
         state = pypck.lcn_defs.MotorStateModifier.DOWN
@@ -104,8 +103,6 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        if self._is_opening or self._is_closing:
-            self._is_closed = self._is_closing
         self._is_closing = False
         self._is_opening = False
         state = pypck.lcn_defs.MotorStateModifier.STOP
@@ -129,6 +126,8 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
                 self._is_closing = True
             self._is_closed = self._is_closing
         else:  # motor is off
+            # cover is assumed to be closed if we were in closing state before
+            self._is_closed = self._is_closing
             self._is_closing = False
             self._is_opening = False
 
@@ -177,7 +176,6 @@ class LcnRelayCover(LcnDevice, CoverEntity):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        self._is_closed = True
         self._is_opening = False
         self._is_closing = True
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
@@ -197,8 +195,6 @@ class LcnRelayCover(LcnDevice, CoverEntity):
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        if self._is_opening or self._is_closing:
-            self._is_closed = self._is_closing
         self._is_closing = False
         self._is_opening = False
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
@@ -215,9 +211,9 @@ class LcnRelayCover(LcnDevice, CoverEntity):
         if states[self.motor_port_onoff]:  # motor is on
             self._is_opening = not states[self.motor_port_updown]  # set direction
             self._is_closing = states[self.motor_port_updown]  # set direction
-            self._is_closed = self._is_closing
         else:  # motor is off
             self._is_opening = False
             self._is_closing = False
+            self._is_closed = states[self.motor_port_updown]
 
         self.async_write_ha_state()

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -49,9 +49,10 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
             ]
         else:
             self.reverse_time = None
-        self._closed = None
-        self.state_up = False
-        self.state_down = False
+
+        self._is_closed = False
+        self._is_closing = False
+        self._is_opening = False
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
@@ -66,26 +67,47 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self._closed
+        return self._is_closed
+
+    @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return self._is_opening
+
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return self._is_closing
+
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of the entity."""
+        return True
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        self._closed = True
-
+        self._is_closed = True
+        self._is_opening = False
+        self._is_closing = True
         state = pypck.lcn_defs.MotorStateModifier.DOWN
         self.address_connection.control_motors_outputs(state)
         self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        self._closed = False
+        self._is_closed = False
+        self._is_opening = True
+        self._is_closing = False
         state = pypck.lcn_defs.MotorStateModifier.UP
         self.address_connection.control_motors_outputs(state, self.reverse_time)
         self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        self._closed = None
+        if self._is_opening or self._is_closing:
+            self._is_closed = self._is_closing
+        self._is_closing = False
+        self._is_opening = False
         state = pypck.lcn_defs.MotorStateModifier.STOP
         self.address_connection.control_motors_outputs(state, self.reverse_time)
         self.async_write_ha_state()
@@ -98,15 +120,17 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
         ):
             return
 
-        if input_obj.get_output_id() == self.output_ids[0]:
-            self.state_up = input_obj.get_percent() > 0
-        else:  # self.output_ids[1]
-            self.state_down = input_obj.get_percent() > 0
-
-        if self.state_up and not self.state_down:
-            self._closed = False  # Cover open
-        elif self.state_down and not self.state_up:
-            self._closed = True  # Cover closed
+        if input_obj.get_percent() > 0:  # motor is on
+            if input_obj.get_output_id() == self.output_ids[0]:
+                self._is_opening = True
+                self._is_closing = False
+            else:  # self.output_ids[1]
+                self._is_opening = False
+                self._is_closing = True
+            self._is_closed = self._is_closing
+        else:  # motor is off
+            self._is_closing = False
+            self._is_opening = False
 
         self.async_write_ha_state()
 
@@ -192,7 +216,7 @@ class LcnRelayCover(LcnDevice, CoverEntity):
             self._is_opening = not states[self.motor_port_updown]  # set direction
             self._is_closing = states[self.motor_port_updown]  # set direction
             self._is_closed = self._is_closing
-        else:
+        else:  # motor is off
             self._is_opening = False
             self._is_closing = False
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #35050 a fix for LCN covers connected to the hardware relays was introduced which corrects the behavior of the cover entities. This PR applies the same fix but for covers connected to the current output ports of a LCN hardware module.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #35008
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
