### PR TITLE
Revert "Update fritzconnection to 1.3.0"

### DIFF
--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -2,6 +2,6 @@
   "domain": "fritz",
   "name": "AVM FRITZ!Box",
   "documentation": "https://www.home-assistant.io/integrations/fritz",
-  "requirements": ["fritzconnection==1.3.0"],
+  "requirements": ["fritzconnection==1.2.0"],
   "codeowners": []
 }

--- a/homeassistant/components/fritzbox_callmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_callmonitor/manifest.json
@@ -2,6 +2,6 @@
   "domain": "fritzbox_callmonitor",
   "name": "AVM FRITZ!Box Call Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_callmonitor",
-  "requirements": ["fritzconnection==1.3.0"],
+  "requirements": ["fritzconnection==1.2.0"],
   "codeowners": []
 }

--- a/homeassistant/components/fritzbox_netmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_netmonitor/manifest.json
@@ -2,6 +2,6 @@
   "domain": "fritzbox_netmonitor",
   "name": "AVM FRITZ!Box Net Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_netmonitor",
-  "requirements": ["fritzconnection==1.3.0"],
+  "requirements": ["fritzconnection==1.2.0"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -610,7 +610,7 @@ freesms==0.1.2
 # homeassistant.components.fritz
 # homeassistant.components.fritzbox_callmonitor
 # homeassistant.components.fritzbox_netmonitor
-fritzconnection==1.3.0
+fritzconnection==1.2.0
 
 # homeassistant.components.google_translate
 gTTS-token==1.1.3


### PR DESCRIPTION
Reverts home-assistant/core#37212

The fix in #37212 seems to cause more issues than it solved, reverting this for 0.112.

@svenstaro maybe version 1.3.1 will fix things, but I don't have a fritzbox to test it.