### PR TITLE
Add option to specify port to PS4

### DIFF
--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -4,6 +4,7 @@ CONFIG_ENTRY_VERSION = 3
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
 DEFAULT_ALIAS = "Home-Assistant"
+DEFAULT_PORT = 0
 DOMAIN = "ps4"
 GAMES_FILE = ".ps4-games.{}.json"
 PS4_DATA = "ps4_data"

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -77,9 +77,8 @@ async def update_listener(hass, config_entry):
     """Handle PS4 options update."""
     _LOGGER.debug("PS4 options applied")
     for device in hass.data[PS4_DATA].devices:
-        if (
-            device._entry_id == config_entry.entry_id
-        ):  # noqa: pylint: disable=protected-access
+        # noqa: pylint: disable=protected-access
+        if device._entry_id == config_entry.entry_id:
             await device.async_options_port_update(config_entry.options[CONF_PORT])
 
 
@@ -159,7 +158,7 @@ class PS4Device(MediaPlayerEntity):
             # Manually set protocol to default protocol.
             protocol = self._ps4.ddp_protocol
             protocol.close()
-            self._ps4._port = DEFAULT_PORT  # noqa: pylint: disable=protected-access
+            self._ps4.change_port(DEFAULT_PORT)
             self._ps4.ddp_protocol = self.hass.data[PS4_DATA].protocol
             _LOGGER.debug("Closing: %s; Using Default", protocol)
         else:
@@ -180,7 +179,7 @@ class PS4Device(MediaPlayerEntity):
         # New Protocol will be assigned if port available.
         port_available = await self._ps4.get_ddp_endpoint()
         if not port_available:
-            self._ps4._port = DEFAULT_PORT  # noqa: pylint: disable=protected-access
+            self._ps4.change_port(DEFAULT_PORT)
             _LOGGER.warning(
                 "Port %s is unavailable, Using default port", port,
             )

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -77,7 +77,9 @@ async def update_listener(hass, config_entry):
     """Handle PS4 options update."""
     _LOGGER.debug("PS4 options applied")
     for device in hass.data[PS4_DATA].devices:
-        if device._entry_id == config_entry.entry_id:
+        if (
+            device._entry_id == config_entry.entry_id
+        ):  # noqa: pylint: disable=protected-access
             await device.async_options_port_update(config_entry.options[CONF_PORT])
 
 
@@ -157,7 +159,7 @@ class PS4Device(MediaPlayerEntity):
             # Manually set protocol to default protocol.
             protocol = self._ps4.ddp_protocol
             protocol.close()
-            self._ps4._port = DEFAULT_PORT
+            self._ps4._port = DEFAULT_PORT  # noqa: pylint: disable=protected-access
             self._ps4.ddp_protocol = self.hass.data[PS4_DATA].protocol
             _LOGGER.debug("Closing: %s; Using Default", protocol)
         else:
@@ -178,7 +180,7 @@ class PS4Device(MediaPlayerEntity):
         # New Protocol will be assigned if port available.
         port_available = await self._ps4.get_ddp_endpoint()
         if not port_available:
-            self._ps4._port = DEFAULT_PORT
+            self._ps4._port = DEFAULT_PORT  # noqa: pylint: disable=protected-access
             _LOGGER.warning(
                 "Port %s is unavailable, Using default port", port,
             )

--- a/homeassistant/components/ps4/strings.json
+++ b/homeassistant/components/ps4/strings.json
@@ -37,5 +37,19 @@
       "port_987_bind_error": "Could not bind to port 987. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
       "port_997_bind_error": "Could not bind to port 997. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info."
     }
+  },
+  "options": {
+    "step": {
+      "port": {
+        "description": "Specify local UDP port to use. Defaults to 0 (any).",
+        "title": "PlayStation 4 Options - Port",
+        "data": {
+          "port": "Port Number"
+        }
+      }
+    },
+    "error": {
+      "port_unavailable": "Port is already being used or is not available."
+    }
   }
 }

--- a/homeassistant/components/ps4/translations/en.json
+++ b/homeassistant/components/ps4/translations/en.json
@@ -37,5 +37,19 @@
                 "title": "PlayStation 4"
             }
         }
+    },
+    "options": {
+        "error": {
+            "port_unavailable": "Port is already being used or is not available."
+        },
+        "step": {
+            "port": {
+                "data": {
+                    "port": "Port Number"
+                },
+                "description": "Specify local UDP port to use. Defaults to 0 (any).",
+                "title": "PlayStation 4 Options - Port"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds option to specify local UDP port to use for PS4.

The default behavior is that the local UDP port is selected randomly. When messages are received they always originate from a random remote port. Some users would like to harden their HA instance by using firewalls.  Currently the most specific rule that can be used with the PS4 integration specifies IP Address and protocol. Some users would like to implement firewalls with more granularity to include ports. This PR implements options flow to allow this feature.

Additional Details:
- Default local port is 0 (randomly selected)
- Entities will by default, use the default port (current behavior)
- Port can be hotswapped without restarting the instance
- A specified port can only be used with one PS4 entity


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
