### PR TITLE
Cleanup async_track_state_change and augment docstring

### DIFF
--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -4,7 +4,7 @@ import voluptuous as vol
 from homeassistant.const import CONF_ENTITY_ID, CONF_EVENT, CONF_PLATFORM, CONF_ZONE
 from homeassistant.core import callback
 from homeassistant.helpers import condition, config_validation as cv, location
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -31,8 +31,12 @@ async def async_attach_trigger(hass, config, action, automation_info):
     event = config.get(CONF_EVENT)
 
     @callback
-    def zone_automation_listener(entity, from_s, to_s):
+    def zone_automation_listener(zone_event):
         """Listen for state changes and calls action."""
+        entity = zone_event.data.get("entity_id")
+        from_s = zone_event.data.get("old_state")
+        to_s = zone_event.data.get("new_state")
+
         if (
             from_s
             and not location.has_location(from_s)
@@ -68,4 +72,4 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 )
             )
 
-    return async_track_state_change(hass, entity_id, zone_automation_listener)
+    return async_track_state_change_event(hass, entity_id, zone_automation_listener)

--- a/homeassistant/components/automation/zone.py
+++ b/homeassistant/components/automation/zone.py
@@ -1,13 +1,7 @@
 """Offer zone automation rules."""
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_ENTITY_ID,
-    CONF_EVENT,
-    CONF_PLATFORM,
-    CONF_ZONE,
-    MATCH_ALL,
-)
+from homeassistant.const import CONF_ENTITY_ID, CONF_EVENT, CONF_PLATFORM, CONF_ZONE
 from homeassistant.core import callback
 from homeassistant.helpers import condition, config_validation as cv, location
 from homeassistant.helpers.event import async_track_state_change
@@ -74,6 +68,4 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 )
             )
 
-    return async_track_state_change(
-        hass, entity_id, zone_automation_listener, MATCH_ALL, MATCH_ALL
-    )
+    return async_track_state_change(hass, entity_id, zone_automation_listener)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -72,10 +72,15 @@ def async_track_state_change(
 
     Returns a function that can be called to remove the listener.
 
+    If entity_ids are not MATCH_ALL along with from_state and to_state
+    being None, async_track_state_change_event should be used instead
+    as it is slightly faster.
+
     Must be run within the event loop.
     """
-    match_from_state = process_state_match(from_state)
-    match_to_state = process_state_match(to_state)
+    if from_state is not None and to_state is not None:
+        match_from_state = process_state_match(from_state)
+        match_to_state = process_state_match(to_state)
 
     # Ensure it is a lowercase list with entity ids we want to match on
     if entity_ids == MATCH_ALL:
@@ -88,21 +93,24 @@ def async_track_state_change(
     @callback
     def state_change_listener(event: Event) -> None:
         """Handle specific state changes."""
-        old_state = event.data.get("old_state")
-        if old_state is not None:
-            old_state = old_state.state
+        if from_state is not None and to_state is not None:
+            old_state = event.data.get("old_state")
+            if old_state is not None:
+                old_state = old_state.state
 
-        new_state = event.data.get("new_state")
-        if new_state is not None:
-            new_state = new_state.state
+            new_state = event.data.get("new_state")
+            if new_state is not None:
+                new_state = new_state.state
 
-        if match_from_state(old_state) and match_to_state(new_state):
-            hass.async_run_job(
-                action,
-                event.data.get("entity_id"),
-                event.data.get("old_state"),
-                event.data.get("new_state"),
-            )
+            if not match_from_state(old_state) or not match_to_state(new_state):
+                return
+
+        hass.async_run_job(
+            action,
+            event.data.get("entity_id"),
+            event.data.get("old_state"),
+            event.data.get("new_state"),
+        )
 
     if entity_ids != MATCH_ALL:
         # If we have a list of entity ids we use

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -577,5 +577,5 @@ def process_state_match(
     if isinstance(parameter, str) or not hasattr(parameter, "__iter__"):
         return lambda state: state == parameter
 
-    parameter_tuple = tuple(parameter)
-    return lambda state: state in parameter_tuple
+    parameter_set = set(parameter)
+    return lambda state: state in parameter_set

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -78,8 +78,9 @@ def async_track_state_change(
 
     Must be run within the event loop.
     """
-    if from_state is not None and to_state is not None:
+    if from_state is not None:
         match_from_state = process_state_match(from_state)
+    if to_state is not None:
         match_to_state = process_state_match(to_state)
 
     # Ensure it is a lowercase list with entity ids we want to match on
@@ -93,16 +94,19 @@ def async_track_state_change(
     @callback
     def state_change_listener(event: Event) -> None:
         """Handle specific state changes."""
-        if from_state is not None and to_state is not None:
+        if from_state is not None:
             old_state = event.data.get("old_state")
             if old_state is not None:
                 old_state = old_state.state
 
+            if not match_from_state(old_state):
+                return
+        if to_state is not None:
             new_state = event.data.get("new_state")
             if new_state is not None:
                 new_state = new_state.state
 
-            if not match_from_state(old_state) or not match_to_state(new_state):
+            if not match_to_state(new_state):
                 return
 
         hass.async_run_job(

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -114,7 +114,7 @@ async def time_changed_helper(hass):
 
 @benchmark
 async def state_changed_helper(hass):
-    """Run a million events through state changed helper."""
+    """Run a million events through state changed helper with 1000 entities."""
     count = 0
     entity_id = "light.kitchen"
     event = asyncio.Event()
@@ -128,9 +128,48 @@ async def state_changed_helper(hass):
         if count == 10 ** 6:
             event.set()
 
-    hass.helpers.event.async_track_state_change(entity_id, listener, "off", "on")
+    for idx in range(1000):
+        hass.helpers.event.async_track_state_change(
+            f"{entity_id}{idx}", listener, "off", "on"
+        )
     event_data = {
-        "entity_id": entity_id,
+        "entity_id": f"{entity_id}0",
+        "old_state": core.State(entity_id, "off"),
+        "new_state": core.State(entity_id, "on"),
+    }
+
+    for _ in range(10 ** 6):
+        hass.bus.async_fire(EVENT_STATE_CHANGED, event_data)
+
+    start = timer()
+
+    await event.wait()
+
+    return timer() - start
+
+
+@benchmark
+async def state_changed_event_helper(hass):
+    """Run a million events through state changed event helper with 1000 entities."""
+    count = 0
+    entity_id = "light.kitchen"
+    event = asyncio.Event()
+
+    @core.callback
+    def listener(*args):
+        """Handle event."""
+        nonlocal count
+        count += 1
+
+        if count == 10 ** 6:
+            event.set()
+
+    hass.helpers.event.async_track_state_change_event(
+        [f"{entity_id}{idx}" for idx in range(1000)], listener
+    )
+
+    event_data = {
+        "entity_id": f"{entity_id}0",
         "old_state": core.State(entity_id, "off"),
         "new_state": core.State(entity_id, "on"),
     }

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -86,6 +86,8 @@ async def test_track_state_change_from_to_state_match(hass):
     from_and_to_state_runs = []
     only_from_runs = []
     only_to_runs = []
+    match_all_runs = []
+    no_to_from_specified_runs = []
 
     def from_and_to_state_callback(entity_id, old_state, new_state):
         from_and_to_state_runs.append(1)
@@ -96,47 +98,69 @@ async def test_track_state_change_from_to_state_match(hass):
     def only_to_state_callback(entity_id, old_state, new_state):
         only_to_runs.append(1)
 
+    def match_all_callback(entity_id, old_state, new_state):
+        match_all_runs.append(1)
+
+    def no_to_from_specified_callback(entity_id, old_state, new_state):
+        no_to_from_specified_runs.append(1)
+
     async_track_state_change(
         hass, "light.Bowl", from_and_to_state_callback, "on", "off"
     )
     async_track_state_change(hass, "light.Bowl", only_from_state_callback, "on", None)
     async_track_state_change(hass, "light.Bowl", only_to_state_callback, None, "off")
+    async_track_state_change(
+        hass, "light.Bowl", match_all_callback, MATCH_ALL, MATCH_ALL
+    )
+    async_track_state_change(hass, "light.Bowl", no_to_from_specified_callback)
 
     hass.states.async_set("light.Bowl", "on")
     await hass.async_block_till_done()
     assert len(from_and_to_state_runs) == 0
     assert len(only_from_runs) == 0
     assert len(only_to_runs) == 0
+    assert len(match_all_runs) == 1
+    assert len(no_to_from_specified_runs) == 1
 
     hass.states.async_set("light.Bowl", "off")
     await hass.async_block_till_done()
     assert len(from_and_to_state_runs) == 1
     assert len(only_from_runs) == 1
     assert len(only_to_runs) == 1
+    assert len(match_all_runs) == 2
+    assert len(no_to_from_specified_runs) == 2
 
     hass.states.async_set("light.Bowl", "on")
     await hass.async_block_till_done()
     assert len(from_and_to_state_runs) == 1
     assert len(only_from_runs) == 1
     assert len(only_to_runs) == 1
+    assert len(match_all_runs) == 3
+    assert len(no_to_from_specified_runs) == 3
 
     hass.states.async_set("light.Bowl", "on")
     await hass.async_block_till_done()
     assert len(from_and_to_state_runs) == 1
     assert len(only_from_runs) == 1
     assert len(only_to_runs) == 1
+    assert len(match_all_runs) == 3
+    assert len(no_to_from_specified_runs) == 3
 
     hass.states.async_set("light.Bowl", "off")
     await hass.async_block_till_done()
     assert len(from_and_to_state_runs) == 2
     assert len(only_from_runs) == 2
     assert len(only_to_runs) == 2
+    assert len(match_all_runs) == 4
+    assert len(no_to_from_specified_runs) == 4
 
     hass.states.async_set("light.Bowl", "off")
     await hass.async_block_till_done()
     assert len(from_and_to_state_runs) == 2
     assert len(only_from_runs) == 2
     assert len(only_to_runs) == 2
+    assert len(match_all_runs) == 4
+    assert len(no_to_from_specified_runs) == 4
 
 
 async def test_track_state_change(hass):

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -91,12 +91,14 @@ async def test_track_state_change(hass):
     def specific_run_callback(entity_id, old_state, new_state):
         specific_runs.append(1)
 
+    # This is the rare use case
     async_track_state_change(hass, "light.Bowl", specific_run_callback, "on", "off")
 
     @ha.callback
     def wildcard_run_callback(entity_id, old_state, new_state):
         wildcard_runs.append((old_state, new_state))
 
+    # This is the most common use case
     async_track_state_change(hass, "light.Bowl", wildcard_run_callback)
 
     async def wildercard_run_callback(entity_id, old_state, new_state):


### PR DESCRIPTION
Followup to #37174

**This is easier to review with skipping whitespace**

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Skip from_state and to_state matching in
async_track_state_change when they are None

Optimize the state change listener for the most
common use case: no to_state and from_state
matching.

Updated the benchmarks to be more realistic as the
previous version assumed the Home Assistant install
would only have one entity.

With the updated benchmark:
`hass --script benchmark state_changed_helper`
```
0.112.0b3
Out of memory

0.113dev
Benchmark state_changed_helper done in 14.739943576045334s

This branch
Benchmark state_changed_helper done in 14.193275898694992s
```

`hass --script benchmark state_changed_event_helper`
```
0.113dev and this branch
Benchmark state_changed_event_helper done in 8.130546748172492s
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
