### PR TITLE
Publish birth and will messages by default

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -201,10 +201,10 @@ CONFIG_SCHEMA = vol.Schema(
                         cv.string, vol.In([PROTOCOL_31, PROTOCOL_311])
                     ),
                     vol.Optional(
-                        CONF_WILL_MESSAGE, default=dict(DEFAULT_WILL)
+                        CONF_WILL_MESSAGE, default=DEFAULT_WILL
                     ): MQTT_WILL_BIRTH_SCHEMA,
                     vol.Optional(
-                        CONF_BIRTH_MESSAGE, default=dict(DEFAULT_BIRTH)
+                        CONF_BIRTH_MESSAGE, default=DEFAULT_BIRTH
                     ): MQTT_WILL_BIRTH_SCHEMA,
                     vol.Optional(CONF_DISCOVERY, default=DEFAULT_DISCOVERY): cv.boolean,
                     # discovery_prefix must be a valid publish topic because if no

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -108,7 +108,7 @@ PROTOCOL_31 = "3.1"
 DEFAULT_PORT = 1883
 DEFAULT_KEEPALIVE = 60
 DEFAULT_PROTOCOL = PROTOCOL_311
-DEFAULT_DISCOVERY_PREFIX = "homeassistant"
+DEFAULT_PREFIX = "homeassistant"
 DEFAULT_TLS_PROTOCOL = "auto"
 DEFAULT_PAYLOAD_AVAILABLE = "online"
 DEFAULT_PAYLOAD_NOT_AVAILABLE = "offline"
@@ -137,10 +137,24 @@ CLIENT_KEY_AUTH_MSG = (
     "the MQTT broker configuration"
 )
 
+DEFAULT_BIRTH = {
+    ATTR_TOPIC: DEFAULT_PREFIX + "/status",
+    CONF_PAYLOAD: DEFAULT_PAYLOAD_AVAILABLE,
+    ATTR_QOS: DEFAULT_QOS,
+    ATTR_RETAIN: DEFAULT_RETAIN,
+}
+
+DEFAULT_WILL = {
+    ATTR_TOPIC: DEFAULT_PREFIX + "/status",
+    CONF_PAYLOAD: DEFAULT_PAYLOAD_NOT_AVAILABLE,
+    ATTR_QOS: DEFAULT_QOS,
+    ATTR_RETAIN: DEFAULT_RETAIN,
+}
+
 MQTT_WILL_BIRTH_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_TOPIC): valid_publish_topic,
-        vol.Required(ATTR_PAYLOAD, CONF_PAYLOAD): cv.string,
+        vol.Inclusive(ATTR_TOPIC, "topic_payload"): valid_publish_topic,
+        vol.Inclusive(ATTR_PAYLOAD, "topic_payload"): cv.string,
         vol.Optional(ATTR_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA,
         vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
     },
@@ -186,13 +200,17 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): vol.All(
                         cv.string, vol.In([PROTOCOL_31, PROTOCOL_311])
                     ),
-                    vol.Optional(CONF_WILL_MESSAGE): MQTT_WILL_BIRTH_SCHEMA,
-                    vol.Optional(CONF_BIRTH_MESSAGE): MQTT_WILL_BIRTH_SCHEMA,
+                    vol.Optional(
+                        CONF_WILL_MESSAGE, default=dict(DEFAULT_WILL)
+                    ): MQTT_WILL_BIRTH_SCHEMA,
+                    vol.Optional(
+                        CONF_BIRTH_MESSAGE, default=dict(DEFAULT_BIRTH)
+                    ): MQTT_WILL_BIRTH_SCHEMA,
                     vol.Optional(CONF_DISCOVERY, default=DEFAULT_DISCOVERY): cv.boolean,
                     # discovery_prefix must be a valid publish topic because if no
                     # state topic is specified, it will be created with the given prefix.
                     vol.Optional(
-                        CONF_DISCOVERY_PREFIX, default=DEFAULT_DISCOVERY_PREFIX
+                        CONF_DISCOVERY_PREFIX, default=DEFAULT_PREFIX
                     ): valid_publish_topic,
                 }
             ),
@@ -668,7 +686,10 @@ class MQTT:
         self._mqttc.on_disconnect = self._mqtt_on_disconnect
         self._mqttc.on_message = self._mqtt_on_message
 
-        if CONF_WILL_MESSAGE in self.conf:
+        if (
+            CONF_WILL_MESSAGE in self.conf
+            and ATTR_TOPIC in self.conf[CONF_WILL_MESSAGE]
+        ):
             will_message = Message(**self.conf[CONF_WILL_MESSAGE])
         else:
             will_message = None
@@ -719,7 +740,7 @@ class MQTT:
 
         def stop():
             """Stop the MQTT client."""
-            self._mqttc.disconnect()
+            # Do not disconnect, we want the broker to always publish will
             self._mqttc.loop_stop()
 
         await self.hass.async_add_executor_job(stop)
@@ -818,7 +839,10 @@ class MQTT:
             max_qos = max(subscription.qos for subscription in subs)
             self.hass.add_job(self._async_perform_subscription, topic, max_qos)
 
-        if CONF_BIRTH_MESSAGE in self.conf:
+        if (
+            CONF_BIRTH_MESSAGE in self.conf
+            and ATTR_TOPIC in self.conf[CONF_BIRTH_MESSAGE]
+        ):
             birth_message = Message(**self.conf[CONF_BIRTH_MESSAGE])
             self.hass.add_job(
                 self.async_publish(  # pylint: disable=no-value-for-parameter

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -755,7 +755,7 @@ async def test_setup_without_tls_config_uses_tlsv1_under_python36(hass):
         }
     ],
 )
-async def test_birth_message(hass, mqtt_client_mock, mqtt_mock):
+async def test_custom_birth_message(hass, mqtt_client_mock, mqtt_mock):
     """Test sending birth message."""
     calls = []
     mqtt_client_mock.publish.side_effect = lambda *args: calls.append(args)
@@ -764,6 +764,62 @@ async def test_birth_message(hass, mqtt_client_mock, mqtt_mock):
     assert calls[-1] == ("birth", "birth", 0, False)
 
 
+async def test_default_birth_message(hass, mqtt_client_mock, mqtt_mock):
+    """Test sending birth message."""
+    calls = []
+    mqtt_client_mock.publish.side_effect = lambda *args: calls.append(args)
+    mqtt_mock._mqtt_on_connect(None, None, 0, 0)
+    await hass.async_block_till_done()
+    assert calls[-1] == ("homeassistant/status", "online", 0, False)
+
+
+@pytest.mark.parametrize(
+    "mqtt_config", [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_BIRTH_MESSAGE: {}}],
+)
+async def test_no_birth_message(hass, mqtt_client_mock, mqtt_mock):
+    """Test sending birth message."""
+    calls = []
+    mqtt_client_mock.publish.side_effect = lambda *args: calls.append(args)
+    mqtt_mock._mqtt_on_connect(None, None, 0, 0)
+    await hass.async_block_till_done()
+    assert not calls
+
+
+@pytest.mark.parametrize(
+    "mqtt_config",
+    [
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            mqtt.CONF_WILL_MESSAGE: {
+                mqtt.ATTR_TOPIC: "death",
+                mqtt.ATTR_PAYLOAD: "death",
+            },
+        }
+    ],
+)
+async def test_custom_will_message(hass, mqtt_client_mock, mqtt_mock):
+    """Test will message."""
+    mqtt_client_mock.will_set.assert_called_with("death", "death", 0, False, None)
+
+
+async def test_default_will_message(hass, mqtt_client_mock, mqtt_mock):
+    """Test will message."""
+    mqtt_client_mock.will_set.assert_called_with(
+        "homeassistant/status", "offline", 0, False, None
+    )
+
+
+@pytest.mark.parametrize(
+    "mqtt_config", [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_WILL_MESSAGE: {}}],
+)
+async def test_no_will_message(hass, mqtt_client_mock, mqtt_mock):
+    """Test will message."""
+    mqtt_client_mock.will_set.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "mqtt_config", [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_BIRTH_MESSAGE: {}}],
+)
 async def test_mqtt_subscribes_topics_on_connect(hass, mqtt_client_mock, mqtt_mock):
     """Test subscription to topic on connect."""
     await mqtt.async_subscribe(hass, "topic/test", None)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
MQTT birth message defaults to: `{"topic": "homeassistant/status", "payload": "online"}`
MQTT will message defaults to: `{"topic": "homeassistant/status", "payload": "offline"}`
MQTT will published also on clean connect from broker

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT birth message defaults to: `{"topic": "homeassistant/status", "payload": "online"}`
MQTT will message defaults to: `{"topic": "homeassistant/status", "payload": "offline"}`
MQTT will published also on clean connect from broker

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
