### PR TITLE
Changed FilterTest namedtuples to dataclasses

### DIFF
--- a/tests/components/apache_kafka/test_init.py
+++ b/tests/components/apache_kafka/test_init.py
@@ -1,5 +1,7 @@
 """The tests for the Apache Kafka component."""
-from collections import namedtuple
+from asyncio import AbstractEventLoop
+from dataclasses import dataclass
+from typing import Callable, Type
 
 import pytest
 
@@ -16,8 +18,23 @@ MIN_CONFIG = {
     "port": 8080,
     "topic": "topic",
 }
-FilterTest = namedtuple("FilterTest", "id should_pass")
-MockKafkaClient = namedtuple("MockKafkaClient", "init start send_and_wait")
+
+
+@dataclass
+class FilterTest:
+    """Class for capturing a filter test."""
+
+    id: str
+    should_pass: bool
+
+
+@dataclass
+class MockKafkaClient:
+    """Mock of the Apache Kafka client for testing."""
+
+    init: Callable[[Type[AbstractEventLoop], str, str], None]
+    start: Callable[[], None]
+    send_and_wait: Callable[[str, str], None]
 
 
 @pytest.fixture(name="mock_client")

--- a/tests/components/azure_event_hub/test_init.py
+++ b/tests/components/azure_event_hub/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Azure Event Hub component."""
-from collections import namedtuple
+from dataclasses import dataclass
 
 import pytest
 
@@ -17,7 +17,14 @@ MIN_CONFIG = {
     "event_hub_sas_policy": "policy",
     "event_hub_sas_key": "key",
 }
-FilterTest = namedtuple("FilterTest", "id should_pass")
+
+
+@dataclass
+class FilterTest:
+    """Class for capturing a filter test."""
+
+    id: str
+    should_pass: bool
 
 
 @pytest.fixture(autouse=True, name="mock_client", scope="module")

--- a/tests/components/google_pubsub/test_init.py
+++ b/tests/components/google_pubsub/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Google Pub/Sub component."""
-from collections import namedtuple
+from dataclasses import dataclass
 from datetime import datetime
 
 import pytest
@@ -13,6 +13,14 @@ from homeassistant.setup import async_setup_component
 import tests.async_mock as mock
 
 GOOGLE_PUBSUB_PATH = "homeassistant.components.google_pubsub"
+
+
+@dataclass
+class FilterTest:
+    """Class for capturing a filter test."""
+
+    id: str
+    should_pass: bool
 
 
 async def test_datetime():
@@ -107,9 +115,6 @@ async def test_full_config(hass, mock_client):
     assert (
         mock_client.PublisherClient.from_service_account_json.call_args[0][0] == "path"
     )
-
-
-FilterTest = namedtuple("FilterTest", "id should_pass")
 
 
 def make_event(entity_id):

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Prometheus exporter."""
-from collections import namedtuple
+from dataclasses import dataclass
 
 import pytest
 
@@ -20,6 +20,14 @@ from homeassistant.setup import async_setup_component
 import tests.async_mock as mock
 
 PROMETHEUS_PATH = "homeassistant.components.prometheus"
+
+
+@dataclass
+class FilterTest:
+    """Class for capturing a filter test."""
+
+    id: str
+    should_pass: bool
 
 
 @pytest.fixture
@@ -200,9 +208,6 @@ async def test_full_config(hass, mock_client):
     await hass.async_block_till_done()
     assert hass.bus.listen.called
     assert EVENT_STATE_CHANGED == hass.bus.listen.call_args_list[0][0][0]
-
-
-FilterTest = namedtuple("FilterTest", "id should_pass")
 
 
 def make_event(entity_id):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Small change to tests created for https://github.com/home-assistant/core/pull/36913. I was unaware of python's `dataclasses` at the time so I used `namedtuples` where I should've been using them. Now that @MartinHjelmare showed me this concept wanted to clean up this bit of tech debt I inadvertently introduced.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
