### PR TITLE
Re-add ability to use remote files (by URL) in Slack messages

### DIFF
--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -105,7 +105,7 @@ async def _async_get_remote_file_contents(hass, url, *, username=None, password=
     session = aiohttp_client.async_get_clientsession(hass)
 
     kwargs = {}
-    if username and password:
+    if username and password is not None:
         kwargs = {"auth": BasicAuth(username, password=password)}
 
     async with session.request("get", url, **kwargs) as resp:

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -154,7 +154,12 @@ class SlackNotificationService(BaseNotificationService):
     async def _async_send_remote_file_message(
         self, url, targets, message, title, *, username=None, password=None
     ):
-        """Upload a remote file (with message) to Slack."""
+        """Upload a remote file (with message) to Slack.
+
+        Note that we bypass the python-slackclient WebClient and use aiohttp directly,
+        as the former would require us to download the entire remote file into memory
+        first before uploadint it to Slack.
+        """
         if not self._hass.config.is_allowed_external_url(url):
             _LOGGER.error("URL is not allowed: %s", url)
             return

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -147,6 +147,12 @@ class SlackNotificationService(BaseNotificationService):
         )
 
         if ATTR_FILE in data:
+            if not self.hass.config.is_allowed_path(data[ATTR_FILE]):
+                _LOGGER.error(
+                    "Filepath does not exist or is not allowed: %s", data[ATTR_FILE]
+                )
+                return
+
             return await self._async_send_local_file_message(
                 data[ATTR_FILE], targets, message, title
             )

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -158,7 +158,7 @@ class SlackNotificationService(BaseNotificationService):
 
         Note that we bypass the python-slackclient WebClient and use aiohttp directly,
         as the former would require us to download the entire remote file into memory
-        first before uploadint it to Slack.
+        first before uploading it to Slack.
         """
         if not self._hass.config.is_allowed_external_url(url):
             _LOGGER.error("URL is not allowed: %s", url)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The data schema for sending files in Slack messages has changed; be sure to update any Slack-related service calls with the new schema: https://www.home-assistant.io/integrations/slack

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Now that we can add remote URLs to an `is_allowed_external_url` configuration key, this PR re-adds the ability to upload remote files to Slack (which was removed https://github.com/home-assistant/core/pull/33287). The PR also adjusts the YAML used when sending any file (local or remote) to be clearer.

Note that while https://github.com/home-assistant/core/pull/33287 offered support for remote files using Basic Auth and Digest Auth, this PR only adds support for Basic Auth because `aiohttp` has yet to implemented a Digest Auth helper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13860

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
