### PR TITLE
Ensure recorder data integrity and MySQL lock error handling

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -1,8 +1,9 @@
 """Purge old data helper."""
 from datetime import timedelta
 import logging
+import time
 
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
 import homeassistant.util.dt as dt_util
 
@@ -18,47 +19,46 @@ def purge_old_data(instance, purge_days: int, repack: bool) -> bool:
     Cleans up an timeframe of an hour, based on the oldest record.
     """
     purge_before = dt_util.utcnow() - timedelta(days=purge_days)
-    _LOGGER.debug("Purging events before %s", purge_before)
+    _LOGGER.debug("Purging states and events before target %s", purge_before)
 
     try:
         with session_scope(session=instance.get_session()) as session:
+            # Purge a max of 1 hour, based on the oldest states or events record
+            batch_purge_before = purge_before
+
             query = session.query(States).order_by(States.last_updated.asc()).limit(1)
             states = execute(query, to_native=True, validate_entity_ids=False)
-
-            states_purge_before = purge_before
             if states:
-                states_purge_before = min(
-                    purge_before, states[0].last_updated + timedelta(hours=1)
+                batch_purge_before = min(
+                    batch_purge_before, states[0].last_updated + timedelta(hours=1),
                 )
-
-            deleted_rows_states = (
-                session.query(States)
-                .filter(States.last_updated < states_purge_before)
-                .delete(synchronize_session=False)
-            )
-            _LOGGER.debug("Deleted %s states", deleted_rows_states)
 
             query = session.query(Events).order_by(Events.time_fired.asc()).limit(1)
             events = execute(query, to_native=True)
-
-            events_purge_before = purge_before
             if events:
-                events_purge_before = min(
-                    purge_before, events[0].time_fired + timedelta(hours=1)
+                batch_purge_before = min(
+                    batch_purge_before, events[0].time_fired + timedelta(hours=1),
                 )
 
-            deleted_rows_events = (
-                session.query(Events)
-                .filter(Events.time_fired < events_purge_before)
+            _LOGGER.debug("Purging states and events before %s", batch_purge_before)
+
+            deleted_rows = (
+                session.query(States)
+                .filter(States.last_updated < batch_purge_before)
                 .delete(synchronize_session=False)
             )
-            _LOGGER.debug("Deleted %s events", deleted_rows_events)
+            _LOGGER.debug("Deleted %s states", deleted_rows)
+
+            deleted_rows = (
+                session.query(Events)
+                .filter(Events.time_fired < batch_purge_before)
+                .delete(synchronize_session=False)
+            )
+            _LOGGER.debug("Deleted %s events", deleted_rows)
 
             # If states or events purging isn't processing the purge_before yet,
             # return false, as we are not done yet.
-            if (states_purge_before and states_purge_before != purge_before) or (
-                events_purge_before and events_purge_before != purge_before
-            ):
+            if batch_purge_before != purge_before:
                 _LOGGER.debug("Purging hasn't fully completed yet.")
                 return False
 
@@ -80,7 +80,21 @@ def purge_old_data(instance, purge_days: int, repack: bool) -> bool:
                 _LOGGER.debug("Optimizing SQL DB to free space")
                 instance.engine.execute("OPTIMIZE TABLE states, events, recorder_runs")
 
+    except OperationalError as err:
+        # Retry when one of the following MySQL errors occurred:
+        # 1205: Lock wait timeout exceeded; try restarting transaction
+        # 1206: The total number of locks exceeds the lock table size
+        # 1213: Deadlock found when trying to get lock; try restarting transaction
+        if instance.engine.driver in ("mysqldb", "pymysql") and err.orig.args[0] in (
+            1205,
+            1206,
+            1213,
+        ):
+            _LOGGER.info("%s; purge not completed, retrying", err.orig.args[1])
+            time.sleep(instance.db_retry_wait)
+            return False
+
+        _LOGGER.warning("Error purging history: %s.", err)
     except SQLAlchemyError as err:
         _LOGGER.warning("Error purging history: %s.", err)
-
     return True

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -224,6 +224,6 @@ class TestRecorderPurge(unittest.TestCase):
                 self.hass.block_till_done()
                 self.hass.data[DATA_INSTANCE].block_till_done()
                 assert (
-                    mock_logger.debug.mock_calls[4][1][0]
+                    mock_logger.debug.mock_calls[5][1][0]
                     == "Vacuuming SQL DB to free space"
                 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR makes to changes to the purge of the recorder.

- If during one of the purge batches, on a MySQL database, a lock error occurs the purging is marked as incomplete, causing it to retry. It was reported in #37178 and found multiple occurrences over the past years on the community forum.
- Addresses a [review comment by @amelchio](https://github.com/home-assistant/core/pull/37140#pullrequestreview-438640699) to, implicitly, guarantee, referential data integrity.


Additionally, a PR for the official Home Assistant MariaDB add-on will be made to reduce the occurrences of the MySQL locking issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37178
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
