### PR TITLE
Improve Smappee integration

### DIFF
--- a/homeassistant/components/smappee/__init__.py
+++ b/homeassistant/components/smappee/__init__.py
@@ -26,7 +26,6 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Required(CONF_CLIENT_SECRET): cv.string,
-                vol.Optional(CONF_PLATFORM, default="PRODUCTION"): cv.string,
             }
         )
     },
@@ -40,7 +39,15 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
     if DOMAIN not in config:
         return True
-    hass.data[DOMAIN][CONF_PLATFORM] = config[DOMAIN][CONF_PLATFORM]
+
+    # decide platform
+    PLATFORM = "PRODUCTION"
+    if config[DOMAIN][CONF_CLIENT_ID] == "homeassistant_f2":
+        PLATFORM = "ACCEPTANCE"
+    elif config[DOMAIN][CONF_CLIENT_ID] == "homeassistant_f3":
+        PLATFORM = "DEVELOPMENT"
+
+    hass.data[DOMAIN][CONF_PLATFORM] = PLATFORM
 
     config_flow.SmappeeFlowHandler.async_register_implementation(
         hass,
@@ -49,8 +56,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
             DOMAIN,
             config[DOMAIN][CONF_CLIENT_ID],
             config[DOMAIN][CONF_CLIENT_SECRET],
-            AUTHORIZE_URL[config[DOMAIN][CONF_PLATFORM]],
-            TOKEN_URL[config[DOMAIN][CONF_PLATFORM]],
+            AUTHORIZE_URL[PLATFORM],
+            TOKEN_URL[PLATFORM],
         ),
     )
 

--- a/homeassistant/components/smappee/__init__.py
+++ b/homeassistant/components/smappee/__init__.py
@@ -41,13 +41,13 @@ async def async_setup(hass: HomeAssistant, config: dict):
         return True
 
     # decide platform
-    PLATFORM = "PRODUCTION"
+    platform = "PRODUCTION"
     if config[DOMAIN][CONF_CLIENT_ID] == "homeassistant_f2":
-        PLATFORM = "ACCEPTANCE"
+        platform = "ACCEPTANCE"
     elif config[DOMAIN][CONF_CLIENT_ID] == "homeassistant_f3":
-        PLATFORM = "DEVELOPMENT"
+        platform = "DEVELOPMENT"
 
-    hass.data[DOMAIN][CONF_PLATFORM] = PLATFORM
+    hass.data[DOMAIN][CONF_PLATFORM] = platform
 
     config_flow.SmappeeFlowHandler.async_register_implementation(
         hass,
@@ -56,8 +56,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
             DOMAIN,
             config[DOMAIN][CONF_CLIENT_ID],
             config[DOMAIN][CONF_CLIENT_SECRET],
-            AUTHORIZE_URL[PLATFORM],
-            TOKEN_URL[PLATFORM],
+            AUTHORIZE_URL[platform],
+            TOKEN_URL[platform],
         ),
     )
 

--- a/homeassistant/components/smappee/__init__.py
+++ b/homeassistant/components/smappee/__init__.py
@@ -40,6 +40,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
     if DOMAIN not in config:
         return True
+    hass.data[DOMAIN][CONF_PLATFORM] = config[DOMAIN][CONF_PLATFORM]
 
     config_flow.SmappeeFlowHandler.async_register_implementation(
         hass,
@@ -90,6 +91,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     if unload_ok:
         hass.data[DOMAIN].pop(BASE, None)
+        hass.data[DOMAIN].pop(CONF_PLATFORM, None)
 
     return unload_ok
 

--- a/homeassistant/components/smappee/__init__.py
+++ b/homeassistant/components/smappee/__init__.py
@@ -5,7 +5,7 @@ from pysmappee import Smappee
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.util import Throttle
@@ -26,6 +26,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Required(CONF_CLIENT_SECRET): cv.string,
+                vol.Optional(CONF_PLATFORM, default="PRODUCTION"): cv.string,
             }
         )
     },
@@ -47,8 +48,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
             DOMAIN,
             config[DOMAIN][CONF_CLIENT_ID],
             config[DOMAIN][CONF_CLIENT_SECRET],
-            AUTHORIZE_URL,
-            TOKEN_URL,
+            AUTHORIZE_URL[config[DOMAIN][CONF_PLATFORM]],
+            TOKEN_URL[config[DOMAIN][CONF_PLATFORM]],
         ),
     )
 

--- a/homeassistant/components/smappee/api.py
+++ b/homeassistant/components/smappee/api.py
@@ -4,7 +4,10 @@ from asyncio import run_coroutine_threadsafe
 from pysmappee import api
 
 from homeassistant import config_entries, core
+from homeassistant.const import CONF_PLATFORM
 from homeassistant.helpers import config_entry_oauth2_flow
+
+from .const import DOMAIN
 
 
 class ConfigEntrySmappeeApi(api.SmappeeApi):
@@ -32,7 +35,7 @@ class ConfigEntrySmappeeApi(api.SmappeeApi):
             None,
             None,
             token=self.session.token,
-            farm=platform_to_farm[config_entry["PLATFORM"]],
+            farm=platform_to_farm[hass.data[DOMAIN][CONF_PLATFORM]],
         )
 
     def refresh_tokens(self) -> dict:

--- a/homeassistant/components/smappee/api.py
+++ b/homeassistant/components/smappee/api.py
@@ -22,7 +22,18 @@ class ConfigEntrySmappeeApi(api.SmappeeApi):
         self.session = config_entry_oauth2_flow.OAuth2Session(
             hass, config_entry, implementation
         )
-        super().__init__(None, None, token=self.session.token)
+
+        platform_to_farm = {
+            "PRODUCTION": 1,
+            "ACCEPTANCE": 2,
+            "DEVELOPMENT": 3,
+        }
+        super().__init__(
+            None,
+            None,
+            token=self.session.token,
+            farm=platform_to_farm[config_entry["PLATFORM"]],
+        )
 
     def refresh_tokens(self) -> dict:
         """Refresh and return new Smappee tokens using Home Assistant OAuth2 session."""

--- a/homeassistant/components/smappee/binary_sensor.py
+++ b/homeassistant/components/smappee/binary_sensor.py
@@ -142,8 +142,7 @@ class SmappeeAppliance(BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
-        # Only lights can be mapped onto the generic list of binary sensors
-        return "light" if self._appliance_type == "Lights" else "power"
+        return None
 
     @property
     def unique_id(self,):

--- a/homeassistant/components/smappee/binary_sensor.py
+++ b/homeassistant/components/smappee/binary_sensor.py
@@ -140,11 +140,6 @@ class SmappeeAppliance(BinarySensorEntity):
         return icon_mapping.get(self._appliance_type)
 
     @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return None
-
-    @property
     def unique_id(self,):
         """Return the unique ID for this binary sensor."""
         return (

--- a/homeassistant/components/smappee/config_flow.py
+++ b/homeassistant/components/smappee/config_flow.py
@@ -24,7 +24,4 @@ class SmappeeFlowHandler(
 
     async def async_step_user(self, user_input=None):
         """Handle a flow start."""
-        if self.hass.config_entries.async_entries(DOMAIN):
-            return self.async_abort(reason="single_instance_allowed")
-
         return await super().async_step_user(user_input)

--- a/homeassistant/components/smappee/config_flow.py
+++ b/homeassistant/components/smappee/config_flow.py
@@ -21,7 +21,3 @@ class SmappeeFlowHandler(
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
-
-    async def async_step_user(self, user_input=None):
-        """Handle a flow start."""
-        return await super().async_step_user(user_input)

--- a/homeassistant/components/smappee/const.py
+++ b/homeassistant/components/smappee/const.py
@@ -11,5 +11,13 @@ SMAPPEE_PLATFORMS = ["binary_sensor", "sensor", "switch"]
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
-AUTHORIZE_URL = "https://app1pub.smappee.net/dev/v1/oauth2/authorize"
-TOKEN_URL = "https://app1pub.smappee.net/dev/v3/oauth2/token"
+AUTHORIZE_URL = {
+    "PRODUCTION": "https://app1pub.smappee.net/dev/v1/oauth2/authorize",
+    "ACCEPTANCE": "https://farm2pub.smappee.net/dev/v1/oauth2/authorize",
+    "DEVELOPMENT": "https://farm3pub.smappee.net/dev/v1/oauth2/authorize",
+}
+TOKEN_URL = {
+    "PRODUCTION": "https://app1pub.smappee.net/dev/v3/oauth2/token",
+    "ACCEPTANCE": "https://farm2pub.smappee.net/dev/v3/oauth2/token",
+    "DEVELOPMENT": "https://farm3pub.smappee.net/dev/v3/oauth2/token",
+}

--- a/homeassistant/components/smappee/sensor.py
+++ b/homeassistant/components/smappee/sensor.py
@@ -16,6 +16,13 @@ TREND_SENSORS = {
         "total_power",
         DEVICE_CLASS_POWER,
     ],
+    "total_reactive_power": [
+        "Total consumption - Reactive power",
+        None,
+        POWER_WATT,
+        "total_reactive_power",
+        DEVICE_CLASS_POWER,
+    ],
     "alwayson": [
         "Always on - Active power",
         None,
@@ -290,6 +297,8 @@ class SmappeeSensor(Entity):
 
         if self._sensor == "total_power":
             self._state = self._service_location.total_power
+        elif self._sensor == "total_reactive_power":
+            self._state = self._service_location.total_reactive_power
         elif self._sensor == "solar_power":
             self._state = self._service_location.solar_power
         elif self._sensor == "alwayson":

--- a/homeassistant/components/smappee/sensor.py
+++ b/homeassistant/components/smappee/sensor.py
@@ -16,13 +16,6 @@ TREND_SENSORS = {
         "total_power",
         DEVICE_CLASS_POWER,
     ],
-    "total_reactive_power": [
-        "Total consumption - Reactive power",
-        None,
-        POWER_WATT,
-        "total_reactive_power",
-        DEVICE_CLASS_POWER,
-    ],
     "alwayson": [
         "Always on - Active power",
         None,
@@ -297,8 +290,6 @@ class SmappeeSensor(Entity):
 
         if self._sensor == "total_power":
             self._state = self._service_location.total_power
-        elif self._sensor == "total_reactive_power":
-            self._state = self._service_location.total_reactive_power
         elif self._sensor == "solar_power":
             self._state = self._service_location.solar_power
         elif self._sensor == "alwayson":

--- a/homeassistant/components/smappee/strings.json
+++ b/homeassistant/components/smappee/strings.json
@@ -7,7 +7,6 @@
         },
         "abort": {
             "authorize_url_timeout": "Timeout generating authorize url.",
-            "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
             "missing_configuration": "The component is not configured. Please follow the documentation."
         }
     }

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock):
     state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
 
     assert result["url"] == (
-        f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
+        f"{AUTHORIZE_URL['PRODUCTION']}?response_type=code&client_id={CLIENT_ID}"
         "&redirect_uri=https://example.com/auth/external/callback"
         f"&state={state}"
     )
@@ -50,7 +50,7 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock):
     assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
     aioclient_mock.post(
-        TOKEN_URL,
+        TOKEN_URL["PRODUCTION"],
         json={
             "refresh_token": "mock-refresh-token",
             "access_token": "mock-access-token",

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -1,25 +1,13 @@
 """Test the Smappee config flow."""
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, setup
 from homeassistant.components.smappee.const import AUTHORIZE_URL, DOMAIN, TOKEN_URL
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.async_mock import patch
-from tests.common import MockConfigEntry
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
-
-
-async def test_abort_if_existing_entry(hass):
-    """Check flow abort when an entry already exist."""
-    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_full_flow(hass, aiohttp_client, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tweaks of the Smappee integration
- Allow multiple instances
- Add optional platform selection (internal use)
- Remove device_class in binary_sensor entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
smappee:
   client_id: 1234
   client_server: 5678
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
