### PR TITLE
Track entity sources

### DIFF
--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -77,11 +77,6 @@ class DeconzDevice(DeconzBase, Entity):
                 self.hass, self.gateway.signal_reachable, self.async_update_callback
             )
         )
-        self.listeners.append(
-            async_dispatcher_connect(
-                self.hass, self.gateway.signal_remove_entity, self.async_remove_self
-            )
-        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect device object when removed."""
@@ -90,15 +85,6 @@ class DeconzDevice(DeconzBase, Entity):
             del self.gateway.deconz_ids[self.entity_id]
             for unsub_dispatcher in self.listeners:
                 unsub_dispatcher()
-
-    async def async_remove_self(self, deconz_ids: list) -> None:
-        """Schedule removal of this entity.
-
-        Called by signal_remove_entity scheduled by async_added_to_hass.
-        """
-        if self._device.deconz_id not in deconz_ids:
-            return
-        await self.async_remove()
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -196,11 +196,6 @@ class DeconzGateway:
         }
         return new_device[device_type]
 
-    @property
-    def signal_remove_entity(self) -> str:
-        """Gateway specific event to signal removal of entity."""
-        return f"deconz-remove-{self.bridgeid}"
-
     @callback
     def async_add_device_callback(self, device_type, device) -> None:
         """Handle event of new device creation in deCONZ."""

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -164,15 +164,14 @@ class DeconzGateway:
             else:
                 deconz_ids += [group.deconz_id for group in groups]
 
-        if deconz_ids:
-            async_dispatcher_send(self.hass, self.signal_remove_entity, deconz_ids)
-
         entity_registry = await self.hass.helpers.entity_registry.async_get_registry()
 
         for entity_id, deconz_id in self.deconz_ids.items():
             if deconz_id in deconz_ids and entity_registry.async_is_registered(
                 entity_id
             ):
+                # Removing an entity from the entity registry will also remove them
+                # from Home Assistant
                 entity_registry.async_remove(entity_id)
 
     @property

--- a/homeassistant/components/dyson/air_quality.py
+++ b/homeassistant/components/dyson/air_quality.py
@@ -27,9 +27,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Get Dyson Devices from parent component
     device_ids = [device.unique_id for device in hass.data[DYSON_AIQ_DEVICES]]
+    new_entities = []
     for device in hass.data[DYSON_DEVICES]:
+        print(device.serial)
         if isinstance(device, DysonPureCool) and device.serial not in device_ids:
-            hass.data[DYSON_AIQ_DEVICES].append(DysonAirSensor(device))
+            new_entities.append(DysonAirSensor(device))
+
+    if not new_entities:
+        return
+
+    hass.data[DYSON_AIQ_DEVICES].extend(new_entities)
     add_entities(hass.data[DYSON_AIQ_DEVICES])
 
 

--- a/homeassistant/components/dyson/sensor.py
+++ b/homeassistant/components/dyson/sensor.py
@@ -41,18 +41,24 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Get Dyson Devices from parent component
     device_ids = [device.unique_id for device in hass.data[DYSON_SENSOR_DEVICES]]
+    new_entities = []
     for device in hass.data[DYSON_DEVICES]:
         if isinstance(device, DysonPureCool):
             if f"{device.serial}-temperature" not in device_ids:
-                devices.append(DysonTemperatureSensor(device, unit))
+                new_entities.append(DysonTemperatureSensor(device, unit))
             if f"{device.serial}-humidity" not in device_ids:
-                devices.append(DysonHumiditySensor(device))
+                new_entities.append(DysonHumiditySensor(device))
         elif isinstance(device, DysonPureCoolLink):
-            devices.append(DysonFilterLifeSensor(device))
-            devices.append(DysonDustSensor(device))
-            devices.append(DysonHumiditySensor(device))
-            devices.append(DysonTemperatureSensor(device, unit))
-            devices.append(DysonAirQualitySensor(device))
+            new_entities.append(DysonFilterLifeSensor(device))
+            new_entities.append(DysonDustSensor(device))
+            new_entities.append(DysonHumiditySensor(device))
+            new_entities.append(DysonTemperatureSensor(device, unit))
+            new_entities.append(DysonAirQualitySensor(device))
+
+    if not new_entities:
+        return
+
+    devices.extend(new_entities)
     add_entities(devices)
 
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -274,7 +274,6 @@ SIGNAL_REMOVE = "remove"
 SIGNAL_SET_LEVEL = "set_level"
 SIGNAL_STATE_ATTR = "update_state_attribute"
 SIGNAL_UPDATE_DEVICE = "{}_zha_update_device"
-SIGNAL_REMOVE_GROUP = "remove_group"
 SIGNAL_GROUP_ENTITY_REMOVED = "group_entity_removed"
 SIGNAL_GROUP_MEMBERSHIP_CHANGE = "group_membership_change"
 

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -615,7 +615,8 @@ class ZHAGateway:
         if not group:
             _LOGGER.debug("Group: %s:0x%04x could not be found", group.name, group_id)
             return
-        if group and group.members:
+        group.deleting = True
+        if group.members:
             tasks = []
             for member in group.members:
                 tasks.append(member.async_remove_from_group())

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -615,7 +615,6 @@ class ZHAGateway:
         if not group:
             _LOGGER.debug("Group: %s:0x%04x could not be found", group.name, group_id)
             return
-        group.deleting = True
         if group.members:
             tasks = []
             for member in group.members:

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -297,7 +297,7 @@ class ZHAGateway:
         self._send_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_ADDED)
 
     def group_removed(self, zigpy_group: ZigpyGroupType) -> None:
-        """Handle zigpy group added event."""
+        """Handle zigpy group removed event."""
         self._send_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_REMOVED)
         zha_group = self._groups.pop(zigpy_group.group_id, None)
         zha_group.info("group_removed")

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -57,7 +57,6 @@ from .const import (
     SIGNAL_ADD_ENTITIES,
     SIGNAL_GROUP_MEMBERSHIP_CHANGE,
     SIGNAL_REMOVE,
-    SIGNAL_REMOVE_GROUP,
     UNKNOWN_MANUFACTURER,
     UNKNOWN_MODEL,
     ZHA_GW_MSG,
@@ -302,9 +301,6 @@ class ZHAGateway:
         self._send_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_REMOVED)
         zha_group = self._groups.pop(zigpy_group.group_id, None)
         zha_group.info("group_removed")
-        async_dispatcher_send(
-            self._hass, f"{SIGNAL_REMOVE_GROUP}_0x{zigpy_group.group_id:04x}"
-        )
         self._cleanup_group_entity_registry_entries(zigpy_group)
 
     def _send_group_gateway_message(

--- a/homeassistant/components/zha/core/group.py
+++ b/homeassistant/components/zha/core/group.py
@@ -119,8 +119,6 @@ class ZHAGroup(LogMixin):
         self.hass: HomeAssistantType = hass
         self._zigpy_group: ZigpyGroupType = zigpy_group
         self._zha_gateway: ZhaGatewayType = zha_gateway
-        # Keep track if we're deleting the group so event handlers can act accordingly
-        self.deleting = False
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/zha/core/group.py
+++ b/homeassistant/components/zha/core/group.py
@@ -119,6 +119,8 @@ class ZHAGroup(LogMixin):
         self.hass: HomeAssistantType = hass
         self._zigpy_group: ZigpyGroupType = zigpy_group
         self._zha_gateway: ZhaGatewayType = zha_gateway
+        # Keep track if we're deleting the group so event handlers can act accordingly
+        self.deleting = False
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -24,7 +24,6 @@ from .core.const import (
     SIGNAL_GROUP_ENTITY_REMOVED,
     SIGNAL_GROUP_MEMBERSHIP_CHANGE,
     SIGNAL_REMOVE,
-    SIGNAL_REMOVE_GROUP,
 )
 from .core.helpers import LogMixin
 from .core.typing import CALLABLE_T, ChannelType, ZhaDeviceType
@@ -232,12 +231,6 @@ class ZhaGroupEntity(BaseZhaEntity):
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()
-        self.async_accept_signal(
-            None,
-            f"{SIGNAL_REMOVE_GROUP}_0x{self._group_id:04x}",
-            self.async_remove,
-            signal_override=True,
-        )
 
         self.async_accept_signal(
             None,

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -230,9 +230,8 @@ class ZhaGroupEntity(BaseZhaEntity):
 
     async def _handle_group_membership_changed(self):
         """Handle group membership changed."""
-        # Make sure we don't call remove twice if we're deleting the group or
-        # 2 members are removed at same time.
-        if self._group.deleting or self._handled_group_membership:
+        # Make sure we don't call remove twice as members are removed
+        if self._handled_group_membership:
             return
 
         self._handled_group_membership = True

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -54,6 +54,10 @@ class Unauthorized(HomeAssistantError):
         """Unauthorized error."""
         super().__init__(self.__class__.__name__)
         self.context = context
+
+        if user_id is None and context is not None:
+            user_id = context.user_id
+
         self.user_id = user_id
         self.entity_id = entity_id
         self.config_entry_id = config_entry_id

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -545,7 +545,11 @@ class Entity(ABC):
         """
         if self.platform:
             assert self.hass is not None
-            self.hass.data[DATA_ENTITY_SOURCE].pop(self.entity_id)
+            self.hass.data[DATA_ENTITY_SOURCE].pop(
+                self.entity_id,
+                # In rare cases removal can be called twice, this will prevent it from blowing up
+                None,
+            )
 
     async def _async_registry_updated(self, event: Event) -> None:
         """Handle entity registry update."""

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -574,6 +574,11 @@ class Entity(ABC):
             self.hass.data.setdefault(DATA_ENTITY_SOURCE, {})[self.entity_id] = info
 
         if self.registry_entry is not None:
+            # This is an assert as it should never happen, but helps in tests
+            assert (
+                not self.registry_entry.disabled_by
+            ), f"Entity {self.entity_id} is being added while it's disabled"
+
             self.async_on_remove(
                 async_track_entity_registry_updated_event(
                     self.hass, self.entity_id, self._async_registry_updated

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -528,9 +528,9 @@ class Entity(ABC):
         assert self.hass is not None
 
         if self.platform and not self._added:
-            # Can be converted to an error once ZHA groups have been updated
-            _LOGGER.warning("Entity %s async_remove called twice", self.entity_id)
-            return
+            raise HomeAssistantError(
+                f"Entity {self.entity_id} async_remove called twice"
+            )
 
         self._added = False
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -6,7 +6,7 @@ from logging import Logger
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable, Coroutine, Dict, Iterable, List, Optional
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant import config_entries
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.core import (
     CALLBACK_TYPE,
@@ -60,7 +60,7 @@ class EntityPlatform:
         self.platform = platform
         self.scan_interval = scan_interval
         self.entity_namespace = entity_namespace
-        self.config_entry: Optional[ConfigEntry] = None
+        self.config_entry: Optional[config_entries.ConfigEntry] = None
         self.entities: Dict[str, Entity] = {}  # pylint: disable=used-before-assignment
         self._tasks: List[asyncio.Future] = []
         # Method to cancel the state change listener
@@ -149,7 +149,7 @@ class EntityPlatform:
 
         await self._async_setup_platform(async_create_setup_task)
 
-    async def async_setup_entry(self, config_entry: ConfigEntry) -> bool:
+    async def async_setup_entry(self, config_entry: config_entries.ConfigEntry) -> bool:
         """Set up the platform from a config entry."""
         # Store it so that we can save config entry ID in entity registry
         self.config_entry = config_entry

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -332,10 +332,10 @@ class EntityPlatform:
         if entity is None:
             raise ValueError("Entity cannot be None")
 
-        entity.hass = self.hass
-        entity.platform = self
-        entity.parallel_updates = self._get_parallel_updates_semaphore(
-            hasattr(entity, "async_update")
+        entity.add_to_platform_start(
+            self.hass,
+            self,
+            self._get_parallel_updates_semaphore(hasattr(entity, "async_update")),
         )
 
         # Update properties before we generate the entity_id
@@ -344,8 +344,7 @@ class EntityPlatform:
                 await entity.async_device_update(warning=False)
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception("%s: Error on device update!", self.platform_name)
-                entity.hass = None
-                entity.platform = None
+                entity.add_to_platform_abort()
                 return
 
         requested_entity_id = None
@@ -423,8 +422,7 @@ class EntityPlatform:
                     or entity.name
                     or f'"{self.platform_name} {entity.unique_id}"',
                 )
-                entity.hass = None
-                entity.platform = None
+                entity.add_to_platform_abort()
                 return
 
         # We won't generate an entity ID if the platform has already set one
@@ -450,8 +448,7 @@ class EntityPlatform:
 
         # Make sure it is valid in case an entity set the value themselves
         if not valid_entity_id(entity.entity_id):
-            entity.hass = None
-            entity.platform = None
+            entity.add_to_platform_abort()
             raise HomeAssistantError(f"Invalid entity id: {entity.entity_id}")
 
         already_exists = entity.entity_id in self.entities
@@ -472,18 +469,14 @@ class EntityPlatform:
             else:
                 msg = f"Entity id already exists - ignoring: {entity.entity_id}"
             self.logger.error(msg)
-            entity.hass = None
-            entity.platform = None
+            entity.add_to_platform_abort()
             return
 
         entity_id = entity.entity_id
         self.entities[entity_id] = entity
         entity.async_on_remove(lambda: self.entities.pop(entity_id))
 
-        await entity.async_internal_added_to_hass()
-        await entity.async_added_to_hass()
-
-        entity.async_write_ha_state()
+        await entity.add_to_platform_finish()
 
     async def async_reset(self) -> None:
         """Remove all entities and reset data.

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -1,85 +1,55 @@
 """The tests for the Switch component."""
-# pylint: disable=protected-access
-import unittest
+import pytest
 
 from homeassistant import core
 from homeassistant.components import switch
 from homeassistant.const import CONF_PLATFORM
-from homeassistant.setup import async_setup_component, setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant, mock_entity_platform
 from tests.components.switch import common
 
 
-class TestSwitch(unittest.TestCase):
-    """Test the switch module."""
-
-    # pylint: disable=invalid-name
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        platform = getattr(self.hass.components, "test.switch")
-        platform.init()
-        # Switch 1 is ON, switch 2 is OFF
-        self.switch_1, self.switch_2, self.switch_3 = platform.ENTITIES
-        self.addCleanup(self.hass.stop)
-
-    def test_methods(self):
-        """Test is_on, turn_on, turn_off methods."""
-        assert setup_component(
-            self.hass, switch.DOMAIN, {switch.DOMAIN: {CONF_PLATFORM: "test"}}
-        )
-        self.hass.block_till_done()
-        assert switch.is_on(self.hass, self.switch_1.entity_id)
-        assert not switch.is_on(self.hass, self.switch_2.entity_id)
-        assert not switch.is_on(self.hass, self.switch_3.entity_id)
-
-        common.turn_off(self.hass, self.switch_1.entity_id)
-        common.turn_on(self.hass, self.switch_2.entity_id)
-
-        self.hass.block_till_done()
-
-        assert not switch.is_on(self.hass, self.switch_1.entity_id)
-        assert switch.is_on(self.hass, self.switch_2.entity_id)
-
-        # Turn all off
-        common.turn_off(self.hass)
-
-        self.hass.block_till_done()
-
-        assert not switch.is_on(self.hass, self.switch_1.entity_id)
-        assert not switch.is_on(self.hass, self.switch_2.entity_id)
-        assert not switch.is_on(self.hass, self.switch_3.entity_id)
-
-        # Turn all on
-        common.turn_on(self.hass)
-
-        self.hass.block_till_done()
-
-        assert switch.is_on(self.hass, self.switch_1.entity_id)
-        assert switch.is_on(self.hass, self.switch_2.entity_id)
-        assert switch.is_on(self.hass, self.switch_3.entity_id)
-
-    def test_setup_two_platforms(self):
-        """Test with bad configuration."""
-        # Test if switch component returns 0 switches
-        test_platform = getattr(self.hass.components, "test.switch")
-        test_platform.init(True)
-
-        mock_entity_platform(self.hass, "switch.test2", test_platform)
-        test_platform.init(False)
-
-        assert setup_component(
-            self.hass,
-            switch.DOMAIN,
-            {
-                switch.DOMAIN: {CONF_PLATFORM: "test"},
-                f"{switch.DOMAIN} 2": {CONF_PLATFORM: "test2"},
-            },
-        )
+@pytest.fixture(autouse=True)
+def entities(hass):
+    """Initialize the test switch."""
+    platform = getattr(hass.components, "test.switch")
+    platform.init()
+    yield platform.ENTITIES
 
 
-async def test_switch_context(hass, hass_admin_user):
+async def test_methods(hass, entities):
+    """Test is_on, turn_on, turn_off methods."""
+    switch_1, switch_2, switch_3 = entities
+    assert await async_setup_component(
+        hass, switch.DOMAIN, {switch.DOMAIN: {CONF_PLATFORM: "test"}}
+    )
+    await hass.async_block_till_done()
+    assert switch.is_on(hass, switch_1.entity_id)
+    assert not switch.is_on(hass, switch_2.entity_id)
+    assert not switch.is_on(hass, switch_3.entity_id)
+
+    await common.async_turn_off(hass, switch_1.entity_id)
+    await common.async_turn_on(hass, switch_2.entity_id)
+
+    assert not switch.is_on(hass, switch_1.entity_id)
+    assert switch.is_on(hass, switch_2.entity_id)
+
+    # Turn all off
+    await common.async_turn_off(hass)
+
+    assert not switch.is_on(hass, switch_1.entity_id)
+    assert not switch.is_on(hass, switch_2.entity_id)
+    assert not switch.is_on(hass, switch_3.entity_id)
+
+    # Turn all on
+    await common.async_turn_on(hass)
+
+    assert switch.is_on(hass, switch_1.entity_id)
+    assert switch.is_on(hass, switch_2.entity_id)
+    assert switch.is_on(hass, switch_3.entity_id)
+
+
+async def test_switch_context(hass, entities, hass_admin_user):
     """Test that switch context works."""
     assert await async_setup_component(hass, "switch", {"switch": {"platform": "test"}})
 

--- a/tests/testing_config/custom_components/test/switch.py
+++ b/tests/testing_config/custom_components/test/switch.py
@@ -29,4 +29,5 @@ async def async_setup_platform(
     hass, config, async_add_entities_callback, discovery_info=None
 ):
     """Return mock entities."""
+    print("YOOO")
     async_add_entities_callback(ENTITIES)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow tracking entity sources, so we can use this in the frontend to better organize entities.

New websocket API: `entity/source` that takes optionally a list of entity IDs. Response is

```python
{
        "test_domain.platform_config_source": {
            "source": "platform_config",
            "domain": "test_platform",
        },
        "test_domain.config_entry_source": {
            "source": "config_entry",
            "config_entry": "abcdefg",
            "domain": "test_platform",
        },
    }
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
