### PR TITLE
Fix recorder purging by batch processing purges

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -64,7 +64,7 @@ class Events(Base):  # type: ignore
             context_parent_id=event.context.parent_id,
         )
 
-    def to_native(self):
+    def to_native(self, validate_entity_id=True):
         """Convert to a natve HA Event."""
         context = Context(
             id=self.context_id,
@@ -183,7 +183,7 @@ class RecorderRuns(Base):  # type: ignore
 
         return [row[0] for row in query]
 
-    def to_native(self):
+    def to_native(self, validate_entity_id=True):
         """Return self, native format is this model."""
         return self
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -54,16 +54,15 @@ def purge_old_data(instance, purge_days: int, repack: bool) -> bool:
             )
             _LOGGER.debug("Deleted %s events", deleted_rows_events)
 
-        # If states or events purging isn't processing the purge_before yet,
-        # return false, as we are not done yet.
-        if (states_purge_before and states_purge_before != purge_before) or (
-            events_purge_before and events_purge_before != purge_before
-        ):
-            _LOGGER.debug("Purging hasn't fully completed yet.")
-            return False
+            # If states or events purging isn't processing the purge_before yet,
+            # return false, as we are not done yet.
+            if (states_purge_before and states_purge_before != purge_before) or (
+                events_purge_before and events_purge_before != purge_before
+            ):
+                _LOGGER.debug("Purging hasn't fully completed yet.")
+                return False
 
-        # Recorder runs is small, no need to batch run it
-        with session_scope(session=instance.get_session()) as session:
+            # Recorder runs is small, no need to batch run it
             deleted_rows = (
                 session.query(RecorderRuns)
                 .filter(RecorderRuns.start < purge_before)

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -7,32 +7,63 @@ from sqlalchemy.exc import SQLAlchemyError
 import homeassistant.util.dt as dt_util
 
 from .models import Events, RecorderRuns, States
-from .util import session_scope
+from .util import execute, session_scope
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def purge_old_data(instance, purge_days, repack):
-    """Purge events and states older than purge_days ago."""
+def purge_old_data(instance, purge_days: int, repack: bool) -> bool:
+    """Purge events and states older than purge_days ago.
+
+    Cleans up an timeframe of an hour, based on the oldest record.
+    """
     purge_before = dt_util.utcnow() - timedelta(days=purge_days)
     _LOGGER.debug("Purging events before %s", purge_before)
 
     try:
         with session_scope(session=instance.get_session()) as session:
-            deleted_rows = (
+            query = session.query(States).order_by(States.last_updated.asc()).limit(1)
+            states = execute(query, to_native=True, validate_entity_ids=False)
+
+            states_purge_before = purge_before
+            if states:
+                states_purge_before = min(
+                    purge_before, states[0].last_updated + timedelta(hours=1)
+                )
+
+            deleted_rows_states = (
                 session.query(States)
-                .filter(States.last_updated < purge_before)
+                .filter(States.last_updated < states_purge_before)
                 .delete(synchronize_session=False)
             )
-            _LOGGER.debug("Deleted %s states", deleted_rows)
+            _LOGGER.debug("Deleted %s states", deleted_rows_states)
 
-            deleted_rows = (
+            query = session.query(Events).order_by(Events.time_fired.asc()).limit(1)
+            events = execute(query, to_native=True)
+
+            events_purge_before = purge_before
+            if events:
+                events_purge_before = min(
+                    purge_before, events[0].time_fired + timedelta(hours=1)
+                )
+
+            deleted_rows_events = (
                 session.query(Events)
-                .filter(Events.time_fired < purge_before)
+                .filter(Events.time_fired < events_purge_before)
                 .delete(synchronize_session=False)
             )
-            _LOGGER.debug("Deleted %s events", deleted_rows)
+            _LOGGER.debug("Deleted %s events", deleted_rows_events)
 
+        # If states or events purging isn't processing the purge_before yet,
+        # return false, as we are not done yet.
+        if (states_purge_before and states_purge_before != purge_before) or (
+            events_purge_before and events_purge_before != purge_before
+        ):
+            _LOGGER.debug("Purging hasn't fully completed yet.")
+            return False
+
+        # Recorder runs is small, no need to batch run it
+        with session_scope(session=instance.get_session()) as session:
             deleted_rows = (
                 session.query(RecorderRuns)
                 .filter(RecorderRuns.start < purge_before)
@@ -52,3 +83,5 @@ def purge_old_data(instance, purge_days, repack):
 
     except SQLAlchemyError as err:
         _LOGGER.warning("Error purging history: %s.", err)
+
+    return True

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -317,7 +317,7 @@ def test_auto_purge(hass_recorder):
     test_time = tz.localize(datetime(2020, 1, 1, 4, 12, 0))
 
     with patch(
-        "homeassistant.components.recorder.purge.purge_old_data"
+        "homeassistant.components.recorder.purge.purge_old_data", return_value=True
     ) as purge_old_data:
         for delta in (-1, 0, 1):
             hass.bus.fire(

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -130,9 +130,16 @@ class TestRecorderPurge(unittest.TestCase):
             assert states.count() == 6
 
             # run purge_old_data()
-            purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            finished = purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            assert not finished
+            assert states.count() == 4
 
-            # we should only have 2 states left after purging
+            finished = purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            assert not finished
+            assert states.count() == 2
+
+            finished = purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            assert finished
             assert states.count() == 2
 
     def test_purge_old_events(self):
@@ -144,9 +151,17 @@ class TestRecorderPurge(unittest.TestCase):
             assert events.count() == 6
 
             # run purge_old_data()
-            purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            finished = purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            assert not finished
+            assert events.count() == 4
+
+            finished = purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            assert not finished
+            assert events.count() == 2
 
             # we should only have 2 events left
+            finished = purge_old_data(self.hass.data[DATA_INSTANCE], 4, repack=False)
+            assert finished
             assert events.count() == 2
 
     def test_purge_method(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

During the beta of 0.112, I've noticed the migration took a long time. Problem: My database is huge!

My huge database wasn't personal choice, but due to the way, we handle purges. In my case, I run MariaDB as the database server for the Home Assistant recorder.

The delete queries produced by SQLAlchemy are highly inefficient for the Home Assistant database on MariaDB and can run a long time. In my case, the purge never finishes. Result: The database just keeps growing until I run out of disk space.

Besides that, it causes database locking issues. This I've also experienced, but actually always ignored.

This PR implements batch processing when purging. It finds the oldest record, and starts purging with an offset of 1 hour from that record until the keep_days is reached.

Each batch is enqueued, which prevents issues with locking as well. During the purge process, the queue will be processed as normal.

Downsides: Purging takes longer, but isn't intrusive, blocking or problematic.

PS: I've tested this with batches of 10.000 records, however, SQLAlchemy doesn't support limits on deletes statements. I tried it using a limit on a subquery, but this isn't supported by MariaDB. This solution implemented in this PR might be slightly less elegant but is fully compatible with all databases we support.


![image](https://user-images.githubusercontent.com/195327/85870575-79ed6080-b7cd-11ea-84e8-edfda099e41c.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR **might** fix or close issue: #35241
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
