### PR TITLE
Catch additional exception for Plex account login failures

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -164,7 +164,7 @@ async def async_setup_entry(hass, entry):
     def get_plex_account(plex_server):
         try:
             return plex_server.account
-        except plexapi.exceptions.Unauthorized:
+        except (plexapi.exceptions.BadRequest, plexapi.exceptions.Unauthorized):
             return None
 
     plex_account = await hass.async_add_executor_job(get_plex_account, plex_server)

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -4,7 +4,7 @@ import ssl
 import time
 from urllib.parse import urlparse
 
-from plexapi.exceptions import NotFound, Unauthorized
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 import plexapi.myplex
 import plexapi.playqueue
 import plexapi.server
@@ -98,7 +98,7 @@ class PlexServer:
         if not self._plex_account and self._use_plex_tv:
             try:
                 self._plex_account = plexapi.myplex.MyPlexAccount(token=self._token)
-            except Unauthorized:
+            except (BadRequest, Unauthorized):
                 self._use_plex_tv = False
                 _LOGGER.error("Not authorized to access plex.tv with provided token")
                 raise


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The fix for handling unauthenticated Plex servers in #37096 was incomplete as the Plex endpoints sometimes return unexpected HTTP error codes. This PR catches a 'fallback' exception for those instances.

Example traceback:
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 220, in async_setup
    hass, self
  File "/usr/src/homeassistant/homeassistant/components/plex/__init__.py", line 170, in async_setup_entry
    plex_account = await hass.async_add_executor_job(get_plex_account, plex_server)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/plex/__init__.py", line 166, in get_plex_account
    return plex_server.account
  File "/usr/src/homeassistant/homeassistant/components/plex/server.py", line 100, in account
    self._plex_account = plexapi.myplex.MyPlexAccount(token=self._token)
  File "/usr/local/lib/python3.7/site-packages/plexapi/myplex.py", line 94, in __init__
    data, initpath = self._signin(username, password, timeout)
  File "/usr/local/lib/python3.7/site-packages/plexapi/myplex.py", line 99, in _signin
    return self.query(self.key), self.key
  File "/usr/local/lib/python3.7/site-packages/plexapi/myplex.py", line 195, in query
    raise BadRequest(message)
plexapi.exceptions.BadRequest: (422) unprocessable_entity; https://plex.tv/users/account <?xml version="1.0" encoding="UTF-8"?> <errors>   <error>Invalid token</error> </errors>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
