### PR TITLE
Add prometheus metric naming guidelines

### DIFF
--- a/homeassistant/components/prometheus/README.md
+++ b/homeassistant/components/prometheus/README.md
@@ -9,7 +9,7 @@ Please follow these guidelines while defining metrics.
 * Metric and label names should conform to [Prometheus
   naming guidelines](https://prometheus.io/docs/practices/naming/).
 * Domain-specific metrics should have the domain (`sensor`, `switch`,
-  `climate`, etc) as a metric name prefix.
+  `climate`, etc.) as a metric name prefix.
 * Enum-like values (e.g. entity state or current mode) should be exported using
   a "boolean" metric (values of 0 or 1) broken down by state/mode (as a metric
   label).

--- a/homeassistant/components/prometheus/README.md
+++ b/homeassistant/components/prometheus/README.md
@@ -1,0 +1,15 @@
+# Prometheus integration
+
+This integration exposes metrics in a Prometheus compatible format.
+
+## Metric naming guidelines
+
+Please follow these guidelines while defining metrics.
+
+* Metric and label names should conform to [Prometheus
+  naming guidelines](https://prometheus.io/docs/practices/naming/).
+* Domain-specific metrics should have the domain (`sensor`, `switch`,
+  `climate`, etc) as a metric name prefix.
+* Enum-like values (e.g. entity state or current mode) should be exported using
+  a "boolean" metric (values of 0 or 1) broken down by state/mode (as a metric
+  label).


### PR DESCRIPTION
## Proposed change

Document prometheus metric naming guidelines as discussed in
https://github.com/home-assistant/architecture/issues/391

cc @mweinelt 

## Type of change

Documentation change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests