### PR TITLE
Add REST API support for Aruba Instant

### DIFF
--- a/homeassistant/components/aruba/const.py
+++ b/homeassistant/components/aruba/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Aruba component."""
+
+DEFAULT_MODE = "ssh"

--- a/homeassistant/components/aruba/device_tracker.py
+++ b/homeassistant/components/aruba/device_tracker.py
@@ -1,7 +1,10 @@
 """Support for Aruba Access Points."""
+import json
 import logging
 import re
 
+import requests
+from requests import Session
 import pexpect
 import voluptuous as vol
 
@@ -29,6 +32,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+DEFAULT_USE_API = False
+DEFAULT_TIMEOUT = 10
+USE_API = False
+login_result_sid = ''
 
 def get_scanner(hass, config):
     """Validate the configuration and return a Aruba scanner."""
@@ -46,9 +53,41 @@ class ArubaDeviceScanner(DeviceScanner):
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
 
+        global USE_API
+        global login_result_sid
+
         self.last_results = {}
 
-        # Test the router is accessible.
+        # Test if we can use REST API
+        # Aruba Instant API only likes double quotes in the json data and rejects single quotes
+        login_data = '{"user": "' + self.username+ '", "passwd": "'+ self.password +'" }'
+        login_headers = {'Content-Type': 'application/json' }
+        login_method = "POST"
+        login_resource = "https://" + self.host + ":4343/rest/login"
+
+        rest_login = RestData(
+            login_method,
+            login_resource,
+            login_headers,
+            login_data,
+            False,
+            DEFAULT_TIMEOUT
+        )
+        rest_login.update()
+
+        if rest_login.headers is not None:
+            login_result_content_type = rest_login.headers.get("content-type")
+            if login_result_content_type == "application/json":
+                login_result_json = json.loads(rest_login.data)
+                login_result_status = login_result_json.get("Status")
+                if login_result_status == "Success":
+                    USE_API = True
+                    login_result_sid = login_result_json.get("sid")
+                    _LOGGER.debug("Successfully logged in to Aruba Instant REST API")
+                else:
+                    USE_API = DEFAULT_USE_API
+                    _LOGGER.debug("Error logging in to Aruba Instant REST API")
+
         data = self.get_aruba_data()
         self.success_init = data is not None
 
@@ -84,44 +123,76 @@ class ArubaDeviceScanner(DeviceScanner):
     def get_aruba_data(self):
         """Retrieve data from Aruba Access Point and return parsed result."""
 
-        connect = f"ssh {self.username}@{self.host}"
-        ssh = pexpect.spawn(connect)
-        query = ssh.expect(
-            [
-                "password:",
-                pexpect.TIMEOUT,
-                pexpect.EOF,
-                "continue connecting (yes/no)?",
-                "Host key verification failed.",
-                "Connection refused",
-                "Connection timed out",
-            ],
-            timeout=120,
-        )
-        if query == 1:
-            _LOGGER.error("Timeout")
-            return
-        if query == 2:
-            _LOGGER.error("Unexpected response from router")
-            return
-        if query == 3:
-            ssh.sendline("yes")
-            ssh.expect("password:")
-        elif query == 4:
-            _LOGGER.error("Host key changed")
-            return
-        elif query == 5:
-            _LOGGER.error("Connection refused by server")
-            return
-        elif query == 6:
-            _LOGGER.error("Connection timed out")
-            return
-        ssh.sendline(self.password)
-        ssh.expect("#")
-        ssh.sendline("show clients")
-        ssh.expect("#")
-        devices_result = ssh.before.split(b"\r\n")
-        ssh.sendline("exit")
+        if USE_API == True:
+            _LOGGER.debug("Using REST API")
+            show_clients_data = ''
+            show_clients_headers = {'Content-Type': 'application/json' }
+            show_clients_method = "GET"
+            show_clients_resource = "https://" + self.host + ":4343/rest/show-cmd?iap_ip_addr=" + self.host + "&cmd=show%20clients&sid=" + login_result_sid
+
+            rest_show_clients = RestData(
+                show_clients_method,
+                show_clients_resource,
+                show_clients_headers,
+                show_clients_data,
+                False,
+                DEFAULT_TIMEOUT
+            )
+            rest_show_clients.update()
+
+            if rest_show_clients.headers is not None:
+                show_clients_result_content_type = rest_show_clients.headers.get("content-type")
+                if show_clients_result_content_type == "application/json":
+                    show_clients_result_json = json.loads(rest_show_clients.data)
+                    show_clients_result_status = show_clients_result_json.get("Status")
+                    if show_clients_result_status == "Success":
+                        show_clients_result_command_output = show_clients_result_json.get("Command output")
+                        show_clients_result_bytes = (json.dumps(show_clients_result_command_output)).encode()
+                        devices_result = show_clients_result_bytes.split(b"\\n")
+                    else:
+                        _LOGGER.debug("Error getting client list via Aruba Instant REST API")
+                        return
+
+        else:
+            _LOGGER.debug("Using SSH")
+            connect = f"ssh {self.username}@{self.host}"
+            ssh = pexpect.spawn(connect)
+            query = ssh.expect(
+                [
+                    "password:",
+                    pexpect.TIMEOUT,
+                    pexpect.EOF,
+                    "continue connecting (yes/no)?",
+                    "Host key verification failed.",
+                    "Connection refused",
+                    "Connection timed out",
+                ],
+                timeout=120,
+            )
+            if query == 1:
+                _LOGGER.error("Timeout")
+                return
+            if query == 2:
+                _LOGGER.error("Unexpected response from router")
+                return
+            if query == 3:
+                ssh.sendline("yes")
+                ssh.expect("password:")
+            elif query == 4:
+                _LOGGER.error("Host key changed")
+                return
+            elif query == 5:
+                _LOGGER.error("Connection refused by server")
+                return
+            elif query == 6:
+                _LOGGER.error("Connection timed out")
+                return
+            ssh.sendline(self.password)
+            ssh.expect("#")
+            ssh.sendline("show clients")
+            ssh.expect("#")
+            devices_result = ssh.before.split(b"\r\n")
+            ssh.sendline("exit")
 
         devices = {}
         for device in devices_result:
@@ -133,3 +204,43 @@ class ArubaDeviceScanner(DeviceScanner):
                     "name": match.group("name"),
                 }
         return devices
+
+class RestData:
+    """Class for handling the data retrieval."""
+
+    def __init__(
+        self, method, resource, headers, data, verify_ssl, timeout=DEFAULT_TIMEOUT
+    ):
+        """Initialize the data object."""
+        self._method = method
+        self._resource = resource
+        self._headers = headers
+        self._request_data = data
+        self._verify_ssl = verify_ssl
+        self._timeout = timeout
+        self._http_session = Session()
+        self.data = None
+        self.headers = None
+
+    def __del__(self):
+        """Destroy the http session on destroy."""
+        self._http_session.close()
+
+    def update(self):
+        """Get the latest data from REST service with provided method."""
+        _LOGGER.debug("Updating from %s", self._resource)
+        try:
+            response = self._http_session.request(
+                self._method,
+                self._resource,
+                headers=self._headers,
+                data=self._request_data,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+            )
+            self.data = response.text
+            self.headers = response.headers
+        except requests.exceptions.RequestException as ex:
+            _LOGGER.error("Error fetching data: %s failed with %s", self._resource, ex)
+            self.data = None
+            self.headers = None

--- a/homeassistant/components/aruba/device_tracker.py
+++ b/homeassistant/components/aruba/device_tracker.py
@@ -1,10 +1,8 @@
 """Support for Aruba Access Points."""
-import json
 import logging
 import re
 
-import requests
-from requests import Session
+import instantpy
 import pexpect
 import voluptuous as vol
 
@@ -13,7 +11,13 @@ from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA,
     DeviceScanner,
 )
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MODE,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from .const import DEFAULT_MODE
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,15 +31,11 @@ _DEVICES_REGEX = re.compile(
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_MODE, default=DEFAULT_MODE): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
     }
 )
-
-DEFAULT_USE_API = False
-DEFAULT_TIMEOUT = 10
-USE_API = False
-login_result_sid = ""
 
 
 def get_scanner(hass, config):
@@ -51,45 +51,11 @@ class ArubaDeviceScanner(DeviceScanner):
     def __init__(self, config):
         """Initialize the scanner."""
         self.host = config[CONF_HOST]
+        self.mode = config[CONF_MODE]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
 
-        global USE_API
-        global login_result_sid
-
         self.last_results = {}
-
-        # Test if we can use REST API
-        # Aruba Instant API only likes double quotes in the json data and rejects single quotes
-        login_data = (
-            '{"user": "' + self.username + '", "passwd": "' + self.password + '" }'
-        )
-        login_headers = {"Content-Type": "application/json"}
-        login_method = "POST"
-        login_resource = "https://" + self.host + ":4343/rest/login"
-
-        rest_login = RestData(
-            login_method,
-            login_resource,
-            login_headers,
-            login_data,
-            False,
-            DEFAULT_TIMEOUT,
-        )
-        rest_login.update()
-
-        if rest_login.headers is not None:
-            login_result_content_type = rest_login.headers.get("content-type")
-            if login_result_content_type == "application/json":
-                login_result_json = json.loads(rest_login.data)
-                login_result_status = login_result_json.get("Status")
-                if login_result_status == "Success":
-                    USE_API = True
-                    login_result_sid = login_result_json.get("sid")
-                    _LOGGER.debug("Successfully logged in to Aruba Instant REST API")
-                else:
-                    USE_API = DEFAULT_USE_API
-                    _LOGGER.debug("Error logging in to Aruba Instant REST API")
 
         data = self.get_aruba_data()
         self.success_init = data is not None
@@ -126,53 +92,15 @@ class ArubaDeviceScanner(DeviceScanner):
     def get_aruba_data(self):
         """Retrieve data from Aruba Access Point and return parsed result."""
 
-        if USE_API is True:
-            _LOGGER.debug("Using REST API")
-            show_clients_data = ""
-            show_clients_headers = {"Content-Type": "application/json"}
-            show_clients_method = "GET"
-            show_clients_resource = (
-                "https://"
-                + self.host
-                + ":4343/rest/show-cmd?iap_ip_addr="
-                + self.host
-                + "&cmd=show%20clients&sid="
-                + login_result_sid
-            )
+        devices = {}
 
-            rest_show_clients = RestData(
-                show_clients_method,
-                show_clients_resource,
-                show_clients_headers,
-                show_clients_data,
-                False,
-                DEFAULT_TIMEOUT,
-            )
-            rest_show_clients.update()
+        if self.mode == "api":
+            """Setup API module for Aruba Instant"""
+            arubaInstant = instantpy.InstantVC(self.username, self.password, self.host)
+            devices = arubaInstant.clients()
+            arubaInstant.logout()
 
-            if rest_show_clients.headers is not None:
-                show_clients_result_content_type = rest_show_clients.headers.get(
-                    "content-type"
-                )
-                if show_clients_result_content_type == "application/json":
-                    show_clients_result_json = json.loads(rest_show_clients.data)
-                    show_clients_result_status = show_clients_result_json.get("Status")
-                    if show_clients_result_status == "Success":
-                        show_clients_result_command_output = show_clients_result_json.get(
-                            "Command output"
-                        )
-                        show_clients_result_bytes = (
-                            json.dumps(show_clients_result_command_output)
-                        ).encode()
-                        devices_result = show_clients_result_bytes.split(b"\\n")
-                    else:
-                        _LOGGER.debug(
-                            "Error getting client list via Aruba Instant REST API"
-                        )
-                        return
-
-        else:
-            _LOGGER.debug("Using SSH")
+        elif self.mode == "ssh":
             connect = f"ssh {self.username}@{self.host}"
             ssh = pexpect.spawn(connect)
             query = ssh.expect(
@@ -212,54 +140,13 @@ class ArubaDeviceScanner(DeviceScanner):
             devices_result = ssh.before.split(b"\r\n")
             ssh.sendline("exit")
 
-        devices = {}
-        for device in devices_result:
-            match = _DEVICES_REGEX.search(device.decode("utf-8"))
-            if match:
-                devices[match.group("ip")] = {
-                    "ip": match.group("ip"),
-                    "mac": match.group("mac").upper(),
-                    "name": match.group("name"),
-                }
+            for device in devices_result:
+                match = _DEVICES_REGEX.search(device.decode("utf-8"))
+                if match:
+                    devices[match.group("ip")] = {
+                        "ip": match.group("ip"),
+                        "mac": match.group("mac").upper(),
+                        "name": match.group("name"),
+                    }
+
         return devices
-
-
-class RestData:
-    """Class for handling the data retrieval."""
-
-    def __init__(
-        self, method, resource, headers, data, verify_ssl, timeout=DEFAULT_TIMEOUT
-    ):
-        """Initialize the data object."""
-        self._method = method
-        self._resource = resource
-        self._headers = headers
-        self._request_data = data
-        self._verify_ssl = verify_ssl
-        self._timeout = timeout
-        self._http_session = Session()
-        self.data = None
-        self.headers = None
-
-    def __del__(self):
-        """Destroy the http session on destroy."""
-        self._http_session.close()
-
-    def update(self):
-        """Get the latest data from REST service with provided method."""
-        _LOGGER.debug("Updating from %s", self._resource)
-        try:
-            response = self._http_session.request(
-                self._method,
-                self._resource,
-                headers=self._headers,
-                data=self._request_data,
-                timeout=self._timeout,
-                verify=self._verify_ssl,
-            )
-            self.data = response.text
-            self.headers = response.headers
-        except requests.exceptions.RequestException as ex:
-            _LOGGER.error("Error fetching data: %s failed with %s", self._resource, ex)
-            self.data = None
-            self.headers = None

--- a/homeassistant/components/aruba/device_tracker.py
+++ b/homeassistant/components/aruba/device_tracker.py
@@ -35,7 +35,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 DEFAULT_USE_API = False
 DEFAULT_TIMEOUT = 10
 USE_API = False
-login_result_sid = ''
+login_result_sid = ""
+
 
 def get_scanner(hass, config):
     """Validate the configuration and return a Aruba scanner."""
@@ -60,8 +61,10 @@ class ArubaDeviceScanner(DeviceScanner):
 
         # Test if we can use REST API
         # Aruba Instant API only likes double quotes in the json data and rejects single quotes
-        login_data = '{"user": "' + self.username+ '", "passwd": "'+ self.password +'" }'
-        login_headers = {'Content-Type': 'application/json' }
+        login_data = (
+            '{"user": "' + self.username + '", "passwd": "' + self.password + '" }'
+        )
+        login_headers = {"Content-Type": "application/json"}
         login_method = "POST"
         login_resource = "https://" + self.host + ":4343/rest/login"
 
@@ -71,7 +74,7 @@ class ArubaDeviceScanner(DeviceScanner):
             login_headers,
             login_data,
             False,
-            DEFAULT_TIMEOUT
+            DEFAULT_TIMEOUT,
         )
         rest_login.update()
 
@@ -125,10 +128,17 @@ class ArubaDeviceScanner(DeviceScanner):
 
         if USE_API == True:
             _LOGGER.debug("Using REST API")
-            show_clients_data = ''
-            show_clients_headers = {'Content-Type': 'application/json' }
+            show_clients_data = ""
+            show_clients_headers = {"Content-Type": "application/json"}
             show_clients_method = "GET"
-            show_clients_resource = "https://" + self.host + ":4343/rest/show-cmd?iap_ip_addr=" + self.host + "&cmd=show%20clients&sid=" + login_result_sid
+            show_clients_resource = (
+                "https://"
+                + self.host
+                + ":4343/rest/show-cmd?iap_ip_addr="
+                + self.host
+                + "&cmd=show%20clients&sid="
+                + login_result_sid
+            )
 
             rest_show_clients = RestData(
                 show_clients_method,
@@ -136,21 +146,29 @@ class ArubaDeviceScanner(DeviceScanner):
                 show_clients_headers,
                 show_clients_data,
                 False,
-                DEFAULT_TIMEOUT
+                DEFAULT_TIMEOUT,
             )
             rest_show_clients.update()
 
             if rest_show_clients.headers is not None:
-                show_clients_result_content_type = rest_show_clients.headers.get("content-type")
+                show_clients_result_content_type = rest_show_clients.headers.get(
+                    "content-type"
+                )
                 if show_clients_result_content_type == "application/json":
                     show_clients_result_json = json.loads(rest_show_clients.data)
                     show_clients_result_status = show_clients_result_json.get("Status")
                     if show_clients_result_status == "Success":
-                        show_clients_result_command_output = show_clients_result_json.get("Command output")
-                        show_clients_result_bytes = (json.dumps(show_clients_result_command_output)).encode()
+                        show_clients_result_command_output = show_clients_result_json.get(
+                            "Command output"
+                        )
+                        show_clients_result_bytes = (
+                            json.dumps(show_clients_result_command_output)
+                        ).encode()
                         devices_result = show_clients_result_bytes.split(b"\\n")
                     else:
-                        _LOGGER.debug("Error getting client list via Aruba Instant REST API")
+                        _LOGGER.debug(
+                            "Error getting client list via Aruba Instant REST API"
+                        )
                         return
 
         else:
@@ -204,6 +222,7 @@ class ArubaDeviceScanner(DeviceScanner):
                     "name": match.group("name"),
                 }
         return devices
+
 
 class RestData:
     """Class for handling the data retrieval."""

--- a/homeassistant/components/aruba/device_tracker.py
+++ b/homeassistant/components/aruba/device_tracker.py
@@ -126,7 +126,7 @@ class ArubaDeviceScanner(DeviceScanner):
     def get_aruba_data(self):
         """Retrieve data from Aruba Access Point and return parsed result."""
 
-        if USE_API == True:
+        if USE_API is True:
             _LOGGER.debug("Using REST API")
             show_clients_data = ""
             show_clients_headers = {"Content-Type": "application/json"}

--- a/homeassistant/components/aruba/manifest.json
+++ b/homeassistant/components/aruba/manifest.json
@@ -2,6 +2,6 @@
   "domain": "aruba",
   "name": "Aruba",
   "documentation": "https://www.home-assistant.io/integrations/aruba",
-  "requirements": ["pexpect==4.6.0"],
+  "requirements": ["instantpy==0.0.1", "pexpect==4.6.0"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -794,6 +794,9 @@ influxdb-client==1.6.0
 # homeassistant.components.influxdb
 influxdb==5.2.3
 
+# homeassistant.components.aruba
+instantpy==0.0.1
+
 # homeassistant.components.iperf3
 iperf3==0.1.11
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add REST API support for Aruba Instant device tracker. The configuration will need to be changed in order to leverage the API.  See example below.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
Default mode will use SSH:
```
device_tracker:
  - platform: aruba
    host: 192.168.1.1
    username: admin
    password: password
```
To use REST API, specify **api** in **mode**
```
device_tracker:
  - platform: aruba
    host: 192.168.1.1
    username: admin
    password: password
    mode: api
```
Or also can specify **ssh** for ssh mode
```
device_tracker:
  - platform: aruba
    host: 192.168.1.1
    username: admin
    password: password
    mode: ssh
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13861

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
