### PR TITLE
Fix missing service call context in multiple locations

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -305,7 +305,9 @@ class Alert(ToggleEntity):
         _LOGGER.debug(msg_payload)
 
         for target in self._notifiers:
-            await self.hass.services.async_call(DOMAIN_NOTIFY, target, msg_payload)
+            await self.hass.services.async_call(
+                DOMAIN_NOTIFY, target, msg_payload, context=self._context
+            )
 
     async def async_turn_on(self, **kwargs):
         """Async Unacknowledge alert."""

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -449,12 +449,16 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
     async def _async_heater_turn_on(self):
         """Turn heater toggleable device on."""
         data = {ATTR_ENTITY_ID: self.heater_entity_id}
-        await self.hass.services.async_call(HA_DOMAIN, SERVICE_TURN_ON, data)
+        await self.hass.services.async_call(
+            HA_DOMAIN, SERVICE_TURN_ON, data, context=self._context
+        )
 
     async def _async_heater_turn_off(self):
         """Turn heater toggleable device off."""
         data = {ATTR_ENTITY_ID: self.heater_entity_id}
-        await self.hass.services.async_call(HA_DOMAIN, SERVICE_TURN_OFF, data)
+        await self.hass.services.async_call(
+            HA_DOMAIN, SERVICE_TURN_OFF, data, context=self._context
+        )
 
     async def async_set_preset_mode(self, preset_mode: str):
         """Set new preset mode."""

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -209,21 +209,21 @@ class CoverGroup(CoverEntity):
         """Move the covers up."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_OPEN_COVER, data, blocking=True
+            DOMAIN, SERVICE_OPEN_COVER, data, blocking=True, context=self._context
         )
 
     async def async_close_cover(self, **kwargs):
         """Move the covers down."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_CLOSE_COVER, data, blocking=True
+            DOMAIN, SERVICE_CLOSE_COVER, data, blocking=True, context=self._context
         )
 
     async def async_stop_cover(self, **kwargs):
         """Fire the stop action."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_STOP]}
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_STOP_COVER, data, blocking=True
+            DOMAIN, SERVICE_STOP_COVER, data, blocking=True, context=self._context
         )
 
     async def async_set_cover_position(self, **kwargs):
@@ -233,28 +233,32 @@ class CoverGroup(CoverEntity):
             ATTR_POSITION: kwargs[ATTR_POSITION],
         }
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_SET_COVER_POSITION, data, blocking=True
+            DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            data,
+            blocking=True,
+            context=self._context,
         )
 
     async def async_open_cover_tilt(self, **kwargs):
         """Tilt covers open."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_OPEN_COVER_TILT, data, blocking=True
+            DOMAIN, SERVICE_OPEN_COVER_TILT, data, blocking=True, context=self._context
         )
 
     async def async_close_cover_tilt(self, **kwargs):
         """Tilt covers closed."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_CLOSE_COVER_TILT, data, blocking=True
+            DOMAIN, SERVICE_CLOSE_COVER_TILT, data, blocking=True, context=self._context
         )
 
     async def async_stop_cover_tilt(self, **kwargs):
         """Stop cover tilt."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_STOP]}
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_STOP_COVER_TILT, data, blocking=True
+            DOMAIN, SERVICE_STOP_COVER_TILT, data, blocking=True, context=self._context
         )
 
     async def async_set_cover_tilt_position(self, **kwargs):
@@ -264,7 +268,11 @@ class CoverGroup(CoverEntity):
             ATTR_TILT_POSITION: kwargs[ATTR_TILT_POSITION],
         }
         await self.hass.services.async_call(
-            DOMAIN, SERVICE_SET_COVER_TILT_POSITION, data, blocking=True
+            DOMAIN,
+            SERVICE_SET_COVER_TILT_POSITION,
+            data,
+            blocking=True,
+            context=self._context,
         )
 
     async def async_update(self):

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -233,7 +233,11 @@ class LightGroup(light.LightEntity):
 
         if not emulate_color_temp_entity_ids:
             await self.hass.services.async_call(
-                light.DOMAIN, light.SERVICE_TURN_ON, data, blocking=True
+                light.DOMAIN,
+                light.SERVICE_TURN_ON,
+                data,
+                blocking=True,
+                context=self._context,
             )
             return
 
@@ -249,13 +253,18 @@ class LightGroup(light.LightEntity):
 
         await asyncio.gather(
             self.hass.services.async_call(
-                light.DOMAIN, light.SERVICE_TURN_ON, data, blocking=True
+                light.DOMAIN,
+                light.SERVICE_TURN_ON,
+                data,
+                blocking=True,
+                context=self._context,
             ),
             self.hass.services.async_call(
                 light.DOMAIN,
                 light.SERVICE_TURN_ON,
                 emulate_color_temp_data,
                 blocking=True,
+                context=self._context,
             ),
         )
 
@@ -267,7 +276,11 @@ class LightGroup(light.LightEntity):
             data[ATTR_TRANSITION] = kwargs[ATTR_TRANSITION]
 
         await self.hass.services.async_call(
-            light.DOMAIN, light.SERVICE_TURN_OFF, data, blocking=True
+            light.DOMAIN,
+            light.SERVICE_TURN_OFF,
+            data,
+            blocking=True,
+            context=self._context,
         )
 
     async def async_update(self):

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -78,7 +78,9 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
             data[ATTR_ENTITY_ID] = list(ent_ids)
 
             tasks.append(
-                hass.services.async_call(domain, service.service, data, blocking)
+                hass.services.async_call(
+                    domain, service.service, data, blocking, context=service.context
+                )
             )
 
         if tasks:

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -641,7 +641,9 @@ class LIFXLight(LightEntity):
         """Start an effect with default parameters."""
         service = kwargs[ATTR_EFFECT]
         data = {ATTR_ENTITY_ID: self.entity_id}
-        await self.hass.services.async_call(LIFX_DOMAIN, service, data)
+        await self.hass.services.async_call(
+            LIFX_DOMAIN, service, data, context=self._context
+        )
 
     async def async_update(self):
         """Update bulb status."""

--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -84,14 +84,22 @@ class LightSwitch(LightEntity):
         """Forward the turn_on command to the switch in this light switch."""
         data = {ATTR_ENTITY_ID: self._switch_entity_id}
         await self.hass.services.async_call(
-            switch.DOMAIN, switch.SERVICE_TURN_ON, data, blocking=True
+            switch.DOMAIN,
+            switch.SERVICE_TURN_ON,
+            data,
+            blocking=True,
+            context=self._context,
         )
 
     async def async_turn_off(self, **kwargs):
         """Forward the turn_off command to the switch in this light switch."""
         data = {ATTR_ENTITY_ID: self._switch_entity_id}
         await self.hass.services.async_call(
-            switch.DOMAIN, switch.SERVICE_TURN_OFF, data, blocking=True
+            switch.DOMAIN,
+            switch.SERVICE_TURN_OFF,
+            data,
+            blocking=True,
+            context=self._context,
         )
 
     async def async_update(self):

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -175,7 +175,11 @@ async def async_setup(hass, config):
             }
 
             await hass.services.async_call(
-                DOMAIN_MP, SERVICE_PLAY_MEDIA, data, blocking=True
+                DOMAIN_MP,
+                SERVICE_PLAY_MEDIA,
+                data,
+                blocking=True,
+                context=service.context,
             )
 
         service_name = p_config.get(CONF_SERVICE_NAME, f"{p_type}_{SERVICE_SAY}")

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -205,7 +205,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         service_data[ATTR_ENTITY_ID] = active_child.entity_id
 
         await self.hass.services.async_call(
-            DOMAIN, service_name, service_data, blocking=True
+            DOMAIN, service_name, service_data, blocking=True, context=self._context
         )
 
     @property

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -570,14 +570,14 @@ async def test_invalid_service_calls(hass):
         await grouped_light.async_turn_on(brightness=150, four_oh_four="404")
         data = {ATTR_ENTITY_ID: ["light.test1", "light.test2"], ATTR_BRIGHTNESS: 150}
         mock_call.assert_called_once_with(
-            LIGHT_DOMAIN, SERVICE_TURN_ON, data, blocking=True
+            LIGHT_DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=None
         )
         mock_call.reset_mock()
 
         await grouped_light.async_turn_off(transition=4, four_oh_four="404")
         data = {ATTR_ENTITY_ID: ["light.test1", "light.test2"], ATTR_TRANSITION: 4}
         mock_call.assert_called_once_with(
-            LIGHT_DOMAIN, SERVICE_TURN_OFF, data, blocking=True
+            LIGHT_DOMAIN, SERVICE_TURN_OFF, data, blocking=True, context=None
         )
         mock_call.reset_mock()
 
@@ -596,5 +596,5 @@ async def test_invalid_service_calls(hass):
         data.pop(ATTR_RGB_COLOR)
         data.pop(ATTR_XY_COLOR)
         mock_call.assert_called_once_with(
-            LIGHT_DOMAIN, SERVICE_TURN_ON, data, blocking=True
+            LIGHT_DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=None
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In Home Assistant Core 0.112 the user triggering an "action", is now visible in the logbook.

During the beta of 0.112.0, I've played with this a bit and noticed the following:

When I toggle on a group of lights, the logbook would show me as the user that took the action, however, all individual light entities as a result of toggling that group, did not show my name.

A quick look showed that the context isn't passed down.

Using the following command I've created a list of locations where this might occur. This PR addresses most of these cases.

`astpath ".//Call[func/Attribute/@attr='call' or func/Attribute/@attr='async_call'][not(keywords//@arg='context')]" -d homeassistant/`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
