### PR TITLE
Ensure Mobile App device names are unique and stay unique

### DIFF
--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -107,7 +107,7 @@ class RegistrationsView(HomeAssistantView):
         if data[ATTR_DEVICE_NAME] != requested_name:
             _LOGGER.warning(
                 "Using device name %s instead of %s to ensure unique",
-                data[ATTR_APP_NAME],
+                data[ATTR_DEVICE_NAME],
                 requested_name,
             )
 

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -343,10 +343,12 @@ async def webhook_update_registration(hass, config_entry, data):
     if current_name:
         if new_registration[ATTR_DEVICE_NAME] != current_name:
             # Ensure that device name changes are not propagated to avoid mismatches
-            _LOGGER.info(
-                f"Refusing to change device name from {current_name} "
-                + f"to {new_registration[ATTR_DEVICE_NAME]} proceeding with with "
-                + f"registration update using {current_name}"
+            _LOGGER.debug(
+                "Refusing to change device name from %s to %s. "
+                "Proceeding with with registration update using %s",
+                current_name,
+                new_registration[ATTR_DEVICE_NAME],
+                current_name,
             )
             new_registration[ATTR_DEVICE_NAME] = current_name
 

--- a/tests/components/mobile_app/const.py
+++ b/tests/components/mobile_app/const.py
@@ -14,7 +14,7 @@ REGISTER = {
     "app_id": "io.homeassistant.mobile_app_test",
     "app_name": "Mobile App Tests",
     "app_version": "1.0.0",
-    "device_name": "Test 1",
+    "device_name": "Test Encrypted",
     "manufacturer": "mobile_app",
     "model": "Test",
     "os_name": "Linux",
@@ -27,10 +27,24 @@ REGISTER_CLEARTEXT = {
     "app_id": "io.homeassistant.mobile_app_test",
     "app_name": "Mobile App Tests",
     "app_version": "1.0.0",
-    "device_name": "Test 1",
+    "device_name": "Test Clear",
     "manufacturer": "mobile_app",
     "model": "Test",
     "device_id": "mock-device-id",
+    "os_name": "Linux",
+    "os_version": "1.0",
+    "supports_encryption": False,
+}
+
+REGISTER_CLEARTEXT_DUPLICATE_NAME = {
+    "app_data": {"foo": "bar"},
+    "app_id": "io.homeassistant.mobile_app_test",
+    "app_name": "Mobile App Tests",
+    "app_version": "1.0.0",
+    "device_name": REGISTER_CLEARTEXT["device_name"],
+    "manufacturer": "mobile_app",
+    "model": "Test",
+    "device_id": "mock-device-id-2",
     "os_name": "Linux",
     "os_version": "1.0",
     "supports_encryption": False,
@@ -44,7 +58,16 @@ RENDER_TEMPLATE = {
 UPDATE = {
     "app_data": {"foo": "bar"},
     "app_version": "2.0.0",
-    "device_name": "Test 1",
+    "device_name": "Test Clear",
+    "manufacturer": "mobile_app",
+    "model": "Test",
+    "os_version": "1.0",
+}
+
+UPDATE_NEW_NAME = {
+    "app_data": {"foo": "bar"},
+    "app_version": "2.0.0",
+    "device_name": "New Name",
     "manufacturer": "mobile_app",
     "model": "Test",
     "os_version": "1.0",

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -22,9 +22,9 @@ async def test_sending_location(hass, create_registrations, webhook_client):
 
     assert resp.status == 200
     await hass.async_block_till_done()
-    state = hass.states.get("device_tracker.test_1_2")
+    state = hass.states.get("device_tracker.test_clear")
     assert state is not None
-    assert state.name == "Test 1"
+    assert state.name == "Test Clear"
     assert state.state == "bar"
     assert state.attributes["source_type"] == "gps"
     assert state.attributes["latitude"] == 10
@@ -54,7 +54,7 @@ async def test_sending_location(hass, create_registrations, webhook_client):
 
     assert resp.status == 200
     await hass.async_block_till_done()
-    state = hass.states.get("device_tracker.test_1_2")
+    state = hass.states.get("device_tracker.test_clear")
     assert state is not None
     assert state.state == "not_home"
     assert state.attributes["source_type"] == "gps"
@@ -89,7 +89,7 @@ async def test_restoring_location(hass, create_registrations, webhook_client):
 
     assert resp.status == 200
     await hass.async_block_till_done()
-    state_1 = hass.states.get("device_tracker.test_1_2")
+    state_1 = hass.states.get("device_tracker.test_clear")
     assert state_1 is not None
 
     config_entry = hass.config_entries.async_entries("mobile_app")[1]
@@ -99,11 +99,11 @@ async def test_restoring_location(hass, create_registrations, webhook_client):
     await hass.config_entries.async_forward_entry_setup(config_entry, "device_tracker")
     await hass.async_block_till_done()
 
-    state_2 = hass.states.get("device_tracker.test_1_2")
+    state_2 = hass.states.get("device_tracker.test_clear")
     assert state_2 is not None
 
     assert state_1 is not state_2
-    assert state_2.name == "Test 1"
+    assert state_2.name == "Test Clear"
     assert state_2.attributes["source_type"] == "gps"
     assert state_2.attributes["latitude"] == 10
     assert state_2.attributes["longitude"] == 20

--- a/tests/components/mobile_app/test_entity.py
+++ b/tests/components/mobile_app/test_entity.py
@@ -36,7 +36,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert json == {"success": True}
     await hass.async_block_till_done()
 
-    entity = hass.states.get("sensor.test_1_battery_state")
+    entity = hass.states.get("sensor.test_clear_battery_state")
     assert entity is not None
 
     assert entity.attributes["device_class"] == "battery"
@@ -44,7 +44,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert entity.attributes["unit_of_measurement"] == UNIT_PERCENTAGE
     assert entity.attributes["foo"] == "bar"
     assert entity.domain == "sensor"
-    assert entity.name == "Test 1 Battery State"
+    assert entity.name == "Test Clear Battery State"
     assert entity.state == "100"
 
     update_resp = await webhook_client.post(
@@ -69,7 +69,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     json = await update_resp.json()
     assert json["invalid_state"]["success"] is False
 
-    updated_entity = hass.states.get("sensor.test_1_battery_state")
+    updated_entity = hass.states.get("sensor.test_clear_battery_state")
     assert updated_entity.state == "123"
 
     dev_reg = await device_registry.async_get_registry(hass)
@@ -124,7 +124,7 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
 
     assert "Re-register existing sensor" not in caplog.text
 
-    entity = hass.states.get("sensor.test_1_battery_state")
+    entity = hass.states.get("sensor.test_clear_battery_state")
     assert entity is not None
 
     assert entity.attributes["device_class"] == "battery"
@@ -132,7 +132,7 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
     assert entity.attributes["unit_of_measurement"] == UNIT_PERCENTAGE
     assert entity.attributes["foo"] == "bar"
     assert entity.domain == "sensor"
-    assert entity.name == "Test 1 Battery State"
+    assert entity.name == "Test Clear Battery State"
     assert entity.state == "100"
 
     payload["data"]["state"] = 99
@@ -145,7 +145,7 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
 
     assert "Re-register existing sensor" in caplog.text
 
-    entity = hass.states.get("sensor.test_1_battery_state")
+    entity = hass.states.get("sensor.test_clear_battery_state")
     assert entity is not None
 
     assert entity.attributes["device_class"] == "battery"
@@ -153,7 +153,7 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
     assert entity.attributes["unit_of_measurement"] == UNIT_PERCENTAGE
     assert entity.attributes["foo"] == "bar"
     assert entity.domain == "sensor"
-    assert entity.name == "Test 1 Battery State"
+    assert entity.name == "Test Clear Battery State"
     assert entity.state == "99"
 
 
@@ -181,11 +181,11 @@ async def test_register_sensor_no_state(hass, create_registrations, webhook_clie
     assert json == {"success": True}
     await hass.async_block_till_done()
 
-    entity = hass.states.get("sensor.test_1_battery_state")
+    entity = hass.states.get("sensor.test_clear_battery_state")
     assert entity is not None
 
     assert entity.domain == "sensor"
-    assert entity.name == "Test 1 Battery State"
+    assert entity.name == "Test Clear Battery State"
     assert entity.state == STATE_UNKNOWN
 
     reg_resp = await webhook_client.post(
@@ -206,11 +206,11 @@ async def test_register_sensor_no_state(hass, create_registrations, webhook_clie
     assert json == {"success": True}
     await hass.async_block_till_done()
 
-    entity = hass.states.get("sensor.test_1_backup_battery_state")
+    entity = hass.states.get("sensor.test_clear_backup_battery_state")
     assert entity
 
     assert entity.domain == "sensor"
-    assert entity.name == "Test 1 Backup Battery State"
+    assert entity.name == "Test Clear Backup Battery State"
     assert entity.state == STATE_UNKNOWN
 
 
@@ -238,7 +238,7 @@ async def test_update_sensor_no_state(hass, create_registrations, webhook_client
     assert json == {"success": True}
     await hass.async_block_till_done()
 
-    entity = hass.states.get("sensor.test_1_battery_state")
+    entity = hass.states.get("sensor.test_clear_battery_state")
     assert entity is not None
     assert entity.state == "100"
 
@@ -255,5 +255,5 @@ async def test_update_sensor_no_state(hass, create_registrations, webhook_client
     json = await update_resp.json()
     assert json == {"battery_state": {"success": True}}
 
-    updated_entity = hass.states.get("sensor.test_1_battery_state")
+    updated_entity = hass.states.get("sensor.test_clear_battery_state")
     assert updated_entity.state == STATE_UNKNOWN

--- a/tests/components/mobile_app/test_http_api.py
+++ b/tests/components/mobile_app/test_http_api.py
@@ -1,6 +1,5 @@
 """Tests for the mobile_app HTTP API."""
 import json
-from unittest.mock import patch
 
 import pytest
 
@@ -15,7 +14,7 @@ from .const import (
     RENDER_TEMPLATE,
 )
 
-from tests.common import mock_coro
+from tests.async_mock import patch
 
 
 async def test_registration(hass, hass_client, hass_admin_user):
@@ -25,9 +24,7 @@ async def test_registration(hass, hass_client, hass_admin_user):
     api_client = await hass_client()
 
     with patch(
-        "homeassistant.components.person.async_add_user_device_tracker",
-        spec=True,
-        return_value=mock_coro(),
+        "homeassistant.components.person.async_add_user_device_tracker"
     ) as add_user_dev_track:
         resp = await api_client.post(
             "/api/mobile_app/registrations", json=REGISTER_CLEARTEXT
@@ -115,9 +112,7 @@ async def test_duplicate_device_name(hass, hass_client, hass_admin_user):
 
     # Register first device
     with patch(
-        "homeassistant.components.person.async_add_user_device_tracker",
-        spec=True,
-        return_value=mock_coro(),
+        "homeassistant.components.person.async_add_user_device_tracker"
     ) as add_user_dev_track:
         resp = await api_client.post(
             "/api/mobile_app/registrations", json=REGISTER_CLEARTEXT
@@ -130,9 +125,7 @@ async def test_duplicate_device_name(hass, hass_client, hass_admin_user):
 
     # Register second device with same name
     with patch(
-        "homeassistant.components.person.async_add_user_device_tracker",
-        spec=True,
-        return_value=mock_coro(),
+        "homeassistant.components.person.async_add_user_device_tracker"
     ) as add_user_dev_track:
         resp = await api_client.post(
             "/api/mobile_app/registrations", json=REGISTER_CLEARTEXT_DUPLICATE_NAME


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**TL;DR**: Mobile app notify services require unique device name within the mobile app domain in the device registry and also can be changed by changing the device name on the device. This causes possible errors setting up duplicate services. Here ensure device name is unique at time of registration and isn't changed.

Currently if a user tries to register two (or more) devices with the same device name (commonly "iPhone"), a notify.mobile_app... service cannot be created for the second device due to the duplicate and the user will see a error of the form:

```
WARNING (MainThread) [homeassistant.components.mobile_app.notify] Found duplicate device name iPhone
Previously we have handled these issues by asking users to change their device's names. This doesn't feel ideal and in some edge cases is not possible.
```

This handles the problem by checking the device name is unique at time of registration and appended a suffix if needed. I.e. our devices would be "iPhone" and "iPhone_2". It also makes sure that the device name remains unique and unchanged for the lifetime of the registration. Currently if the device name is changed by the user at some time after registration, the Device Name in the Device Register will change and the the `notify.mobile_app...` service will be changed on the next restart of Home Assistant. This is not ideal as we end up with a mismatch between the device name/notify service and sensor ID's which use the device name at registration and don't update. To address this we ensure that the device name supplied on a `update_registration` webhook matches the name we settled on at registration and if it doesn't we substitute for the registered name. This avoids potential breaking changes to notification automatons when a user can't control device name or if `slugify` substitutions ever change.  Users can always force the name to be changed by re installing app.

This also has the bonus of moving the suffix to the device name part of sensor ID and including it in the sensor name. Previously we would have for example for the first device: `sensor.iphone_battery` names "iPhone Battery" and for the second device we would have `sensor.iphone_battery_2` but also named "iPhone Battery". With this fix, the first device's IDs and names stay the same and the second would become `sensor.iphone_2_battery` with name "iPhone_2 Battery". Obviously all of this only applies to new registrations.

I've added tests to cover duplicate device names and also refined the existing tests which caused unneed duplicates

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34950, fixes home-assistant/iOS#415
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
