### PR TITLE
Bump voluptuous-serialize 2.4.0

### DIFF
--- a/homeassistant/components/demo/config_flow.py
+++ b/homeassistant/components/demo/config_flow.py
@@ -53,6 +53,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             step_id="options_1",
             data_schema=vol.Schema(
                 {
+                    vol.Required("constant"): "Constant Value",
                     vol.Optional(
                         CONF_BOOLEAN,
                         default=self.config_entry.options.get(CONF_BOOLEAN, False),

--- a/homeassistant/components/demo/strings.json
+++ b/homeassistant/components/demo/strings.json
@@ -7,6 +7,7 @@
       },
       "options_1": {
         "data": {
+          "constant": "Constant",
           "bool": "Optional boolean",
           "int": "Numeric input"
         }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,7 +24,7 @@ pyyaml==5.3.1
 requests==2.24.0
 ruamel.yaml==0.15.100
 sqlalchemy==1.3.18
-voluptuous-serialize==2.3.0
+voluptuous-serialize==2.4.0
 voluptuous==0.11.7
 zeroconf==0.27.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ pyyaml==5.3.1
 requests==2.24.0
 ruamel.yaml==0.15.100
 voluptuous==0.11.7
-voluptuous-serialize==2.3.0
+voluptuous-serialize==2.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,7 +18,7 @@ pyyaml==5.3.1
 requests==2.24.0
 ruamel.yaml==0.15.100
 voluptuous==0.11.7
-voluptuous-serialize==2.3.0
+voluptuous-serialize==2.4.0
 
 # homeassistant.components.nuimo_controller
 --only-binary=all nuimo==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRES = [
     "requests==2.24.0",
     "ruamel.yaml==0.15.100",
     "voluptuous==0.11.7",
-    "voluptuous-serialize==2.3.0",
+    "voluptuous-serialize==2.4.0",
 ]
 
 MIN_PY_VERSION = ".".join(map(str, hass_const.REQUIRED_PYTHON_VER))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant-libs/voluptuous-serialize/releases

Adds support to define constants. This way we will be able to add information to our forms like the hostname of a discovered device.

Usage:

```python
vol.Schema({
  CONF_HOST: "http://192.168.1.23"
})
```

Will need frontend support too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
