### PR TITLE
Remove support for deprecated hidden attribute from logbook and history

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -27,7 +27,6 @@ from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
-    ATTR_HIDDEN,
     ATTR_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_EXCLUDE,
@@ -481,10 +480,6 @@ def _keep_event(hass, event, entities_filter, entity_attr_cache):
         if not event.has_old_and_new_state:
             return False
 
-        # exclude entities which are customized hidden
-        if event.hidden:
-            return False
-
         if event.domain in CONTINUOUS_DOMAINS and entity_attr_cache.get(
             entity_id, ATTR_UNIT_OF_MEASUREMENT, event
         ):
@@ -697,13 +692,6 @@ class LazyEventPartialState:
             '"old_state": {' in self._row.event_data
             and '"new_state": {' in self._row.event_data
         )
-
-    @property
-    def hidden(self):
-        """Check the json to see if hidden."""
-        if '"hidden":' in self._row.attributes:
-            return self.attributes.get(ATTR_HIDDEN, False)
-        return False
 
 
 class EntityAttributeCache:

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -696,12 +696,6 @@ class TestComponentHistory(unittest.TestCase):
         ):
             # This state will be skipped only different in time
             set_state(mp, "YouTube", attributes={"media_title": str(sentinel.mt3)})
-            # This state will be skipped as it hidden
-            set_state(
-                mp3,
-                "Apple TV",
-                attributes={"media_title": str(sentinel.mt2), "hidden": True},
-            )
             # This state will be skipped because domain blacklisted
             set_state(zone, "zoning")
             set_state(script_nc, "off")
@@ -728,8 +722,6 @@ class TestComponentHistory(unittest.TestCase):
             states[therm].append(
                 set_state(therm, 21, attributes={"current_temperature": 20})
             )
-            # state will be skipped since entity is hidden
-            set_state(therm, 22, attributes={"current_temperature": 21, "hidden": True})
 
         return zero, four, states
 

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -17,7 +17,6 @@ from homeassistant.components.recorder.models import process_timestamp_to_utc_is
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_HIDDEN,
     ATTR_NAME,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
@@ -208,39 +207,6 @@ class TestComponentLogbook(unittest.TestCase):
         ).as_dict()
         eventA = self.create_state_changed_event_from_old_new(
             None, pointA, state_on, None,
-        )
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        entities_filter = logbook._generate_filter_from_config({})
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_STOP),
-                eventA,
-                eventB,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
-
-        assert len(entries) == 2
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_exclude_events_hidden(self):
-        """Test if events are excluded if entity is hidden."""
-        entity_id = "sensor.bla"
-        entity_id2 = "sensor.blu"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        eventA = self.create_state_changed_event(
-            pointA, entity_id, 10, {ATTR_HIDDEN: "true"}
         )
         eventB = self.create_state_changed_event(pointB, entity_id2, 20)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Remove support for the deprecated hidden attribute from logbook and history.

To exclude entities from logbook or history, please refer to the logbook (https://www.home-assistant.io/integrations/logbook/#exclude) and history (https://www.home-assistant.io/integrations/history/#exclude) documentation examples.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We have been removing these attributes from the codebase over time (see #32038 #31643 #31760 #30730 #30729 #30728 #30727)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37010
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13820 https://github.com/home-assistant/home-assistant.io/pull/13821

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
