### PR TITLE
Add mobile_app webhook action to get all entities grouped by area

### DIFF
--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -567,7 +567,7 @@ async def webhook_get_entities_by_area(hass, config_entry, data):
             area_to_entity_map[device.area_id] = list()
         area_to_entity_map[device.area_id].append(entity.entity_id)
 
-    for area_id, entities in area_to_entity_map.items():
+    for area_id, entity_ids in area_to_entity_map.items():
         area = area_registry.async_get_area(area_id)
 
         area_obj = {"id": area.id, "name": area.name, "entity_ids": entity_ids}

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -570,7 +570,7 @@ async def webhook_get_entities_by_area(hass, config_entry, data):
     for area_id, entities in area_to_entity_map.items():
         area = area_registry.async_get_area(area_id)
 
-        area_obj = {"id": area.id, "name": area.name, "entities": entities}
+        area_obj = {"id": area.id, "name": area.name, "entity_ids": entity_ids}
 
         resp.append(area_obj)
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -142,6 +142,7 @@ class DeviceRegistry:
         self,
         *,
         config_entry_id,
+        area_id=_UNDEF,
         connections=None,
         identifiers=None,
         manufacturer=_UNDEF,
@@ -186,6 +187,7 @@ class DeviceRegistry:
         return self._async_update_device(
             device.id,
             add_config_entry_id=config_entry_id,
+            area_id=area_id,
             via_device_id=via_device_id,
             merge_connections=connections or _UNDEF,
             merge_identifiers=identifiers or _UNDEF,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new mobile_app webhook action `get_entities_by_area` which outputs an array of areas with its containing entities within. This is needed for [the iOS app to sync Areas to HomeKit Rooms](https://github.com/home-assistant/iOS/pull/715).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
