### PR TITLE
Ensure all async_track_state_change_event callbacks run if one throws

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1,6 +1,7 @@
 """Helpers for listening to events."""
 from datetime import datetime, timedelta
 import functools as ft
+import logging
 from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Union
 
 import attr
@@ -23,6 +24,8 @@ from homeassistant.util.async_ import run_callback_threadsafe
 
 TRACK_STATE_CHANGE_CALLBACKS = "track_state_change_callbacks"
 TRACK_STATE_CHANGE_LISTENER = "track_state_change_listener"
+
+_LOGGER = logging.getLogger(__name__)
 
 # PyLint does not like the use of threaded_listener_factory
 # pylint: disable=invalid-name
@@ -146,7 +149,12 @@ def async_track_state_change_event(
                 return
 
             for action in entity_callbacks[entity_id]:
-                hass.async_run_job(action, event)
+                try:
+                    hass.async_run_job(action, event)
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception(
+                        "Error while processing state changed for %s", entity_id
+                    )
 
         hass.data[TRACK_STATE_CHANGE_LISTENER] = hass.bus.async_listen(
             EVENT_STATE_CHANGED, _async_state_change_dispatcher

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -183,11 +183,18 @@ async def test_async_track_state_change_event(hass):
 
         multiple_entity_id_tracker.append((old_state, new_state))
 
+    @ha.callback
+    def callback_that_throws(event):
+        raise ValueError
+
     unsub_single = async_track_state_change_event(
         hass, ["light.Bowl"], single_run_callback
     )
     unsub_multi = async_track_state_change_event(
         hass, ["light.Bowl", "switch.kitchen"], multiple_run_callback
+    )
+    unsub_throws = async_track_state_change_event(
+        hass, ["light.Bowl", "switch.kitchen"], callback_that_throws
     )
 
     # Adding state to state machine
@@ -247,6 +254,7 @@ async def test_async_track_state_change_event(hass):
     assert len(multiple_entity_id_tracker) == 7
 
     unsub_multi()
+    unsub_throws()
 
 
 async def test_track_template(hass):
@@ -428,6 +436,7 @@ async def test_track_same_state_simple_trigger_check_funct(hass):
 
     # Adding state to state machine
     hass.states.async_set("light.Bowl", "on")
+    await hass.async_block_till_done()
     await hass.async_block_till_done()
     assert len(callback_runs) == 0
     assert check_func[-1][2].state == "on"


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure all async_track_state_change_event callbacks run if one throws

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
