### PR TITLE
Remove invalidation version from ZHA deprecated config options

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -51,9 +51,9 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             vol.All(
-                cv.deprecated(CONF_USB_PATH, invalidation_version="0.112"),
-                cv.deprecated(CONF_BAUDRATE, invalidation_version="0.112"),
-                cv.deprecated(CONF_RADIO_TYPE, invalidation_version="0.112"),
+                cv.deprecated(CONF_USB_PATH),
+                cv.deprecated(CONF_BAUDRATE),
+                cv.deprecated(CONF_RADIO_TYPE),
                 ZHA_CONFIG_SCHEMA,
             ),
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some YAML options of ZHA have been deprecated and marked as invalid as of Home Assistant Core 0.112.0.
However, they have not been removed, and while bumping the `dev` branch to 0.113.0dev0 (#37071), it broke the build.

As the beta has been cut already, I've removed the `invalidation_version` as a hotfix to pick for the 0.112.0 release (in the current state, the final stable release would fail building).

Nevertheless, this still needs clean up afterward.

```
=================================== FAILURES ===================================
_________________ test_migration_from_v1_with_baudrate[pyloop] _________________
[gw1] linux -- Python 3.7.0 /__w/1/s/venv/bin/python

hass = <homeassistant.core.HomeAssistant object at 0x7fa157655ef0>
config_entry_v1 = <tests.common.MockConfigEntry object at 0x7fa1576bd048>

    @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
    async def test_migration_from_v1_with_baudrate(hass, config_entry_v1):
        """Test migration of config entry from v1 with baudrate in config."""
        config_entry_v1.add_to_hass(hass)
>       assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_BAUDRATE: 115200}})
E       assert False

tests/components/zha/test_init.py:51: AssertionError
---------------------------- Captured stderr setup -----------------------------
DEBUG:asyncio:Using selector: EpollSelector
------------------------------ Captured log setup ------------------------------
DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
----------------------------- Captured stderr call -----------------------------
INFO:homeassistant.loader:Loaded test from custom_components.test
INFO:homeassistant.loader:Loaded test_package from custom_components.test_package
INFO:homeassistant.loader:Loaded zha from homeassistant.components.zha
ERROR:homeassistant.config:Invalid config for [zha]: The 'baudrate' option is deprecated, please remove it from your configuration. This option became invalid in version 0.112 for dictionary value @ data['zha']. Got {'baudrate': 115200}. (See ?, line ?). Please check the docs at https://www.home-assistant.io/integrations/zha
ERROR:homeassistant.setup:Setup failed for zha: Invalid config.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
