### PR TITLE
Transition Guardian to use DataUpdateCoordinator objects

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -313,6 +313,7 @@ omit =
     homeassistant/components/guardian/binary_sensor.py
     homeassistant/components/guardian/sensor.py
     homeassistant/components/guardian/switch.py
+    homeassistant/components/guardian/util.py
     homeassistant/components/habitica/*
     homeassistant/components/hangouts/*
     homeassistant/components/hangouts/__init__.py

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     API_SYSTEM_DIAGNOSTICS,
@@ -148,7 +148,7 @@ class Guardian(DataUpdateCoordinator):
 
         for api, result in zip(tasks, results):
             if isinstance(result, GuardianError):
-                raise UpdateFailed(f"{api} returned {result}")
+                LOGGER.error("Error fetching %s data: %s", self.name, result)
             data[api] = result["data"]
 
         return data

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -87,6 +87,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
     if unload_ok:
+        hass.data[DOMAIN][DATA_CLIENT].pop(entry.entry_id)
         hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -218,11 +218,11 @@ class GuardianEntity(Entity):
         """Perform tasks when the entity is added."""
 
         @callback
-        def update_callback(self):
-            """Define a callback to update the entity's state from the latest data."""
+        def update(self):
+            """Update the state."""
             self._async_update_from_latest_data()
             self.async_write_ha_state()
 
         await self._async_internal_added_to_hass()
-        self.async_on_remove(self._guardian.async_add_listener(update_callback))
+        self.async_on_remove(self._guardian.async_add_listener(update))
         self._async_update_from_latest_data()

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -214,14 +214,15 @@ class GuardianEntity(Entity):
         """Update the entity."""
         raise NotImplementedError
 
-    @callback
-    def _update_callback(self):
-        """Define a callback to update the entity's state from the latest data."""
-        self._async_update_from_latest_data()
-        self.async_write_ha_state()
-
     async def async_added_to_hass(self):
         """Perform tasks when the entity is added."""
+
+        @callback
+        def update_callback(self):
+            """Define a callback to update the entity's state from the latest data."""
+            self._async_update_from_latest_data()
+            self.async_write_ha_state()
+
         await self._async_internal_added_to_hass()
-        self.async_on_remove(self._guardian.async_add_listener(self._update_callback))
+        self.async_on_remove(self._guardian.async_add_listener(update_callback))
         self._async_update_from_latest_data()

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -1,6 +1,7 @@
 """The Elexa Guardian integration."""
 import asyncio
 from datetime import timedelta
+from typing import Awaitable, Callable
 
 from aioguardian import Client
 from aioguardian.errors import GuardianError
@@ -9,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     API_SYSTEM_DIAGNOSTICS,
@@ -17,6 +18,7 @@ from .const import (
     API_VALVE_STATUS,
     API_WIFI_STATUS,
     CONF_UID,
+    DATA_CLIENT,
     DATA_COORDINATOR,
     DOMAIN,
     LOGGER,
@@ -29,15 +31,50 @@ PLATFORMS = ["binary_sensor", "sensor", "switch"]
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Elexa Guardian component."""
-    hass.data[DOMAIN] = {DATA_COORDINATOR: {}}
+    hass.data[DOMAIN] = {DATA_CLIENT: {}, DATA_COORDINATOR: {}}
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Elexa Guardian from a config entry."""
-    guardian = Guardian(hass, entry)
-    await guardian.async_refresh()
-    hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = guardian
+    client = Client(entry.data[CONF_IP_ADDRESS], port=entry.data[CONF_PORT])
+    hass.data[DOMAIN][DATA_CLIENT][entry.entry_id] = client
+    hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = {}
+
+    # The valve controller's UDP-based API can't handle concurrent requests very well,
+    # so we use a lock to ensure that only one API request is reaching it at a time:
+    lock = asyncio.Lock()
+    initial_fetch_tasks = []
+
+    async def api_request(coro: Callable[..., Awaitable]) -> dict:
+        """Execute an AP request against the valve controller."""
+        async with lock, client:
+            try:
+                resp = await coro()
+            except GuardianError as err:
+                raise UpdateFailed(err)
+        return resp["data"]
+
+    for api, api_coro in [
+        (API_SYSTEM_DIAGNOSTICS, client.system.diagnostics),
+        (API_SYSTEM_ONBOARD_SENSOR_STATUS, client.system.onboard_sensor_status),
+        (API_VALVE_STATUS, client.valve.status),
+        (API_WIFI_STATUS, client.wifi.status),
+    ]:
+        hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
+            api
+        ] = DataUpdateCoordinator(
+            hass,
+            LOGGER,
+            name=f"{entry.data[CONF_UID]}_{api}",
+            update_interval=DEFAULT_UPDATE_INTERVAL,
+            update_method=lambda c=api_coro: api_request(c),
+        )
+        initial_fetch_tasks.append(
+            hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][api].async_refresh()
+        )
+
+    await asyncio.gather(*initial_fetch_tasks)
 
     for component in PLATFORMS:
         hass.async_create_task(
@@ -63,125 +100,48 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class Guardian(DataUpdateCoordinator):
-    """Define a class to communicate with a Guardian valve controller.
-
-    Normally, we'd use a single DataUpdateCoordinator class for each API call; however,
-    because the valve controller's API-over-UDP cannot handle concurrent connections,
-    we extend a single DataUpdateCoordinator with the needed functionality.
-    """
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize."""
-        super().__init__(
-            hass,
-            LOGGER,
-            name=entry.data[CONF_UID],
-            update_interval=DEFAULT_UPDATE_INTERVAL,
-            update_method=self.async_update,
-        )
-
-        self._hass = hass
-        self.client = Client(entry.data[CONF_IP_ADDRESS], port=entry.data[CONF_PORT])
-        self.uid = entry.data[CONF_UID]
-
-        self._api_init_lock = asyncio.Lock()
-        self._api_interest_count = {
-            API_SYSTEM_ONBOARD_SENSOR_STATUS: 0,
-            API_VALVE_STATUS: 0,
-            API_WIFI_STATUS: 0,
-        }
-        self._api_optional_coros = {
-            API_SYSTEM_ONBOARD_SENSOR_STATUS: self.client.system.onboard_sensor_status,
-            API_VALVE_STATUS: self.client.valve.status,
-            API_WIFI_STATUS: self.client.wifi.status,
-        }
-
-    @callback
-    def async_deregister_api_interest(self, api: str) -> None:
-        """Decrement interest in an API category."""
-        if self._api_interest_count[api] > 0:
-            self._api_interest_count[api] -= 1
-
-    async def async_register_api_interest(self, api: str) -> None:
-        """Increment interest in an API category."""
-        self._api_interest_count[api] += 1
-
-        # If an entity registers interest in a particular API category and the data
-        # doesn't exist for it yet, make the API call and grab the data right away:
-        async with self._api_init_lock:
-            if api in self.data:
-                return
-
-            try:
-                async with self.client:
-                    resp = await self._api_optional_coros[api]()
-            except GuardianError as err:
-                LOGGER.error(
-                    "Error fetching initial %s data for %s: %s", api, self.name, err,
-                )
-                self.data[api] = {}
-                return
-
-            self.data[api] = resp["data"]
-
-    async def async_update(self) -> dict:
-        """Get updated data from the valve controller."""
-        data = {}
-
-        # Diagnostics info will be relevant no matter which entities are active:
-        tasks = {API_SYSTEM_DIAGNOSTICS: self.client.system.diagnostics()}
-
-        # If at least one entity has registered interest in an API call, include it
-        # in the update:
-        for api in self._api_interest_count:
-            if self._api_interest_count[api] == 0:
-                continue
-            tasks[api] = self._api_optional_coros[api]()
-
-        async with self.client:
-            results = await asyncio.gather(*tasks.values(), return_exceptions=True)
-
-        for api, result in zip(tasks, results):
-            if isinstance(result, GuardianError):
-                LOGGER.error("Error fetching %s data: %s", self.name, result)
-            data[api] = result["data"]
-
-        return data
-
-
 class GuardianEntity(Entity):
     """Define a base Guardian entity."""
 
     def __init__(
-        self, guardian: Guardian, kind: str, name: str, device_class: str, icon: str
-    ):
+        self,
+        entry: ConfigEntry,
+        client: Client,
+        kind: str,
+        name: str,
+        device_class: str,
+        icon: str,
+    ) -> None:
         """Initialize."""
         self._attrs = {ATTR_ATTRIBUTION: "Data provided by Elexa"}
         self._available = True
+        self._client = client
         self._device_class = device_class
-        self._guardian = guardian
+        self._entry = entry
         self._icon = icon
         self._kind = kind
         self._name = name
+        self._valve_controller_uid = entry.data[CONF_UID]
 
     @property
-    def device_class(self):
+    def device_class(self) -> str:
         """Return the device class."""
         return self._device_class
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict:
         """Return device registry information for this entity."""
         return {
-            "identifiers": {(DOMAIN, self._guardian.uid)},
+            "identifiers": {(DOMAIN, self._valve_controller_uid)},
             "manufacturer": "Elexa",
-            "model": self._guardian.data[API_SYSTEM_DIAGNOSTICS]["firmware"],
-            "name": f"Guardian {self._guardian.uid}",
+            "model": self.hass.data[DOMAIN][DATA_COORDINATOR][self._entry.entry_id][
+                API_SYSTEM_DIAGNOSTICS
+            ].data["firmware"],
+            "name": f"Guardian {self._valve_controller_uid}",
         }
 
     @property
-    def device_state_attributes(self):
+    def device_state_attributes(self) -> dict:
         """Return the state attributes."""
         return self._attrs
 
@@ -191,9 +151,9 @@ class GuardianEntity(Entity):
         return self._icon
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the entity."""
-        return f"Guardian {self._guardian.uid}: {self._name}"
+        return f"Guardian {self._valve_controller_uid}: {self._name}"
 
     @property
     def should_poll(self) -> bool:
@@ -203,26 +163,41 @@ class GuardianEntity(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        return f"{self._guardian.uid}_{self._kind}"
+        return f"{self._valve_controller_uid}_{self._kind}"
 
     async def _async_internal_added_to_hass(self):
-        """Perform additional, internal tasks when added. To be extended."""
+        """Perform additional, internal tasks when the entity is about to be added.
+
+        This should be extended by Guardian platforms.
+        """
         raise NotImplementedError
 
     @callback
     def _async_update_from_latest_data(self):
-        """Update the entity."""
+        """Update the entity.
+
+        This should be extended by Guardian platforms.
+        """
         raise NotImplementedError
 
-    async def async_added_to_hass(self):
-        """Perform tasks when the entity is added."""
+    @callback
+    def async_add_coordinator_update_listener(self, api: str) -> None:
+        """Add a listener to a DataUpdateCoordinator based on the API referenced."""
 
         @callback
-        def update(self):
-            """Update the state."""
+        def async_update():
+            """Update the entity's state."""
             self._async_update_from_latest_data()
             self.async_write_ha_state()
 
+        self.async_on_remove(
+            self.hass.data[DOMAIN][DATA_COORDINATOR][self._entry.entry_id][
+                api
+            ].async_add_listener(async_update)
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Perform tasks when the entity is added."""
         await self._async_internal_added_to_hass()
-        self.async_on_remove(self._guardian.async_add_listener(update))
+        self.async_add_coordinator_update_listener(API_SYSTEM_DIAGNOSTICS)
         self._async_update_from_latest_data()

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -8,30 +8,18 @@ from aioguardian.errors import GuardianError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    API_SENSOR_PAIR_DUMP,
     API_SYSTEM_DIAGNOSTICS,
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
     API_VALVE_STATUS,
+    API_WIFI_STATUS,
     CONF_UID,
     DATA_CLIENT,
-    DATA_VALVE_STATUS,
-    DATA_WIFI_STATUS,
     DOMAIN,
     LOGGER,
-    SENSOR_KIND_AP_INFO,
-    SENSOR_KIND_LEAK_DETECTED,
-    SENSOR_KIND_TEMPERATURE,
-    SWITCH_KIND_VALVE,
-    TOPIC_UPDATE,
 )
 
 DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
@@ -39,16 +27,16 @@ DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
 PLATFORMS = ["binary_sensor", "sensor", "switch"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Elexa Guardian component."""
     hass.data[DOMAIN] = {DATA_CLIENT: {}}
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Elexa Guardian from a config entry."""
     guardian = Guardian(hass, entry)
-    await guardian.async_init()
+    await guardian.async_refresh()
     hass.data[DOMAIN][DATA_CLIENT][entry.entry_id] = guardian
 
     for component in PLATFORMS:
@@ -59,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = all(
         await asyncio.gather(
@@ -76,9 +64,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 class Guardian(DataUpdateCoordinator):
-    """Define a class to communicate with a Guardian valve controller."""
+    """Define a class to communicate with a Guardian valve controller.
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
+    Normally, we'd use a single DataUpdateCoordinator class for each API call; however,
+    because the valve controller's API-over-UDP cannot handle concurrent connections
+    easily, we extend a single DataUpdateCoordinator with the needed functionality.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize."""
         super().__init__(
             hass,
@@ -88,117 +81,87 @@ class Guardian(DataUpdateCoordinator):
             update_method=self.async_update,
         )
 
+        self._client = Client(entry.data[CONF_IP_ADDRESS], port=entry.data[CONF_PORT])
         self._hass = hass
-        self._ip_address = entry.data[CONF_IP_ADDRESS]
-        self._port = entry.data[CONF_PORT]
-        self._paried_sensor_uids = []
+        self.uid = entry.data[CONF_UID]
 
+        self._api_init_lock = asyncio.Lock()
         self._api_interest_count = {
-            API_SENSOR_PAIR_DUMP: 0,
             API_SYSTEM_ONBOARD_SENSOR_STATUS: 0,
             API_VALVE_STATUS: 0,
+            API_WIFI_STATUS: 0,
+        }
+        self._api_optional_coros = {
+            API_SYSTEM_ONBOARD_SENSOR_STATUS: self._client.system.onboard_sensor_status,
+            API_VALVE_STATUS: self._client.valve.status,
+            API_WIFI_STATUS: self._client.wifi.status,
         }
 
-    async def async_update(self):
-        """Get updated daata from the valve controller."""
-        async with Client(self._ip_address, port=self._port) as client:
-            tasks = {API_SYSTEM_DIAGNOSTICS: client.system.diagnostics()}
+    @callback
+    def async_deregister_api_interest(self, api: str) -> None:
+        """Decrement interest in an API category."""
+        if self._api_interest_count[api] == 0:
+            return
 
+        self._api_interest_count[api] -= 1
 
-# class Guardian:
-#     """Define a class to communicate with the Guardian device."""
+        LOGGER.debug(
+            "Decremented %s API count: %s (%s)",
+            self.name,
+            api,
+            self._api_interest_count[api],
+        )
 
-#     def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
-#         """Initialize."""
-#         self._async_cancel_time_interval_listener = None
-#         self._hass = hass
-#         self.client = Client(entry.data[CONF_IP_ADDRESS])
-#         self.data = {}
-#         self.uid = entry.data[CONF_UID]
+    async def async_register_api_interest(self, api: str) -> None:
+        """Increment interest in an API category."""
+        self._api_interest_count[api] += 1
 
-#         self._api_coros = {
-#             DATA_DIAGNOSTICS: self.client.system.diagnostics,
-#             DATA_PAIR_DUMP: self.client.sensor.pair_dump,
-#             DATA_PING: self.client.system.ping,
-#             DATA_SENSOR_STATUS: self.client.system.onboard_sensor_status,
-#             DATA_VALVE_STATUS: self.client.valve.status,
-#             DATA_WIFI_STATUS: self.client.wifi.status,
-#         }
+        LOGGER.debug(
+            "Incremented %s API count: %s (%s)",
+            self.name,
+            api,
+            self._api_interest_count[api],
+        )
 
-#         self._api_category_count = {
-#             DATA_SENSOR_STATUS: 0,
-#             DATA_VALVE_STATUS: 0,
-#             DATA_WIFI_STATUS: 0,
-#         }
+        # If an entity registers interest in a particular API category and the data
+        # doesn't exist for it yet, make the API call and grab the data:
+        if api not in self.data:
+            LOGGER.debug("Fetching first API data: %s", api)
+            async with self._api_init_lock:
+                try:
+                    self.data[api] = await self._api_optional_coros[api]()
+                except GuardianError as err:
+                    LOGGER.error(
+                        "Error fetching %s data: initial %s returned %s",
+                        self.name,
+                        api,
+                        err,
+                    )
+                    self.data[api] = {}
 
-#         self._api_lock = asyncio.Lock()
+    async def async_update(self) -> dict:
+        """Get updated data from the valve controller."""
+        data = {}
 
-#     async def _async_get_data_from_api(self, api_category: str):
-#         """Update and save data for a particular API category."""
-#         if self._api_category_count.get(api_category) == 0:
-#             return
+        async with self._client:
+            # Diagnostics info will be relevant no matter which entities are active:
+            tasks = {API_SYSTEM_DIAGNOSTICS: self._client.system.diagnostics()}
 
-#         try:
-#             result = await self._api_coros[api_category]()
-#         except GuardianError as err:
-#             LOGGER.error("Error while fetching %s data: %s", api_category, err)
-#             self.data[api_category] = {}
-#         else:
-#             self.data[api_category] = result["data"]
+            # If at least one entity has registered interest in an API call, include it
+            # in the update:
+            for api in self._api_interest_count:
+                if self._api_interest_count[api] == 0:
+                    continue
+                tasks[api] = self._api_optional_coros[api]()
 
-#     async def _async_update_listener_action(self, _):
-#         """Define an async_track_time_interval action to update data."""
-#         await self.async_update()
+            results = await asyncio.gather(*tasks.values(), return_exceptions=True)
 
-#     @callback
-#     def async_deregister_api_interest(self, sensor_kind: str):
-#         """Decrement the number of entities with data needs from an API category."""
-#         # If this deregistration should leave us with no registration at all, remove the
-#         # time interval:
-#         if sum(self._api_category_count.values()) == 0:
-#             if self._async_cancel_time_interval_listener:
-#                 self._async_cancel_time_interval_listener()
-#                 self._async_cancel_time_interval_listener = None
-#             return
+        for api, result in zip(tasks, results):
+            if isinstance(result, GuardianError):
+                raise UpdateFailed(f"{api} returned {result}")
+            data[api] = result
 
-#         api_category = async_get_api_category(sensor_kind)
-#         if api_category:
-#             self._api_category_count[api_category] -= 1
-
-#     async def async_register_api_interest(self, sensor_kind: str):
-#         """Increment the number of entities with data needs from an API category."""
-#         # If this is the first registration we have, start a time interval:
-#         if not self._async_cancel_time_interval_listener:
-#             self._async_cancel_time_interval_listener = async_track_time_interval(
-#                 self._hass, self._async_update_listener_action, DEFAULT_UPDATE_INTERVAL,
-#             )
-
-#         api_category = async_get_api_category(sensor_kind)
-
-#         if not api_category:
-#             return
-
-#         self._api_category_count[api_category] += 1
-
-#         # If a sensor registers interest in a particular API call and the data doesn't
-#         # exist for it yet, make the API call and grab the data:
-#         async with self._api_lock:
-#             if api_category not in self.data:
-#                 async with self.client:
-#                     await self._async_get_data_from_api(api_category)
-
-#     async def async_update(self):
-#         """Get updated data from the device."""
-#         async with self.client:
-#             tasks = [
-#                 self._async_get_data_from_api(api_category)
-#                 for api_category in self._api_coros
-#             ]
-
-#             await asyncio.gather(*tasks)
-
-#         LOGGER.debug("Received new data: %s", self.data)
-#         async_dispatcher_send(self._hass, TOPIC_UPDATE.format(self.uid))
+        return data
 
 
 class GuardianEntity(Entity):
@@ -219,7 +182,7 @@ class GuardianEntity(Entity):
     @property
     def available(self):
         """Return whether the entity is available."""
-        return bool(self._guardian.data[DATA_PING])
+        return bool(self._guardian.data[API_SYSTEM_DIAGNOSTICS])
 
     @property
     def device_class(self):
@@ -232,7 +195,7 @@ class GuardianEntity(Entity):
         return {
             "identifiers": {(DOMAIN, self._guardian.uid)},
             "manufacturer": "Elexa",
-            "model": self._guardian.data[DATA_DIAGNOSTICS]["firmware"],
+            "model": self._guardian.data[API_SYSTEM_DIAGNOSTICS]["firmware"],
             "name": f"Guardian {self._guardian.uid}",
         }
 
@@ -262,29 +225,18 @@ class GuardianEntity(Entity):
         return f"{self._guardian.uid}_{self._kind}"
 
     @callback
-    def _update_from_latest_data(self):
+    def _async_setup_listeners(self):
+        """Perform tasks when the entity is added."""
+        self.async_on_remove(self._guardian.async_add_listener(self._update_callback))
+        self._async_update_from_latest_data()
+
+    @callback
+    def _async_update_from_latest_data(self):
         """Update the entity."""
         raise NotImplementedError
 
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-
-        @callback
-        def update():
-            """Update the state."""
-            self._update_from_latest_data()
-            self.async_write_ha_state()
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass, TOPIC_UPDATE.format(self._guardian.uid), update
-            )
-        )
-
-        await self._guardian.async_register_api_interest(self._kind)
-
-        self._update_from_latest_data()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect dispatcher listener when removed."""
-        self._guardian.async_deregister_api_interest(self._kind)
+    @callback
+    def _update_callback(self):
+        """Define a callback to update the entity's state from the latest data."""
+        self._async_update_from_latest_data()
+        self.async_write_ha_state()

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -6,7 +6,7 @@ from aioguardian import Client
 from aioguardian.errors import GuardianError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_IP_ADDRESS
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -14,14 +14,15 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    API_SENSOR_PAIR_DUMP,
+    API_SYSTEM_DIAGNOSTICS,
+    API_SYSTEM_ONBOARD_SENSOR_STATUS,
+    API_VALVE_STATUS,
     CONF_UID,
     DATA_CLIENT,
-    DATA_DIAGNOSTICS,
-    DATA_PAIR_DUMP,
-    DATA_PING,
-    DATA_SENSOR_STATUS,
     DATA_VALVE_STATUS,
     DATA_WIFI_STATUS,
     DOMAIN,
@@ -33,22 +34,9 @@ from .const import (
     TOPIC_UPDATE,
 )
 
-DATA_ENTITY_TYPE_MAP = {
-    SENSOR_KIND_AP_INFO: DATA_WIFI_STATUS,
-    SENSOR_KIND_LEAK_DETECTED: DATA_SENSOR_STATUS,
-    SENSOR_KIND_TEMPERATURE: DATA_SENSOR_STATUS,
-    SWITCH_KIND_VALVE: DATA_VALVE_STATUS,
-}
-
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
 
 PLATFORMS = ["binary_sensor", "sensor", "switch"]
-
-
-@callback
-def async_get_api_category(entity_kind: str):
-    """Get the API data category to which an entity belongs."""
-    return DATA_ENTITY_TYPE_MAP.get(entity_kind)
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -60,7 +48,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Elexa Guardian from a config entry."""
     guardian = Guardian(hass, entry)
-    await guardian.async_update()
+    await guardian.async_init()
     hass.data[DOMAIN][DATA_CLIENT][entry.entry_id] = guardian
 
     for component in PLATFORMS:
@@ -87,100 +75,130 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     return unload_ok
 
 
-class Guardian:
-    """Define a class to communicate with the Guardian device."""
+class Guardian(DataUpdateCoordinator):
+    """Define a class to communicate with a Guardian valve controller."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
         """Initialize."""
-        self._async_cancel_time_interval_listener = None
+        super().__init__(
+            hass,
+            LOGGER,
+            name=entry.data[CONF_UID],
+            update_interval=DEFAULT_UPDATE_INTERVAL,
+            update_method=self.async_update,
+        )
+
         self._hass = hass
-        self.client = Client(entry.data[CONF_IP_ADDRESS])
-        self.data = {}
-        self.uid = entry.data[CONF_UID]
+        self._ip_address = entry.data[CONF_IP_ADDRESS]
+        self._port = entry.data[CONF_PORT]
+        self._paried_sensor_uids = []
 
-        self._api_coros = {
-            DATA_DIAGNOSTICS: self.client.system.diagnostics,
-            DATA_PAIR_DUMP: self.client.sensor.pair_dump,
-            DATA_PING: self.client.system.ping,
-            DATA_SENSOR_STATUS: self.client.system.onboard_sensor_status,
-            DATA_VALVE_STATUS: self.client.valve.status,
-            DATA_WIFI_STATUS: self.client.wifi.status,
+        self._api_interest_count = {
+            API_SENSOR_PAIR_DUMP: 0,
+            API_SYSTEM_ONBOARD_SENSOR_STATUS: 0,
+            API_VALVE_STATUS: 0,
         }
-
-        self._api_category_count = {
-            DATA_SENSOR_STATUS: 0,
-            DATA_VALVE_STATUS: 0,
-            DATA_WIFI_STATUS: 0,
-        }
-
-        self._api_lock = asyncio.Lock()
-
-    async def _async_get_data_from_api(self, api_category: str):
-        """Update and save data for a particular API category."""
-        if self._api_category_count.get(api_category) == 0:
-            return
-
-        try:
-            result = await self._api_coros[api_category]()
-        except GuardianError as err:
-            LOGGER.error("Error while fetching %s data: %s", api_category, err)
-            self.data[api_category] = {}
-        else:
-            self.data[api_category] = result["data"]
-
-    async def _async_update_listener_action(self, _):
-        """Define an async_track_time_interval action to update data."""
-        await self.async_update()
-
-    @callback
-    def async_deregister_api_interest(self, sensor_kind: str):
-        """Decrement the number of entities with data needs from an API category."""
-        # If this deregistration should leave us with no registration at all, remove the
-        # time interval:
-        if sum(self._api_category_count.values()) == 0:
-            if self._async_cancel_time_interval_listener:
-                self._async_cancel_time_interval_listener()
-                self._async_cancel_time_interval_listener = None
-            return
-
-        api_category = async_get_api_category(sensor_kind)
-        if api_category:
-            self._api_category_count[api_category] -= 1
-
-    async def async_register_api_interest(self, sensor_kind: str):
-        """Increment the number of entities with data needs from an API category."""
-        # If this is the first registration we have, start a time interval:
-        if not self._async_cancel_time_interval_listener:
-            self._async_cancel_time_interval_listener = async_track_time_interval(
-                self._hass, self._async_update_listener_action, DEFAULT_SCAN_INTERVAL,
-            )
-
-        api_category = async_get_api_category(sensor_kind)
-
-        if not api_category:
-            return
-
-        self._api_category_count[api_category] += 1
-
-        # If a sensor registers interest in a particular API call and the data doesn't
-        # exist for it yet, make the API call and grab the data:
-        async with self._api_lock:
-            if api_category not in self.data:
-                async with self.client:
-                    await self._async_get_data_from_api(api_category)
 
     async def async_update(self):
-        """Get updated data from the device."""
-        async with self.client:
-            tasks = [
-                self._async_get_data_from_api(api_category)
-                for api_category in self._api_coros
-            ]
+        """Get updated daata from the valve controller."""
+        async with Client(self._ip_address, port=self._port) as client:
+            tasks = {API_SYSTEM_DIAGNOSTICS: client.system.diagnostics()}
 
-            await asyncio.gather(*tasks)
 
-        LOGGER.debug("Received new data: %s", self.data)
-        async_dispatcher_send(self._hass, TOPIC_UPDATE.format(self.uid))
+# class Guardian:
+#     """Define a class to communicate with the Guardian device."""
+
+#     def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
+#         """Initialize."""
+#         self._async_cancel_time_interval_listener = None
+#         self._hass = hass
+#         self.client = Client(entry.data[CONF_IP_ADDRESS])
+#         self.data = {}
+#         self.uid = entry.data[CONF_UID]
+
+#         self._api_coros = {
+#             DATA_DIAGNOSTICS: self.client.system.diagnostics,
+#             DATA_PAIR_DUMP: self.client.sensor.pair_dump,
+#             DATA_PING: self.client.system.ping,
+#             DATA_SENSOR_STATUS: self.client.system.onboard_sensor_status,
+#             DATA_VALVE_STATUS: self.client.valve.status,
+#             DATA_WIFI_STATUS: self.client.wifi.status,
+#         }
+
+#         self._api_category_count = {
+#             DATA_SENSOR_STATUS: 0,
+#             DATA_VALVE_STATUS: 0,
+#             DATA_WIFI_STATUS: 0,
+#         }
+
+#         self._api_lock = asyncio.Lock()
+
+#     async def _async_get_data_from_api(self, api_category: str):
+#         """Update and save data for a particular API category."""
+#         if self._api_category_count.get(api_category) == 0:
+#             return
+
+#         try:
+#             result = await self._api_coros[api_category]()
+#         except GuardianError as err:
+#             LOGGER.error("Error while fetching %s data: %s", api_category, err)
+#             self.data[api_category] = {}
+#         else:
+#             self.data[api_category] = result["data"]
+
+#     async def _async_update_listener_action(self, _):
+#         """Define an async_track_time_interval action to update data."""
+#         await self.async_update()
+
+#     @callback
+#     def async_deregister_api_interest(self, sensor_kind: str):
+#         """Decrement the number of entities with data needs from an API category."""
+#         # If this deregistration should leave us with no registration at all, remove the
+#         # time interval:
+#         if sum(self._api_category_count.values()) == 0:
+#             if self._async_cancel_time_interval_listener:
+#                 self._async_cancel_time_interval_listener()
+#                 self._async_cancel_time_interval_listener = None
+#             return
+
+#         api_category = async_get_api_category(sensor_kind)
+#         if api_category:
+#             self._api_category_count[api_category] -= 1
+
+#     async def async_register_api_interest(self, sensor_kind: str):
+#         """Increment the number of entities with data needs from an API category."""
+#         # If this is the first registration we have, start a time interval:
+#         if not self._async_cancel_time_interval_listener:
+#             self._async_cancel_time_interval_listener = async_track_time_interval(
+#                 self._hass, self._async_update_listener_action, DEFAULT_UPDATE_INTERVAL,
+#             )
+
+#         api_category = async_get_api_category(sensor_kind)
+
+#         if not api_category:
+#             return
+
+#         self._api_category_count[api_category] += 1
+
+#         # If a sensor registers interest in a particular API call and the data doesn't
+#         # exist for it yet, make the API call and grab the data:
+#         async with self._api_lock:
+#             if api_category not in self.data:
+#                 async with self.client:
+#                     await self._async_get_data_from_api(api_category)
+
+#     async def async_update(self):
+#         """Get updated data from the device."""
+#         async with self.client:
+#             tasks = [
+#                 self._async_get_data_from_api(api_category)
+#                 for api_category in self._api_coros
+#             ]
+
+#             await asyncio.gather(*tasks)
+
+#         LOGGER.debug("Received new data: %s", self.data)
+#         async_dispatcher_send(self._hass, TOPIC_UPDATE.format(self.uid))
 
 
 class GuardianEntity(Entity):

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -6,7 +6,7 @@ from . import GuardianEntity
 from .const import (
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
     API_WIFI_STATUS,
-    DATA_CLIENT,
+    DATA_COORDINATOR,
     DOMAIN,
 )
 
@@ -22,7 +22,7 @@ SENSORS = [
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Guardian switches based on a config entry."""
-    guardian = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+    guardian = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id]
     async_add_entities(
         [
             GuardianBinarySensor(guardian, kind, name, device_class)
@@ -70,7 +70,7 @@ class GuardianBinarySensor(GuardianEntity, BinarySensorEntity):
                 API_SYSTEM_ONBOARD_SENSOR_STATUS
             )
 
-        self._async_setup_listeners()
+        self._async_internal_added_to_hass()
 
     async def async_will_remove_from_hass(self) -> None:
         """Deregister API interest (and related tasks) when the entity is removed."""
@@ -80,5 +80,3 @@ class GuardianBinarySensor(GuardianEntity, BinarySensorEntity):
             self._guardian.async_deregister_api_interest(
                 API_SYSTEM_ONBOARD_SENSOR_STATUS
             )
-
-        self._guardian.async_remove_listener(self._update_callback)

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -12,4 +12,4 @@ API_WIFI_STATUS = "wifi_status"
 
 CONF_UID = "uid"
 
-DATA_CLIENT = "client"
+DATA_COORDINATOR = "coordinator"

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -12,4 +12,5 @@ API_WIFI_STATUS = "wifi_status"
 
 CONF_UID = "uid"
 
+DATA_CLIENT = "client"
 DATA_COORDINATOR = "coordinator"

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -7,13 +7,14 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_UID = "uid"
 
+API_SENSOR_PAIR_DUMP = "sensor_pair_dump"
+API_SYSTEM_DIAGNOSTICS = "system_diagnostics"
+API_SYSTEM_ONBOARD_SENSOR_STATUS = "system_onboard_sensor_status"
+API_VALVE_STATUS = "valve_status"
+
 DATA_CLIENT = "client"
-DATA_DIAGNOSTICS = "diagnostics"
-DATA_PAIR_DUMP = "pair_sensor"
-DATA_PING = "ping"
-DATA_SENSOR_STATUS = "sensor_status"
-DATA_VALVE_STATUS = "valve_status"
-DATA_WIFI_STATUS = "wifi_status"
+# DATA_VALVE_STATUS = "valve_status"
+# DATA_WIFI_STATUS = "wifi_status"
 
 SENSOR_KIND_AP_INFO = "ap_enabled"
 SENSOR_KIND_LEAK_DETECTED = "leak_detected"

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -5,22 +5,11 @@ DOMAIN = "guardian"
 
 LOGGER = logging.getLogger(__package__)
 
-CONF_UID = "uid"
-
-API_SENSOR_PAIR_DUMP = "sensor_pair_dump"
 API_SYSTEM_DIAGNOSTICS = "system_diagnostics"
 API_SYSTEM_ONBOARD_SENSOR_STATUS = "system_onboard_sensor_status"
 API_VALVE_STATUS = "valve_status"
+API_WIFI_STATUS = "wifi_status"
+
+CONF_UID = "uid"
 
 DATA_CLIENT = "client"
-# DATA_VALVE_STATUS = "valve_status"
-# DATA_WIFI_STATUS = "wifi_status"
-
-SENSOR_KIND_AP_INFO = "ap_enabled"
-SENSOR_KIND_LEAK_DETECTED = "leak_detected"
-SENSOR_KIND_TEMPERATURE = "temperature"
-SENSOR_KIND_UPTIME = "uptime"
-
-SWITCH_KIND_VALVE = "valve"
-
-TOPIC_UPDATE = "guardian_update_{0}"

--- a/homeassistant/components/guardian/sensor.py
+++ b/homeassistant/components/guardian/sensor.py
@@ -6,7 +6,7 @@ from . import Guardian, GuardianEntity
 from .const import (
     API_SYSTEM_DIAGNOSTICS,
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
-    DATA_CLIENT,
+    DATA_COORDINATOR,
     DOMAIN,
 )
 
@@ -26,7 +26,7 @@ SENSORS = [
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Guardian switches based on a config entry."""
-    guardian = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+    guardian = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id]
     async_add_entities(
         [
             GuardianSensor(guardian, kind, name, device_class, icon, unit)
@@ -81,7 +81,7 @@ class GuardianSensor(GuardianEntity):
                 API_SYSTEM_ONBOARD_SENSOR_STATUS
             )
 
-        self._async_setup_listeners()
+        self._async_internal_added_to_hass()
 
     async def async_will_remove_from_hass(self) -> None:
         """Deregister API interest (and related tasks) when the entity is removed."""
@@ -89,5 +89,3 @@ class GuardianSensor(GuardianEntity):
             self._guardian.async_deregister_api_interest(
                 API_SYSTEM_ONBOARD_SENSOR_STATUS
             )
-
-        self._guardian.async_remove_listener(self._update_callback)

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 
 from . import Guardian, GuardianEntity
-from .const import API_VALVE_STATUS, DATA_CLIENT, DOMAIN, LOGGER
+from .const import API_VALVE_STATUS, DATA_COORDINATOR, DOMAIN, LOGGER
 
 ATTR_AVG_CURRENT = "average_current"
 ATTR_INST_CURRENT = "instantaneous_current"
@@ -39,7 +39,7 @@ SERVICE_UPGRADE_FIRMWARE_SCHEMA = vol.Schema(
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Guardian switches based on a config entry."""
-    guardian = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+    guardian = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id]
 
     platform = entity_platform.current_platform.get()
 
@@ -103,7 +103,7 @@ class GuardianSwitch(GuardianEntity, SwitchEntity):
     async def async_added_to_hass(self):
         """Register API interest (and related tasks) when the entity is added."""
         await self._guardian.async_register_api_interest(API_VALVE_STATUS)
-        self._async_setup_listeners()
+        self._async_internal_added_to_hass()
 
     async def async_disable_ap(self):
         """Disable the device's onboard access point."""
@@ -174,4 +174,3 @@ class GuardianSwitch(GuardianEntity, SwitchEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Deregister API interest (and related tasks) when the entity is removed."""
         self._guardian.async_deregister_api_interest(API_VALVE_STATUS)
-        self._guardian.async_remove_listener(self._update_callback)

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -69,9 +69,18 @@ class GuardianSwitch(GuardianEntity, SwitchEntity):
         self._is_on = True
 
     @property
+    def available(self):
+        """Return whether the entity is available."""
+        return bool(self._guardian.data[API_VALVE_STATUS])
+
+    @property
     def is_on(self):
         """Return True if the valve is open."""
         return self._is_on
+
+    async def _async_internal_added_to_hass(self):
+        """Register API interest (and related tasks) when the entity is added."""
+        await self._guardian.async_register_api_interest(API_VALVE_STATUS)
 
     @callback
     def _async_update_from_latest_data(self):
@@ -99,11 +108,6 @@ class GuardianSwitch(GuardianEntity, SwitchEntity):
                 ],
             }
         )
-
-    async def async_added_to_hass(self):
-        """Register API interest (and related tasks) when the entity is added."""
-        await self._guardian.async_register_api_interest(API_VALVE_STATUS)
-        self._async_internal_added_to_hass()
 
     async def async_disable_ap(self):
         """Disable the device's onboard access point."""

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -1,0 +1,49 @@
+"""Define Guardian-specific utilities."""
+import asyncio
+from datetime import timedelta
+from typing import Awaitable, Callable
+
+from aioguardian import Client
+from aioguardian.errors import GuardianError
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import LOGGER
+
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
+
+
+class GuardianDataUpdateCoordinator(DataUpdateCoordinator):
+    """Define an extended DataUpdateCoordinator with some Guardian goodies."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        client: Client,
+        api_name: str,
+        api_coro: Callable[..., Awaitable],
+        api_lock: asyncio.Lock,
+        valve_controller_uid: str,
+    ):
+        """Initialize."""
+        super().__init__(
+            hass,
+            LOGGER,
+            name=f"{valve_controller_uid}_{api_name}",
+            update_interval=DEFAULT_UPDATE_INTERVAL,
+        )
+
+        self._api_coro = api_coro
+        self._api_lock = api_lock
+        self._client = client
+
+    async def _async_update_data(self) -> dict:
+        """Execute a "locked" API request against the valve controller."""
+        async with self._api_lock, self._client:
+            try:
+                resp = await self._api_coro()
+            except GuardianError as err:
+                raise UpdateFailed(err)
+        return resp["data"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR transitions the Guardian integration to use a `DataUpdateCoordinator` for each unique API request.

@MartinHjelmare, [you knew what you were talking about](https://github.com/home-assistant/core/pull/34627#discussion_r430693692) – sorry it took me so long. 😆 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
