### PR TITLE
Add new Solaredge sensors

### DIFF
--- a/homeassistant/components/solaredge/const.py
+++ b/homeassistant/components/solaredge/const.py
@@ -68,7 +68,7 @@ SENSOR_TYPES = {
     "storage_power": ["STORAGE", "Storage Power", None, "mdi:car-battery", False],
     "purchased_power": ["Purchased", "Imported Power", None, "mdi:flash", False],
     "production_power": ["Production", "Production Power", None, "mdi:flash", False],
-    "consumption_power": ["Consumption", "Cosumption Power", None, "mdi:flash", False],
+    "consumption_power": ["Consumption", "Consumption Power", None, "mdi:flash", False],
     "selfconsumption_power": [
         "SelfConsumption",
         "SelfConsumption Power",

--- a/homeassistant/components/solaredge/const.py
+++ b/homeassistant/components/solaredge/const.py
@@ -69,12 +69,12 @@ SENSOR_TYPES = {
     "purchased_power": ["Purchased", "Imported Power", None, "mdi:flash", False],
     "production_power": ["Production", "Production Power", None, "mdi:flash", False],
     "consumption_power": ["Consumption", "Consumption Power", None, "mdi:flash", False],
-    "selfconsumption_power": [
+    "self_consumption_power": [
         "SelfConsumption",
-        "SelfConsumption Power",
+        "Self-Consumption Power",
         None,
         "mdi:flash",
         False,
     ],
-    "feedin_power": ["FeedIn", "Exported Power", None, "mdi:flash", False],
+    "feed_in_power": ["FeedIn", "Exported Power", None, "mdi:flash", False],
 }

--- a/homeassistant/components/solaredge/const.py
+++ b/homeassistant/components/solaredge/const.py
@@ -10,12 +10,13 @@ CONF_SITE_ID = "site_id"
 
 DEFAULT_NAME = "SolarEdge"
 
-OVERVIEW_UPDATE_DELAY = timedelta(minutes=10)
+OVERVIEW_UPDATE_DELAY = timedelta(minutes=15)
 DETAILS_UPDATE_DELAY = timedelta(hours=12)
 INVENTORY_UPDATE_DELAY = timedelta(hours=12)
-POWER_FLOW_UPDATE_DELAY = timedelta(minutes=10)
+POWER_FLOW_UPDATE_DELAY = timedelta(minutes=15)
+ENERGY_DETAILS_DELAY = timedelta(minutes=15)
 
-SCAN_INTERVAL = timedelta(minutes=10)
+SCAN_INTERVAL = timedelta(minutes=15)
 
 # Supported overview sensor types:
 # Key: ['json_key', 'name', unit, icon, default]
@@ -65,4 +66,9 @@ SENSOR_TYPES = {
     "solar_power": ["PV", "Solar Power", None, "mdi:solar-power", False],
     "grid_power": ["GRID", "Grid Power", None, "mdi:power-plug", False],
     "storage_power": ["STORAGE", "Storage Power", None, "mdi:car-battery", False],
+    "purchased_power": ["Purchased", "Imported Power", None, "mdi:flash", False],
+    "production_power": ["Production", "Production Power", None, "mdi:flash", False],
+    "consumption_power": ["Consumption", "Cosumption Power", None, "mdi:flash", False],
+    "selfconsumption_power": ["SelfConsumption", "SelfConsumption Power", None, "mdi:flash", False],
+    "feedin_power": ["FeedIn", "Exported Power", None, "mdi:flash", False],
 }

--- a/homeassistant/components/solaredge/const.py
+++ b/homeassistant/components/solaredge/const.py
@@ -69,6 +69,12 @@ SENSOR_TYPES = {
     "purchased_power": ["Purchased", "Imported Power", None, "mdi:flash", False],
     "production_power": ["Production", "Production Power", None, "mdi:flash", False],
     "consumption_power": ["Consumption", "Cosumption Power", None, "mdi:flash", False],
-    "selfconsumption_power": ["SelfConsumption", "SelfConsumption Power", None, "mdi:flash", False],
+    "selfconsumption_power": [
+        "SelfConsumption",
+        "SelfConsumption Power",
+        None,
+        "mdi:flash",
+        False,
+    ],
     "feedin_power": ["FeedIn", "Exported Power", None, "mdi:flash", False],
 }

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -86,9 +86,9 @@ class SolarEdgeSensorFactory:
         for key in [
             "purchased_power",
             "production_power",
-            "feedin_power",
+            "feed_in_power",
             "consumption_power",
-            "selfconsumption_power",
+            "self_consumption_power",
         ]:
             self.services[key] = (SolarEdgeEnergyDetailsSensor, energy)
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -1,7 +1,6 @@
 """Support for SolarEdge Monitoring API."""
+from datetime import date, datetime
 import logging
-from datetime import date
-from datetime import datetime
 
 from requests.exceptions import ConnectTimeout, HTTPError
 import solaredge
@@ -14,11 +13,11 @@ from homeassistant.util import Throttle
 from .const import (
     CONF_SITE_ID,
     DETAILS_UPDATE_DELAY,
+    ENERGY_DETAILS_DELAY,
     INVENTORY_UPDATE_DELAY,
     OVERVIEW_UPDATE_DELAY,
     POWER_FLOW_UPDATE_DELAY,
     SENSOR_TYPES,
-    ENERGY_DETAILS_DELAY,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -388,15 +388,15 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
 
         for type in meters:
             for key, value in type.items():
-                if key == "type" and value in ["Production", "SelfConsumption", "FeedIn", "Purchased", "Consumption"]:
-                   type = value
-                if key == "values":
-                   for row in value:
-                      for values, value in row.items():
-                         if values == "value":
-                            self.data[type] = value
-                         if values == "date":
-                            self.attributes[type] = {"date": value}
+               if key == "type" and value in ["Production", "SelfConsumption", "FeedIn", "Purchased", "Consumption"]:
+                  type = value
+               if key == "values":
+                  for row in value:
+                     for values, value in row.items():
+                        if values == "value":
+                           self.data[type] = value
+                        if values == "date":
+                           self.attributes[type] = {"date": value}
 
         _LOGGER.debug("Updated SolarEdge energy details: %s, %s", self.data, self.attributes)
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -1,6 +1,5 @@
 """Support for SolarEdge Monitoring API."""
 import logging
-import datetime
 from datetime import date
 from datetime import datetime
 
@@ -53,6 +52,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         if sensor is not None:
             entities.append(sensor)
     async_add_entities(entities)
+
 
 class SolarEdgeSensorFactory:
     """Factory which creates sensors based on the sensor_key."""
@@ -352,6 +352,7 @@ class SolarEdgeInventoryDataService(SolarEdgeDataService):
 
 class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
     """Get and update the latest power flow data."""
+
     def __init__(self, api, site_id):
         """Initialize the power flow data service."""
         super().__init__(api, site_id)
@@ -386,20 +387,18 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
         meters = energy_details["meters"]
 
         for type in meters:
-           for key, value in type.items():
-              if key == "type" and value in ["Production", "SelfConsumption", "FeedIn", "Purchased", "Consumption"]:
-                 type = value
-              if key == "values":
-                 for row in value:
-                    for values, value in row.items():
-                       if values == "value":
-                          self.data[type] = value
-                       if values == "date":
-                          self.attributes[type] = {"date": value}
+            for key, value in type.items():
+                if key == "type" and value in ["Production", "SelfConsumption", "FeedIn", "Purchased", "Consumption"]:
+                   type = value
+                if key == "values":
+                   for row in value:
+                      for values, value in row.items():
+                         if values == "value":
+                            self.data[type] = value
+                         if values == "date":
+                            self.attributes[type] = {"date": value}
 
-        _LOGGER.debug(
-            "Updated SolarEdge energy details: %s, %s", self.data, self.attributes
-        )
+        _LOGGER.debug("Updated SolarEdge energy details: %s, %s", self.data, self.attributes)
 
 
 class SolarEdgePowerFlowDataService(SolarEdgeDataService):

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -84,7 +84,13 @@ class SolarEdgeSensorFactory:
         for key in ["power_consumption", "solar_power", "grid_power", "storage_power"]:
             self.services[key] = (SolarEdgePowerFlowSensor, flow)
 
-        for key in ["purchased_power", "production_power", "feedin_power", "consumption_power", "selfconsumption_power"]:
+        for key in [
+            "purchased_power",
+            "production_power",
+            "feedin_power",
+            "consumption_power",
+            "selfconsumption_power",
+        ]:
             self.services[key] = (SolarEdgeEnergyDetailsSensor, energy)
 
     def create_sensor(self, sensor_key):
@@ -366,7 +372,13 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
             now = datetime.now()
             today = date.today()
             midnight = datetime.combine(today, datetime.min.time())
-            data = self.api.get_energy_details(self.site_id, midnight, now.strftime("%Y-%m-%d %H:%M:%S"), meters=None, time_unit="DAY")
+            data = self.api.get_energy_details(
+                self.site_id,
+                midnight,
+                now.strftime("%Y-%m-%d %H:%M:%S"),
+                meters=None,
+                time_unit="DAY",
+            )
             energy_details = data["energyDetails"]
         except KeyError:
             _LOGGER.error("Missing power flow data, skipping update")
@@ -388,17 +400,25 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
 
         for type in meters:
             for key, value in type.items():
-               if key == "type" and value in ["Production", "SelfConsumption", "FeedIn", "Purchased", "Consumption"]:
-                  type = value
-               if key == "values":
-                  for row in value:
-                     for values, value in row.items():
-                        if values == "value":
-                           self.data[type] = value
-                        if values == "date":
-                           self.attributes[type] = {"date": value}
+                if key == "type" and value in [
+                    "Production",
+                    "SelfConsumption",
+                    "FeedIn",
+                    "Purchased",
+                    "Consumption",
+                ]:
+                    type = value
+                if key == "values":
+                    for row in value:
+                        for values, value in row.items():
+                            if values == "value":
+                                self.data[type] = value
+                            if values == "date":
+                                self.attributes[type] = {"date": value}
 
-        _LOGGER.debug("Updated SolarEdge energy details: %s, %s", self.data, self.attributes)
+        _LOGGER.debug(
+            "Updated SolarEdge energy details: %s, %s", self.data, self.attributes
+        )
 
 
 class SolarEdgePowerFlowDataService(SolarEdgeDataService):

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -399,19 +399,19 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
         meters = energy_details["meters"]
 
         for entity in meters:
-           for key, data in entity.items():
-              if key == "type" and data in [
-                  "Production",
-                  "SelfConsumption",
-                  "FeedIn",
-                  "Purchased",
-                  "Consumption",
-              ]:
-                  type = data
-              if key == "values":
-                 for row in data:
-                    self.data[type] = row['value']
-                    self.attributes[type] = {"date": row['date']}
+            for key, data in entity.items():
+                if key == "type" and data in [
+                    "Production",
+                    "SelfConsumption",
+                    "FeedIn",
+                    "Purchased",
+                    "Consumption",
+                ]:
+                    type = data
+                if key == "values":
+                    for row in data:
+                        self.data[type] = row['value']
+                        self.attributes[type] = {"date": row['date']}
 
         _LOGGER.debug(
             "Updated SolarEdge energy details: %s, %s", self.data, self.attributes

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -1,5 +1,4 @@
 """Support for SolarEdge Monitoring API."""
-# To remove
 from datetime import date, datetime
 import logging
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -410,8 +410,8 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
                     type = data
                 if key == "values":
                     for row in data:
-                        self.data[type] = row['value']
-                        self.attributes[type] = {"date": row['date']}
+                        self.data[type] = row["value"]
+                        self.attributes[type] = {"date": row["date"]}
 
         _LOGGER.debug(
             "Updated SolarEdge energy details: %s, %s", self.data, self.attributes

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -398,23 +398,20 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
         self.unit = energy_details["unit"]
         meters = energy_details["meters"]
 
-        for type in meters:
-            for key, value in type.items():
-                if key == "type" and value in [
-                    "Production",
-                    "SelfConsumption",
-                    "FeedIn",
-                    "Purchased",
-                    "Consumption",
-                ]:
-                    type = value
-                if key == "values":
-                    for row in value:
-                        for values, value in row.items():
-                            if values == "value":
-                                self.data[type] = value
-                            if values == "date":
-                                self.attributes[type] = {"date": value}
+        for entity in meters:
+           for key, data in entity.items():
+              if key == "type" and data in [
+                  "Production",
+                  "SelfConsumption",
+                  "FeedIn",
+                  "Purchased",
+                  "Consumption",
+              ]:
+                  type = data
+              if key == "values":
+                 for row in data:
+                    self.data[type] = row['value']
+                    self.attributes[type] = {"date": row['date']}
 
         _LOGGER.debug(
             "Updated SolarEdge energy details: %s, %s", self.data, self.attributes

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -1,4 +1,5 @@
 """Support for SolarEdge Monitoring API."""
+# To remove
 from datetime import date, datetime
 import logging
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -407,11 +407,11 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
                     "Purchased",
                     "Consumption",
                 ]:
-                    type = data
+                    energy_type = data
                 if key == "values":
                     for row in data:
-                        self.data[type] = row["value"]
-                        self.attributes[type] = {"date": row["date"]}
+                        self.data[energy_type] = row["value"]
+                        self.attributes[energy_type] = {"date": row["date"]}
 
         _LOGGER.debug(
             "Updated SolarEdge energy details: %s, %s", self.data, self.attributes


### PR DESCRIPTION
## Proposed change
Solaredge has recently changed its policy about local api access, so solaredge-local doesn't work with last firmware update for almost users.
Please check https://github.com/drobtravels/solaredge-local/issues/24

Anyway the solardge remote api is still working, but doesn't got some usefull sensors information as Power SelfConsumption, Power Exported, Power Imported.
With my update, I'll fetching API energy details where  we got these new sensors.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information

- Link to documentation pull request: https://github.com/home-assistant/core/pull/34525

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
