### PR TITLE
Handle mysql index/column already exists during migration

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -185,7 +185,7 @@ def _add_columns(engine, table_name, columns_def):
             )
         )
         return
-    except OperationalError:
+    except (InternalError, OperationalError):
         # Some engines support adding all columns at once,
         # this error is when they don't
         _LOGGER.info("Unable to use quick column add. Adding 1 by 1.")
@@ -199,7 +199,7 @@ def _add_columns(engine, table_name, columns_def):
                     )
                 )
             )
-        except OperationalError as err:
+        except (InternalError, OperationalError) as err:
             if "duplicate" not in str(err).lower():
                 raise
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -4,7 +4,7 @@ import os
 
 from sqlalchemy import Table, text
 from sqlalchemy.engine import reflection
-from sqlalchemy.exc import OperationalError, SQLAlchemyError
+from sqlalchemy.exc import InternalError, OperationalError, SQLAlchemyError
 
 from .models import SCHEMA_VERSION, Base, SchemaChanges
 from .util import session_scope
@@ -82,6 +82,13 @@ def _create_index(engine, table_name, index_name):
         index.create(engine)
     except OperationalError as err:
         if "already exists" not in str(err).lower():
+            raise
+
+        _LOGGER.warning(
+            "Index %s already exists on %s, continuing", index_name, table_name
+        )
+    except InternalError as err:
+        if "duplicate" not in str(err).lower():
             raise
 
         _LOGGER.warning(


### PR DESCRIPTION
##  Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While we should never see a duplicate here, its possible users will kill a migration in progress if it takes a while.  We should handle this situation.
 
The existing code only handled sqlite.  We should handle mysql/mariadb as well.

Testing:

Delete the v9 migration row from schema_changes table.  Verify startup ok
Delete the v8 and v9 migration row from schema_changes table.  Verify startup ok

Fixes
```
2020-06-24 17:13:24 ERROR (Recorder) [homeassistant.components.recorder.util] Error executing query: (pymysql.err.InternalError) (1061, "Duplicate key name 'ix_events_event_type_time_fired'")
[SQL: CREATE INDEX ix_events_event_type_time_fired ON events (event_type, time_fired)]
(Background on this error at: http://sqlalche.me/e/2j85)
2020-06-24 17:13:24 ERROR (Recorder) [homeassistant.components.recorder] Error during connection setup: (pymysql.err.InternalError) (1061, "Duplicate key name 'ix_events_event_type_time_fired'")
[SQL: CREATE INDEX ix_events_event_type_time_fired ON events (event_type, time_fired)]
(Background on this error at: http://sqlalche.me/e/2j85) (retrying in 3 seconds)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
