### PR TITLE
Fix Plex when using local tokenless authentication 

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -161,12 +161,20 @@ async def async_setup_entry(hass, entry):
         }
     )
 
-    hass.services.async_register(
-        PLEX_DOMAIN,
-        SERVICE_PLAY_ON_SONOS,
-        async_play_on_sonos_service,
-        schema=play_on_sonos_schema,
-    )
+    def get_plex_account(plex_server):
+        try:
+            return plex_server.account
+        except plexapi.exceptions.Unauthorized:
+            return None
+
+    plex_account = await hass.async_add_executor_job(get_plex_account, plex_server)
+    if plex_account:
+        hass.services.async_register(
+            PLEX_DOMAIN,
+            SERVICE_PLAY_ON_SONOS,
+            async_play_on_sonos_service,
+            schema=play_on_sonos_schema,
+        )
 
     return True
 

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -76,7 +76,7 @@ class PlexServer:
         self._plextv_clients = None
         self._plextv_client_timestamp = 0
         self._plextv_device_cache = {}
-        self._use_plex_tv = True
+        self._use_plex_tv = self._token is not None
         self._version = None
         self.async_update_platforms = Debouncer(
             hass,
@@ -95,7 +95,7 @@ class PlexServer:
     @property
     def account(self):
         """Return a MyPlexAccount instance."""
-        if not self._plex_account and self._token and self._use_plex_tv:
+        if not self._plex_account and self._use_plex_tv:
             try:
                 self._plex_account = plexapi.myplex.MyPlexAccount(token=self._token)
             except Unauthorized:

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -168,8 +168,9 @@ class PlexServer:
                 self._plex_server = self.account.resource(matching_servers[0]).connect(
                     timeout=10
                 )
-            else:
-                _LOGGER.error("Attempt to update plex.direct hostname failed")
+                return True
+            _LOGGER.error("Attempt to update plex.direct hostname failed")
+            return False
 
         if self._url:
             try:
@@ -185,8 +186,8 @@ class PlexServer:
                         _LOGGER.warning(
                             "Plex SSL certificate's hostname changed, updating."
                         )
-                        _update_plexdirect_hostname()
-                        config_entry_update_needed = True
+                        if _update_plexdirect_hostname():
+                            config_entry_update_needed = True
                     else:
                         raise
                 else:

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -367,8 +367,8 @@ async def test_option_flow(hass):
     )
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ) as mock_listen:
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen") as mock_listen:
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -417,8 +417,8 @@ async def test_missing_option_flow(hass):
     )
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ) as mock_listen:
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen") as mock_listen:
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -471,8 +471,8 @@ async def test_option_flow_new_users_available(hass, caplog):
     mock_plex_server = MockPlexServer(config_entry=entry)
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -741,6 +741,8 @@ async def test_setup_with_limited_credentials(hass):
     ), patch.object(
         mock_plex_server, "systemAccounts", side_effect=plexapi.exceptions.Unauthorized
     ) as mock_accounts, patch(
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch(
         "homeassistant.components.plex.PlexWebsocket.listen"
     ) as mock_listen:
         entry.add_to_hass(hass)

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import (
     ENTRY_STATE_SETUP_ERROR,
     ENTRY_STATE_SETUP_RETRY,
 )
-from homeassistant.const import CONF_URL, CONF_VERIFY_SSL
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 import homeassistant.util.dt as dt_util
 
@@ -115,8 +115,8 @@ async def test_set_config_entry_unique_id(hass):
     )
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ) as mock_listen:
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen") as mock_listen:
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -181,8 +181,8 @@ async def test_setup_with_insecure_config_entry(hass):
     )
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ) as mock_listen:
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen") as mock_listen:
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -210,8 +210,8 @@ async def test_unload_config_entry(hass):
     assert entry is config_entries[0]
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ) as mock_listen:
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen") as mock_listen:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         assert mock_listen.called
@@ -243,8 +243,8 @@ async def test_setup_with_photo_session(hass):
     )
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -254,11 +254,8 @@ async def test_setup_with_photo_session(hass):
 
     server_id = mock_plex_server.machineIdentifier
 
-    with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()):
-        async_dispatcher_send(
-            hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id)
-        )
-        await hass.async_block_till_done()
+    async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
 
     media_player = hass.states.get("media_player.plex_product_title")
     assert media_player.state == "idle"
@@ -293,10 +290,33 @@ async def test_setup_when_certificate_changed(hass):
 
     new_entry = MockConfigEntry(domain=const.DOMAIN, data=DEFAULT_DATA)
 
+    # Test with account failure
+    with patch(
+        "plexapi.server.PlexServer", side_effect=WrongCertHostnameException
+    ), patch(
+        "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
+    ):
+        old_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(old_entry.entry_id) is False
+        await hass.async_block_till_done()
+
+    assert old_entry.state == ENTRY_STATE_SETUP_ERROR
+    await hass.config_entries.async_unload(old_entry.entry_id)
+
+    # Test with no servers found
+    with patch(
+        "plexapi.server.PlexServer", side_effect=WrongCertHostnameException
+    ), patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount(servers=0)):
+        assert await hass.config_entries.async_setup(old_entry.entry_id) is False
+        await hass.async_block_till_done()
+
+    assert old_entry.state == ENTRY_STATE_SETUP_ERROR
+    await hass.config_entries.async_unload(old_entry.entry_id)
+
+    # Test with success
     with patch(
         "plexapi.server.PlexServer", side_effect=WrongCertHostnameException
     ), patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()):
-        old_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(old_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -307,3 +327,32 @@ async def test_setup_when_certificate_changed(hass):
         old_entry.data[const.PLEX_SERVER_CONFIG][CONF_URL]
         == new_entry.data[const.PLEX_SERVER_CONFIG][CONF_URL]
     )
+
+
+async def test_tokenless_server(hass):
+    """Test setup with a server with token auth disabled."""
+    mock_plex_server = MockPlexServer()
+
+    TOKENLESS_DATA = copy.deepcopy(DEFAULT_DATA)
+    TOKENLESS_DATA[const.PLEX_SERVER_CONFIG].pop(CONF_TOKEN, None)
+
+    entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        data=TOKENLESS_DATA,
+        options=DEFAULT_OPTIONS,
+        unique_id=DEFAULT_DATA["server_id"],
+    )
+
+    with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
+        "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state == ENTRY_STATE_LOADED
+
+    server_id = mock_plex_server.machineIdentifier
+
+    async_dispatcher_send(hass, const.PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()

--- a/tests/components/plex/test_media_players.py
+++ b/tests/components/plex/test_media_players.py
@@ -23,8 +23,8 @@ async def test_plex_tv_clients(hass):
     mock_plex_account = MockPlexAccount()
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=mock_plex_account
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -37,9 +37,7 @@ async def test_plex_tv_clients(hass):
         for x in mock_plex_account.resources()
         if x.name.startswith("plex.tv Resource Player")
     )
-    with patch(
-        "plexapi.myplex.MyPlexAccount", return_value=mock_plex_account
-    ), patch.object(resource, "connect", side_effect=NotFound):
+    with patch.object(resource, "connect", side_effect=NotFound):
         await plex_server._async_update_platforms()
         await hass.async_block_till_done()
 
@@ -49,16 +47,15 @@ async def test_plex_tv_clients(hass):
     await hass.config_entries.async_unload(entry.entry_id)
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=mock_plex_account
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
-    with patch("plexapi.myplex.MyPlexAccount", return_value=mock_plex_account):
-        await plex_server._async_update_platforms()
-        await hass.async_block_till_done()
+    await plex_server._async_update_platforms()
+    await hass.async_block_till_done()
 
     media_players_after = len(hass.states.async_entity_ids("media_player"))
     assert media_players_after == media_players_before + 1
@@ -70,22 +67,20 @@ async def test_plex_tv_clients(hass):
     mock_plex_server.clear_sessions()
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=mock_plex_account
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
-    with patch("plexapi.myplex.MyPlexAccount", return_value=mock_plex_account):
-        await plex_server._async_update_platforms()
-        await hass.async_block_till_done()
+    await plex_server._async_update_platforms()
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids("media_player")) == 1
 
     # Ensure cache gets called
-    with patch("plexapi.myplex.MyPlexAccount", return_value=mock_plex_account):
-        await plex_server._async_update_platforms()
-        await hass.async_block_till_done()
+    await plex_server._async_update_platforms()
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids("media_player")) == 1

--- a/tests/components/plex/test_playback.py
+++ b/tests/components/plex/test_playback.py
@@ -28,18 +28,14 @@ async def test_sonos_playback(hass):
     mock_plex_server = MockPlexServer(config_entry=entry)
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     server_id = mock_plex_server.machineIdentifier
     loaded_server = hass.data[DOMAIN][SERVERS][server_id]
-
-    with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()):
-        # Access and cache PlexAccount
-        assert loaded_server.account
 
     # Test Sonos integration lookup failure
     with patch.object(

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -55,17 +55,16 @@ async def test_new_users_available(hass):
     mock_plex_server = MockPlexServer(config_entry=entry)
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     server_id = mock_plex_server.machineIdentifier
 
-    with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()):
-        async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-        await hass.async_block_till_done()
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
 
@@ -95,17 +94,16 @@ async def test_new_ignored_users_available(hass, caplog):
     mock_plex_server = MockPlexServer(config_entry=entry)
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     server_id = mock_plex_server.machineIdentifier
 
-    with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()):
-        async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-        await hass.async_block_till_done()
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
 
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
 
@@ -248,17 +246,16 @@ async def test_ignore_plex_web_client(hass):
     mock_plex_server = MockPlexServer(config_entry=entry)
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount(players=0)
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     server_id = mock_plex_server.machineIdentifier
 
-    with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount(players=0)):
-        async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-        await hass.async_block_till_done()
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
 
     sensor = hass.states.get("sensor.plex_plex_server_1")
     assert sensor.state == str(len(mock_plex_server.accounts))
@@ -281,8 +278,8 @@ async def test_media_lookups(hass):
     mock_plex_server = MockPlexServer(config_entry=entry)
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "homeassistant.components.plex.PlexWebsocket.listen"
-    ):
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -291,9 +288,9 @@ async def test_media_lookups(hass):
     loaded_server = hass.data[DOMAIN][SERVERS][server_id]
 
     # Plex Key searches
-    with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()):
-        async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-        await hass.async_block_till_done()
+    async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    await hass.async_block_till_done()
+
     media_player_id = hass.states.async_entity_ids("media_player")[0]
     with patch("homeassistant.components.plex.PlexServer.create_playqueue"):
         assert await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
An additional call which requires a valid Plex token was added in #36857. For users that rely on local tokenless authentication (by allowed IP address) this could cause problems during setup. This PR adds additional guards when this situation is detected.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #36857
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
