### PR TITLE
Add support for glob matching in InfluxDB filters

### DIFF
--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the InfluxDB component."""
-from collections import namedtuple
+from dataclasses import dataclass
 import datetime
 
 import pytest
@@ -23,7 +23,14 @@ BASE_V2_CONFIG = {
     "organization": "org",
     "token": "token",
 }
-FilterTest = namedtuple("FilterTest", "id should_pass")
+
+
+@dataclass
+class FilterTest:
+    """Class for capturing a filter test."""
+
+    id: str
+    should_pass: bool
 
 
 @pytest.fixture(autouse=True)
@@ -446,7 +453,6 @@ def execute_filter_test(hass, tests, handler_method, write_api, get_mock_call):
         ]
         handler_method(event)
         hass.data[influxdb.DOMAIN].block_till_done()
-        print(f"{test} - {write_api.call_count}")
 
         if test.should_pass:
             write_api.assert_called_once()

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the InfluxDB component."""
+from collections import namedtuple
 import datetime
 
 import pytest
@@ -11,6 +12,7 @@ from homeassistant.const import (
     STATE_STANDBY,
     UNIT_PERCENTAGE,
 )
+from homeassistant.core import split_entity_id
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import MagicMock, Mock, call, patch
@@ -21,6 +23,7 @@ BASE_V2_CONFIG = {
     "organization": "org",
     "token": "token",
 }
+FilterTest = namedtuple("FilterTest", "id should_pass")
 
 
 @pytest.fixture(autouse=True)
@@ -421,53 +424,32 @@ async def test_event_listener_states(
         write_api.reset_mock()
 
 
-@pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
-    [
-        (
-            influxdb.DEFAULT_API_VERSION,
-            BASE_V1_CONFIG,
-            _get_write_api_mock_v1,
-            influxdb.DEFAULT_API_VERSION,
-        ),
-        (
-            influxdb.API_VERSION_2,
-            BASE_V2_CONFIG,
-            _get_write_api_mock_v2,
-            influxdb.API_VERSION_2,
-        ),
-    ],
-    indirect=["mock_client", "get_mock_call"],
-)
-async def test_event_listener_blacklist(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
-    """Test the event listener against a blacklist."""
-    handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
-
-    for entity_id in ("ok", "blacklisted"):
+def execute_filter_test(hass, tests, handler_method, write_api, get_mock_call):
+    """Execute all tests for a given filtering test."""
+    for test in tests:
+        domain, entity_id = split_entity_id(test.id)
         state = MagicMock(
             state=1,
-            domain="fake",
-            entity_id=f"fake.{entity_id}",
+            domain=domain,
+            entity_id=test.id,
             object_id=entity_id,
             attributes={},
         )
         event = MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
-                "measurement": f"fake.{entity_id}",
-                "tags": {"domain": "fake", "entity_id": entity_id},
+                "measurement": test.id,
+                "tags": {"domain": domain, "entity_id": entity_id},
                 "time": 12345,
                 "fields": {"value": 1},
             }
         ]
         handler_method(event)
         hass.data[influxdb.DOMAIN].block_till_done()
+        print(f"{test} - {write_api.call_count}")
 
-        write_api = get_write_api(mock_client)
-        if entity_id == "ok":
-            assert write_api.call_count == 1
+        if test.should_pass:
+            write_api.assert_called_once()
             assert write_api.call_args == get_mock_call(body)
         else:
             assert not write_api.called
@@ -492,94 +474,20 @@ async def test_event_listener_blacklist(
     ],
     indirect=["mock_client", "get_mock_call"],
 )
-async def test_event_listener_blacklist_domain(
+async def test_event_listener_denylist(
     hass, mock_client, config_ext, get_write_api, get_mock_call
 ):
-    """Test the event listener against a domain blacklist."""
-    handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
-
-    for domain in ("ok", "another_fake"):
-        state = MagicMock(
-            state=1,
-            domain=domain,
-            entity_id=f"{domain}.something",
-            object_id="something",
-            attributes={},
-        )
-        event = MagicMock(data={"new_state": state}, time_fired=12345)
-        body = [
-            {
-                "measurement": f"{domain}.something",
-                "tags": {"domain": domain, "entity_id": "something"},
-                "time": 12345,
-                "fields": {"value": 1},
-            }
-        ]
-        handler_method(event)
-        hass.data[influxdb.DOMAIN].block_till_done()
-
-        write_api = get_write_api(mock_client)
-        if domain == "ok":
-            assert write_api.call_count == 1
-            assert write_api.call_args == get_mock_call(body)
-        else:
-            assert not write_api.called
-        write_api.reset_mock()
-
-
-@pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
-    [
-        (
-            influxdb.DEFAULT_API_VERSION,
-            BASE_V1_CONFIG,
-            _get_write_api_mock_v1,
-            influxdb.DEFAULT_API_VERSION,
-        ),
-        (
-            influxdb.API_VERSION_2,
-            BASE_V2_CONFIG,
-            _get_write_api_mock_v2,
-            influxdb.API_VERSION_2,
-        ),
-    ],
-    indirect=["mock_client", "get_mock_call"],
-)
-async def test_event_listener_whitelist(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
-    """Test the event listener against a whitelist."""
-    config = {"include": {"entities": ["fake.included"]}}
+    """Test the event listener against a denylist."""
+    config = {"exclude": {"entities": ["fake.denylisted"]}, "include": {}}
     config.update(config_ext)
     handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
 
-    for entity_id in ("included", "default"):
-        state = MagicMock(
-            state=1,
-            domain="fake",
-            entity_id=f"fake.{entity_id}",
-            object_id=entity_id,
-            attributes={},
-        )
-        event = MagicMock(data={"new_state": state}, time_fired=12345)
-        body = [
-            {
-                "measurement": f"fake.{entity_id}",
-                "tags": {"domain": "fake", "entity_id": entity_id},
-                "time": 12345,
-                "fields": {"value": 1},
-            }
-        ]
-        handler_method(event)
-        hass.data[influxdb.DOMAIN].block_till_done()
-
-        write_api = get_write_api(mock_client)
-        if entity_id == "included":
-            assert write_api.call_count == 1
-            assert write_api.call_args == get_mock_call(body)
-        else:
-            assert not write_api.called
-        write_api.reset_mock()
+    tests = [
+        FilterTest("fake.ok", True),
+        FilterTest("fake.denylisted", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
 
 
 @pytest.mark.parametrize(
@@ -600,41 +508,20 @@ async def test_event_listener_whitelist(
     ],
     indirect=["mock_client", "get_mock_call"],
 )
-async def test_event_listener_whitelist_domain(
+async def test_event_listener_denylist_domain(
     hass, mock_client, config_ext, get_write_api, get_mock_call
 ):
-    """Test the event listener against a domain whitelist."""
-    config = {"include": {"domains": ["fake"]}}
+    """Test the event listener against a domain denylist."""
+    config = {"exclude": {"domains": ["another_fake"]}, "include": {}}
     config.update(config_ext)
     handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
 
-    for domain in ("fake", "another_fake"):
-        state = MagicMock(
-            state=1,
-            domain=domain,
-            entity_id=f"{domain}.something",
-            object_id="something",
-            attributes={},
-        )
-        event = MagicMock(data={"new_state": state}, time_fired=12345)
-        body = [
-            {
-                "measurement": f"{domain}.something",
-                "tags": {"domain": domain, "entity_id": "something"},
-                "time": 12345,
-                "fields": {"value": 1},
-            }
-        ]
-        handler_method(event)
-        hass.data[influxdb.DOMAIN].block_till_done()
-
-        write_api = get_write_api(mock_client)
-        if domain == "fake":
-            assert write_api.call_count == 1
-            assert write_api.call_args == get_mock_call(body)
-        else:
-            assert not write_api.called
-        write_api.reset_mock()
+    tests = [
+        FilterTest("fake.ok", True),
+        FilterTest("another_fake.denylisted", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
 
 
 @pytest.mark.parametrize(
@@ -655,69 +542,212 @@ async def test_event_listener_whitelist_domain(
     ],
     indirect=["mock_client", "get_mock_call"],
 )
-async def test_event_listener_whitelist_domain_and_entities(
+async def test_event_listener_denylist_glob(
     hass, mock_client, config_ext, get_write_api, get_mock_call
 ):
-    """Test the event listener against a domain and entity whitelist."""
-    config = {"include": {"domains": ["fake"], "entities": ["other.one"]}}
+    """Test the event listener against a glob denylist."""
+    config = {"exclude": {"entity_globs": ["*.excluded_*"]}, "include": {}}
     config.update(config_ext)
     handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
 
-    for domain in ("fake", "another_fake"):
-        state = MagicMock(
-            state=1,
-            domain=domain,
-            entity_id=f"{domain}.something",
-            object_id="something",
-            attributes={},
-        )
-        event = MagicMock(data={"new_state": state}, time_fired=12345)
-        body = [
-            {
-                "measurement": f"{domain}.something",
-                "tags": {"domain": domain, "entity_id": "something"},
-                "time": 12345,
-                "fields": {"value": 1},
-            }
-        ]
-        handler_method(event)
-        hass.data[influxdb.DOMAIN].block_till_done()
+    tests = [
+        FilterTest("fake.ok", True),
+        FilterTest("fake.excluded_entity", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
 
-        write_api = get_write_api(mock_client)
-        if domain == "fake":
-            assert write_api.call_count == 1
-            assert write_api.call_args == get_mock_call(body)
-        else:
-            assert not write_api.called
-        write_api.reset_mock()
 
-    for entity_id in ("one", "two"):
-        state = MagicMock(
-            state=1,
-            domain="other",
-            entity_id=f"other.{entity_id}",
-            object_id=entity_id,
-            attributes={},
-        )
-        event = MagicMock(data={"new_state": state}, time_fired=12345)
-        body = [
-            {
-                "measurement": f"other.{entity_id}",
-                "tags": {"domain": "other", "entity_id": entity_id},
-                "time": 12345,
-                "fields": {"value": 1},
-            }
-        ]
-        handler_method(event)
-        hass.data[influxdb.DOMAIN].block_till_done()
+@pytest.mark.parametrize(
+    "mock_client, config_ext, get_write_api, get_mock_call",
+    [
+        (
+            influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            _get_write_api_mock_v1,
+            influxdb.DEFAULT_API_VERSION,
+        ),
+        (
+            influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
+            _get_write_api_mock_v2,
+            influxdb.API_VERSION_2,
+        ),
+    ],
+    indirect=["mock_client", "get_mock_call"],
+)
+async def test_event_listener_allowlist(
+    hass, mock_client, config_ext, get_write_api, get_mock_call
+):
+    """Test the event listener against an allowlist."""
+    config = {"include": {"entities": ["fake.included"]}, "exclude": {}}
+    config.update(config_ext)
+    handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
 
-        write_api = get_write_api(mock_client)
-        if entity_id == "one":
-            assert write_api.call_count == 1
-            assert write_api.call_args == get_mock_call(body)
-        else:
-            assert not write_api.called
-        write_api.reset_mock()
+    tests = [
+        FilterTest("fake.included", True),
+        FilterTest("fake.excluded", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
+
+
+@pytest.mark.parametrize(
+    "mock_client, config_ext, get_write_api, get_mock_call",
+    [
+        (
+            influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            _get_write_api_mock_v1,
+            influxdb.DEFAULT_API_VERSION,
+        ),
+        (
+            influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
+            _get_write_api_mock_v2,
+            influxdb.API_VERSION_2,
+        ),
+    ],
+    indirect=["mock_client", "get_mock_call"],
+)
+async def test_event_listener_allowlist_domain(
+    hass, mock_client, config_ext, get_write_api, get_mock_call
+):
+    """Test the event listener against a domain allowlist."""
+    config = {"include": {"domains": ["fake"]}, "exclude": {}}
+    config.update(config_ext)
+    handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
+
+    tests = [
+        FilterTest("fake.ok", True),
+        FilterTest("another_fake.excluded", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
+
+
+@pytest.mark.parametrize(
+    "mock_client, config_ext, get_write_api, get_mock_call",
+    [
+        (
+            influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            _get_write_api_mock_v1,
+            influxdb.DEFAULT_API_VERSION,
+        ),
+        (
+            influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
+            _get_write_api_mock_v2,
+            influxdb.API_VERSION_2,
+        ),
+    ],
+    indirect=["mock_client", "get_mock_call"],
+)
+async def test_event_listener_allowlist_glob(
+    hass, mock_client, config_ext, get_write_api, get_mock_call
+):
+    """Test the event listener against a glob allowlist."""
+    config = {"include": {"entity_globs": ["*.included_*"]}, "exclude": {}}
+    config.update(config_ext)
+    handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
+
+    tests = [
+        FilterTest("fake.included_entity", True),
+        FilterTest("fake.denied", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
+
+
+@pytest.mark.parametrize(
+    "mock_client, config_ext, get_write_api, get_mock_call",
+    [
+        (
+            influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            _get_write_api_mock_v1,
+            influxdb.DEFAULT_API_VERSION,
+        ),
+        (
+            influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
+            _get_write_api_mock_v2,
+            influxdb.API_VERSION_2,
+        ),
+    ],
+    indirect=["mock_client", "get_mock_call"],
+)
+async def test_event_listener_filtered_allowlist(
+    hass, mock_client, config_ext, get_write_api, get_mock_call
+):
+    """Test the event listener against an allowlist filtered by denylist."""
+    config = {
+        "include": {
+            "domains": ["fake"],
+            "entities": ["another_fake.included"],
+            "entity_globs": "*.included_*",
+        },
+        "exclude": {
+            "entities": ["fake.excluded"],
+            "domains": ["another_fake"],
+            "entity_globs": "*.excluded_*",
+        },
+    }
+    config.update(config_ext)
+    handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
+
+    tests = [
+        FilterTest("fake.ok", True),
+        FilterTest("another_fake.included", True),
+        FilterTest("test.included_entity", True),
+        FilterTest("fake.excluded", False),
+        FilterTest("another_fake.denied", False),
+        FilterTest("fake.excluded_entity", False),
+        FilterTest("another_fake.included_entity", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
+
+
+@pytest.mark.parametrize(
+    "mock_client, config_ext, get_write_api, get_mock_call",
+    [
+        (
+            influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            _get_write_api_mock_v1,
+            influxdb.DEFAULT_API_VERSION,
+        ),
+        (
+            influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
+            _get_write_api_mock_v2,
+            influxdb.API_VERSION_2,
+        ),
+    ],
+    indirect=["mock_client", "get_mock_call"],
+)
+async def test_event_listener_filtered_denylist(
+    hass, mock_client, config_ext, get_write_api, get_mock_call
+):
+    """Test the event listener against a domain/glob denylist with an entity id allowlist."""
+    config = {
+        "include": {"entities": ["another_fake.included", "fake.excluded_pass"]},
+        "exclude": {"domains": ["another_fake"], "entity_globs": "*.excluded_*"},
+    }
+    config.update(config_ext)
+    handler_method = await _setup(hass, mock_client, config, get_write_api)
+    write_api = get_write_api(mock_client)
+
+    tests = [
+        FilterTest("fake.ok", True),
+        FilterTest("another_fake.included", True),
+        FilterTest("fake.excluded_pass", True),
+        FilterTest("another_fake.denied", False),
+        FilterTest("fake.excluded_entity", False),
+    ]
+    execute_filter_test(hass, tests, handler_method, write_api, get_mock_call)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
InfluxDB was not using the common filtering logic shared by `recorder`, `logbook`, `homekit`, etc. and as a result had filtering logic that is inconsistent with the filtering logic of every other recorder-like component. This has been corrected causing the following changes in filtering logic:
1. Same domain specified in both include and exclude
  - Previous behavior: All entities in that domain excluded
  - New behavior: All entities of that domain included unless entity is excluded by ID or by glob
2. Same entity ID specified in both include and exclude
  - Previous behavior: Entity excluded
  - New behavior: Entity included
3. Filtering has 1+ exclude domains, 0 include domains, and 1+ include entity ID's specified:
  - Previous behavior: All entities not specifically listed by ID were excluded
  - New behavior: All entities not specifically excluded by either domain or ID are included


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-up to my recent PR: https://github.com/home-assistant/core/pull/36913. I want to bring glob filtering capability to InfluxDB as well since it is also a recorder-like component with an identical filtering config. Users would have a reasonable expectation that the Influx component has identical behavior to `recorder, `logbook` and the others when it comes to entity filtering capability. Unfortunately that is not currently the case since Influx does not currently share the common filtering logic and instead has created its own.

This PR therefore makes the following changes:
1. Bring the new GLOB-filtering capability added to the other recorder-like components to Influx
2. Correct the inconsistencies in Influx's filtering logic when compared to the other recorder-like components (see breaking changes for differences)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
influx:
  include:
    domain: sensor
    entity_globs: binary_sensor.*_occupancy
  exclude:
    entity_globs: sensor.weather_*
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/allow-glob-in-influxdb-white-and-black-list/48793
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13843

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
