### PR TITLE
Toon translation updates + tweaks

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -146,14 +146,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.data[DOMAIN][entry.entry_id].unregister_webhook()
 
     # Unload entities for this entry/device.
-    await asyncio.gather(
-        *(
-            hass.config_entries.async_forward_entry_unload(entry, component)
-            for component in ENTITY_COMPONENTS
+    unload_ok = all(
+        await asyncio.gather(
+            *(
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in ENTITY_COMPONENTS
+            )
         )
     )
 
     # Cleanup
-    del hass.data[DOMAIN][entry.entry_id]
+    if unload_ok:
+        del hass.data[DOMAIN][entry.entry_id]
 
-    return True
+    return unload_ok

--- a/homeassistant/components/toon/strings.json
+++ b/homeassistant/components/toon/strings.json
@@ -1,33 +1,23 @@
 {
   "config": {
     "step": {
-      "authenticate": {
-        "title": "Link your Toon account",
-        "description": "Authenticate with your Eneco Toon account (not the developer account).",
-        "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "tenant": "Tenant"
-        }
+      "pick_implementation": {
+        "title": "Choose your tenant to authenticate with"
       },
-      "display": {
-        "title": "Select display",
-        "description": "Select the Toon display to connect with.",
+      "agreement": {
+        "title": "Select your agreement",
+        "description": "Select the agreement address you want to add.",
         "data": {
-          "display": "Choose display"
+          "agreement": "Agreement"
         }
       }
     },
-    "error": {
-      "credentials": "The provided credentials are invalid.",
-      "display_exists": "The selected display is already configured."
-    },
     "abort": {
-      "client_id": "The client ID from the configuration is invalid.",
-      "client_secret": "The client secret from the configuration is invalid.",
-      "unknown_auth_fail": "Unexpected error occurred, while authenticating.",
-      "no_agreements": "This account has no Toon displays.",
-      "no_app": "You need to configure Toon before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/toon/)."
+      "already_configured": "The selected agreement is already configured.",
+      "authorize_url_fail": "Unknown error generating an authorize url.",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "no_agreements": "This account has no Toon displays."
     }
   }
 }

--- a/homeassistant/components/toon/switch.py
+++ b/homeassistant/components/toon/switch.py
@@ -59,7 +59,7 @@ class ToonSwitch(ToonEntity, SwitchEntity):
     def unique_id(self) -> str:
         """Return the unique ID for this binary sensor."""
         agreement_id = self.coordinator.data.agreement.agreement_id
-        return f"{DOMAIN}_{agreement_id}_switch_{self.key}"
+        return f"{agreement_id}_{self.key}"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/toon/switch.py
+++ b/homeassistant/components/toon/switch.py
@@ -59,8 +59,6 @@ class ToonSwitch(ToonEntity, SwitchEntity):
     def unique_id(self) -> str:
         """Return the unique ID for this binary sensor."""
         agreement_id = self.coordinator.data.agreement.agreement_id
-        # This unique ID is a bit ugly and contains unneeded information.
-        # It is here for legacy / backward compatible reasons.
         return f"{DOMAIN}_{agreement_id}_switch_{self.key}"
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Martin left some comments after merge in #36952 of which this PR addresses a couple.

- Fixes return value when unloading config entry
- Removes a code comment that should not be there

More importantly, I actually didn't update any of the translations 🙈 
Lucky I was not the only one that missed it 😓 


We should definitely check if we can teach hassfest to detect this 😄 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
