### PR TITLE
Fix withings bug that grabbed oldest value instead of the newest

### DIFF
--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -779,7 +779,7 @@ class DataManager:
             query_measure_groups(
                 response, MeasureTypes.ANY, MeasureGroupAttribs.UNAMBIGUOUS
             ),
-            key=get_sort_key,
+            key=lambda group: group.created.datetime,
             reverse=False,
         )
 

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -771,9 +771,6 @@ class DataManager:
 
         response = await self._hass.async_add_executor_job(self._api.measure_get_meas)
 
-        def get_sort_key(group: MeasureGetMeasGroup) -> str:
-            return group.created.datetime
-
         # Sort from oldest to newest.
         groups = sorted(
             query_measure_groups(

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -14,6 +14,7 @@ from withings_api import AbstractWithingsApi
 from withings_api.common import (
     AuthFailedException,
     GetSleepSummaryField,
+    MeasureGetMeasGroup,
     MeasureGroupAttribs,
     MeasureType,
     MeasureTypes,
@@ -770,8 +771,16 @@ class DataManager:
 
         response = await self._hass.async_add_executor_job(self._api.measure_get_meas)
 
-        groups = query_measure_groups(
-            response, MeasureTypes.ANY, MeasureGroupAttribs.UNAMBIGUOUS
+        def get_sort_key(group: MeasureGetMeasGroup) -> str:
+            return group.created.datetime
+
+        # Sort from oldest to newest.
+        groups = sorted(
+            query_measure_groups(
+                response, MeasureTypes.ANY, MeasureGroupAttribs.UNAMBIGUOUS
+            ),
+            key=get_sort_key,
+            reverse=False,
         )
 
         return {

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -14,7 +14,6 @@ from withings_api import AbstractWithingsApi
 from withings_api.common import (
     AuthFailedException,
     GetSleepSummaryField,
-    MeasureGetMeasGroup,
     MeasureGroupAttribs,
     MeasureType,
     MeasureTypes,

--- a/tests/components/withings/test_sensor.py
+++ b/tests/components/withings/test_sensor.py
@@ -1,5 +1,4 @@
 """Tests for the Withings component."""
-import time
 from typing import Any
 from unittest.mock import patch
 
@@ -40,8 +39,8 @@ PERSON0 = new_profile_config(
             MeasureGetMeasGroup(
                 attrib=MeasureGetMeasGroupAttrib.DEVICE_ENTRY_FOR_USER,
                 category=MeasureGetMeasGroupCategory.REAL,
-                created=time.time(),
-                date=time.time(),
+                created=arrow.utcnow().shift(hours=-1),
+                date=arrow.utcnow().shift(hours=-1),
                 deviceid="DEV_ID",
                 grpid=1,
                 measures=(
@@ -88,10 +87,60 @@ PERSON0 = new_profile_config(
                 ),
             ),
             MeasureGetMeasGroup(
+                attrib=MeasureGetMeasGroupAttrib.DEVICE_ENTRY_FOR_USER,
+                category=MeasureGetMeasGroupCategory.REAL,
+                created=arrow.utcnow().shift(hours=-2),
+                date=arrow.utcnow().shift(hours=-2),
+                deviceid="DEV_ID",
+                grpid=1,
+                measures=(
+                    MeasureGetMeasMeasure(type=MeasureType.WEIGHT, unit=0, value=71),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.FAT_MASS_WEIGHT, unit=0, value=51
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.FAT_FREE_MASS, unit=0, value=61
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.MUSCLE_MASS, unit=0, value=51
+                    ),
+                    MeasureGetMeasMeasure(type=MeasureType.BONE_MASS, unit=0, value=11),
+                    MeasureGetMeasMeasure(type=MeasureType.HEIGHT, unit=0, value=21),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.TEMPERATURE, unit=0, value=41
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.BODY_TEMPERATURE, unit=0, value=41
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.SKIN_TEMPERATURE, unit=0, value=21
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.FAT_RATIO, unit=-3, value=71
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.DIASTOLIC_BLOOD_PRESSURE, unit=0, value=71
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.SYSTOLIC_BLOOD_PRESSURE, unit=0, value=101
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.HEART_RATE, unit=0, value=61
+                    ),
+                    MeasureGetMeasMeasure(type=MeasureType.SP02, unit=-2, value=96),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.HYDRATION, unit=-2, value=96
+                    ),
+                    MeasureGetMeasMeasure(
+                        type=MeasureType.PULSE_WAVE_VELOCITY, unit=0, value=101
+                    ),
+                ),
+            ),
+            MeasureGetMeasGroup(
                 attrib=MeasureGetMeasGroupAttrib.DEVICE_ENTRY_FOR_USER_AMBIGUOUS,
                 category=MeasureGetMeasGroupCategory.REAL,
-                created=time.time(),
-                date=time.time(),
+                created=arrow.utcnow(),
+                date=arrow.utcnow(),
                 deviceid="DEV_ID",
                 grpid=1,
                 measures=(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix withings bug that grabbed oldest value instead of the newest.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37321
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
