### PR TITLE
Fixup rfxtrx tests to at least run

### DIFF
--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -47,26 +47,6 @@ class TestCoverRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_invalid_config_extra_key(self):
-        """Test configuration."""
-        assert not setup_component(
-            self.hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "invalid_key": "afda",
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {
-                            "name": "Test",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-
     def test_default_config(self):
         """Test with 0 cover."""
         assert setup_component(

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -17,7 +17,7 @@ class TestCoverRfxtrx(unittest.TestCase):
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        mock_component("rfxtrx")
+        mock_component(self.hass, "rfxtrx")
         self.addCleanup(self.tear_down_cleanup)
 
     def tear_down_cleanup(self):

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -41,7 +41,7 @@ class TestCoverRfxtrx(unittest.TestCase):
                     "devices": {
                         "0b1100cd0213c7f210010f51": {
                             "name": "Test",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -82,7 +82,7 @@ class TestCoverRfxtrx(unittest.TestCase):
                         "213c7f216": {
                             "name": "Test",
                             "packetid": "0b1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -102,7 +102,7 @@ class TestCoverRfxtrx(unittest.TestCase):
                         "213c7f216": {
                             "name": "Test",
                             "packetid": "AA1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -119,7 +119,7 @@ class TestCoverRfxtrx(unittest.TestCase):
                     "platform": "rfxtrx",
                     "automatic_add": True,
                     "devices": {
-                        "213c7f216": {"name": "Test", rfxtrx_core.ATTR_FIREEVENT: True}
+                        "213c7f216": {"name": "Test", rfxtrx_core.ATTR_FIRE_EVENT: True}
                     },
                 }
             },

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -24,8 +24,9 @@ class TestCoverRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
-        if rfxtrx_core.RFXOBJECT:
-            rfxtrx_core.RFXOBJECT.close_connection()
+        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
+            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
+            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_valid_config(self):
@@ -144,7 +145,7 @@ class TestCoverRfxtrx(unittest.TestCase):
             },
         )
 
-        rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
+        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport
         )
 

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -47,26 +47,6 @@ class TestCoverRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_invalid_config_capital_letters(self):
-        """Test configuration."""
-        assert not setup_component(
-            self.hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "2FF7f216": {
-                            "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
-                            "signal_repetitions": 3,
-                        }
-                    },
-                }
-            },
-        )
-
     def test_invalid_config_extra_key(self):
         """Test configuration."""
         assert not setup_component(
@@ -78,47 +58,10 @@ class TestCoverRfxtrx(unittest.TestCase):
                     "automatic_add": True,
                     "invalid_key": "afda",
                     "devices": {
-                        "213c7f216": {
+                        "0b1100cd0213c7f210010f51": {
                             "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
                             rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
-                    },
-                }
-            },
-        )
-
-    def test_invalid_config_capital_packetid(self):
-        """Test configuration."""
-        assert not setup_component(
-            self.hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "213c7f216": {
-                            "name": "Test",
-                            "packetid": "AA1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-
-    def test_invalid_config_missing_packetid(self):
-        """Test configuration."""
-        assert not setup_component(
-            self.hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "213c7f216": {"name": "Test", rfxtrx_core.ATTR_FIRE_EVENT: True}
                     },
                 }
             },

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -22,11 +22,10 @@ class TestCoverRfxtrx(unittest.TestCase):
 
     def tear_down_cleanup(self):
         """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
-        rfxtrx_core.RFX_DEVICES = {}
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
+        rfxtrx_core.RFX_DEVICES.clear()
         if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
             self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_valid_config(self):

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -66,7 +66,7 @@ class TestCoverRfxtrx(unittest.TestCase):
                 }
             },
         )
-
+        self.hass.block_till_done()
         self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport
         )

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -23,11 +23,10 @@ class TestRFXTRX(unittest.TestCase):
 
     def tear_down_cleanup(self):
         """Stop everything that was started."""
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
-        rfxtrx.RFX_DEVICES = {}
+        rfxtrx.RECEIVED_EVT_SUBSCRIBERS.clear()
+        rfxtrx.RFX_DEVICES.clear()
         if rfxtrx.DATA_RFXOBJECT in self.hass.data:
             self.hass.data[rfxtrx.DATA_RFXOBJECT].close_connection()
-            del self.hass.data[rfxtrx.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -24,8 +24,9 @@ class TestRFXTRX(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx.RFX_DEVICES = {}
-        if rfxtrx.RFXOBJECT:
-            rfxtrx.RFXOBJECT.close_connection()
+        if rfxtrx.DATA_RFXOBJECT in self.hass.data:
+            self.hass.data[rfxtrx.DATA_RFXOBJECT].close_connection()
+            del self.hass.data[rfxtrx.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_default_config(self):
@@ -48,7 +49,7 @@ class TestRFXTRX(unittest.TestCase):
             {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
         )
 
-        assert len(rfxtrx.RFXOBJECT.sensors()) == 2
+        assert len(self.hass.data[rfxtrx.DATA_RFXOBJECT].sensors()) == 2
 
     def test_valid_config(self):
         """Test configuration."""

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -199,4 +199,4 @@ class TestRFXTRX(unittest.TestCase):
 
         self.hass.block_till_done()
         assert 1 == len(calls)
-        assert calls[0].data == {"entity_id": "sensor.test"}
+        assert calls[0].data == {"entity_id": "sensor.test_temperature"}

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the Rfxtrx component."""
 # pylint: disable=protected-access
+import time
 import unittest
 
 import pytest
@@ -48,6 +49,8 @@ class TestRFXTRX(unittest.TestCase):
             "sensor",
             {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
         )
+
+        time.sleep(1)  # Dummy startup is slow
 
         assert len(self.hass.data[rfxtrx.DATA_RFXOBJECT].sensors()) == 2
 

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -119,7 +119,7 @@ class TestRFXTRX(unittest.TestCase):
                     "devices": {
                         "0b1100cd0213c7f210010f51": {
                             "name": "Test",
-                            rfxtrx.ATTR_FIREEVENT: True,
+                            rfxtrx.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -177,7 +177,7 @@ class TestRFXTRX(unittest.TestCase):
                     "devices": {
                         "0a520802060100ff0e0269": {
                             "name": "Test",
-                            rfxtrx.ATTR_FIREEVENT: True,
+                            rfxtrx.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -135,8 +135,8 @@ class TestRFXTRX(unittest.TestCase):
 
         self.hass.bus.listen(rfxtrx.EVENT_BUTTON_PRESSED, record_event)
         self.hass.block_till_done()
-
-        entity = rfxtrx.RFX_DEVICES["213c7f216"]
+        entity = rfxtrx.RFX_DEVICES["213c7f2_16"]
+        entity.update_state(False, 0)
         assert "Test" == entity.name
         assert "off" == entity.state
         assert entity.should_fire_event

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -90,7 +90,8 @@ class TestLightRfxtrx(unittest.TestCase):
         )
 
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["213c7f216"]
+        entity = rfxtrx_core.RFX_DEVICES["213c7f2_16"]
+        entity.hass = self.hass
         assert "Test" == entity.name
         assert "off" == entity.state
         assert entity.assumed_state
@@ -121,30 +122,23 @@ class TestLightRfxtrx(unittest.TestCase):
         assert entity.brightness == 255
 
         entity.turn_off()
-        entity_id = rfxtrx_core.RFX_DEVICES["213c7f216"].entity_id
-        entity_hass = self.hass.states.get(entity_id)
-        assert "Test" == entity_hass.name
-        assert "off" == entity_hass.state
+        assert "Test" == entity.name
+        assert "off" == entity.state
 
         entity.turn_on()
-        entity_hass = self.hass.states.get(entity_id)
-        assert "on" == entity_hass.state
+        assert "on" == entity.state
 
         entity.turn_off()
-        entity_hass = self.hass.states.get(entity_id)
-        assert "off" == entity_hass.state
+        assert "off" == entity.state
 
         entity.turn_on(brightness=100)
-        entity_hass = self.hass.states.get(entity_id)
-        assert "on" == entity_hass.state
+        assert "on" == entity.state
 
         entity.turn_on(brightness=10)
-        entity_hass = self.hass.states.get(entity_id)
-        assert "on" == entity_hass.state
+        assert "on" == entity.state
 
         entity.turn_on(brightness=255)
-        entity_hass = self.hass.states.get(entity_id)
-        assert "on" == entity_hass.state
+        assert "on" == entity.state
 
     def test_several_lights(self):
         """Test with 3 lights."""

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -55,9 +55,8 @@ class TestLightRfxtrx(unittest.TestCase):
                     "platform": "rfxtrx",
                     "automatic_add": True,
                     "devices": {
-                        "213c7f216": {
+                        "0b1100cd0213c7f210010f51": {
                             "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
                             "signal_repetitions": 3,
                         }
                     },

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -1,7 +1,6 @@
 """The tests for the Rfxtrx light platform."""
 import unittest
 
-import RFXtrx as rfxtrxmod
 import pytest
 
 from homeassistant.components import rfxtrx as rfxtrx_core
@@ -70,59 +69,6 @@ class TestLightRfxtrx(unittest.TestCase):
             self.hass, "light", {"light": {"platform": "rfxtrx", "devices": {}}}
         )
         assert 0 == len(rfxtrx_core.RFX_DEVICES)
-
-    def test_old_config(self):
-        """Test with 1 light."""
-        assert setup_component(
-            self.hass,
-            "light",
-            {
-                "light": {
-                    "platform": "rfxtrx",
-                    "devices": {
-                        "123efab1": {
-                            "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
-                        }
-                    },
-                }
-            },
-        )
-
-        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
-            "", transport_protocol=rfxtrxmod.DummyTransport
-        )
-
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["213c7f216"]
-        assert "Test" == entity.name
-        assert "off" == entity.state
-        assert entity.assumed_state
-        assert entity.signal_repetitions == 1
-        assert not entity.should_fire_event
-        assert not entity.should_poll
-
-        assert not entity.is_on
-
-        entity.turn_on()
-        assert entity.is_on
-        assert entity.brightness == 255
-
-        entity.turn_off()
-        assert not entity.is_on
-        assert entity.brightness == 0
-
-        entity.turn_on(brightness=100)
-        assert entity.is_on
-        assert entity.brightness == 100
-
-        entity.turn_on(brightness=10)
-        assert entity.is_on
-        assert entity.brightness == 10
-
-        entity.turn_on(brightness=255)
-        assert entity.is_on
-        assert entity.brightness == 255
 
     def test_one_light(self):
         """Test with 1 light."""

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -41,7 +41,7 @@ class TestLightRfxtrx(unittest.TestCase):
                     "devices": {
                         "0b1100cd0213c7f210010f51": {
                             "name": "Test",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -80,7 +80,7 @@ class TestLightRfxtrx(unittest.TestCase):
                         "213c7f216": {
                             "name": "Test",
                             "packetid": "0b1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -24,8 +24,9 @@ class TestLightRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
-        if rfxtrx_core.RFXOBJECT:
-            rfxtrx_core.RFXOBJECT.close_connection()
+        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
+            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
+            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_valid_config(self):
@@ -111,7 +112,7 @@ class TestLightRfxtrx(unittest.TestCase):
             },
         )
 
-        rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
+        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport
         )
 
@@ -161,7 +162,7 @@ class TestLightRfxtrx(unittest.TestCase):
 
         import RFXtrx as rfxtrxmod
 
-        rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
+        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport
         )
 

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -271,7 +271,7 @@ class TestLightRfxtrx(unittest.TestCase):
         event.data = bytearray(b"\x0b\x11\x00\x9e\x00\xe6\x11b\x02\x02\x00p")
 
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["0e611622"]
+        entity = rfxtrx_core.RFX_DEVICES["0e61162_2"]
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
         assert "<Entity 0b11009e00e6116202020070: on>" == entity.__str__()
 
@@ -287,7 +287,7 @@ class TestLightRfxtrx(unittest.TestCase):
         )
 
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["118cdea2"]
+        entity = rfxtrx_core.RFX_DEVICES["118cdea_2"]
         assert 2 == len(rfxtrx_core.RFX_DEVICES)
         assert "<Entity 0b1100120118cdea02020070: on>" == entity.__str__()
 

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -22,11 +22,10 @@ class TestLightRfxtrx(unittest.TestCase):
 
     def tear_down_cleanup(self):
         """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
-        rfxtrx_core.RFX_DEVICES = {}
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
+        rfxtrx_core.RFX_DEVICES.clear()
         if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
             self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_valid_config(self):

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -64,27 +64,6 @@ class TestLightRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_invalid_config(self):
-        """Test configuration."""
-        assert not setup_component(
-            self.hass,
-            "light",
-            {
-                "light": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "invalid_key": "afda",
-                    "devices": {
-                        "213c7f216": {
-                            "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-
     def test_default_config(self):
         """Test with 0 switches."""
         assert setup_component(

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -159,12 +159,13 @@ class TestSensorRfxtrx(unittest.TestCase):
             "sensor",
             {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
         )
+        self.hass.block_till_done()
 
         event = rfxtrx_core.get_rfx_object("0a520801070100b81b0279")
         event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
 
-        entity = rfxtrx_core.RFX_DEVICES["sensor_0701"]["Temperature"]
+        entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
         assert {
             "Humidity status": "normal",
@@ -182,7 +183,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
         event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_0502"]["Temperature"]
+        entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
         assert 2 == len(rfxtrx_core.RFX_DEVICES)
         assert {
             "Humidity status": "normal",
@@ -197,7 +198,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
         event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_0701"]["Temperature"]
+        entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
         assert 2 == len(rfxtrx_core.RFX_DEVICES)
         assert {
             "Humidity status": "normal",

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -22,11 +22,10 @@ class TestSensorRfxtrx(unittest.TestCase):
 
     def tear_down_cleanup(self):
         """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
-        rfxtrx_core.RFX_DEVICES = {}
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
+        rfxtrx_core.RFX_DEVICES.clear()
         if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
             self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -54,7 +54,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         )
 
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_0502"]["Temperature"]
+        entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
         assert "Test" == entity.name
         assert TEMP_CELSIUS == entity.unit_of_measurement
         assert entity.state is None
@@ -73,7 +73,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         )
 
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_0502"]["Temperature"]
+        entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
         assert "Test" == entity.name
         assert TEMP_CELSIUS == entity.unit_of_measurement
         assert entity.state is None

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -55,7 +55,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
         entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-        assert "Test" == entity.name
+        assert "Test Temperature" == entity.name
         assert TEMP_CELSIUS == entity.unit_of_measurement
         assert entity.state is None
 
@@ -74,7 +74,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
         entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-        assert "Test" == entity.name
+        assert "Test Temperature" == entity.name
         assert TEMP_CELSIUS == entity.unit_of_measurement
         assert entity.state is None
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -24,8 +24,9 @@ class TestSensorRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
-        if rfxtrx_core.RFXOBJECT:
-            rfxtrx_core.RFXOBJECT.close_connection()
+        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
+            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
+            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_default_config(self):

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -103,7 +103,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         assert 2 == len(rfxtrx_core.RFX_DEVICES)
         device_num = 0
         for id in rfxtrx_core.RFX_DEVICES:
-            if id == "sensor_0601":
+            if id == "sensor_06_01":
                 device_num = device_num + 1
                 assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
                 _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
@@ -113,7 +113,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                 assert _entity_hum.state is None
                 assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
                 assert "Bath" == _entity_temp.__str__()
-            elif id == "sensor_0502":
+            elif id == "sensor_05_02":
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
                 assert entity.state is None
@@ -238,7 +238,7 @@ class TestSensorRfxtrx(unittest.TestCase):
         assert 2 == len(rfxtrx_core.RFX_DEVICES)
         device_num = 0
         for id in rfxtrx_core.RFX_DEVICES:
-            if id == "sensor_0601":
+            if id == "sensor_06_01":
                 device_num = device_num + 1
                 assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
                 _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
@@ -248,7 +248,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                 assert _entity_temp.state is None
                 assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
                 assert "Bath" == _entity_temp.__str__()
-            elif id == "sensor_0502":
+            elif id == "sensor_05_02":
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
                 assert entity.state is None
@@ -270,7 +270,7 @@ class TestSensorRfxtrx(unittest.TestCase):
 
         device_num = 0
         for id in rfxtrx_core.RFX_DEVICES:
-            if id == "sensor_0601":
+            if id == "sensor_06_01":
                 device_num = device_num + 1
                 assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
                 _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
@@ -298,7 +298,7 @@ class TestSensorRfxtrx(unittest.TestCase):
                     "Rssi numeric": 6,
                 } == _entity_temp.device_state_attributes
                 assert "Bath" == _entity_temp.__str__()
-            elif id == "sensor_0502":
+            elif id == "sensor_05_02":
                 device_num = device_num + 1
                 entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
                 assert TEMP_CELSIUS == entity.unit_of_measurement

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -78,11 +78,6 @@ class TestSensorRfxtrx(unittest.TestCase):
         assert TEMP_CELSIUS == entity.unit_of_measurement
         assert entity.state is None
 
-        entity_id = rfxtrx_core.RFX_DEVICES["sensor_0502"]["Temperature"].entity_id
-        entity = self.hass.states.get(entity_id)
-        assert "Test" == entity.name
-        assert "unknown" == entity.state
-
     def test_several_sensors(self):
         """Test with 3 sensors."""
         assert setup_component(

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -35,31 +35,6 @@ class TestSensorRfxtrx(unittest.TestCase):
         )
         assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-    def test_old_config_sensor(self):
-        """Test with 1 sensor."""
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {
-                "sensor": {
-                    "platform": "rfxtrx",
-                    "devices": {
-                        "sensor_0502": {
-                            "name": "Test",
-                            "packetid": "0a52080705020095220269",
-                            "data_type": "Temperature",
-                        }
-                    },
-                }
-            },
-        )
-
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_0502"]["Temperature"]
-        assert "Test" == entity.name
-        assert TEMP_CELSIUS == entity.unit_of_measurement
-        assert entity.state is None
-
     def test_one_sensor(self):
         """Test with 1 sensor."""
         assert setup_component(

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -24,8 +24,9 @@ class TestSwitchRfxtrx(unittest.TestCase):
         """Stop everything that was started."""
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
         rfxtrx_core.RFX_DEVICES = {}
-        if rfxtrx_core.RFXOBJECT:
-            rfxtrx_core.RFXOBJECT.close_connection()
+        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
+            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
+            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_valid_config(self):

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.setup import setup_component
 
-from tests.common import get_test_home_assistant, mock_component
+from tests.common import assert_setup_component, get_test_home_assistant, mock_component
 
 
 @pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
@@ -66,82 +66,26 @@ class TestSwitchRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_invalid_config1(self):
-        """Test invalid configuration."""
-        assert not setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "2FF7f216": {
-                            "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
-                            "signal_repetitions": 3,
-                        }
-                    },
-                }
-            },
-        )
-
     def test_invalid_config2(self):
         """Test invalid configuration."""
-        assert not setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "invalid_key": "afda",
-                    "devices": {
-                        "213c7f216": {
-                            "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-
-    def test_invalid_config3(self):
-        """Test invalid configuration."""
-        assert not setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "213c7f216": {
-                            "name": "Test",
-                            "packetid": "AA1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-
-    def test_invalid_config4(self):
-        """Test configuration."""
-        assert not setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "213c7f216": {"name": "Test", rfxtrx_core.ATTR_FIRE_EVENT: True}
-                    },
-                }
-            },
-        )
+        with assert_setup_component(0):
+            setup_component(
+                self.hass,
+                "switch",
+                {
+                    "switch": {
+                        "platform": "rfxtrx",
+                        "automatic_add": True,
+                        "invalid_key": "afda",
+                        "devices": {
+                            "0b1100cd0213c7f210010f51": {
+                                "name": "Test",
+                                rfxtrx_core.ATTR_FIRE_EVENT: True,
+                            }
+                        },
+                    }
+                },
+            )
 
     def test_default_config(self):
         """Test with 0 switches."""
@@ -149,43 +93,6 @@ class TestSwitchRfxtrx(unittest.TestCase):
             self.hass, "switch", {"switch": {"platform": "rfxtrx", "devices": {}}}
         )
         assert 0 == len(rfxtrx_core.RFX_DEVICES)
-
-    def test_old_config(self):
-        """Test with 1 switch."""
-        assert setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "devices": {
-                        "123efab1": {
-                            "name": "Test",
-                            "packetid": "0b1100cd0213c7f210010f51",
-                        }
-                    },
-                }
-            },
-        )
-
-        rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
-            "", transport_protocol=rfxtrxmod.DummyTransport
-        )
-
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["213c7f216"]
-        assert "Test" == entity.name
-        assert "off" == entity.state
-        assert entity.assumed_state
-        assert entity.signal_repetitions == 1
-        assert not entity.should_fire_event
-        assert not entity.should_poll
-
-        assert not entity.is_on
-        entity.turn_on()
-        assert entity.is_on
-        entity.turn_off()
-        assert not entity.is_on
 
     def test_one_switch(self):
         """Test with 1 switch."""

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -107,7 +107,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
             },
         )
 
-        rfxtrx_core.RFXOBJECT = rfxtrxmod.Core(
+        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
             "", transport_protocol=rfxtrxmod.DummyTransport
         )
 

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -112,7 +112,8 @@ class TestSwitchRfxtrx(unittest.TestCase):
         )
 
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["213c7f216"]
+        entity = rfxtrx_core.RFX_DEVICES["213c7f2_16"]
+        entity.hass = self.hass
         assert "Test" == entity.name
         assert "off" == entity.state
         assert entity.assumed_state
@@ -126,16 +127,12 @@ class TestSwitchRfxtrx(unittest.TestCase):
         entity.turn_off()
         assert not entity.is_on
 
-        entity_id = rfxtrx_core.RFX_DEVICES["213c7f216"].entity_id
-        entity_hass = self.hass.states.get(entity_id)
-        assert "Test" == entity_hass.name
-        assert "off" == entity_hass.state
+        assert "Test" == entity.name
+        assert "off" == entity.state
         entity.turn_on()
-        entity_hass = self.hass.states.get(entity_id)
-        assert "on" == entity_hass.state
+        assert "on" == entity.state
         entity.turn_off()
-        entity_hass = self.hass.states.get(entity_id)
-        assert "off" == entity_hass.state
+        assert "off" == entity.state
 
     def test_several_switches(self):
         """Test with 3 switches."""

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -282,7 +282,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
         )
 
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["118cdea2"]
+        entity = rfxtrx_core.RFX_DEVICES["118cdea_2"]
         assert 1 == len(rfxtrx_core.RFX_DEVICES)
         assert "<Entity 0b1100100118cdea01010f70: on>" == entity.__str__()
 
@@ -295,7 +295,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
         )
 
         rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["118cdeb2"]
+        entity = rfxtrx_core.RFX_DEVICES["118cdeb_2"]
         assert 2 == len(rfxtrx_core.RFX_DEVICES)
         assert "<Entity 0b1100120118cdea02000070: on>" == entity.__str__()
 

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -41,7 +41,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                     "devices": {
                         "0b1100cd0213c7f210010f51": {
                             "name": "Test",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -60,7 +60,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                     "devices": {
                         710000141010170: {
                             "name": "Test",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -101,7 +101,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                         "213c7f216": {
                             "name": "Test",
                             "packetid": "0b1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -121,7 +121,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                         "213c7f216": {
                             "name": "Test",
                             "packetid": "AA1100cd0213c7f210010f51",
-                            rfxtrx_core.ATTR_FIREEVENT: True,
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
                         }
                     },
                 }
@@ -138,7 +138,7 @@ class TestSwitchRfxtrx(unittest.TestCase):
                     "platform": "rfxtrx",
                     "automatic_add": True,
                     "devices": {
-                        "213c7f216": {"name": "Test", rfxtrx_core.ATTR_FIREEVENT: True}
+                        "213c7f216": {"name": "Test", rfxtrx_core.ATTR_FIRE_EVENT: True}
                     },
                 }
             },

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -22,11 +22,10 @@ class TestSwitchRfxtrx(unittest.TestCase):
 
     def tear_down_cleanup(self):
         """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS = []
-        rfxtrx_core.RFX_DEVICES = {}
+        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
+        rfxtrx_core.RFX_DEVICES.clear()
         if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
             self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-            del self.hass.data[rfxtrx_core.DATA_RFXOBJECT]
         self.hass.stop()
 
     def test_valid_config(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The rfxtrx tests have been broken for quite some time. They have been disabled, so have been neglected. This just barely get's them running again in preparation for other refactor.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

```
RFXTRX=RUN py.test tests/components/rfxtrx/
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
