### PR TITLE
Attempt to set unique id of rfxtrx device

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -409,6 +409,11 @@ class RfxtrxDevice(Entity):
         """Return true if unable to access real state of entity."""
         return True
 
+    @property
+    def unique_id(self):
+        """Return unique identifier of remote device."""
+        return f"{slugify(self._event.device.type_string.lower())}_{slugify(self._event.device.id_string.lower())}"
+
     def turn_off(self, **kwargs):
         """Turn the device off."""
         self._send_command("turn_off")

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -378,6 +378,7 @@ class RfxtrxDevice(Entity):
         self._state = datas[ATTR_STATE]
         self._should_fire_event = datas[ATTR_FIRE_EVENT]
         self._brightness = 0
+        self._unique_id = f"{slugify(self._event.device.type_string.lower())}_{slugify(self._event.device.id_string.lower())}"
         self.added_to_hass = False
 
     async def async_added_to_hass(self):
@@ -412,7 +413,7 @@ class RfxtrxDevice(Entity):
     @property
     def unique_id(self):
         """Return unique identifier of remote device."""
-        return f"{slugify(self._event.device.type_string.lower())}_{slugify(self._event.device.id_string.lower())}"
+        return self._unique_id
 
     def turn_off(self, **kwargs):
         """Turn the device off."""

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -255,6 +255,11 @@ class RfxtrxBinarySensor(BinarySensorEntity):
         """Return true if the sensor state is True."""
         return self._state
 
+    @property
+    def unique_id(self):
+        """Return unique identifier of remote device."""
+        return f"{slugify(self.event.device.type_string.lower())}_{slugify(self.event.device.id_string.lower())}"
+
     def apply_cmd(self, cmd):
         """Apply a command for updating the state."""
         if cmd == self.cmd_on:

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -197,6 +197,7 @@ class RfxtrxBinarySensor(BinarySensorEntity):
         self._data_bits = data_bits
         self._cmd_on = cmd_on
         self._cmd_off = cmd_off
+        self._unique_id = f"{slugify(self.event.device.type_string.lower())}_{slugify(self.event.device.id_string.lower())}"
 
         if data_bits is not None:
             self._masked_id = get_pt2262_deviceid(
@@ -258,7 +259,7 @@ class RfxtrxBinarySensor(BinarySensorEntity):
     @property
     def unique_id(self):
         """Return unique identifier of remote device."""
-        return f"{slugify(self.event.device.type_string.lower())}_{slugify(self.event.device.id_string.lower())}"
+        return self._unique_id
 
     def apply_cmd(self, cmd):
         """Apply a command for updating the state."""

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -155,3 +155,8 @@ class RfxtrxSensor(Entity):
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return self._unit_of_measurement
+
+    @property
+    def unique_id(self):
+        """Return unique identifier of remote device."""
+        return f"{slugify(self.event.device.type_string.lower())}_{slugify(self.event.device.id_string.lower())}_{slugify(self.data_type)}"

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -127,6 +127,7 @@ class RfxtrxSensor(Entity):
         self.should_fire_event = should_fire_event
         self.data_type = data_type
         self._unit_of_measurement = DATA_TYPES.get(data_type, "")
+        self._unique_id = f"{slugify(self.event.device.type_string.lower())}_{slugify(self.event.device.id_string.lower())}_{slugify(self.data_type)}"
 
     def __str__(self):
         """Return the name of the sensor."""
@@ -159,4 +160,4 @@ class RfxtrxSensor(Entity):
     @property
     def unique_id(self):
         """Return unique identifier of remote device."""
-        return f"{slugify(self.event.device.type_string.lower())}_{slugify(self.event.device.id_string.lower())}_{slugify(self.data_type)}"
+        return self._unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Let rfxtrx devices set a unique id.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

rfxtrx:
  device: /dev/bla
  dummy: true
  debug: true

switch:
  platform: rfxtrx
  automatic_add: true

light:
  platform: rfxtrx
  automatic_add: true

sensor:
  platform: rfxtrx
  automatic_add: true

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
