### PR TITLE
Optimize database indexes for existing queries

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -76,8 +76,6 @@ QUERY_STATES = [
     States.last_changed,
     States.last_updated,
     States.created,
-    States.context_id,
-    States.context_user_id,
 ]
 
 
@@ -649,9 +647,7 @@ class LazyState(State):
     def context(self):
         """State context."""
         if not self._context:
-            self._context = Context(
-                id=self._row.context_id, user_id=self._row.context_user_id
-            )
+            self._context = Context(id=None)
         return self._context
 
     @property  # type: ignore
@@ -685,5 +681,4 @@ class LazyState(State):
             and self.entity_id == other.entity_id
             and self.state == other.state
             and self.attributes == other.attributes
-            and self.context == other.context
         )

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -24,7 +24,7 @@ import homeassistant.util.dt as dt_util
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class Events(Base):  # type: ignore
 
     __tablename__ = "events"
     event_id = Column(Integer, primary_key=True)
-    event_type = Column(String(32), index=True)
+    event_type = Column(String(32))
     event_data = Column(Text)
     origin = Column(String(32))
     time_fired = Column(DateTime(timezone=True), index=True)
@@ -44,6 +44,12 @@ class Events(Base):  # type: ignore
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
     context_parent_id = Column(String(36), index=True)
+
+    __table_args__ = (
+        # Used for fetching events at a specific time
+        # see logbook
+        Index("ix_events_event_type_time_fired", "event_type", "time_fired"),
+    )
 
     @staticmethod
     def from_event(event):
@@ -60,7 +66,11 @@ class Events(Base):  # type: ignore
 
     def to_native(self):
         """Convert to a natve HA Event."""
-        context = Context(id=self.context_id, user_id=self.context_user_id)
+        context = Context(
+            id=self.context_id,
+            user_id=self.context_user_id,
+            parent_id=self.context_parent_id,
+        )
         try:
             return Event(
                 self.event_type,
@@ -81,16 +91,13 @@ class States(Base):  # type: ignore
     __tablename__ = "states"
     state_id = Column(Integer, primary_key=True)
     domain = Column(String(64))
-    entity_id = Column(String(255), index=True)
+    entity_id = Column(String(255))
     state = Column(String(255))
     attributes = Column(Text)
     event_id = Column(Integer, ForeignKey("events.event_id"), index=True)
     last_changed = Column(DateTime(timezone=True), default=dt_util.utcnow)
     last_updated = Column(DateTime(timezone=True), default=dt_util.utcnow, index=True)
     created = Column(DateTime(timezone=True), default=dt_util.utcnow)
-    context_id = Column(String(36), index=True)
-    context_user_id = Column(String(36), index=True)
-    context_parent_id = Column(String(36), index=True)
     old_state_id = Column(Integer)
 
     __table_args__ = (
@@ -105,12 +112,7 @@ class States(Base):  # type: ignore
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
 
-        dbstate = States(
-            entity_id=entity_id,
-            context_id=event.context.id,
-            context_user_id=event.context.user_id,
-            context_parent_id=event.context.parent_id,
-        )
+        dbstate = States(entity_id=entity_id)
 
         # State got deleted
         if state is None:
@@ -130,7 +132,6 @@ class States(Base):  # type: ignore
 
     def to_native(self, validate_entity_id=True):
         """Convert to an HA state object."""
-        context = Context(id=self.context_id, user_id=self.context_user_id)
         try:
             return State(
                 self.entity_id,
@@ -138,7 +139,9 @@ class States(Base):  # type: ignore
                 json.loads(self.attributes),
                 process_timestamp(self.last_changed),
                 process_timestamp(self.last_updated),
-                context=context,
+                # Join the events table on event_id to get the context instead
+                # as it will always be there for state_changed events
+                context=Context(id=None),
                 validate_entity_id=validate_entity_id,
             )
         except ValueError:

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -68,6 +68,9 @@ class TestStates(unittest.TestCase):
             {"entity_id": "sensor.temperature", "old_state": None, "new_state": state},
             context=state.context,
         )
+        # We don't restore context unless we need it by joining the
+        # events table on the event_id for state_changed events
+        state.context = ha.Context(id=None)
         assert state == States.from_event(event).to_native()
 
     def test_from_event_to_delete_state(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Context ids are no longer duplicated in the `states` table.  Join the `events` table on on `state.event_id` to `events.event_id` to find the context_id instead.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Cleanup indexes as >50% of the db size was indexes,
many of them unused in any current query. 
After changes, down to 39% of the database being indexes.

Logbook search was having to filter event_types without
an index:

  Created ix_events_event_type_time_fired
  Dropped ix_events_event_type

States had a redundant keys on composite index:

  Dropped ix_states_entity_id
  Its unused since we have ix_states_entity_id_last_updated

De-duplicate storage of context in states as
its always stored in events and can be found
by joining the state on the event_id.

  Dropped ix_states_context_id
  Dropped ix_states_context_parent_id
  Dropped ix_states_context_user_id

After schema v9:
```
*** Page counts for all tables and indices separately *************************
STATES............................................ 9350        38.0% 
EVENTS............................................ 5663        23.0% 
IX_STATES_ENTITY_ID_LAST_UPDATED.................. 2156         8.8% 
IX_EVENTS_EVENT_TYPE_TIME_FIRED................... 1947         7.9% 
IX_EVENTS_CONTEXT_ID.............................. 1902         7.7% 
IX_EVENTS_TIME_FIRED.............................. 1381         5.6% 
IX_STATES_LAST_UPDATED............................ 1089         4.4% 
IX_STATES_EVENT_ID................................ 373          1.5% 
IX_EVENTS_CONTEXT_PARENT_ID....................... 357          1.5% 
IX_EVENTS_CONTEXT_USER_ID......................... 355          1.4% 
IX_RECORDER_RUNS_START_END........................ 1            0.004% 
RECORDER_RUNS..................................... 1            0.004% 
SCHEMA_CHANGES.................................... 1            0.004% 
SQLITE_MASTER..................................... 1            0.004% 

*** All tables ****************************************************************

Percentage of total database......................  61.1%  

*** All indices ***************************************************************

Percentage of total database......................  38.9%  
```

**IX_EVENTS_CONTEXT_ID**, **IX_EVENTS_CONTEXT_PARENT_ID**, and **IX_EVENTS_CONTEXT_USER_ID** are actually never used but logbook might use them in the future so I left them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
