### PR TITLE
Convert rfxtrx tests to pytest async tests and re-enable

### DIFF
--- a/tests/components/rfxtrx/__init__.py
+++ b/tests/components/rfxtrx/__init__.py
@@ -1,1 +1,6 @@
 """Tests for the rfxtrx component."""
+from homeassistant.components import rfxtrx
+
+
+async def _signal_event(hass, event):
+    await hass.async_add_executor_job(rfxtrx.RECEIVED_EVT_SUBSCRIBERS[0], event)

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -67,3 +67,9 @@ async def rfxtrx_cleanup():
 async def rfxtrx_fixture(hass):
     """Stub out core rfxtrx to test platform."""
     mock_component(hass, "rfxtrx")
+
+    yield
+
+    # These test don't listen for stop to do cleanup.
+    if rfxtrx_core.DATA_RFXOBJECT in hass.data:
+        hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -1,4 +1,8 @@
 """Common test tools."""
+import threading
+from unittest import mock
+
+import RFXtrx
 import pytest
 
 from homeassistant.components import rfxtrx as rfxtrx_core
@@ -6,14 +10,57 @@ from homeassistant.components import rfxtrx as rfxtrx_core
 from tests.common import mock_component
 
 
+class FixedDummySerial(RFXtrx._dummySerial):  # pylint: disable=protected-access
+    """Fixed dummy serial that doesn't cause max CPU usage."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._close_event = threading.Event()
+
+    def read(self, data=None):
+        """Read."""
+        res = super().read(data)
+        if not res and not data:
+            self._close_event.wait(0.1)
+        return res
+
+    def close(self):
+        """Close."""
+        self._close_event.set()
+
+
+class FixedDummyTransport(RFXtrx.DummyTransport):
+    """Fixed dummy transport that maxes CPU."""
+
+    def __init__(self, device="", debug=True):
+        """Init."""
+        super().__init__(device, debug)
+        self._close_event = threading.Event()
+
+    def receive_blocking(self, data=None):
+        """Read."""
+        res = super().receive_blocking(data)
+        if not res:
+            self._close_event.wait(0.1)
+        return res
+
+    def close(self):
+        """Close."""
+        self._close_event.set()
+
+
 @pytest.fixture(autouse=True)
-async def rfxtrx_cleanup(hass):
+async def rfxtrx_cleanup():
     """Fixture that cleans up threads from integration."""
-    yield
+
+    with mock.patch("RFXtrx._dummySerial", new=FixedDummySerial), mock.patch(
+        "RFXtrx.DummyTransport", new=FixedDummyTransport
+    ):
+        yield
+
     rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
     rfxtrx_core.RFX_DEVICES.clear()
-    if rfxtrx_core.DATA_RFXOBJECT in hass.data:
-        hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
 
 
 @pytest.fixture(name="rfxtrx")

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -1,0 +1,22 @@
+"""Common test tools."""
+import pytest
+
+from homeassistant.components import rfxtrx as rfxtrx_core
+
+from tests.common import mock_component
+
+
+@pytest.fixture(autouse=True)
+async def rfxtrx_cleanup(hass):
+    """Fixture that cleans up threads from integration."""
+    yield
+    rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
+    rfxtrx_core.RFX_DEVICES.clear()
+    if rfxtrx_core.DATA_RFXOBJECT in hass.data:
+        hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
+
+
+@pytest.fixture(name="rfxtrx")
+async def rfxtrx_fixture(hass):
+    """Stub out core rfxtrx to test platform."""
+    mock_component(hass, "rfxtrx")

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -1,37 +1,19 @@
 """The tests for the Rfxtrx cover platform."""
-import unittest
-
 import RFXtrx as rfxtrxmod
-import pytest
 
 from homeassistant.components import rfxtrx as rfxtrx_core
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant, mock_component
+from . import _signal_event
+
+from tests.common import assert_setup_component
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
-class TestCoverRfxtrx(unittest.TestCase):
-    """Test the Rfxtrx cover platform."""
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        mock_component(self.hass, "rfxtrx")
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
-        rfxtrx_core.RFX_DEVICES.clear()
-        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
-            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-        self.hass.stop()
-
-    def test_valid_config(self):
-        """Test configuration."""
-        assert setup_component(
-            self.hass,
+async def test_valid_config(hass, rfxtrx):
+    """Test configuration."""
+    with assert_setup_component(1):
+        assert await async_setup_component(
+            hass,
             "cover",
             {
                 "cover": {
@@ -47,151 +29,148 @@ class TestCoverRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_default_config(self):
-        """Test with 0 cover."""
-        assert setup_component(
-            self.hass, "cover", {"cover": {"platform": "rfxtrx", "devices": {}}}
-        )
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-    def test_one_cover(self):
-        """Test with 1 cover."""
-        assert setup_component(
-            self.hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "rfxtrx",
-                    "devices": {"0b1400cd0213c7f210010f51": {"name": "Test"}},
-                }
-            },
-        )
-        self.hass.block_till_done()
-        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
-            "", transport_protocol=rfxtrxmod.DummyTransport
-        )
+async def test_default_config(hass, rfxtrx):
+    """Test with 0 cover."""
+    assert await async_setup_component(
+        hass, "cover", {"cover": {"platform": "rfxtrx", "devices": {}}}
+    )
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        for id in rfxtrx_core.RFX_DEVICES:
-            entity = rfxtrx_core.RFX_DEVICES[id]
-            assert entity.signal_repetitions == 1
-            assert not entity.should_fire_event
-            assert not entity.should_poll
-            entity.open_cover()
-            entity.close_cover()
-            entity.stop_cover()
 
-    def test_several_covers(self):
-        """Test with 3 covers."""
-        assert setup_component(
-            self.hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "rfxtrx",
-                    "signal_repetitions": 3,
-                    "devices": {
-                        "0b1100cd0213c7f230010f71": {"name": "Test"},
-                        "0b1100100118cdea02010f70": {"name": "Bath"},
-                        "0b1100101118cdea02010f70": {"name": "Living"},
-                    },
-                }
-            },
-        )
+async def test_one_cover(hass, rfxtrx):
+    """Test with 1 cover."""
+    assert await async_setup_component(
+        hass,
+        "cover",
+        {
+            "cover": {
+                "platform": "rfxtrx",
+                "devices": {"0b1400cd0213c7f210010f51": {"name": "Test"}},
+            }
+        },
+    )
+    hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
+        "", transport_protocol=rfxtrxmod.DummyTransport
+    )
 
-        assert 3 == len(rfxtrx_core.RFX_DEVICES)
-        device_num = 0
-        for id in rfxtrx_core.RFX_DEVICES:
-            entity = rfxtrx_core.RFX_DEVICES[id]
-            assert entity.signal_repetitions == 3
-            if entity.name == "Living":
-                device_num = device_num + 1
-            elif entity.name == "Bath":
-                device_num = device_num + 1
-            elif entity.name == "Test":
-                device_num = device_num + 1
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    for id in rfxtrx_core.RFX_DEVICES:
+        entity = rfxtrx_core.RFX_DEVICES[id]
+        entity.hass = hass
+        assert entity.signal_repetitions == 1
+        assert not entity.should_fire_event
+        assert not entity.should_poll
+        entity.open_cover()
+        entity.close_cover()
+        entity.stop_cover()
 
-        assert 3 == device_num
 
-    def test_discover_covers(self):
-        """Test with discovery of covers."""
-        assert setup_component(
-            self.hass,
-            "cover",
-            {"cover": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
-        )
+async def test_several_covers(hass, rfxtrx):
+    """Test with 3 covers."""
+    assert await async_setup_component(
+        hass,
+        "cover",
+        {
+            "cover": {
+                "platform": "rfxtrx",
+                "signal_repetitions": 3,
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {"name": "Test"},
+                    "0b1100100118cdea02010f70": {"name": "Bath"},
+                    "0b1100101118cdea02010f70": {"name": "Living"},
+                },
+            }
+        },
+    )
 
-        event = rfxtrx_core.get_rfx_object("0a140002f38cae010f0070")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0x02, 0xF3, 0x8C, 0xAE, 0x01, 0x0F, 0x00, 0x70]
-        )
+    assert 3 == len(rfxtrx_core.RFX_DEVICES)
+    device_num = 0
+    for id in rfxtrx_core.RFX_DEVICES:
+        entity = rfxtrx_core.RFX_DEVICES[id]
+        assert entity.signal_repetitions == 3
+        if entity.name == "Living":
+            device_num = device_num + 1
+        elif entity.name == "Bath":
+            device_num = device_num + 1
+        elif entity.name == "Test":
+            device_num = device_num + 1
 
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    assert 3 == device_num
 
-        event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
-        )
 
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+async def test_discover_covers(hass, rfxtrx):
+    """Test with discovery of covers."""
+    assert await async_setup_component(
+        hass,
+        "cover",
+        {"cover": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+    )
 
-        # Trying to add a sensor
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0a140002f38cae010f0070")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0x02, 0xF3, 0x8C, 0xAE, 0x01, 0x0F, 0x00, 0x70]
+    )
 
-        # Trying to add a light
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
-        )
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
 
-    def test_discover_cover_noautoadd(self):
-        """Test with discovery of cover when auto add is False."""
-        assert setup_component(
-            self.hass,
-            "cover",
-            {"cover": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-        )
+    event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
+    )
 
-        event = rfxtrx_core.get_rfx_object("0a1400adf394ab010d0060")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x01, 0x0D, 0x00, 0x60]
-        )
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    # Trying to add a sensor
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
-        )
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    # Trying to add a light
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
+    )
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        # Trying to add a sensor
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-        # Trying to add a light
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
-        )
-        for evt_sub in rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS:
-            evt_sub(event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+async def test_discover_cover_noautoadd(hass, rfxtrx):
+    """Test with discovery of cover when auto add is False."""
+    assert await async_setup_component(
+        hass,
+        "cover",
+        {"cover": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
+    )
+
+    event = rfxtrx_core.get_rfx_object("0a1400adf394ab010d0060")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x01, 0x0D, 0x00, 0x60]
+    )
+
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
+    )
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a sensor
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a light
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
+    )
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -28,6 +28,7 @@ async def test_valid_config(hass, rfxtrx):
                 }
             },
         )
+        await hass.async_block_till_done()
 
 
 async def test_default_config(hass, rfxtrx):
@@ -35,6 +36,8 @@ async def test_default_config(hass, rfxtrx):
     assert await async_setup_component(
         hass, "cover", {"cover": {"platform": "rfxtrx", "devices": {}}}
     )
+    await hass.async_block_till_done()
+
     assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
 
@@ -50,6 +53,8 @@ async def test_one_cover(hass, rfxtrx):
             }
         },
     )
+    await hass.async_block_till_done()
+
     hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
         "", transport_protocol=rfxtrxmod.DummyTransport
     )

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -88,6 +88,7 @@ async def test_several_covers(hass, rfxtrx):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert 3 == len(rfxtrx_core.RFX_DEVICES)
     device_num = 0
@@ -111,6 +112,7 @@ async def test_discover_covers(hass, rfxtrx):
         "cover",
         {"cover": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
     )
+    await hass.async_block_till_done()
 
     event = rfxtrx_core.get_rfx_object("0a140002f38cae010f0070")
     event.data = bytearray(
@@ -150,6 +152,7 @@ async def test_discover_cover_noautoadd(hass, rfxtrx):
         "cover",
         {"cover": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
     )
+    await hass.async_block_till_done()
 
     event = rfxtrx_core.get_rfx_object("0a1400adf394ab010d0060")
     event.data = bytearray(

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,204 +1,199 @@
 """The tests for the Rfxtrx component."""
 # pylint: disable=protected-access
-import time
-import unittest
+import asyncio
 
-import pytest
+from async_timeout import timeout
 
 from homeassistant.components import rfxtrx
 from homeassistant.core import callback
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant
+from . import _signal_event
+
+from tests.common import assert_setup_component
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
-class TestRFXTRX(unittest.TestCase):
-    """Test the Rfxtrx component."""
+async def test_default_config(hass):
+    """Test configuration."""
+    assert await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "/dev/serial/by-id/usb"
+                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
+                "dummy": True,
+            }
+        },
+    )
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS.clear()
-        rfxtrx.RFX_DEVICES.clear()
-        if rfxtrx.DATA_RFXOBJECT in self.hass.data:
-            self.hass.data[rfxtrx.DATA_RFXOBJECT].close_connection()
-        self.hass.stop()
-
-    def test_default_config(self):
-        """Test configuration."""
-        assert setup_component(
-            self.hass,
-            "rfxtrx",
-            {
-                "rfxtrx": {
-                    "device": "/dev/serial/by-id/usb"
-                    + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                    "dummy": True,
-                }
-            },
-        )
-
-        assert setup_component(
-            self.hass,
+    with assert_setup_component(1, "sensor"):
+        await async_setup_component(
+            hass,
             "sensor",
             {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
         )
 
-        time.sleep(1)  # Dummy startup is slow
+    # Dummy startup is slow
+    async with timeout(10):
+        while len(hass.data[rfxtrx.DATA_RFXOBJECT].sensors()) < 2:
+            await asyncio.sleep(0.1)
 
-        assert len(self.hass.data[rfxtrx.DATA_RFXOBJECT].sensors()) == 2
+    assert len(hass.data[rfxtrx.DATA_RFXOBJECT].sensors()) == 2
 
-    def test_valid_config(self):
-        """Test configuration."""
-        assert setup_component(
-            self.hass,
-            "rfxtrx",
-            {
-                "rfxtrx": {
-                    "device": "/dev/serial/by-id/usb"
-                    + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                    "dummy": True,
-                }
-            },
-        )
 
-    def test_valid_config2(self):
-        """Test configuration."""
-        assert setup_component(
-            self.hass,
-            "rfxtrx",
-            {
-                "rfxtrx": {
-                    "device": "/dev/serial/by-id/usb"
-                    + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                    "dummy": True,
-                    "debug": True,
-                }
-            },
-        )
+async def test_valid_config(hass):
+    """Test configuration."""
+    assert await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "/dev/serial/by-id/usb"
+                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
+                "dummy": True,
+            }
+        },
+    )
 
-    def test_invalid_config(self):
-        """Test configuration."""
-        assert not setup_component(self.hass, "rfxtrx", {"rfxtrx": {}})
 
-        assert not setup_component(
-            self.hass,
-            "rfxtrx",
-            {
-                "rfxtrx": {
-                    "device": "/dev/serial/by-id/usb"
-                    + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                    "invalid_key": True,
-                }
-            },
-        )
+async def test_valid_config2(hass):
+    """Test configuration."""
+    assert await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "/dev/serial/by-id/usb"
+                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
+                "dummy": True,
+                "debug": True,
+            }
+        },
+    )
 
-    def test_fire_event(self):
-        """Test fire event."""
-        assert setup_component(
-            self.hass,
-            "rfxtrx",
-            {
-                "rfxtrx": {
-                    "device": "/dev/serial/by-id/usb"
-                    + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                    "dummy": True,
-                }
-            },
-        )
-        assert setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {
-                            "name": "Test",
-                            rfxtrx.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
 
-        calls = []
+async def test_invalid_config(hass):
+    """Test configuration."""
+    assert not await async_setup_component(hass, "rfxtrx", {"rfxtrx": {}})
 
-        @callback
-        def record_event(event):
-            """Add recorded event to set."""
-            calls.append(event)
+    assert not await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "/dev/serial/by-id/usb"
+                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
+                "invalid_key": True,
+            }
+        },
+    )
 
-        self.hass.bus.listen(rfxtrx.EVENT_BUTTON_PRESSED, record_event)
-        self.hass.block_till_done()
-        entity = rfxtrx.RFX_DEVICES["213c7f2_16"]
-        entity.update_state(False, 0)
-        assert "Test" == entity.name
-        assert "off" == entity.state
-        assert entity.should_fire_event
 
-        event = rfxtrx.get_rfx_object("0b1100cd0213c7f210010f51")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
-        )
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        self.hass.block_till_done()
+async def test_fire_event(hass):
+    """Test fire event."""
+    assert await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "/dev/serial/by-id/usb"
+                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
+                "dummy": True,
+            }
+        },
+    )
 
-        assert event.values["Command"] == "On"
-        assert "on" == entity.state
-        assert self.hass.states.get("switch.test").state == "on"
-        assert 1 == len(calls)
-        assert calls[0].data == {"entity_id": "switch.test", "state": "on"}
+    assert await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "rfxtrx",
+                "automatic_add": True,
+                "devices": {
+                    "0b1100cd0213c7f210010f51": {
+                        "name": "Test",
+                        rfxtrx.ATTR_FIRE_EVENT: True,
+                    }
+                },
+            }
+        },
+    )
 
-    def test_fire_event_sensor(self):
-        """Test fire event."""
-        assert setup_component(
-            self.hass,
-            "rfxtrx",
-            {
-                "rfxtrx": {
-                    "device": "/dev/serial/by-id/usb"
-                    + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                    "dummy": True,
-                }
-            },
-        )
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {
-                "sensor": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "0a520802060100ff0e0269": {
-                            "name": "Test",
-                            rfxtrx.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
+    calls = []
 
-        calls = []
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        calls.append(event)
 
-        @callback
-        def record_event(event):
-            """Add recorded event to set."""
-            calls.append(event)
+    hass.bus.async_listen(rfxtrx.EVENT_BUTTON_PRESSED, record_event)
+    await hass.async_block_till_done()
+    entity = rfxtrx.RFX_DEVICES["213c7f2_16"]
+    entity.update_state(False, 0)
+    assert "Test" == entity.name
+    assert "off" == entity.state
+    assert entity.should_fire_event
 
-        self.hass.bus.listen("signal_received", record_event)
-        self.hass.block_till_done()
-        event = rfxtrx.get_rfx_object("0a520802060101ff0f0269")
-        event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
-        rfxtrx.RECEIVED_EVT_SUBSCRIBERS[0](event)
+    event = rfxtrx.get_rfx_object("0b1100cd0213c7f210010f51")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
+    )
+    await _signal_event(hass, event)
+    await hass.async_block_till_done()
 
-        self.hass.block_till_done()
-        assert 1 == len(calls)
-        assert calls[0].data == {"entity_id": "sensor.test_temperature"}
+    assert event.values["Command"] == "On"
+    assert "on" == entity.state
+    assert hass.states.get("switch.test").state == "on"
+    assert 1 == len(calls)
+    assert calls[0].data == {"entity_id": "switch.test", "state": "on"}
+
+
+async def test_fire_event_sensor(hass):
+    """Test fire event."""
+    await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "/dev/serial/by-id/usb"
+                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
+                "dummy": True,
+            }
+        },
+    )
+
+    await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "rfxtrx",
+                "automatic_add": True,
+                "devices": {
+                    "0a520802060100ff0e0269": {
+                        "name": "Test",
+                        rfxtrx.ATTR_FIRE_EVENT: True,
+                    }
+                },
+            }
+        },
+    )
+
+    calls = []
+
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        calls.append(event)
+
+    hass.bus.async_listen("signal_received", record_event)
+    await hass.async_block_till_done()
+    event = rfxtrx.get_rfx_object("0a520802060101ff0f0269")
+    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
+    await _signal_event(hass, event)
+
+    await hass.async_block_till_done()
+    assert 1 == len(calls)
+    assert calls[0].data == {"entity_id": "sensor.test_temperature"}

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -120,6 +120,7 @@ async def test_fire_event(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     calls = []
 
@@ -180,6 +181,7 @@ async def test_fire_event_sensor(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
     calls = []
 

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -1,36 +1,17 @@
 """The tests for the Rfxtrx light platform."""
-import unittest
-
-import pytest
-
 from homeassistant.components import rfxtrx as rfxtrx_core
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant, mock_component
+from . import _signal_event
+
+from tests.common import assert_setup_component
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
-class TestLightRfxtrx(unittest.TestCase):
-    """Test the Rfxtrx light platform."""
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        mock_component(self.hass, "rfxtrx")
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
-        rfxtrx_core.RFX_DEVICES.clear()
-        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
-            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-        self.hass.stop()
-
-    def test_valid_config(self):
-        """Test configuration."""
-        assert setup_component(
-            self.hass,
+async def test_valid_config(hass, rfxtrx):
+    """Test configuration."""
+    with assert_setup_component(1):
+        assert await async_setup_component(
+            hass,
             "light",
             {
                 "light": {
@@ -46,8 +27,8 @@ class TestLightRfxtrx(unittest.TestCase):
             },
         )
 
-        assert setup_component(
-            self.hass,
+        assert await async_setup_component(
+            hass,
             "light",
             {
                 "light": {
@@ -63,226 +44,232 @@ class TestLightRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_default_config(self):
-        """Test with 0 switches."""
-        assert setup_component(
-            self.hass, "light", {"light": {"platform": "rfxtrx", "devices": {}}}
+
+async def test_default_config(hass, rfxtrx):
+    """Test with 0 switches."""
+    with assert_setup_component(1):
+        await async_setup_component(
+            hass, "light", {"light": {"platform": "rfxtrx", "devices": {}}}
         )
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-    def test_one_light(self):
-        """Test with 1 light."""
-        assert setup_component(
-            self.hass,
-            "light",
-            {
-                "light": {
-                    "platform": "rfxtrx",
-                    "devices": {"0b1100cd0213c7f210010f51": {"name": "Test"}},
-                }
-            },
-        )
 
-        import RFXtrx as rfxtrxmod
+async def test_one_light(hass, rfxtrx):
+    """Test with 1 light."""
+    await async_setup_component(
+        hass,
+        "light",
+        {
+            "light": {
+                "platform": "rfxtrx",
+                "devices": {"0b1100cd0213c7f210010f51": {"name": "Test"}},
+            }
+        },
+    )
 
-        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
-            "", transport_protocol=rfxtrxmod.DummyTransport
-        )
+    import RFXtrx as rfxtrxmod
 
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["213c7f2_16"]
-        entity.hass = self.hass
-        assert "Test" == entity.name
-        assert "off" == entity.state
-        assert entity.assumed_state
-        assert entity.signal_repetitions == 1
-        assert not entity.should_fire_event
-        assert not entity.should_poll
+    hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
+        "", transport_protocol=rfxtrxmod.DummyTransport
+    )
 
-        assert not entity.is_on
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    entity = rfxtrx_core.RFX_DEVICES["213c7f2_16"]
+    entity.hass = hass
+    assert "Test" == entity.name
+    assert "off" == entity.state
+    assert entity.assumed_state
+    assert entity.signal_repetitions == 1
+    assert not entity.should_fire_event
+    assert not entity.should_poll
 
-        entity.turn_on()
-        assert entity.is_on
-        assert entity.brightness == 255
+    assert not entity.is_on
 
-        entity.turn_off()
-        assert not entity.is_on
-        assert entity.brightness == 0
+    entity.turn_on()
+    assert entity.is_on
+    assert entity.brightness == 255
 
-        entity.turn_on(brightness=100)
-        assert entity.is_on
-        assert entity.brightness == 100
+    entity.turn_off()
+    assert not entity.is_on
+    assert entity.brightness == 0
 
-        entity.turn_on(brightness=10)
-        assert entity.is_on
-        assert entity.brightness == 10
+    entity.turn_on(brightness=100)
+    assert entity.is_on
+    assert entity.brightness == 100
 
-        entity.turn_on(brightness=255)
-        assert entity.is_on
-        assert entity.brightness == 255
+    entity.turn_on(brightness=10)
+    assert entity.is_on
+    assert entity.brightness == 10
 
-        entity.turn_off()
-        assert "Test" == entity.name
-        assert "off" == entity.state
+    entity.turn_on(brightness=255)
+    assert entity.is_on
+    assert entity.brightness == 255
 
-        entity.turn_on()
-        assert "on" == entity.state
+    entity.turn_off()
+    assert "Test" == entity.name
+    assert "off" == entity.state
 
-        entity.turn_off()
-        assert "off" == entity.state
+    entity.turn_on()
+    assert "on" == entity.state
 
-        entity.turn_on(brightness=100)
-        assert "on" == entity.state
+    entity.turn_off()
+    assert "off" == entity.state
 
-        entity.turn_on(brightness=10)
-        assert "on" == entity.state
+    entity.turn_on(brightness=100)
+    assert "on" == entity.state
 
-        entity.turn_on(brightness=255)
-        assert "on" == entity.state
+    entity.turn_on(brightness=10)
+    assert "on" == entity.state
 
-    def test_several_lights(self):
-        """Test with 3 lights."""
-        assert setup_component(
-            self.hass,
-            "light",
-            {
-                "light": {
-                    "platform": "rfxtrx",
-                    "signal_repetitions": 3,
-                    "devices": {
-                        "0b1100cd0213c7f230010f71": {"name": "Test"},
-                        "0b1100100118cdea02010f70": {"name": "Bath"},
-                        "0b1100101118cdea02010f70": {"name": "Living"},
-                    },
-                }
-            },
-        )
+    entity.turn_on(brightness=255)
+    assert "on" == entity.state
 
-        assert 3 == len(rfxtrx_core.RFX_DEVICES)
-        device_num = 0
-        for id in rfxtrx_core.RFX_DEVICES:
-            entity = rfxtrx_core.RFX_DEVICES[id]
-            assert entity.signal_repetitions == 3
-            if entity.name == "Living":
-                device_num = device_num + 1
-                assert "off" == entity.state
-                assert "<Entity Living: off>" == entity.__str__()
-            elif entity.name == "Bath":
-                device_num = device_num + 1
-                assert "off" == entity.state
-                assert "<Entity Bath: off>" == entity.__str__()
-            elif entity.name == "Test":
-                device_num = device_num + 1
-                assert "off" == entity.state
-                assert "<Entity Test: off>" == entity.__str__()
 
-        assert 3 == device_num
+async def test_several_lights(hass, rfxtrx):
+    """Test with 3 lights."""
+    await async_setup_component(
+        hass,
+        "light",
+        {
+            "light": {
+                "platform": "rfxtrx",
+                "signal_repetitions": 3,
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {"name": "Test"},
+                    "0b1100100118cdea02010f70": {"name": "Bath"},
+                    "0b1100101118cdea02010f70": {"name": "Living"},
+                },
+            }
+        },
+    )
 
-    def test_discover_light(self):
-        """Test with discovery of lights."""
-        assert setup_component(
-            self.hass,
-            "light",
-            {"light": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
-        )
+    assert 3 == len(rfxtrx_core.RFX_DEVICES)
+    device_num = 0
+    for id in rfxtrx_core.RFX_DEVICES:
+        entity = rfxtrx_core.RFX_DEVICES[id]
+        assert entity.signal_repetitions == 3
+        if entity.name == "Living":
+            device_num = device_num + 1
+            assert "off" == entity.state
+            assert "<Entity Living: off>" == entity.__str__()
+        elif entity.name == "Bath":
+            device_num = device_num + 1
+            assert "off" == entity.state
+            assert "<Entity Bath: off>" == entity.__str__()
+        elif entity.name == "Test":
+            device_num = device_num + 1
+            assert "off" == entity.state
+            assert "<Entity Test: off>" == entity.__str__()
 
-        event = rfxtrx_core.get_rfx_object("0b11009e00e6116202020070")
-        event.data = bytearray(b"\x0b\x11\x00\x9e\x00\xe6\x11b\x02\x02\x00p")
+    assert 3 == device_num
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["0e61162_2"]
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        assert "<Entity 0b11009e00e6116202020070: on>" == entity.__str__()
 
-        event = rfxtrx_core.get_rfx_object("0b11009e00e6116201010070")
-        event.data = bytearray(b"\x0b\x11\x00\x9e\x00\xe6\x11b\x01\x01\x00p")
+async def test_discover_light(hass, rfxtrx):
+    """Test with discovery of lights."""
+    await async_setup_component(
+        hass,
+        "light",
+        {"light": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+    )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0b11009e00e6116202020070")
+    event.data = bytearray(b"\x0b\x11\x00\x9e\x00\xe6\x11b\x02\x02\x00p")
 
-        event = rfxtrx_core.get_rfx_object("0b1100120118cdea02020070")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x02, 0x00, 0x70]
-        )
+    await _signal_event(hass, event)
+    entity = rfxtrx_core.RFX_DEVICES["0e61162_2"]
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    assert "<Entity 0b11009e00e6116202020070: on>" == entity.__str__()
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["118cdea_2"]
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
-        assert "<Entity 0b1100120118cdea02020070: on>" == entity.__str__()
+    event = rfxtrx_core.get_rfx_object("0b11009e00e6116201010070")
+    event.data = bytearray(b"\x0b\x11\x00\x9e\x00\xe6\x11b\x01\x01\x00p")
 
-        # trying to add a sensor
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
 
-        # trying to add a switch
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
-        )
+    event = rfxtrx_core.get_rfx_object("0b1100120118cdea02020070")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x02, 0x00, 0x70]
+    )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    entity = rfxtrx_core.RFX_DEVICES["118cdea_2"]
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert "<Entity 0b1100120118cdea02020070: on>" == entity.__str__()
 
-        # Trying to add a rollershutter
-        event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    # trying to add a sensor
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-    def test_discover_light_noautoadd(self):
-        """Test with discover of light when auto add is False."""
-        assert setup_component(
-            self.hass,
-            "light",
-            {"light": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-        )
+    # trying to add a switch
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
+    )
 
-        event = rfxtrx_core.get_rfx_object("0b1100120118cdea02020070")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x02, 0x00, 0x70]
-        )
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    # Trying to add a rollershutter
+    event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
+    )
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        event = rfxtrx_core.get_rfx_object("0b1100120118cdea02010070")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x01, 0x00, 0x70]
-        )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+async def test_discover_light_noautoadd(hass, rfxtrx):
+    """Test with discover of light when auto add is False."""
+    await async_setup_component(
+        hass,
+        "light",
+        {"light": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
+    )
 
-        event = rfxtrx_core.get_rfx_object("0b1100120118cdea02020070")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x02, 0x00, 0x70]
-        )
+    event = rfxtrx_core.get_rfx_object("0b1100120118cdea02020070")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x02, 0x00, 0x70]
+    )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-        # Trying to add a sensor
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0b1100120118cdea02010070")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x01, 0x00, 0x70]
+    )
 
-        # Trying to add a switch
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-        # Trying to add a rollershutter
-        event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0b1100120118cdea02020070")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x02, 0x00, 0x70]
+    )
+
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a sensor
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a switch
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
+    )
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a rollershutter
+    event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
+    )
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -51,6 +51,8 @@ async def test_default_config(hass, rfxtrx):
         await async_setup_component(
             hass, "light", {"light": {"platform": "rfxtrx", "devices": {}}}
         )
+        await hass.async_block_till_done()
+
     assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
 
@@ -66,6 +68,7 @@ async def test_one_light(hass, rfxtrx):
             }
         },
     )
+    await hass.async_block_till_done()
 
     import RFXtrx as rfxtrxmod
 
@@ -142,6 +145,7 @@ async def test_several_lights(hass, rfxtrx):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert 3 == len(rfxtrx_core.RFX_DEVICES)
     device_num = 0
@@ -171,6 +175,7 @@ async def test_discover_light(hass, rfxtrx):
         "light",
         {"light": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
     )
+    await hass.async_block_till_done()
 
     event = rfxtrx_core.get_rfx_object("0b11009e00e6116202020070")
     event.data = bytearray(b"\x0b\x11\x00\x9e\x00\xe6\x11b\x02\x02\x00p")
@@ -227,6 +232,7 @@ async def test_discover_light_noautoadd(hass, rfxtrx):
         "light",
         {"light": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
     )
+    await hass.async_block_till_done()
 
     event = rfxtrx_core.get_rfx_object("0b1100120118cdea02020070")
     event.data = bytearray(

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -11,6 +11,8 @@ async def test_default_config(hass, rfxtrx):
     await async_setup_component(
         hass, "sensor", {"sensor": {"platform": "rfxtrx", "devices": {}}}
     )
+    await hass.async_block_till_done()
+
     assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -1,317 +1,306 @@
 """The tests for the Rfxtrx sensor platform."""
-import unittest
-
-import pytest
-
 from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.const import TEMP_CELSIUS, UNIT_PERCENTAGE
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant, mock_component
+from . import _signal_event
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
-class TestSensorRfxtrx(unittest.TestCase):
-    """Test the Rfxtrx sensor platform."""
+async def test_default_config(hass, rfxtrx):
+    """Test with 0 sensor."""
+    await async_setup_component(
+        hass, "sensor", {"sensor": {"platform": "rfxtrx", "devices": {}}}
+    )
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        mock_component(self.hass, "rfxtrx")
-        self.addCleanup(self.tear_down_cleanup)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
-        rfxtrx_core.RFX_DEVICES.clear()
-        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
-            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-        self.hass.stop()
+async def test_one_sensor(hass, rfxtrx):
+    """Test with 1 sensor."""
+    await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "rfxtrx",
+                "devices": {
+                    "0a52080705020095220269": {
+                        "name": "Test",
+                        "data_type": "Temperature",
+                    }
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
 
-    def test_default_config(self):
-        """Test with 0 sensor."""
-        assert setup_component(
-            self.hass, "sensor", {"sensor": {"platform": "rfxtrx", "devices": {}}}
-        )
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
+    assert "Test Temperature" == entity.name
+    assert TEMP_CELSIUS == entity.unit_of_measurement
+    assert entity.state is None
 
-    def test_one_sensor(self):
-        """Test with 1 sensor."""
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {
-                "sensor": {
-                    "platform": "rfxtrx",
-                    "devices": {
-                        "0a52080705020095220269": {
-                            "name": "Test",
-                            "data_type": "Temperature",
-                        }
+
+async def test_one_sensor_no_datatype(hass, rfxtrx):
+    """Test with 1 sensor."""
+    await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "rfxtrx",
+                "devices": {"0a52080705020095220269": {"name": "Test"}},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
+    assert "Test Temperature" == entity.name
+    assert TEMP_CELSIUS == entity.unit_of_measurement
+    assert entity.state is None
+
+
+async def test_several_sensors(hass, rfxtrx):
+    """Test with 3 sensors."""
+    await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "rfxtrx",
+                "devices": {
+                    "0a52080705020095220269": {
+                        "name": "Test",
+                        "data_type": "Temperature",
                     },
-                }
-            },
-        )
-
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-        assert "Test Temperature" == entity.name
-        assert TEMP_CELSIUS == entity.unit_of_measurement
-        assert entity.state is None
-
-    def test_one_sensor_no_datatype(self):
-        """Test with 1 sensor."""
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {
-                "sensor": {
-                    "platform": "rfxtrx",
-                    "devices": {"0a52080705020095220269": {"name": "Test"}},
-                }
-            },
-        )
-
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-        assert "Test Temperature" == entity.name
-        assert TEMP_CELSIUS == entity.unit_of_measurement
-        assert entity.state is None
-
-    def test_several_sensors(self):
-        """Test with 3 sensors."""
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {
-                "sensor": {
-                    "platform": "rfxtrx",
-                    "devices": {
-                        "0a52080705020095220269": {
-                            "name": "Test",
-                            "data_type": "Temperature",
-                        },
-                        "0a520802060100ff0e0269": {
-                            "name": "Bath",
-                            "data_type": ["Temperature", "Humidity"],
-                        },
+                    "0a520802060100ff0e0269": {
+                        "name": "Bath",
+                        "data_type": ["Temperature", "Humidity"],
                     },
-                }
-            },
-        )
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
 
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
-        device_num = 0
-        for id in rfxtrx_core.RFX_DEVICES:
-            if id == "sensor_06_01":
-                device_num = device_num + 1
-                assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
-                _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-                _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
-                assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
-                assert "Bath" == _entity_hum.__str__()
-                assert _entity_hum.state is None
-                assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
-                assert "Bath" == _entity_temp.__str__()
-            elif id == "sensor_05_02":
-                device_num = device_num + 1
-                entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-                assert entity.state is None
-                assert TEMP_CELSIUS == entity.unit_of_measurement
-                assert "Test" == entity.__str__()
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    device_num = 0
+    for id in rfxtrx_core.RFX_DEVICES:
+        if id == "sensor_06_01":
+            device_num = device_num + 1
+            assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
+            _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
+            _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
+            assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
+            assert "Bath" == _entity_hum.__str__()
+            assert _entity_hum.state is None
+            assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
+            assert "Bath" == _entity_temp.__str__()
+        elif id == "sensor_05_02":
+            device_num = device_num + 1
+            entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
+            assert entity.state is None
+            assert TEMP_CELSIUS == entity.unit_of_measurement
+            assert "Test" == entity.__str__()
 
-        assert 2 == device_num
+    assert 2 == device_num
 
-    def test_discover_sensor(self):
-        """Test with discovery of sensor."""
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
-        )
-        self.hass.block_till_done()
 
-        event = rfxtrx_core.get_rfx_object("0a520801070100b81b0279")
-        event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+async def test_discover_sensor(hass, rfxtrx):
+    """Test with discovery of sensor."""
+    await async_setup_component(
+        hass,
+        "sensor",
+        {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+    )
+    await hass.async_block_till_done()
 
-        entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        assert {
-            "Humidity status": "normal",
-            "Temperature": 18.4,
-            "Rssi numeric": 7,
-            "Humidity": 27,
-            "Battery numeric": 9,
-            "Humidity status numeric": 2,
-        } == entity.device_state_attributes
-        assert "0a520801070100b81b0279" == entity.__str__()
+    event = rfxtrx_core.get_rfx_object("0a520801070100b81b0279")
+    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
+    await _signal_event(hass, event)
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    assert {
+        "Humidity status": "normal",
+        "Temperature": 18.4,
+        "Rssi numeric": 7,
+        "Humidity": 27,
+        "Battery numeric": 9,
+        "Humidity status numeric": 2,
+    } == entity.device_state_attributes
+    assert "0a520801070100b81b0279" == entity.__str__()
 
-        event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
-        event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
-        assert {
-            "Humidity status": "normal",
-            "Temperature": 14.9,
-            "Rssi numeric": 7,
-            "Humidity": 36,
-            "Battery numeric": 9,
-            "Humidity status numeric": 2,
-        } == entity.device_state_attributes
-        assert "0a52080405020095240279" == entity.__str__()
+    await _signal_event(hass, event)
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
 
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
-        assert {
-            "Humidity status": "normal",
-            "Temperature": 17.9,
-            "Rssi numeric": 7,
-            "Humidity": 27,
-            "Battery numeric": 9,
-            "Humidity status numeric": 2,
-        } == entity.device_state_attributes
-        assert "0a520801070100b81b0279" == entity.__str__()
+    event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
+    event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
+    await hass.async_add_executor_job(rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0], event)
+    entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert {
+        "Humidity status": "normal",
+        "Temperature": 14.9,
+        "Rssi numeric": 7,
+        "Humidity": 36,
+        "Battery numeric": 9,
+        "Humidity status numeric": 2,
+    } == entity.device_state_attributes
+    assert "0a52080405020095240279" == entity.__str__()
 
-        # trying to add a switch
-        event = rfxtrx_core.get_rfx_object("0b1100cd0213c7f210010f70")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert {
+        "Humidity status": "normal",
+        "Temperature": 17.9,
+        "Rssi numeric": 7,
+        "Humidity": 27,
+        "Battery numeric": 9,
+        "Humidity status numeric": 2,
+    } == entity.device_state_attributes
+    assert "0a520801070100b81b0279" == entity.__str__()
 
-    def test_discover_sensor_noautoadd(self):
-        """Test with discover of sensor when auto add is False."""
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {"sensor": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-        )
+    # trying to add a switch
+    event = rfxtrx_core.get_rfx_object("0b1100cd0213c7f210010f70")
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        event = rfxtrx_core.get_rfx_object("0a520801070100b81b0279")
-        event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
 
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+async def test_discover_sensor_noautoadd(hass, rfxtrx):
+    """Test with discover of sensor when auto add is False."""
+    await async_setup_component(
+        hass,
+        "sensor",
+        {"sensor": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
+    )
+    await hass.async_block_till_done()
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0a520801070100b81b0279")
+    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
 
-        event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
-        event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-    def test_update_of_sensors(self):
-        """Test with 3 sensors."""
-        assert setup_component(
-            self.hass,
-            "sensor",
-            {
-                "sensor": {
-                    "platform": "rfxtrx",
-                    "devices": {
-                        "0a52080705020095220269": {
-                            "name": "Test",
-                            "data_type": "Temperature",
-                        },
-                        "0a520802060100ff0e0269": {
-                            "name": "Bath",
-                            "data_type": ["Temperature", "Humidity"],
-                        },
+    event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
+    event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+
+async def test_update_of_sensors(hass, rfxtrx):
+    """Test with 3 sensors."""
+    await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": {
+                "platform": "rfxtrx",
+                "devices": {
+                    "0a52080705020095220269": {
+                        "name": "Test",
+                        "data_type": "Temperature",
                     },
-                }
-            },
-        )
+                    "0a520802060100ff0e0269": {
+                        "name": "Bath",
+                        "data_type": ["Temperature", "Humidity"],
+                    },
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
 
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
-        device_num = 0
-        for id in rfxtrx_core.RFX_DEVICES:
-            if id == "sensor_06_01":
-                device_num = device_num + 1
-                assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
-                _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-                _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
-                assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
-                assert "Bath" == _entity_hum.__str__()
-                assert _entity_temp.state is None
-                assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
-                assert "Bath" == _entity_temp.__str__()
-            elif id == "sensor_05_02":
-                device_num = device_num + 1
-                entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-                assert entity.state is None
-                assert TEMP_CELSIUS == entity.unit_of_measurement
-                assert "Test" == entity.__str__()
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    device_num = 0
+    for id in rfxtrx_core.RFX_DEVICES:
+        if id == "sensor_06_01":
+            device_num = device_num + 1
+            assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
+            _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
+            _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
+            assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
+            assert "Bath" == _entity_hum.__str__()
+            assert _entity_temp.state is None
+            assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
+            assert "Bath" == _entity_temp.__str__()
+        elif id == "sensor_05_02":
+            device_num = device_num + 1
+            entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
+            assert entity.state is None
+            assert TEMP_CELSIUS == entity.unit_of_measurement
+            assert "Test" == entity.__str__()
 
-        assert 2 == device_num
+    assert 2 == device_num
 
-        event = rfxtrx_core.get_rfx_object("0a520802060101ff0f0269")
-        event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+    event = rfxtrx_core.get_rfx_object("0a520802060101ff0f0269")
+    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
+    await _signal_event(hass, event)
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        event = rfxtrx_core.get_rfx_object("0a52080705020085220269")
-        event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
+    await _signal_event(hass, event)
+    event = rfxtrx_core.get_rfx_object("0a52080705020085220269")
+    event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
+    await _signal_event(hass, event)
 
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        device_num = 0
-        for id in rfxtrx_core.RFX_DEVICES:
-            if id == "sensor_06_01":
-                device_num = device_num + 1
-                assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
-                _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-                _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
-                assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
-                assert 15 == _entity_hum.state
-                assert {
-                    "Battery numeric": 9,
-                    "Temperature": 51.1,
-                    "Humidity": 15,
-                    "Humidity status": "normal",
-                    "Humidity status numeric": 2,
-                    "Rssi numeric": 6,
-                } == _entity_hum.device_state_attributes
-                assert "Bath" == _entity_hum.__str__()
+    device_num = 0
+    for id in rfxtrx_core.RFX_DEVICES:
+        if id == "sensor_06_01":
+            device_num = device_num + 1
+            assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
+            _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
+            _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
+            assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
+            assert 15 == _entity_hum.state
+            assert {
+                "Battery numeric": 9,
+                "Temperature": 51.1,
+                "Humidity": 15,
+                "Humidity status": "normal",
+                "Humidity status numeric": 2,
+                "Rssi numeric": 6,
+            } == _entity_hum.device_state_attributes
+            assert "Bath" == _entity_hum.__str__()
 
-                assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
-                assert 51.1 == _entity_temp.state
-                assert {
-                    "Battery numeric": 9,
-                    "Temperature": 51.1,
-                    "Humidity": 15,
-                    "Humidity status": "normal",
-                    "Humidity status numeric": 2,
-                    "Rssi numeric": 6,
-                } == _entity_temp.device_state_attributes
-                assert "Bath" == _entity_temp.__str__()
-            elif id == "sensor_05_02":
-                device_num = device_num + 1
-                entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-                assert TEMP_CELSIUS == entity.unit_of_measurement
-                assert 13.3 == entity.state
-                assert {
-                    "Humidity status": "normal",
-                    "Temperature": 13.3,
-                    "Rssi numeric": 6,
-                    "Humidity": 34,
-                    "Battery numeric": 9,
-                    "Humidity status numeric": 2,
-                } == entity.device_state_attributes
-                assert "Test" == entity.__str__()
+            assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
+            assert 51.1 == _entity_temp.state
+            assert {
+                "Battery numeric": 9,
+                "Temperature": 51.1,
+                "Humidity": 15,
+                "Humidity status": "normal",
+                "Humidity status numeric": 2,
+                "Rssi numeric": 6,
+            } == _entity_temp.device_state_attributes
+            assert "Bath" == _entity_temp.__str__()
+        elif id == "sensor_05_02":
+            device_num = device_num + 1
+            entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
+            assert TEMP_CELSIUS == entity.unit_of_measurement
+            assert 13.3 == entity.state
+            assert {
+                "Humidity status": "normal",
+                "Temperature": 13.3,
+                "Rssi numeric": 6,
+                "Humidity": 34,
+                "Battery numeric": 9,
+                "Humidity status numeric": 2,
+            } == entity.device_state_attributes
+            assert "Test" == entity.__str__()
 
-        assert 2 == device_num
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert 2 == device_num
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -137,7 +137,7 @@ async def test_discover_sensor(hass, rfxtrx):
 
     event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
     event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
-    await hass.async_add_executor_job(rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0], event)
+    await _signal_event(hass, event)
     entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
     assert 2 == len(rfxtrx_core.RFX_DEVICES)
     assert {

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -28,6 +28,7 @@ async def test_valid_config(hass, rfxtrx):
                 }
             },
         )
+        await hass.async_block_till_done()
 
 
 async def test_valid_config_int_device_id(hass, rfxtrx):
@@ -49,6 +50,7 @@ async def test_valid_config_int_device_id(hass, rfxtrx):
                 }
             },
         )
+        await hass.async_block_till_done()
 
 
 async def test_invalid_config2(hass, rfxtrx):
@@ -71,6 +73,7 @@ async def test_invalid_config2(hass, rfxtrx):
                 }
             },
         )
+        await hass.async_block_till_done()
 
 
 async def test_default_config(hass, rfxtrx):
@@ -78,6 +81,8 @@ async def test_default_config(hass, rfxtrx):
     await async_setup_component(
         hass, "switch", {"switch": {"platform": "rfxtrx", "devices": {}}}
     )
+    await hass.async_block_till_done()
+
     assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
 
@@ -93,6 +98,7 @@ async def test_one_switch(hass, rfxtrx):
             }
         },
     )
+    await hass.async_block_till_done()
 
     hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
         "", transport_protocol=rfxtrxmod.DummyTransport
@@ -139,6 +145,7 @@ async def test_several_switches(hass, rfxtrx):
             }
         },
     )
+    await hass.async_block_till_done()
 
     assert 3 == len(rfxtrx_core.RFX_DEVICES)
     device_num = 0
@@ -168,6 +175,7 @@ async def test_discover_switch(hass, rfxtrx):
         "switch",
         {"switch": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
     )
+    await hass.async_block_till_done()
 
     event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
     event.data = bytearray(
@@ -222,6 +230,7 @@ async def test_discover_switch_noautoadd(hass, rfxtrx):
         "switch",
         {"switch": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
     )
+    await hass.async_block_till_done()
 
     event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
     event.data = bytearray(

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -1,37 +1,19 @@
 """The tests for the RFXtrx switch platform."""
-import unittest
-
 import RFXtrx as rfxtrxmod
-import pytest
 
 from homeassistant.components import rfxtrx as rfxtrx_core
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import assert_setup_component, get_test_home_assistant, mock_component
+from . import _signal_event
+
+from tests.common import assert_setup_component
 
 
-@pytest.mark.skipif("os.environ.get('RFXTRX') != 'RUN'")
-class TestSwitchRfxtrx(unittest.TestCase):
-    """Test the RFXtrx switch platform."""
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        mock_component(self.hass, "rfxtrx")
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS.clear()
-        rfxtrx_core.RFX_DEVICES.clear()
-        if rfxtrx_core.DATA_RFXOBJECT in self.hass.data:
-            self.hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
-        self.hass.stop()
-
-    def test_valid_config(self):
-        """Test configuration."""
-        assert setup_component(
-            self.hass,
+async def test_valid_config(hass, rfxtrx):
+    """Test configuration."""
+    with assert_setup_component(1):
+        await async_setup_component(
+            hass,
             "switch",
             {
                 "switch": {
@@ -47,10 +29,12 @@ class TestSwitchRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_valid_config_int_device_id(self):
-        """Test configuration."""
-        assert setup_component(
-            self.hass,
+
+async def test_valid_config_int_device_id(hass, rfxtrx):
+    """Test configuration."""
+    with assert_setup_component(1):
+        await async_setup_component(
+            hass,
             "switch",
             {
                 "switch": {
@@ -66,210 +50,216 @@ class TestSwitchRfxtrx(unittest.TestCase):
             },
         )
 
-    def test_invalid_config2(self):
-        """Test invalid configuration."""
-        with assert_setup_component(0):
-            setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "rfxtrx",
-                        "automatic_add": True,
-                        "invalid_key": "afda",
-                        "devices": {
-                            "0b1100cd0213c7f210010f51": {
-                                "name": "Test",
-                                rfxtrx_core.ATTR_FIRE_EVENT: True,
-                            }
-                        },
-                    }
-                },
-            )
 
-    def test_default_config(self):
-        """Test with 0 switches."""
-        assert setup_component(
-            self.hass, "switch", {"switch": {"platform": "rfxtrx", "devices": {}}}
-        )
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
-
-    def test_one_switch(self):
-        """Test with 1 switch."""
-        assert setup_component(
-            self.hass,
+async def test_invalid_config2(hass, rfxtrx):
+    """Test invalid configuration."""
+    with assert_setup_component(0):
+        await async_setup_component(
+            hass,
             "switch",
             {
                 "switch": {
                     "platform": "rfxtrx",
-                    "devices": {"0b1100cd0213c7f210010f51": {"name": "Test"}},
-                }
-            },
-        )
-
-        self.hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
-            "", transport_protocol=rfxtrxmod.DummyTransport
-        )
-
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        entity = rfxtrx_core.RFX_DEVICES["213c7f2_16"]
-        entity.hass = self.hass
-        assert "Test" == entity.name
-        assert "off" == entity.state
-        assert entity.assumed_state
-        assert entity.signal_repetitions == 1
-        assert not entity.should_fire_event
-        assert not entity.should_poll
-
-        assert not entity.is_on
-        entity.turn_on()
-        assert entity.is_on
-        entity.turn_off()
-        assert not entity.is_on
-
-        assert "Test" == entity.name
-        assert "off" == entity.state
-        entity.turn_on()
-        assert "on" == entity.state
-        entity.turn_off()
-        assert "off" == entity.state
-
-    def test_several_switches(self):
-        """Test with 3 switches."""
-        assert setup_component(
-            self.hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "signal_repetitions": 3,
+                    "automatic_add": True,
+                    "invalid_key": "afda",
                     "devices": {
-                        "0b1100cd0213c7f230010f71": {"name": "Test"},
-                        "0b1100100118cdea02010f70": {"name": "Bath"},
-                        "0b1100101118cdea02010f70": {"name": "Living"},
+                        "0b1100cd0213c7f210010f51": {
+                            "name": "Test",
+                            rfxtrx_core.ATTR_FIRE_EVENT: True,
+                        }
                     },
                 }
             },
         )
 
-        assert 3 == len(rfxtrx_core.RFX_DEVICES)
-        device_num = 0
-        for id in rfxtrx_core.RFX_DEVICES:
-            entity = rfxtrx_core.RFX_DEVICES[id]
-            assert entity.signal_repetitions == 3
-            if entity.name == "Living":
-                device_num = device_num + 1
-                assert "off" == entity.state
-                assert "<Entity Living: off>" == entity.__str__()
-            elif entity.name == "Bath":
-                device_num = device_num + 1
-                assert "off" == entity.state
-                assert "<Entity Bath: off>" == entity.__str__()
-            elif entity.name == "Test":
-                device_num = device_num + 1
-                assert "off" == entity.state
-                assert "<Entity Test: off>" == entity.__str__()
 
-        assert 3 == device_num
+async def test_default_config(hass, rfxtrx):
+    """Test with 0 switches."""
+    await async_setup_component(
+        hass, "switch", {"switch": {"platform": "rfxtrx", "devices": {}}}
+    )
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
 
-    def test_discover_switch(self):
-        """Test with discovery of switches."""
-        assert setup_component(
-            self.hass,
-            "switch",
-            {"switch": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
-        )
 
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
-        )
+async def test_one_switch(hass, rfxtrx):
+    """Test with 1 switch."""
+    await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "rfxtrx",
+                "devices": {"0b1100cd0213c7f210010f51": {"name": "Test"}},
+            }
+        },
+    )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["118cdea_2"]
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
-        assert "<Entity 0b1100100118cdea01010f70: on>" == entity.__str__()
+    hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxtrxmod.Core(
+        "", transport_protocol=rfxtrxmod.DummyTransport
+    )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    entity = rfxtrx_core.RFX_DEVICES["213c7f2_16"]
+    entity.hass = hass
+    assert "Test" == entity.name
+    assert "off" == entity.state
+    assert entity.assumed_state
+    assert entity.signal_repetitions == 1
+    assert not entity.should_fire_event
+    assert not entity.should_poll
 
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdeb02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x00, 0x00, 0x70]
-        )
+    assert not entity.is_on
+    entity.turn_on()
+    assert entity.is_on
+    entity.turn_off()
+    assert not entity.is_on
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        entity = rfxtrx_core.RFX_DEVICES["118cdeb_2"]
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
-        assert "<Entity 0b1100120118cdea02000070: on>" == entity.__str__()
+    assert "Test" == entity.name
+    assert "off" == entity.state
+    entity.turn_on()
+    assert "on" == entity.state
+    entity.turn_off()
+    assert "off" == entity.state
 
-        # Trying to add a sensor
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
 
-        # Trying to add a light
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+async def test_several_switches(hass, rfxtrx):
+    """Test with 3 switches."""
+    await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "rfxtrx",
+                "signal_repetitions": 3,
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {"name": "Test"},
+                    "0b1100100118cdea02010f70": {"name": "Bath"},
+                    "0b1100101118cdea02010f70": {"name": "Living"},
+                },
+            }
+        },
+    )
 
-        # Trying to add a rollershutter
-        event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert 3 == len(rfxtrx_core.RFX_DEVICES)
+    device_num = 0
+    for id in rfxtrx_core.RFX_DEVICES:
+        entity = rfxtrx_core.RFX_DEVICES[id]
+        assert entity.signal_repetitions == 3
+        if entity.name == "Living":
+            device_num = device_num + 1
+            assert "off" == entity.state
+            assert "<Entity Living: off>" == entity.__str__()
+        elif entity.name == "Bath":
+            device_num = device_num + 1
+            assert "off" == entity.state
+            assert "<Entity Bath: off>" == entity.__str__()
+        elif entity.name == "Test":
+            device_num = device_num + 1
+            assert "off" == entity.state
+            assert "<Entity Test: off>" == entity.__str__()
 
-    def test_discover_switch_noautoadd(self):
-        """Test with discovery of switch when auto add is False."""
-        assert setup_component(
-            self.hass,
-            "switch",
-            {"switch": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-        )
+    assert 3 == device_num
 
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
-        )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+async def test_discover_switch(hass, rfxtrx):
+    """Test with discovery of switches."""
+    await async_setup_component(
+        hass,
+        "switch",
+        {"switch": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+    )
 
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
+    )
 
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdeb02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x00, 0x00, 0x70]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    entity = rfxtrx_core.RFX_DEVICES["118cdea_2"]
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    assert "<Entity 0b1100100118cdea01010f70: on>" == entity.__str__()
 
-        # Trying to add a sensor
-        event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-        event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    assert 1 == len(rfxtrx_core.RFX_DEVICES)
 
-        # Trying to add a light
-        event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
-        event.data = bytearray(
-            [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdeb02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x00, 0x00, 0x70]
+    )
 
-        # Trying to add a rollershutter
-        event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
-        event.data = bytearray(
-            [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
-        )
-        rfxtrx_core.RECEIVED_EVT_SUBSCRIBERS[0](event)
-        assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, event)
+    entity = rfxtrx_core.RFX_DEVICES["118cdeb_2"]
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert "<Entity 0b1100120118cdea02000070: on>" == entity.__str__()
+
+    # Trying to add a sensor
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a light
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
+    )
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a rollershutter
+    event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
+    )
+    await _signal_event(hass, event)
+    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+
+
+async def test_discover_switch_noautoadd(hass, rfxtrx):
+    """Test with discovery of switch when auto add is False."""
+    await async_setup_component(
+        hass,
+        "switch",
+        {"switch": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
+    )
+
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
+    )
+
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdeb02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x00, 0x12, 0x01, 0x18, 0xCD, 0xEA, 0x02, 0x00, 0x00, 0x70]
+    )
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a sensor
+    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
+    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a light
+    event = rfxtrx_core.get_rfx_object("0b1100100118cdea02010f70")
+    event.data = bytearray(
+        [0x0B, 0x11, 0x11, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x02, 0x0F, 0x70]
+    )
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+
+    # Trying to add a rollershutter
+    event = rfxtrx_core.get_rfx_object("0a1400adf394ab020e0060")
+    event.data = bytearray(
+        [0x0A, 0x14, 0x00, 0xAD, 0xF3, 0x94, 0xAB, 0x02, 0x0E, 0x00, 0x60]
+    )
+    await _signal_event(hass, event)
+    assert 0 == len(rfxtrx_core.RFX_DEVICES)


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert rfxtrx tests to pytest async tests and re-enable.

The tests in test_init.py previously did not cleanup connections, and left running threads. This should now be resolved with an autouse fixture.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
