### PR TITLE
Adding global_set and global_get yaml tags 

### DIFF
--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -320,7 +320,7 @@ def _global_set(loader: SafeLineLoader, node: yaml.nodes.Node) -> None:
     for node_key, node_value in node.value:
         if node_key in loader.__global_tags__:
             _LOGGER.warning(
-                f"Duplicated key %s. It is going to override the previous value", node_key
+                "Duplicated key %s. It is going to override the previous value", node_key
             )
         loader.__global_tags__.setdefault(node_key.value, node_key.value)
 
@@ -329,7 +329,7 @@ def _global_get(loader: SafeLineLoader, node: yaml.nodes.Node) -> str:
     """Set the value previously cached within the __global_tags__ attribute."""
     if node.value not in loader.__global_tags__:
         raise HomeAssistantError(
-            f"Can not find any cached global value with key %s", node.value
+            "Can not find any cached global value with key %s", node.value
         )
     return loader.__global_tags__[node.value]
 

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -320,7 +320,7 @@ def _global_set(loader: SafeLineLoader, node: yaml.nodes.Node) -> None:
     for node_key, node_value in node.value:
         if node_key in loader.__global_tags__:
             _LOGGER.warning(
-                f"Duplicated key {node_key}. It is going to override the previous value"
+                f"Duplicated key %s. It is going to override the previous value", node_key
             )
         loader.__global_tags__.setdefault(node_key.value, node_key.value)
 
@@ -329,7 +329,7 @@ def _global_get(loader: SafeLineLoader, node: yaml.nodes.Node) -> str:
     """Set the value previously cached within the __global_tags__ attribute."""
     if node.value not in loader.__global_tags__:
         raise HomeAssistantError(
-            f"Can not find any cached global value with key {node.value}"
+            f"Can not find any cached global value with key %s", node.value
         )
     return loader.__global_tags__[node.value]
 

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -330,7 +330,7 @@ def _global_get(loader: SafeLineLoader, node: yaml.nodes.Node) -> str:
     """Set the value previously cached within the __global_tags__ attribute."""
     if node.value not in loader.__global_tags__:
         raise HomeAssistantError(
-            "Can not find any cached global value with key %s", node.value
+            f"Can not find any cached global value with key {node.value}"
         )
     return loader.__global_tags__[node.value]
 

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -313,7 +313,7 @@ def secret_yaml(loader: SafeLineLoader, node: yaml.nodes.Node) -> JSON_TYPE:
 
 
 def _global_set(loader: SafeLineLoader, node: yaml.nodes.Node):
-    """Cache the given node mapping, to be reused in future calls"""
+    """Cache the given node mapping, to be reused in future calls."""
     if not isinstance(node, yaml.MappingNode):
         raise HomeAssistantError("Tag '!global_set' can be used only in MappingNodes")
 
@@ -326,7 +326,7 @@ def _global_set(loader: SafeLineLoader, node: yaml.nodes.Node):
 
 
 def _global_get(loader: SafeLineLoader, node: yaml.nodes.Node) -> str:
-    """Set the value previously cached within the __global_tags__ attribute"""
+    """Set the value previously cached within the __global_tags__ attribute."""
     if node.value not in loader.__global_tags__:
         raise HomeAssistantError(
             f"Can not find any cached global value with key {node.value}"

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -320,7 +320,8 @@ def _global_set(loader: SafeLineLoader, node: yaml.nodes.Node) -> None:
     for node_key, node_value in node.value:
         if node_key in loader.__global_tags__:
             _LOGGER.warning(
-                "Duplicated key %s. It is going to override the previous value", node_key
+                "Duplicated key %s. It is going to override the previous value",
+                node_key,
             )
         loader.__global_tags__.setdefault(node_key.value, node_key.value)
 

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -44,7 +44,7 @@ def clear_secret_cache() -> None:
 class SafeLineLoader(yaml.SafeLoader):
     """Loader class that keeps track of line numbers."""
 
-    __global_tags__ = {}
+    __global_tags__: Dict[str, str] = {}
 
     def compose_node(self, parent: yaml.nodes.Node, index: int) -> yaml.nodes.Node:
         """Annotate a node with the first line it was seen."""
@@ -312,7 +312,7 @@ def secret_yaml(loader: SafeLineLoader, node: yaml.nodes.Node) -> JSON_TYPE:
     raise HomeAssistantError(f"Secret {node.value} not defined")
 
 
-def _global_set(loader: SafeLineLoader, node: yaml.nodes.Node):
+def _global_set(loader: SafeLineLoader, node: yaml.nodes.Node) -> None:
     """Cache the given node mapping, to be reused in future calls."""
     if not isinstance(node, yaml.MappingNode):
         raise HomeAssistantError("Tag '!global_set' can be used only in MappingNodes")
@@ -331,7 +331,7 @@ def _global_get(loader: SafeLineLoader, node: yaml.nodes.Node) -> str:
         raise HomeAssistantError(
             f"Can not find any cached global value with key {node.value}"
         )
-    return loader.__global_tags__.get(node.value)
+    return loader.__global_tags__[node.value]
 
 
 yaml.SafeLoader.add_constructor("!include", _include_yaml)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following the guide [splitting-configuration](https://www.home-assistant.io/docs/configuration/splitting_configuration/), this PR support a new way of splitting some part of the configuration with "global tags/anchors".
YAML support local Anchors. That means, that you can just reuse the Anchors that you have in the file, but not across multiple files.
Ex:
* You can do

`color-scheme.yaml`
```yaml
background-color: &background-color red
color: *background-color
```

* You can NOT do

`color-scheme.yaml`
```yaml
background-color: &background-color red
```

`color-scheme.yaml`
```yaml
color: *background-color red
```

This PR try to solve this issue implementing a couple of new tags.
* `global_set`: Set a MappingNode as a global, and save the values of all it's children within the class attribute `__global_tags__`, so they can be reused anytime after loading this file

* `global_get`: Get the value of the previously cached global tag, and applies the value into it.

With this new implementation, we are able to split the config a little bit more.
User cases examples:
* I want to create different color palettes for my Lovelace UI. With this new tags, I can create a `colors.yaml` file, that contains and set all the colors of that scheme.
```yaml
colors: !global_set
  background-color: black
  color: white
  border: 2px solid red
  ...
```
* Then, I just need to reference those values already declared, in my Lovelace yaml file.
```yaml
...
styles:
  card:
    background-color: !global_get background-color
  icon:
    color: !global_get color
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
