### PR TITLE
Improve scalability of state change event routing

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -6,12 +6,13 @@ from typing import Dict
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.const import CONF_FOR, CONF_PLATFORM, EVENT_STATE_CHANGED, MATCH_ALL
+from homeassistant.const import CONF_FOR, CONF_PLATFORM, MATCH_ALL
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.event import (
     Event,
     async_track_same_state,
+    async_track_state_change_event,
     process_state_match,
 )
 
@@ -153,7 +154,7 @@ async def async_attach_trigger(
             hass, period[entity], call_action, _check_same_state, entity_ids=entity,
         )
 
-    unsub = hass.bus.async_listen(EVENT_STATE_CHANGED, state_automation_listener)
+    unsub = async_track_state_change_event(hass, entity_id, state_automation_listener)
 
     @callback
     def async_remove():

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -133,10 +133,7 @@ def async_track_state_change_event(
     do a fast dict lookup to route events.
     """
 
-    if TRACK_STATE_CHANGE_CALLBACKS not in hass.data:
-        hass.data[TRACK_STATE_CHANGE_CALLBACKS] = {}
-
-    entity_callbacks = hass.data[TRACK_STATE_CHANGE_CALLBACKS]
+    entity_callbacks = hass.data.setdefault(TRACK_STATE_CHANGE_CALLBACKS, {})
 
     if TRACK_STATE_CHANGE_LISTENER not in hass.data:
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1,7 +1,7 @@
 """Helpers for listening to events."""
 from datetime import datetime, timedelta
 import functools as ft
-from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Union, cast
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Union
 
 import attr
 
@@ -20,6 +20,9 @@ from homeassistant.helpers.template import Template
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
 from homeassistant.util.async_ import run_callback_threadsafe
+
+TRACK_STATE_CHANGE_CALLBACKS = "track_state_change_callbacks"
+TRACK_STATE_CHANGE_LISTENER = "track_state_change_listener"
 
 # PyLint does not like the use of threaded_listener_factory
 # pylint: disable=invalid-name
@@ -81,12 +84,6 @@ def async_track_state_change(
     @callback
     def state_change_listener(event: Event) -> None:
         """Handle specific state changes."""
-        if (
-            entity_ids != MATCH_ALL
-            and cast(str, event.data.get("entity_id")) not in entity_ids
-        ):
-            return
-
         old_state = event.data.get("old_state")
         if old_state is not None:
             old_state = old_state.state
@@ -103,10 +100,92 @@ def async_track_state_change(
                 event.data.get("new_state"),
             )
 
+    if entity_ids != MATCH_ALL:
+        # If we have a list of entity ids we use
+        # async_track_state_change_event to route
+        # by entity_id to avoid iterating though state change
+        # events and creating a jobs where the most
+        # common outcome is to return right away because
+        # the entity_id does not match since usually
+        # only one or two listeners want that specific
+        # entity_id.
+        return async_track_state_change_event(hass, entity_ids, state_change_listener)
+
     return hass.bus.async_listen(EVENT_STATE_CHANGED, state_change_listener)
 
 
 track_state_change = threaded_listener_factory(async_track_state_change)
+
+
+@bind_hass
+def async_track_state_change_event(
+    hass: HomeAssistant, entity_ids: Iterable[str], action: Callable[[Event], None]
+) -> Callable[[], None]:
+    """Track specific state change events indexed by entity_id.
+
+    Unlike async_track_state_change, async_track_state_change_event
+    passes the full event to the callback.
+
+    In order to avoid having to iterate a long list
+    of EVENT_STATE_CHANGED and fire and create a job
+    for each one, we keep a dict of entity ids that
+    care about the state change events so we can
+    do a fast dict lookup to route events.
+    """
+
+    if TRACK_STATE_CHANGE_CALLBACKS not in hass.data:
+        hass.data[TRACK_STATE_CHANGE_CALLBACKS] = {}
+
+    entity_callbacks = hass.data[TRACK_STATE_CHANGE_CALLBACKS]
+
+    if TRACK_STATE_CHANGE_LISTENER not in hass.data:
+
+        @callback
+        def _async_state_change_dispatcher(event: Event) -> None:
+            """Dispatch state changes by entity_id."""
+            entity_id = event.data.get("entity_id")
+
+            if entity_id not in entity_callbacks:
+                return
+
+            for action in entity_callbacks[entity_id]:
+                hass.async_run_job(action, event)
+
+        hass.data[TRACK_STATE_CHANGE_LISTENER] = hass.bus.async_listen(
+            EVENT_STATE_CHANGED, _async_state_change_dispatcher
+        )
+
+    entity_ids = [entity_id.lower() for entity_id in entity_ids]
+
+    for entity_id in entity_ids:
+        if entity_id not in entity_callbacks:
+            entity_callbacks[entity_id] = []
+
+        entity_callbacks[entity_id].append(action)
+
+    @callback
+    def remove_listener() -> None:
+        """Remove state change listener."""
+        _async_remove_state_change_listeners(hass, entity_ids, action)
+
+    return remove_listener
+
+
+@callback
+def _async_remove_state_change_listeners(
+    hass: HomeAssistant, entity_ids: Iterable[str], action: Callable[[Event], None]
+) -> None:
+    """Remove a listener."""
+    entity_callbacks = hass.data[TRACK_STATE_CHANGE_CALLBACKS]
+
+    for entity_id in entity_ids:
+        entity_callbacks[entity_id].remove(action)
+        if len(entity_callbacks[entity_id]) == 0:
+            del entity_callbacks[entity_id]
+
+    if not entity_callbacks:
+        hass.data[TRACK_STATE_CHANGE_LISTENER]()
+        del hass.data[TRACK_STATE_CHANGE_LISTENER]
 
 
 @callback

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -390,7 +390,7 @@ class TestComponentsGroup(unittest.TestCase):
             "group.second_group",
             "group.test_group",
         ]
-        assert self.hass.bus.listeners["state_changed"] == 3
+        assert self.hass.bus.listeners["state_changed"] == 1
 
         with patch(
             "homeassistant.config.load_yaml_config_file",
@@ -405,7 +405,7 @@ class TestComponentsGroup(unittest.TestCase):
             "group.all_tests",
             "group.hello",
         ]
-        assert self.hass.bus.listeners["state_changed"] == 2
+        assert self.hass.bus.listeners["state_changed"] == 1
 
     def test_modify_group(self):
         """Test modifying a group."""

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers.event import TRACK_STATE_CHANGE_CALLBACKS
 from homeassistant.setup import async_setup_component, setup_component
 
 from tests.async_mock import patch
@@ -391,6 +392,11 @@ class TestComponentsGroup(unittest.TestCase):
             "group.test_group",
         ]
         assert self.hass.bus.listeners["state_changed"] == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["hello.world"]) == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["sensor.happy"]) == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["light.bowl"]) == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["test.one"]) == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["test.two"]) == 1
 
         with patch(
             "homeassistant.config.load_yaml_config_file",
@@ -406,6 +412,9 @@ class TestComponentsGroup(unittest.TestCase):
             "group.hello",
         ]
         assert self.hass.bus.listeners["state_changed"] == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["light.bowl"]) == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["test.one"]) == 1
+        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["test.two"]) == 1
 
     def test_modify_group(self):
         """Test modifying a group."""

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_same_state,
     async_track_state_change,
+    async_track_state_change_event,
     async_track_sunrise,
     async_track_sunset,
     async_track_template,
@@ -161,6 +162,91 @@ async def test_track_state_change(hass):
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 5
     assert len(wildercard_runs) == 6
+
+
+async def test_async_track_state_change_event(hass):
+    """Test async_track_state_change_event."""
+    single_entity_id_tracker = []
+    multiple_entity_id_tracker = []
+
+    @ha.callback
+    def single_run_callback(event):
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        single_entity_id_tracker.append((old_state, new_state))
+
+    @ha.callback
+    def multiple_run_callback(event):
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        multiple_entity_id_tracker.append((old_state, new_state))
+
+    unsub_single = async_track_state_change_event(
+        hass, ["light.Bowl"], single_run_callback
+    )
+    unsub_multi = async_track_state_change_event(
+        hass, ["light.Bowl", "switch.kitchen"], multiple_run_callback
+    )
+
+    # Adding state to state machine
+    hass.states.async_set("light.Bowl", "on")
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 1
+    assert single_entity_id_tracker[-1][0] is None
+    assert single_entity_id_tracker[-1][1] is not None
+    assert len(multiple_entity_id_tracker) == 1
+    assert multiple_entity_id_tracker[-1][0] is None
+    assert multiple_entity_id_tracker[-1][1] is not None
+
+    # Set same state should not trigger a state change/listener
+    hass.states.async_set("light.Bowl", "on")
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 1
+    assert len(multiple_entity_id_tracker) == 1
+
+    # State change off -> on
+    hass.states.async_set("light.Bowl", "off")
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 2
+    assert len(multiple_entity_id_tracker) == 2
+
+    # State change off -> off
+    hass.states.async_set("light.Bowl", "off", {"some_attr": 1})
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 3
+    assert len(multiple_entity_id_tracker) == 3
+
+    # State change off -> on
+    hass.states.async_set("light.Bowl", "on")
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 4
+    assert len(multiple_entity_id_tracker) == 4
+
+    hass.states.async_remove("light.bowl")
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 5
+    assert single_entity_id_tracker[-1][0] is not None
+    assert single_entity_id_tracker[-1][1] is None
+    assert len(multiple_entity_id_tracker) == 5
+    assert multiple_entity_id_tracker[-1][0] is not None
+    assert multiple_entity_id_tracker[-1][1] is None
+
+    # Set state for different entity id
+    hass.states.async_set("switch.kitchen", "on")
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 5
+    assert len(multiple_entity_id_tracker) == 6
+
+    unsub_single()
+    # Ensure unsubing the listener works
+    hass.states.async_set("light.Bowl", "off")
+    await hass.async_block_till_done()
+    assert len(single_entity_id_tracker) == 5
+    assert len(multiple_entity_id_tracker) == 7
+
+    unsub_multi()
 
 
 async def test_track_template(hass):


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an instance has hundreds of listeners for state change events, we have to iterate all the listeners, create jobs for them every time there is a state change.  Most of the jobs reject the entity_id and return right away because they only care about one specific entity_id.

If an instance has 402 state changed listeners, 402 jobs get to run every time an entity_id changes state, and in most cases, 400 of them return right away because they do not care about the entity_id and only 2 of them continue to do something.  On a busy instance, that is getting a state change event ~second or more, that is a lot of jobs to create that return right away.  In this scenario, when a whole slew of entities change state concurrently, CPU spikes, and everything stalls.

This solution uses a hash lookup to route the state change events to get from O(402) to O(1) or O(2)

Even when there are not a lot of state changes at the same time, `async_add_job` can be seen in a `py-spy` profile.  I took the below `py-spy` sample when for a 120s period **when there was not a significant jump in state change events**:

Before:
`async_add_job` is taking up a ~9.4% of the event loop (The event loop is ~10.96% of the sample time, and async_add_job 1.03% of the sample time).  When including the time to call `async_fire` (one frame above) its ~15.60% of the event loop. When the instance gets busy with a lot of state changes, this hotspot doesn't play nice.
<img width="1013" alt="Screen Shot 2020-06-27 at 10 10 05 AM" src="https://user-images.githubusercontent.com/663432/85925519-7eae2500-b85e-11ea-8a60-fa072bbdb7be.png">

After:
`async_add_job` and `async_fire` are no longer perceptible in the profile.
<img width="1012" alt="Screen Shot 2020-06-27 at 10 10 41 AM" src="https://user-images.githubusercontent.com/663432/85925522-8372d900-b85e-11ea-9dc1-3e9fc3c3d29e.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
