### PR TITLE
Move logbook continuous domain filtering to sql

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import time
 
+import sqlalchemy
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import aliased
 import voluptuous as vol
@@ -28,7 +29,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_NAME,
-    ATTR_UNIT_OF_MEASUREMENT,
     CONF_EXCLUDE,
     CONF_INCLUDE,
     EVENT_HOMEASSISTANT_START,
@@ -66,6 +66,8 @@ DOMAIN = "logbook"
 GROUP_BY_MINUTES = 15
 
 EMPTY_JSON_OBJECT = "{}"
+UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
+
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA}, extra=vol.ALLOW_EXTRA
 )
@@ -414,6 +416,19 @@ def _get_events(hass, config, start_day, end_day, entity_id=None):
                     & (States.state != old_state.state)
                 )
             )
+            #
+            # Prefilter out continuous domains that have
+            # ATTR_UNIT_OF_MEASUREMENT as its much faster in sql.
+            #
+            .filter(
+                (Events.event_type != EVENT_STATE_CHANGED)
+                | (
+                    sqlalchemy.not_(States.domain.in_(CONTINUOUS_DOMAINS))
+                    | sqlalchemy.not_(
+                        States.attributes.contains(UNIT_OF_MEASUREMENT_JSON)
+                    )
+                )
+            )
             .filter(
                 Events.event_type.in_(ALL_EVENT_TYPES + list(hass.data.get(DOMAIN, {})))
             )
@@ -448,12 +463,6 @@ def _keep_event(hass, event, entities_filter, entity_attr_cache):
         # Do not report on new entities
         # Do not report on entity removal
         if not event.has_old_and_new_state:
-            return False
-
-        if event.domain in CONTINUOUS_DOMAINS and entity_attr_cache.get(
-            entity_id, ATTR_UNIT_OF_MEASUREMENT, event
-        ):
-            # Don't show continuous sensor value changes in the logbook
             return False
     elif event.event_type in HOMEASSISTANT_EVENTS:
         entity_id = f"{HA_DOMAIN}."

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -422,12 +422,8 @@ def _get_events(hass, config, start_day, end_day, entity_id=None):
             #
             .filter(
                 (Events.event_type != EVENT_STATE_CHANGED)
-                | (
-                    sqlalchemy.not_(States.domain.in_(CONTINUOUS_DOMAINS))
-                    | sqlalchemy.not_(
-                        States.attributes.contains(UNIT_OF_MEASUREMENT_JSON)
-                    )
-                )
+                | sqlalchemy.not_(States.domain.in_(CONTINUOUS_DOMAINS))
+                | sqlalchemy.not_(States.attributes.contains(UNIT_OF_MEASUREMENT_JSON))
             )
             .filter(
                 Events.event_type.in_(ALL_EVENT_TYPES + list(hass.data.get(DOMAIN, {})))


### PR DESCRIPTION
For cherry-picking see https://github.com/home-assistant/core/pull/37395#issuecomment-653760793

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previous PRs were optimizing for 3 hour and 1 day chunks.

This merge focused on larger queries: Test query is one week of logbook 

Before 6.28s
After 2.85s

Sensors tend to generate a significant amount of states
that are filtered out by logbook.  In testing 75% of
states can be filtered away in sql to avoid the
sqlalchemy ORM overhead of creating objects that will
be discarded.

The speed up is smaller.. ~35% for the 3hr/1d chunks because the overhead of the sql session and api call itself can't be decreased.  For longer time frames the speedup is 50-60%



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
