### PR TITLE
Enhance script integration to use new features in script helper

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     ATTR_NAME,
     CONF_ALIAS,
     CONF_ICON,
+    CONF_MODE,
     SERVICE_RELOAD,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
@@ -21,7 +22,13 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.script import Script
+from homeassistant.helpers.script import (
+    DEFAULT_QUEUE_MAX,
+    SCRIPT_MODE_CHOICES,
+    SCRIPT_MODE_LEGACY,
+    SCRIPT_MODE_QUEUE,
+    Script,
+)
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.loader import bind_hass
 
@@ -37,10 +44,46 @@ CONF_DESCRIPTION = "description"
 CONF_EXAMPLE = "example"
 CONF_FIELDS = "fields"
 CONF_SEQUENCE = "sequence"
+CONF_QUEUE_MAX = "queue_size"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
 EVENT_SCRIPT_STARTED = "script_started"
+
+
+def _deprecated_legacy_mode(config):
+    legacy_scripts = []
+    for object_id, cfg in config.items():
+        mode = cfg.get(CONF_MODE)
+        if mode is None:
+            legacy_scripts.append(object_id)
+            cfg[CONF_MODE] = SCRIPT_MODE_LEGACY
+    if legacy_scripts:
+        _LOGGER.warning(
+            "Script behavior has changed. "
+            "To continue using previous behavior, which is now deprecated, "
+            "add '%s: %s' to script(s): %s.",
+            CONF_MODE,
+            SCRIPT_MODE_LEGACY,
+            ", ".join(legacy_scripts),
+        )
+    return config
+
+
+def _queue_max(config):
+    for object_id, cfg in config.items():
+        mode = cfg[CONF_MODE]
+        queue_max = cfg.get(CONF_QUEUE_MAX)
+        if mode == SCRIPT_MODE_QUEUE:
+            if queue_max is None:
+                cfg[CONF_QUEUE_MAX] = DEFAULT_QUEUE_MAX
+        elif queue_max is not None:
+            raise vol.Invalid(
+                f"{CONF_QUEUE_MAX} not valid with {mode} {CONF_MODE} "
+                f"for script '{object_id}'"
+            )
+    return config
+
 
 SCRIPT_ENTRY_SCHEMA = vol.Schema(
     {
@@ -54,11 +97,20 @@ SCRIPT_ENTRY_SCHEMA = vol.Schema(
                 vol.Optional(CONF_EXAMPLE): cv.string,
             }
         },
+        vol.Optional(CONF_MODE): vol.In(SCRIPT_MODE_CHOICES),
+        vol.Optional(CONF_QUEUE_MAX): vol.All(vol.Coerce(int), vol.Range(min=2)),
     }
 )
 
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: cv.schema_with_slug_keys(SCRIPT_ENTRY_SCHEMA)}, extra=vol.ALLOW_EXTRA
+    {
+        DOMAIN: vol.All(
+            cv.schema_with_slug_keys(SCRIPT_ENTRY_SCHEMA),
+            _deprecated_legacy_mode,
+            _queue_max,
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 SCRIPT_SERVICE_SCHEMA = vol.Schema(dict)
@@ -91,7 +143,7 @@ def scripts_with_entity(hass: HomeAssistant, entity_id: str) -> List[str]:
 
 @callback
 def entities_in_script(hass: HomeAssistant, entity_id: str) -> List[str]:
-    """Return all entities in a scene."""
+    """Return all entities in script."""
     if DOMAIN not in hass.data:
         return []
 
@@ -122,7 +174,7 @@ def scripts_with_device(hass: HomeAssistant, device_id: str) -> List[str]:
 
 @callback
 def devices_in_script(hass: HomeAssistant, entity_id: str) -> List[str]:
-    """Return all devices in a scene."""
+    """Return all devices in script."""
     if DOMAIN not in hass.data:
         return []
 
@@ -152,13 +204,16 @@ async def async_setup(hass, config):
 
     async def turn_on_service(service):
         """Call a service to turn script on."""
-        # We could turn on script directly here, but we only want to offer
-        # one way to do it. Otherwise no easy way to detect invocations.
-        var = service.data.get(ATTR_VARIABLES)
-        for script in await component.async_extract_from_service(service):
-            await hass.services.async_call(
-                DOMAIN, script.object_id, var, context=service.context
-            )
+        variables = service.data.get(ATTR_VARIABLES)
+        for script_entity in await component.async_extract_from_service(service):
+            if script_entity.script.is_legacy:
+                await hass.services.async_call(
+                    DOMAIN, script_entity.object_id, variables, context=service.context
+                )
+            else:
+                await script_entity.async_turn_on(
+                    variables=variables, context=service.context, wait=False
+                )
 
     async def turn_off_service(service):
         """Cancel a script."""
@@ -172,8 +227,8 @@ async def async_setup(hass, config):
 
     async def toggle_service(service):
         """Toggle a script."""
-        for script in await component.async_extract_from_service(service):
-            await script.async_toggle(context=service.context)
+        for script_entity in await component.async_extract_from_service(service):
+            await script_entity.async_toggle(context=service.context)
 
     hass.services.async_register(
         DOMAIN, SERVICE_RELOAD, reload_service, schema=RELOAD_SERVICE_SCHEMA
@@ -197,24 +252,40 @@ async def _async_process_config(hass, config, component):
     async def service_handler(service):
         """Execute a service call to script.<script name>."""
         entity_id = ENTITY_ID_FORMAT.format(service.service)
-        script = component.get_entity(entity_id)
-        if script.is_on:
+        script_entity = component.get_entity(entity_id)
+        if script_entity.script.is_legacy and script_entity.is_on:
             _LOGGER.warning("Script %s already running.", entity_id)
             return
-        await script.async_turn_on(variables=service.data, context=service.context)
+        await script_entity.async_turn_on(
+            variables=service.data, context=service.context
+        )
 
-    scripts = []
+    script_entities = []
 
     for object_id, cfg in config.get(DOMAIN, {}).items():
-        scripts.append(
+        script_entities.append(
             ScriptEntity(
                 hass,
                 object_id,
                 cfg.get(CONF_ALIAS, object_id),
                 cfg.get(CONF_ICON),
                 cfg[CONF_SEQUENCE],
+                cfg[CONF_MODE],
+                cfg.get(CONF_QUEUE_MAX, 0),
             )
         )
+
+    await component.async_add_entities(script_entities)
+
+    # Register services for all entities that were created successfully.
+    for script_entity in script_entities:
+        object_id = script_entity.object_id
+        if component.get_entity(script_entity.entity_id) is None:
+            _LOGGER.error("Couldn't load script %s", object_id)
+            continue
+
+        cfg = config[DOMAIN][object_id]
+
         hass.services.async_register(
             DOMAIN, object_id, service_handler, schema=SCRIPT_SERVICE_SCHEMA
         )
@@ -226,22 +297,27 @@ async def _async_process_config(hass, config, component):
         }
         async_set_service_schema(hass, DOMAIN, object_id, service_desc)
 
-    await component.async_add_entities(scripts)
-
 
 class ScriptEntity(ToggleEntity):
     """Representation of a script entity."""
 
     icon = None
 
-    def __init__(self, hass, object_id, name, icon, sequence):
+    def __init__(self, hass, object_id, name, icon, sequence, mode, queue_max):
         """Initialize the script."""
         self.object_id = object_id
         self.icon = icon
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self.script = Script(
-            hass, sequence, name, self.async_write_ha_state, logger=_LOGGER
+            hass,
+            sequence,
+            name,
+            self.async_change_listener,
+            mode,
+            queue_max,
+            logging.getLogger(f"{__name__}.{object_id}"),
         )
+        self._changed = asyncio.Event()
 
     @property
     def should_poll(self):
@@ -268,16 +344,36 @@ class ScriptEntity(ToggleEntity):
         """Return true if script is on."""
         return self.script.is_running
 
+    @callback
+    def async_change_listener(self):
+        """Update state."""
+        self.async_write_ha_state()
+        self._changed.set()
+
     async def async_turn_on(self, **kwargs):
         """Turn the script on."""
+        variables = kwargs.get("variables")
         context = kwargs.get("context")
+        wait = kwargs.get("wait", True)
         self.async_set_context(context)
         self.hass.bus.async_fire(
             EVENT_SCRIPT_STARTED,
             {ATTR_NAME: self.script.name, ATTR_ENTITY_ID: self.entity_id},
             context=context,
         )
-        await self.script.async_run(kwargs.get(ATTR_VARIABLES), context)
+        coro = self.script.async_run(variables, context)
+        if wait:
+            await coro
+        else:
+            # Caller does not want to wait for called script to finish so let script run
+            # in separate Task. However, wait for first state change so we can guarantee
+            # that it is written to the State Machine before we return. Only do this for
+            # non-legacy scripts, since legacy scripts don't necessarily change state
+            # immediately.
+            self._changed.clear()
+            self.hass.async_create_task(coro)
+            if not self.script.is_legacy:
+                await self._changed.wait()
 
     async def async_turn_off(self, **kwargs):
         """Turn script off."""

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -364,16 +364,17 @@ class ScriptEntity(ToggleEntity):
         coro = self.script.async_run(variables, context)
         if wait:
             await coro
-        else:
-            # Caller does not want to wait for called script to finish so let script run
-            # in separate Task. However, wait for first state change so we can guarantee
-            # that it is written to the State Machine before we return. Only do this for
-            # non-legacy scripts, since legacy scripts don't necessarily change state
-            # immediately.
-            self._changed.clear()
-            self.hass.async_create_task(coro)
-            if not self.script.is_legacy:
-                await self._changed.wait()
+            return
+
+        # Caller does not want to wait for called script to finish so let script run in
+        # separate Task. However, wait for first state change so we can guarantee that
+        # it is written to the State Machine before we return. Only do this for
+        # non-legacy scripts, since legacy scripts don't necessarily change state
+        # immediately.
+        self._changed.clear()
+        self.hass.async_create_task(coro)
+        if not self.script.is_legacy:
+            await self._changed.wait()
 
     async def async_turn_off(self, **kwargs):
         """Turn script off."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-on to PR #36202 which, together with a few previous PRs, added new modes to the script "helper" (`homeassistant/helpers/script.py`.) This PR makes those new modes available in the script integration. It also makes sure that services are only registered for scripts that are initialized successfully.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #25419
- Link to documentation pull request: home-assistant/home-assistant.io#13859

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
