### PR TITLE
Add kwargs to send_magic_packet() service individually

### DIFF
--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -31,23 +31,23 @@ async def async_setup(hass, config):
         mac_address = call.data.get(CONF_MAC)
         broadcast_address = call.data.get(CONF_BROADCAST_ADDRESS)
         broadcast_port = call.data.get(CONF_BROADCAST_PORT)
+
+        service_kwargs = {}
+        if broadcast_address is not None:
+            service_kwargs["ip_address"] = broadcast_address
+        if broadcast_port is not None:
+            service_kwargs["port"] = broadcast_port
+
         _LOGGER.info(
             "Send magic packet to mac %s (broadcast: %s, port: %s)",
             mac_address,
             broadcast_address,
             broadcast_port,
         )
-        if broadcast_address is not None:
-            await hass.async_add_job(
-                partial(
-                    wakeonlan.send_magic_packet,
-                    mac_address,
-                    ip_address=broadcast_address,
-                    port=broadcast_port,
-                )
-            )
-        else:
-            await hass.async_add_job(partial(wakeonlan.send_magic_packet, mac_address))
+
+        await hass.async_add_job(
+            partial(wakeonlan.send_magic_packet, mac_address, **service_kwargs)
+        )
 
     hass.services.async_register(
         DOMAIN,

--- a/tests/components/wake_on_lan/test_init.py
+++ b/tests/components/wake_on_lan/test_init.py
@@ -28,6 +28,28 @@ async def test_send_magic_packet(hass):
         assert mocked_wakeonlan.mock_calls[-1][2]["ip_address"] == bc_ip
         assert mocked_wakeonlan.mock_calls[-1][2]["port"] == bc_port
 
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SEND_MAGIC_PACKET,
+            {"mac": mac, "broadcast_address": bc_ip},
+            blocking=True,
+        )
+        assert len(mocked_wakeonlan.mock_calls) == 2
+        assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
+        assert mocked_wakeonlan.mock_calls[-1][2]["ip_address"] == bc_ip
+        assert "port" not in mocked_wakeonlan.mock_calls[-1][2]
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SEND_MAGIC_PACKET,
+            {"mac": mac, "broadcast_port": bc_port},
+            blocking=True,
+        )
+        assert len(mocked_wakeonlan.mock_calls) == 3
+        assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
+        assert mocked_wakeonlan.mock_calls[-1][2]["port"] == bc_port
+        assert "ip_address" not in mocked_wakeonlan.mock_calls[-1][2]
+
         with pytest.raises(vol.Invalid):
             await hass.services.async_call(
                 DOMAIN,
@@ -35,11 +57,11 @@ async def test_send_magic_packet(hass):
                 {"broadcast_address": bc_ip},
                 blocking=True,
             )
-        assert len(mocked_wakeonlan.mock_calls) == 1
+        assert len(mocked_wakeonlan.mock_calls) == 3
 
         await hass.services.async_call(
             DOMAIN, SERVICE_SEND_MAGIC_PACKET, {"mac": mac}, blocking=True
         )
-        assert len(mocked_wakeonlan.mock_calls) == 2
+        assert len(mocked_wakeonlan.mock_calls) == 4
         assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
         assert not mocked_wakeonlan.mock_calls[-1][2]


### PR DESCRIPTION
Port kwarg was always being passed even if the config returned None
which breaks in the 3rd party lib.  You probably don't ever want to send
just a port but the library supports it so both are optional and not
dependent on one another.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow both `broadcast_ip` and `broardcast_port` be optional and only pass what is provided.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
wakeonlan:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37107
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
