### PR TITLE
Handle duplicate device names during mobile app registrations

### DIFF
--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -29,10 +29,10 @@ from .const import (
     CONF_REMOTE_UI_URL,
     CONF_SECRET,
     CONF_USER_ID,
+    DATA_CONFIG_ENTRIES,
     DOMAIN,
 )
 from .helpers import supports_encryption
-from .notify import push_registrations
 
 
 class RegistrationsView(HomeAssistantView):
@@ -92,8 +92,13 @@ class RegistrationsView(HomeAssistantView):
             # Fallback to DEVICE_ID
             data[ATTR_DEVICE_NAME] = data[ATTR_DEVICE_ID]
 
+        registrations = [
+            entry.data[ATTR_DEVICE_NAME]
+            for webhook_id, entry in hass.data[DOMAIN][DATA_CONFIG_ENTRIES].items()
+        ]
+
         data[ATTR_APP_NAME] = ensure_unique_string(
-            data[ATTR_DEVICE_NAME], push_registrations(hass)
+            data[ATTR_DEVICE_NAME], registrations
         )
 
         await hass.async_create_task(

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -1,4 +1,5 @@
 """Provides an HTTP API for mobile_app."""
+import logging
 import secrets
 from typing import Dict
 
@@ -33,6 +34,8 @@ from .const import (
     DOMAIN,
 )
 from .helpers import supports_encryption
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class RegistrationsView(HomeAssistantView):
@@ -96,6 +99,8 @@ class RegistrationsView(HomeAssistantView):
             entry.data[ATTR_DEVICE_NAME]
             for webhook_id, entry in hass.data[DOMAIN][DATA_CONFIG_ENTRIES].items()
         ]
+
+        _LOGGER.warning(f"Existing {registrations}")
 
         data[ATTR_APP_NAME] = ensure_unique_string(
             data[ATTR_DEVICE_NAME], registrations

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -1,5 +1,4 @@
 """Provides an HTTP API for mobile_app."""
-import logging
 import secrets
 from typing import Dict
 
@@ -34,8 +33,6 @@ from .const import (
     DOMAIN,
 )
 from .helpers import supports_encryption
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class RegistrationsView(HomeAssistantView):
@@ -100,15 +97,9 @@ class RegistrationsView(HomeAssistantView):
             for webhook_id, entry in hass.data[DOMAIN][DATA_CONFIG_ENTRIES].items()
         ]
 
-        _LOGGER.warning(f"Current device name {data[ATTR_DEVICE_NAME]}")
-
-        _LOGGER.warning(f"Existing {registrations}")
-
         data[ATTR_DEVICE_NAME] = ensure_unique_string(
             data[ATTR_DEVICE_NAME], registrations
         )
-
-        _LOGGER.warning(f"Final device name {data[ATTR_DEVICE_NAME]}")
 
         await hass.async_create_task(
             hass.config_entries.flow.async_init(

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -93,7 +93,7 @@ class RegistrationsView(HomeAssistantView):
             data[ATTR_DEVICE_NAME] = data[ATTR_DEVICE_ID]
 
         data[ATTR_APP_NAME] = ensure_unique_string(
-            data[ATTR_DEVICE_NAME], push_registrations
+            data[ATTR_DEVICE_NAME], push_registrations(hass)
         )
 
         await hass.async_create_task(

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -11,7 +11,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.const import CONF_WEBHOOK_ID, HTTP_CREATED
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import slugify
+from homeassistant.util import ensure_unique_string, slugify
 
 from .const import (
     ATTR_APP_DATA,
@@ -32,6 +32,7 @@ from .const import (
     DOMAIN,
 )
 from .helpers import supports_encryption
+from .notify import push_registrations
 
 
 class RegistrationsView(HomeAssistantView):
@@ -90,6 +91,10 @@ class RegistrationsView(HomeAssistantView):
         else:
             # Fallback to DEVICE_ID
             data[ATTR_DEVICE_NAME] = data[ATTR_DEVICE_ID]
+
+        data[ATTR_APP_NAME] = ensure_unique_string(
+            data[ATTR_DEVICE_NAME], push_registrations
+        )
 
         await hass.async_create_task(
             hass.config_entries.flow.async_init(

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -100,11 +100,15 @@ class RegistrationsView(HomeAssistantView):
             for webhook_id, entry in hass.data[DOMAIN][DATA_CONFIG_ENTRIES].items()
         ]
 
+        _LOGGER.warning(f"Current device name {data[ATTR_DEVICE_NAME]}")
+
         _LOGGER.warning(f"Existing {registrations}")
 
-        data[ATTR_APP_NAME] = ensure_unique_string(
+        data[ATTR_DEVICE_NAME] = ensure_unique_string(
             data[ATTR_DEVICE_NAME], registrations
         )
+
+        _LOGGER.warning(f"Final device name {data[ATTR_DEVICE_NAME]}")
 
         await hass.async_create_task(
             hass.config_entries.flow.async_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently if a user tries to register two (or more) devices with the same device name (commonly "iPhone"), a `notify.mobile_app...` service cannot be created for the second device due to the duplicate and the user will see a error of the form:

```
WARNING (MainThread) [homeassistant.components.mobile_app.notify] Found duplicate device name iPhone
```

Previously we have handled these issues by asking users to change their device's names. This doesn't feel ideal and in some edge cases is not possible.

This handle the problem by checking the device name is unique at time of registration and appended a suffix if needed. I.e. our devices would be "iPhone" and "iPhone_2". This also has the bonus of moving the suffix to the device name part of sensor ID and including it in the sensor name. Previously we would have for example for the first device: `sensor.iphone_battery` names "iPhone Battery" and for the second device we would have `sensor.iphone_battery_2` but also named "iPhone Battery". With this fix, the first device's IDs and names stay the same and the second would become `sensor.iphone_2.battery` with name "iPhone_2 Battery". Obviously this only applies to new registrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34950, fixes home-assistant/ios#415
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
