### PR TITLE
Add first unit test to config flow for Plum Lightpad

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -621,7 +621,8 @@ omit =
     homeassistant/components/plugwise/climate.py
     homeassistant/components/plugwise/sensor.py
     homeassistant/components/plugwise/switch.py
-    homeassistant/components/plum_lightpad/*
+    homeassistant/components/plum_lightpad/__init__.py
+    homeassistant/components/plum_lightpad/light.py
     homeassistant/components/pocketcasts/sensor.py
     homeassistant/components/point/*
     homeassistant/components/prezzibenzina/sensor.py

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -489,6 +489,9 @@ plexauth==0.0.5
 # homeassistant.components.plex
 plexwebsocket==0.0.11
 
+# homeassistant.components.plum_lightpad
+plumlightpad==0.0.11
+
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm
 pmsensor==0.4

--- a/tests/components/plum_lightpad/__init__.py
+++ b/tests/components/plum_lightpad/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Plum Lightpad integration."""

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -45,8 +45,7 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.test_lightpad.config_flow.PlaceholderHub.authenticate",
-        side_effect=ConnectTimeout,
+        "plumlightpad.Plum.loadCloudData", side_effect=ConnectTimeout,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -8,6 +8,7 @@ from tests.async_mock import patch
 async def test_form(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -33,3 +34,28 @@ async def test_form(hass):
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import(hass):
+    """Test configuring the flow using configuration.yaml."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch("plumlightpad.Plum.loadCloudData"), patch(
+        "homeassistant.components.plum_lightpad.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.plum_lightpad.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={"username": "test-plum-username", "password": "test-plum-password"},
+        )
+        assert result["type"] == "create_entry"
+        assert result["title"] == "test-plum-username"
+        assert result["data"] == {
+            "username": "test-plum-username",
+            "password": "test-plum-password",
+        }
+        await hass.async_block_till_done()
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -1,0 +1,35 @@
+"""Test the Plum Lightpad config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.plum_lightpad.const import DOMAIN
+
+from tests.async_mock import patch
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch("plumlightpad.Plum.loadCloudData"), patch(
+        "homeassistant.components.plum_lightpad.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.plum_lightpad.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-plum-username", "password": "test-plum-password"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "test-plum-username"
+    assert result2["data"] == {
+        "username": "test-plum-username",
+        "password": "test-plum-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -17,7 +17,9 @@ async def test_form(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch("plumlightpad.Plum.loadCloudData"), patch(
+    with patch(
+        "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
+    ), patch(
         "homeassistant.components.plum_lightpad.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.plum_lightpad.async_setup_entry", return_value=True,
@@ -45,7 +47,8 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "plumlightpad.Plum.loadCloudData", side_effect=ConnectTimeout,
+        "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData",
+        side_effect=ConnectTimeout,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -60,7 +63,9 @@ async def test_import(hass):
     """Test configuring the flow using configuration.yaml."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    with patch("plumlightpad.Plum.loadCloudData"), patch(
+    with patch(
+        "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
+    ), patch(
         "homeassistant.components.plum_lightpad.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.plum_lightpad.async_setup_entry", return_value=True,

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -5,6 +5,7 @@ from homeassistant import config_entries, setup
 from homeassistant.components.plum_lightpad.const import DOMAIN
 
 from tests.async_mock import patch
+from tests.common import MockConfigEntry
 
 
 async def test_form(hass):
@@ -57,6 +58,36 @@ async def test_form_cannot_connect(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_one_entry_per_email_allowed(hass):
+    """Test that only one entry allowed per Plum cloud email address."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test-plum-username",
+        data={"username": "test-plum-username", "password": "test-plum-password"},
+    ).add_to_hass(hass)
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
+    ), patch("homeassistant.components.plum_lightpad.async_setup") as mock_setup, patch(
+        "homeassistant.components.plum_lightpad.async_setup_entry"
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "test-plum-username", "password": "test-plum-password"},
+        )
+
+    assert result2["type"] == "abort"
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 0
+    assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_import(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
No changes - only adding first simple unit test to config flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
