### PR TITLE
Move Guardian services to entity platform services

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -3,34 +3,20 @@ import asyncio
 from datetime import timedelta
 
 from aioguardian import Client
-from aioguardian.commands.system import (
-    DEFAULT_FIRMWARE_UPGRADE_FILENAME,
-    DEFAULT_FIRMWARE_UPGRADE_PORT,
-    DEFAULT_FIRMWARE_UPGRADE_URL,
-)
 from aioguardian.errors import GuardianError
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
-    CONF_FILENAME,
     CONF_IP_ADDRESS,
-    CONF_PORT,
-    CONF_URL,
 )
 from homeassistant.core import HomeAssistant, callback
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.service import (
-    async_register_admin_service,
-    verify_domain_control,
-)
 
 from .const import (
     CONF_UID,
@@ -61,16 +47,6 @@ DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 
 PLATFORMS = ["binary_sensor", "sensor", "switch"]
 
-SERVICE_UPGRADE_FIRMWARE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_URL, default=DEFAULT_FIRMWARE_UPGRADE_URL): cv.url,
-        vol.Optional(CONF_PORT, default=DEFAULT_FIRMWARE_UPGRADE_PORT): cv.port,
-        vol.Optional(
-            CONF_FILENAME, default=DEFAULT_FIRMWARE_UPGRADE_FILENAME
-        ): cv.string,
-    }
-)
-
 
 @callback
 def async_get_api_category(entity_kind: str):
@@ -86,8 +62,6 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Elexa Guardian from a config entry."""
-    _verify_domain_control = verify_domain_control(hass, DOMAIN)
-
     guardian = Guardian(hass, entry)
     await guardian.async_update()
     hass.data[DOMAIN][DATA_CLIENT][entry.entry_id] = guardian
@@ -96,69 +70,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
-
-    @_verify_domain_control
-    async def disable_ap(call):
-        """Disable the device's onboard access point."""
-        try:
-            async with guardian.client:
-                await guardian.client.wifi.disable_ap()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def enable_ap(call):
-        """Enable the device's onboard access point."""
-        try:
-            async with guardian.client:
-                await guardian.client.wifi.enable_ap()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def reboot(call):
-        """Reboot the device."""
-        try:
-            async with guardian.client:
-                await guardian.client.system.reboot()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def reset_valve_diagnostics(call):
-        """Fully reset system motor diagnostics."""
-        try:
-            async with guardian.client:
-                await guardian.client.valve.reset()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def upgrade_firmware(call):
-        """Upgrade the device firmware."""
-        try:
-            async with guardian.client:
-                await guardian.client.system.upgrade_firmware(
-                    url=call.data[CONF_URL],
-                    port=call.data[CONF_PORT],
-                    filename=call.data[CONF_FILENAME],
-                )
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    for service, method, schema in [
-        ("disable_ap", disable_ap, None),
-        ("enable_ap", enable_ap, None),
-        ("reboot", reboot, None),
-        ("reset_valve_diagnostics", reset_valve_diagnostics, None),
-        ("upgrade_firmware", upgrade_firmware, SERVICE_UPGRADE_FIRMWARE_SCHEMA),
-    ]:
-        async_register_admin_service(hass, DOMAIN, service, method, schema=schema)
 
     return True
 

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -6,10 +6,7 @@ from aioguardian import Client
 from aioguardian.errors import GuardianError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    CONF_IP_ADDRESS,
-)
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -43,25 +43,18 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     platform = entity_platform.current_platform.get()
 
-    for service_name, method in [
-        (SERVICE_DISABLE_AP, "async_disable_ap"),
-        (SERVICE_ENABLE_AP, "async_enable_ap"),
-        (SERVICE_REBOOT, "async_reboot"),
-        (SERVICE_RESET_VALVE_DIAGNOSTICS, "async_reset_valve_diagnostics"),
+    for service_name, schema, method in [
+        (SERVICE_DISABLE_AP, None, "async_disable_ap"),
+        (SERVICE_ENABLE_AP, None, "async_enable_ap"),
+        (SERVICE_REBOOT, None, "async_reboot"),
+        (SERVICE_RESET_VALVE_DIAGNOSTICS, None, "async_reset_valve_diagnostics"),
+        (
+            SERVICE_UPGRADE_FIRMWARE,
+            SERVICE_UPGRADE_FIRMWARE_SCHEMA,
+            "async_upgrade_firmware",
+        ),
     ]:
-        platform.async_register_entity_service(service_name, None, method)
-
-    async def async_handle_firmware_update(entity, call):
-        """Handle a firmware upgrade entity platform service call."""
-        await entity.async_upgrade_firmware(
-            call.data[CONF_URL], call.data[CONF_PORT], call.data[CONF_FILENAME]
-        )
-
-    platform.async_register_entity_service(
-        SERVICE_UPGRADE_FIRMWARE,
-        SERVICE_UPGRADE_FIRMWARE_SCHEMA,
-        async_handle_firmware_update,
-    )
+        platform.async_register_entity_service(service_name, schema, method)
 
     async_add_entities([GuardianSwitch(guardian)], True)
 
@@ -139,7 +132,7 @@ class GuardianSwitch(GuardianEntity, SwitchEntity):
         except GuardianError as err:
             LOGGER.error("Error during service call: %s", err)
 
-    async def async_upgrade_firmware(self, url, port, filename):
+    async def async_upgrade_firmware(self, *, url, port, filename):
         """Upgrade the device firmware."""
         try:
             async with self._guardian.client:

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -1,8 +1,17 @@
 """Switches for the Elexa Guardian integration."""
+from aioguardian.commands.system import (
+    DEFAULT_FIRMWARE_UPGRADE_FILENAME,
+    DEFAULT_FIRMWARE_UPGRADE_PORT,
+    DEFAULT_FIRMWARE_UPGRADE_URL,
+)
 from aioguardian.errors import GuardianError
+import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_FILENAME, CONF_PORT, CONF_URL
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.service import verify_domain_control
 
 from . import Guardian, GuardianEntity
 from .const import DATA_CLIENT, DATA_VALVE_STATUS, DOMAIN, LOGGER, SWITCH_KIND_VALVE
@@ -12,10 +21,88 @@ ATTR_INST_CURRENT = "instantaneous_current"
 ATTR_INST_CURRENT_DDT = "instantaneous_current_ddt"
 ATTR_TRAVEL_COUNT = "travel_count"
 
+SERVICE_UPGRADE_FIRMWARE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_URL, default=DEFAULT_FIRMWARE_UPGRADE_URL): cv.url,
+        vol.Optional(CONF_PORT, default=DEFAULT_FIRMWARE_UPGRADE_PORT): cv.port,
+        vol.Optional(
+            CONF_FILENAME, default=DEFAULT_FIRMWARE_UPGRADE_FILENAME
+        ): cv.string,
+    }
+)
+
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Guardian switches based on a config entry."""
+    _verify_domain_control = verify_domain_control(hass, DOMAIN)
+
     guardian = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+
+    @_verify_domain_control
+    async def disable_ap(call):
+        """Disable the device's onboard access point."""
+        try:
+            async with guardian.client:
+                await guardian.client.wifi.disable_ap()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+            return
+
+    @_verify_domain_control
+    async def enable_ap(call):
+        """Enable the device's onboard access point."""
+        try:
+            async with guardian.client:
+                await guardian.client.wifi.enable_ap()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+            return
+
+    @_verify_domain_control
+    async def reboot(call):
+        """Reboot the device."""
+        try:
+            async with guardian.client:
+                await guardian.client.system.reboot()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+            return
+
+    @_verify_domain_control
+    async def reset_valve_diagnostics(call):
+        """Fully reset system motor diagnostics."""
+        try:
+            async with guardian.client:
+                await guardian.client.valve.reset()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+            return
+
+    @_verify_domain_control
+    async def upgrade_firmware(call):
+        """Upgrade the device firmware."""
+        try:
+            async with guardian.client:
+                await guardian.client.system.upgrade_firmware(
+                    url=call.data[CONF_URL],
+                    port=call.data[CONF_PORT],
+                    filename=call.data[CONF_FILENAME],
+                )
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+            return
+
+    platform = entity_platform.current_platform.get()
+
+    for service, method, schema in [
+        ("disable_ap", disable_ap, None),
+        ("enable_ap", enable_ap, None),
+        ("reboot", reboot, None),
+        ("reset_valve_diagnostics", reset_valve_diagnostics, None),
+        ("upgrade_firmware", upgrade_firmware, SERVICE_UPGRADE_FIRMWARE_SCHEMA),
+    ]:
+        platform.async_register_entity_service(service, schema, method)
+
     async_add_entities([GuardianSwitch(guardian)], True)
 
 

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -11,7 +11,6 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_FILENAME, CONF_PORT, CONF_URL
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.helpers.service import verify_domain_control
 
 from . import Guardian, GuardianEntity
 from .const import DATA_CLIENT, DATA_VALVE_STATUS, DOMAIN, LOGGER, SWITCH_KIND_VALVE
@@ -20,6 +19,12 @@ ATTR_AVG_CURRENT = "average_current"
 ATTR_INST_CURRENT = "instantaneous_current"
 ATTR_INST_CURRENT_DDT = "instantaneous_current_ddt"
 ATTR_TRAVEL_COUNT = "travel_count"
+
+SERVICE_DISABLE_AP = "disable_ap"
+SERVICE_ENABLE_AP = "enable_ap"
+SERVICE_REBOOT = "reboot"
+SERVICE_RESET_VALVE_DIAGNOSTICS = "reset_valve_diagnostics"
+SERVICE_UPGRADE_FIRMWARE = "upgrade_firmware"
 
 SERVICE_UPGRADE_FIRMWARE_SCHEMA = vol.Schema(
     {
@@ -34,74 +39,29 @@ SERVICE_UPGRADE_FIRMWARE_SCHEMA = vol.Schema(
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Guardian switches based on a config entry."""
-    _verify_domain_control = verify_domain_control(hass, DOMAIN)
-
     guardian = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
-
-    @_verify_domain_control
-    async def disable_ap(call):
-        """Disable the device's onboard access point."""
-        try:
-            async with guardian.client:
-                await guardian.client.wifi.disable_ap()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def enable_ap(call):
-        """Enable the device's onboard access point."""
-        try:
-            async with guardian.client:
-                await guardian.client.wifi.enable_ap()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def reboot(call):
-        """Reboot the device."""
-        try:
-            async with guardian.client:
-                await guardian.client.system.reboot()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def reset_valve_diagnostics(call):
-        """Fully reset system motor diagnostics."""
-        try:
-            async with guardian.client:
-                await guardian.client.valve.reset()
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
-
-    @_verify_domain_control
-    async def upgrade_firmware(call):
-        """Upgrade the device firmware."""
-        try:
-            async with guardian.client:
-                await guardian.client.system.upgrade_firmware(
-                    url=call.data[CONF_URL],
-                    port=call.data[CONF_PORT],
-                    filename=call.data[CONF_FILENAME],
-                )
-        except GuardianError as err:
-            LOGGER.error("Error during service call: %s", err)
-            return
 
     platform = entity_platform.current_platform.get()
 
-    for service, method, schema in [
-        ("disable_ap", disable_ap, None),
-        ("enable_ap", enable_ap, None),
-        ("reboot", reboot, None),
-        ("reset_valve_diagnostics", reset_valve_diagnostics, None),
-        ("upgrade_firmware", upgrade_firmware, SERVICE_UPGRADE_FIRMWARE_SCHEMA),
+    for service_name, method in [
+        (SERVICE_DISABLE_AP, "async_disable_ap"),
+        (SERVICE_ENABLE_AP, "async_enable_ap"),
+        (SERVICE_REBOOT, "async_reboot"),
+        (SERVICE_RESET_VALVE_DIAGNOSTICS, "async_reset_valve_diagnostics"),
     ]:
-        platform.async_register_entity_service(service, schema, method)
+        platform.async_register_entity_service(service_name, None, method)
+
+    async def async_handle_firmware_update(entity, call):
+        """Handle a firmware upgrade entity platform service call."""
+        await entity.async_upgrade_firmware(
+            call.data[CONF_URL], call.data[CONF_PORT], call.data[CONF_FILENAME]
+        )
+
+    platform.async_register_entity_service(
+        SERVICE_UPGRADE_FIRMWARE,
+        SERVICE_UPGRADE_FIRMWARE_SCHEMA,
+        async_handle_firmware_update,
+    )
 
     async_add_entities([GuardianSwitch(guardian)], True)
 
@@ -146,6 +106,48 @@ class GuardianSwitch(GuardianEntity, SwitchEntity):
                 ],
             }
         )
+
+    async def async_disable_ap(self):
+        """Disable the device's onboard access point."""
+        try:
+            async with self._guardian.client:
+                await self._guardian.client.wifi.disable_ap()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+
+    async def async_enable_ap(self):
+        """Enable the device's onboard access point."""
+        try:
+            async with self._guardian.client:
+                await self._guardian.client.wifi.enable_ap()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+
+    async def async_reboot(self):
+        """Reboot the device."""
+        try:
+            async with self._guardian.client:
+                await self._guardian.client.system.reboot()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+
+    async def async_reset_valve_diagnostics(self):
+        """Fully reset system motor diagnostics."""
+        try:
+            async with self._guardian.client:
+                await self._guardian.client.valve.reset()
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
+
+    async def async_upgrade_firmware(self, url, port, filename):
+        """Upgrade the device firmware."""
+        try:
+            async with self._guardian.client:
+                await self._guardian.client.system.upgrade_firmware(
+                    url=url, port=port, filename=filename,
+                )
+        except GuardianError as err:
+            LOGGER.error("Error during service call: %s", err)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the valve off (closed)."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per https://github.com/home-assistant/core/pull/37188#discussion_r446599690, this PR moves all of Guardian's services to entity platform services (so that more than one Guardian device can be accommodated).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
