### PR TITLE
Switch homekit to use async_track_state_change_event

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback as ha_callback, split_entity_id
 from homeassistant.helpers.event import (
-    async_track_state_change,
+    async_track_state_change_event,
     track_point_in_utc_time,
 )
 from homeassistant.util import dt as dt_util
@@ -346,10 +346,10 @@ class HomeAccessory(Accessory):
         Run inside the Home Assistant event loop.
         """
         state = self.hass.states.get(self.entity_id)
-        self.async_update_state_callback(None, None, state)
+        self.async_update_state_callback(state)
         self._subscriptions.append(
-            async_track_state_change(
-                self.hass, self.entity_id, self.async_update_state_callback
+            async_track_state_change_event(
+                self.hass, [self.entity_id], self.async_update_event_state_callback
             )
         )
 
@@ -364,9 +364,9 @@ class HomeAccessory(Accessory):
                 ATTR_BATTERY_CHARGING
             )
             self._subscriptions.append(
-                async_track_state_change(
+                async_track_state_change_event(
                     self.hass,
-                    self.linked_battery_sensor,
+                    [self.linked_battery_sensor],
                     self.async_update_linked_battery_callback,
                 )
             )
@@ -378,9 +378,9 @@ class HomeAccessory(Accessory):
                 == STATE_ON
             )
             self._subscriptions.append(
-                async_track_state_change(
+                async_track_state_change_event(
                     self.hass,
-                    self.linked_battery_charging_sensor,
+                    [self.linked_battery_charging_sensor],
                     self.async_update_linked_battery_charging_callback,
                 )
             )
@@ -391,9 +391,12 @@ class HomeAccessory(Accessory):
             self.async_update_battery(battery_state, battery_charging_state)
 
     @ha_callback
-    def async_update_state_callback(
-        self, entity_id=None, old_state=None, new_state=None
-    ):
+    def async_update_event_state_callback(self, event):
+        """Handle state change event listener callback."""
+        self.async_update_state_callback(event.data.get("new_state"))
+
+    @ha_callback
+    def async_update_state_callback(self, new_state):
         """Handle state change listener callback."""
         _LOGGER.debug("New_state: %s", new_state)
         if new_state is None:
@@ -415,10 +418,9 @@ class HomeAccessory(Accessory):
         self.async_update_state(new_state)
 
     @ha_callback
-    def async_update_linked_battery_callback(
-        self, entity_id=None, old_state=None, new_state=None
-    ):
+    def async_update_linked_battery_callback(self, event):
         """Handle linked battery sensor state change listener callback."""
+        new_state = event.data.get("new_state")
         if self.linked_battery_charging_sensor:
             battery_charging_state = None
         else:
@@ -426,10 +428,9 @@ class HomeAccessory(Accessory):
         self.async_update_battery(new_state.state, battery_charging_state)
 
     @ha_callback
-    def async_update_linked_battery_charging_callback(
-        self, entity_id=None, old_state=None, new_state=None
-    ):
+    def async_update_linked_battery_charging_callback(self, event):
         """Handle linked battery charging sensor state change listener callback."""
+        new_state = event.data.get("new_state")
         self.async_update_battery(None, new_state.state == STATE_ON)
 
     @ha_callback

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -370,13 +370,11 @@ class HomeAccessory(Accessory):
                     self.async_update_linked_battery_callback,
                 )
             )
-        else:
+        elif state is not None:
             battery_state = state.attributes.get(ATTR_BATTERY_LEVEL)
         if self.linked_battery_charging_sensor:
-            battery_charging_state = (
-                self.hass.states.get(self.linked_battery_charging_sensor).state
-                == STATE_ON
-            )
+            state = self.hass.states.get(self.linked_battery_charging_sensor)
+            battery_charging_state = state and state.state == STATE_ON
             self._subscriptions.append(
                 async_track_state_change_event(
                     self.hass,
@@ -384,7 +382,7 @@ class HomeAccessory(Accessory):
                     self.async_update_linked_battery_charging_callback,
                 )
             )
-        elif battery_charging_state is None:
+        elif battery_charging_state is None and state is not None:
             battery_charging_state = state.attributes.get(ATTR_BATTERY_CHARGING)
 
         if battery_state is not None or battery_charging_state is not None:

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -421,6 +421,8 @@ class HomeAccessory(Accessory):
     def async_update_linked_battery_callback(self, event):
         """Handle linked battery sensor state change listener callback."""
         new_state = event.data.get("new_state")
+        if new_state is None:
+            return
         if self.linked_battery_charging_sensor:
             battery_charging_state = None
         else:
@@ -431,6 +433,8 @@ class HomeAccessory(Accessory):
     def async_update_linked_battery_charging_callback(self, event):
         """Handle linked battery charging sensor state change listener callback."""
         new_state = event.data.get("new_state")
+        if new_state is None:
+            return
         self.async_update_battery(None, new_state.state == STATE_ON)
 
     @ha_callback

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -207,6 +207,7 @@ async def test_battery_service(hass, hk_driver, caplog):
         await hass.async_block_till_done()
         state = hass.states.get(entity_id)
         mock_async_update_state.assert_called_with(state)
+
     assert acc._char_battery.value == 15
     assert acc._char_low_battery.value == 1
     assert acc._char_charging.value == 2
@@ -218,6 +219,7 @@ async def test_battery_service(hass, hk_driver, caplog):
         await hass.async_block_till_done()
         state = hass.states.get(entity_id)
         mock_async_update_state.assert_called_with(state)
+
     assert acc._char_battery.value == 15
     assert acc._char_low_battery.value == 1
     assert acc._char_charging.value == 2
@@ -341,7 +343,12 @@ async def test_linked_battery_sensor(hass, hk_driver, caplog):
 
     hass.states.async_set(linked_battery, 100, {ATTR_BATTERY_CHARGING: False})
     await hass.async_block_till_done()
-    state = hass.states.get(entity_id)
+    assert acc._char_battery.value == 100
+    assert acc._char_low_battery.value == 0
+    assert acc._char_charging.value == 0
+
+    hass.states.async_remove(linked_battery)
+    await hass.async_block_till_done()
     assert acc._char_battery.value == 100
     assert acc._char_low_battery.value == 0
     assert acc._char_charging.value == 0
@@ -396,6 +403,14 @@ async def test_linked_battery_charging_sensor(hass, hk_driver, caplog):
         mock_async_update_state.assert_called_with(state)
     assert acc._char_charging.value == 1
 
+    with patch(
+        "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+    ) as mock_async_update_state:
+        hass.states.async_remove(linked_battery_charging_sensor)
+        await acc.run_handler()
+        await hass.async_block_till_done()
+    assert acc._char_charging.value == 1
+
 
 async def test_linked_battery_sensor_and_linked_battery_charging_sensor(
     hass, hk_driver, caplog
@@ -439,6 +454,12 @@ async def test_linked_battery_sensor_and_linked_battery_charging_sensor(
     assert acc._char_low_battery.value == 0
     assert acc._char_charging.value == 0
 
+    hass.states.async_remove(linked_battery_charging_sensor)
+    await hass.async_block_till_done()
+    assert acc._char_battery.value == 50
+    assert acc._char_low_battery.value == 0
+    assert acc._char_charging.value == 0
+
 
 async def test_missing_linked_battery_charging_sensor(hass, hk_driver, caplog):
     """Test battery service with linked_battery_charging_sensor that is mapping to a missing entity."""
@@ -456,6 +477,8 @@ async def test_missing_linked_battery_charging_sensor(hass, hk_driver, caplog):
         {CONF_LINKED_BATTERY_CHARGING_SENSOR: linked_battery_charging_sensor},
     )
     assert acc.linked_battery_charging_sensor is None
+
+    hass.states.async_remove(entity_id)
 
 
 async def test_missing_linked_battery_sensor(hass, hk_driver, caplog):
@@ -488,6 +511,18 @@ async def test_missing_linked_battery_sensor(hass, hk_driver, caplog):
     assert acc._char_low_battery is None
     assert acc._char_charging is None
 
+    with patch(
+        "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+    ) as mock_async_update_state:
+        hass.states.async_remove(entity_id)
+        await acc.run_handler()
+        await hass.async_block_till_done()
+
+    assert not acc.linked_battery_sensor
+    assert acc._char_battery is None
+    assert acc._char_low_battery is None
+    assert acc._char_charging is None
+
 
 async def test_battery_appears_after_startup(hass, hk_driver, caplog):
     """Test battery level appears after homekit is started."""
@@ -511,6 +546,13 @@ async def test_battery_appears_after_startup(hass, hk_driver, caplog):
         "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
     ):
         hass.states.async_set(entity_id, None, {ATTR_BATTERY_LEVEL: 15})
+        await hass.async_block_till_done()
+    assert acc._char_battery is None
+
+    with patch(
+        "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+    ):
+        hass.states.async_remove(entity_id)
         await hass.async_block_till_done()
     assert acc._char_battery is None
 

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -478,7 +478,23 @@ async def test_missing_linked_battery_charging_sensor(hass, hk_driver, caplog):
     )
     assert acc.linked_battery_charging_sensor is None
 
+    # Make sure we don't throw if the linked_battery_charging_sensor
+    # is removed
+    hass.states.async_remove(linked_battery_charging_sensor)
+    with patch(
+        "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+    ):
+        await acc.run_handler()
+        await hass.async_block_till_done()
+
+    # Make sure we don't throw if the entity_id
+    # is removed
     hass.states.async_remove(entity_id)
+    with patch(
+        "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+    ):
+        await acc.run_handler()
+        await hass.async_block_till_done()
 
 
 async def test_missing_linked_battery_sensor(hass, hk_driver, caplog):


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Calling async_track_state_change_event directly
is faster than async_track_state_change (see #37251) and has
slightly lower latency triggering state updates
in homekit

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
