### PR TITLE
Add current temperature as separate sensor in Toon

### DIFF
--- a/homeassistant/components/toon/const.py
+++ b/homeassistant/components/toon/const.py
@@ -5,7 +5,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_PROBLEM,
 )
-from homeassistant.components.sensor import DEVICE_CLASS_POWER
+from homeassistant.components.sensor import DEVICE_CLASS_POWER, DEVICE_CLASS_TEMPERATURE
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
@@ -13,6 +13,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT,
+    TEMP_CELSIUS,
     UNIT_PERCENTAGE,
 )
 
@@ -112,6 +113,15 @@ BINARY_SENSOR_ENTITIES = {
 }
 
 SENSOR_ENTITIES = {
+    "current_display_temperature": {
+        ATTR_NAME: "Temperature",
+        ATTR_SECTION: "thermostat",
+        ATTR_MEASUREMENT: "current_display_temperature",
+        ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        ATTR_ICON: None,
+        ATTR_DEFAULT_ENABLED: True,
+    },
     "gas_average": {
         ATTR_NAME: "Average Gas Usage",
         ATTR_SECTION: "gas_usage",

--- a/homeassistant/components/toon/const.py
+++ b/homeassistant/components/toon/const.py
@@ -120,7 +120,7 @@ SENSOR_ENTITIES = {
         ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_ICON: None,
-        ATTR_DEFAULT_ENABLED: True,
+        ATTR_DEFAULT_ENABLED: False,
     },
     "gas_average": {
         ATTR_NAME: "Average Gas Usage",

--- a/homeassistant/components/toon/sensor.py
+++ b/homeassistant/components/toon/sensor.py
@@ -19,6 +19,7 @@ from .const import (
 from .coordinator import ToonDataUpdateCoordinator
 from .models import (
     ToonBoilerDeviceEntity,
+    ToonDisplayDeviceEntity,
     ToonElectricityMeterDeviceEntity,
     ToonEntity,
     ToonGasMeterDeviceEntity,
@@ -48,6 +49,10 @@ async def async_setup_entry(
             "solar_meter_reading_produced",
         )
     ]
+
+    sensors.extend(
+        [ToonDisplayDeviceSensor(coordinator, key="current_display_temperature")]
+    )
 
     if coordinator.data.gas_usage and coordinator.data.gas_usage.is_smart:
         sensors.extend(
@@ -147,3 +152,7 @@ class ToonSolarDeviceSensor(ToonSensor, ToonSolarDeviceEntity):
 
 class ToonBoilerDeviceSensor(ToonSensor, ToonBoilerDeviceEntity):
     """Defines a Boiler sensor."""
+
+
+class ToonDisplayDeviceSensor(ToonSensor, ToonDisplayDeviceEntity):
+    """Defines a Display sensor."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I've noticed I had a template sensor to extract the current temperature from the climate entity. On the Dutch Domotica Discord server, some people did the same.

This PR extracts the value into its own sensor, so it is easier to use and automate on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13884

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
