### PR TITLE
Remove Hue configurator demo from demo integration

### DIFF
--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -1,7 +1,6 @@
 """Set up the demo environment that mimics interaction with devices."""
 import asyncio
 import logging
-import time
 
 from homeassistant import bootstrap, config_entries
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
@@ -135,37 +134,6 @@ async def async_setup(hass, config):
     hass.components.persistent_notification.async_create(
         "This is an example of a persistent notification.", title="Example Notification"
     )
-
-    # Set up configurator
-    configurator_ids = []
-    configurator = hass.components.configurator
-
-    def hue_configuration_callback(data):
-        """Fake callback, mark config as done."""
-        time.sleep(2)
-
-        # First time it is called, pretend it failed.
-        if len(configurator_ids) == 1:
-            configurator.notify_errors(
-                configurator_ids[0], "Failed to register, please try again."
-            )
-
-            configurator_ids.append(0)
-        else:
-            configurator.request_done(configurator_ids[0])
-
-    request_id = configurator.async_request_config(
-        "Philips Hue",
-        hue_configuration_callback,
-        description=(
-            "Press the button on the bridge to register Philips "
-            "Hue with Home Assistant."
-        ),
-        description_image="/static/images/config_philips_hue.jpg",
-        fields=[{"id": "username", "name": "Username"}],
-        submit_caption="I have pressed the button",
-    )
-    configurator_ids.append(request_id)
 
     async def demo_start_listener(_event):
         """Finish set up."""

--- a/homeassistant/components/demo/manifest.json
+++ b/homeassistant/components/demo/manifest.json
@@ -2,7 +2,7 @@
   "domain": "demo",
   "name": "Demo",
   "documentation": "https://www.home-assistant.io/integrations/demo",
-  "dependencies": ["conversation", "zone", "group", "configurator"],
+  "dependencies": ["conversation", "zone", "group"],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removing the Hue configurator demo from the demo integration.

First of all, this threw me off big time on dev, as I actually tried to pair my manually configured Hue bridge while having the demo component active. Of course, the configuration was fake... I didn't know...

Second of all, the configurator is old and should not be used anymore, so lets not demo it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
