### PR TITLE
Use shared zeroconf for discovery netdisco

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -14,6 +14,7 @@ from netdisco.discovery import NetworkDiscovery
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import zeroconf
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -147,6 +148,8 @@ async def async_setup(hass, config):
                 platform,
             )
 
+    zeroconf_instance = await zeroconf.async_get_instance(hass)
+
     async def new_service_found(service, info):
         """Handle a new service if one is found."""
         if service in MIGRATED_SERVICE_HANDLERS:
@@ -193,7 +196,7 @@ async def async_setup(hass, config):
     async def scan_devices(now):
         """Scan for devices."""
         try:
-            results = await hass.async_add_job(_discover, netdisco)
+            results = await hass.async_add_job(_discover, netdisco, zeroconf_instance)
 
             for result in results:
                 hass.async_create_task(new_service_found(*result))
@@ -214,11 +217,11 @@ async def async_setup(hass, config):
     return True
 
 
-def _discover(netdisco):
+def _discover(netdisco, zeroconf_instance):
     """Discover devices."""
     results = []
     try:
-        netdisco.scan()
+        netdisco.scan(zeroconf_instance=zeroconf_instance)
 
         for disc in netdisco.discover():
             for service in netdisco.get_info(disc):

--- a/homeassistant/components/discovery/manifest.json
+++ b/homeassistant/components/discovery/manifest.json
@@ -2,7 +2,7 @@
   "domain": "discovery",
   "name": "Discovery",
   "documentation": "https://www.home-assistant.io/integrations/discovery",
-  "requirements": ["netdisco==2.7.1"],
+  "requirements": ["netdisco==2.8.0"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],
   "quality_scale": "internal"

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["defusedxml==0.6.0", "netdisco==2.7.1"],
+  "requirements": ["defusedxml==0.6.0", "netdisco==2.8.0"],
   "after_dependencies": ["zeroconf"],
   "codeowners": []
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,7 @@ hass-nabucasa==0.34.7
 home-assistant-frontend==20200626.1
 importlib-metadata==1.6.0;python_version<'3.8'
 jinja2>=2.11.1
-netdisco==2.7.1
+netdisco==2.8.0
 pip>=8.0.3
 python-slugify==4.0.0
 pytz>=2020.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -953,7 +953,7 @@ netdata==0.2.0
 
 # homeassistant.components.discovery
 # homeassistant.components.ssdp
-netdisco==2.7.1
+netdisco==2.8.0
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -424,7 +424,7 @@ nessclient==0.9.15
 
 # homeassistant.components.discovery
 # homeassistant.components.ssdp
-netdisco==2.7.1
+netdisco==2.8.0
 
 # homeassistant.components.nexia
 nexia==0.9.3

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -58,7 +58,7 @@ async def mock_discovery(hass, discoveries, config=BASE_CONFIG):
 async def test_unknown_service(hass):
     """Test that unknown service is ignored."""
 
-    def discover(netdisco):
+    def discover(netdisco, zeroconf_instance):
         """Fake discovery."""
         return [("this_service_will_never_be_supported", {"info": "some"})]
 
@@ -71,7 +71,7 @@ async def test_unknown_service(hass):
 async def test_load_platform(hass):
     """Test load a platform."""
 
-    def discover(netdisco):
+    def discover(netdisco, zeroconf_instance):
         """Fake discovery."""
         return [(SERVICE, SERVICE_INFO)]
 
@@ -87,7 +87,7 @@ async def test_load_platform(hass):
 async def test_load_component(hass):
     """Test load a component."""
 
-    def discover(netdisco):
+    def discover(netdisco, zeroconf_instance):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
@@ -107,7 +107,7 @@ async def test_load_component(hass):
 async def test_ignore_service(hass):
     """Test ignore service."""
 
-    def discover(netdisco):
+    def discover(netdisco, zeroconf_instance):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
@@ -120,7 +120,7 @@ async def test_ignore_service(hass):
 async def test_discover_duplicates(hass):
     """Test load a component."""
 
-    def discover(netdisco):
+    def discover(netdisco, zeroconf_instance):
         """Fake discovery."""
         return [
             (SERVICE_NO_PLATFORM, SERVICE_INFO),
@@ -145,7 +145,7 @@ async def test_discover_config_flow(hass):
     """Test discovery triggering a config flow."""
     discovery_info = {"hello": "world"}
 
-    def discover(netdisco):
+    def discover(netdisco, zeroconf_instance):
         """Fake discovery."""
         return [("mock-service", discovery_info)]
 


### PR DESCRIPTION
I started looking at the performance of other instances beyond my primary install to get an idea on how Home Assistant performed with other use cases. I thought I had solved the performance issues with zeroconf, however there is another place where the update code gets called that is unneeded.

I can't actually make a PR against netdisco because its archived so the branch is here: https://github.com/bdraco/netdisco/tree/shared_zeroconf_single_service_browser (https://github.com/bdraco/netdisco/commit/6dd89c68a49e843dd0a532f364923d34ad7898ff)

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use shared zeroconf for netdisco and avoid processed un-needed updates.

This 400 second sample was taken on a relatively quiet instance with only 13 integrations on my larger subnet with lots of mdns traffic.

Before:
<img width="1043" alt="Screen Shot 2020-06-29 at 3 53 09 PM" src="https://user-images.githubusercontent.com/663432/86055083-e57b3c00-ba20-11ea-8c21-933e287f8a0b.png">

After:
<img width="1038" alt="Screen Shot 2020-06-29 at 3 52 56 PM" src="https://user-images.githubusercontent.com/663432/86055059-dac0a700-ba20-11ea-83b4-458a53c0c59a.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
