### PR TITLE
Check buckets/dbs for validity during Influx sensor startup

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -282,6 +282,7 @@ def _generate_event_to_json(conf: Dict) -> Callable[[Dict], str]:
 class InfluxClient:
     """An InfluxDB client wrapper for V1 or V2."""
 
+    data_repositories: List[str]
     write: Callable[[str], None]
     query: Callable[[str, str], List[Any]]
     close: Callable[[], None]
@@ -330,20 +331,24 @@ def get_influx_connection(conf, test_write=False, test_read=False):
             """Close V2 influx client."""
             influx.close()
 
-        influx_client = InfluxClient(write_v2, query_v2, close_v2)
+        buckets = None
         if test_write:
             # Try to write [] to influx. If we can connect and creds are valid
             # Then invalid inputs is returned. Anything else is a broken config
             try:
-                influx_client.write([])
+                write_v2([])
             except ValueError:
                 pass
             write_api = influx.write_api(write_options=ASYNCHRONOUS)
 
         if test_read:
-            influx_client.query(TEST_QUERY_V2)
+            tables = query_v2(TEST_QUERY_V2)
+            if tables and tables[0].records:
+                buckets = [bucket.values["name"] for bucket in tables[0].records]
+            else:
+                buckets = []
 
-        return influx_client
+        return InfluxClient(buckets, write_v2, query_v2, close_v2)
 
     # Else it's a V1 client
     kwargs[CONF_VERIFY_SSL] = conf[CONF_VERIFY_SSL]
@@ -405,14 +410,14 @@ def get_influx_connection(conf, test_write=False, test_read=False):
         """Close the V1 Influx client."""
         influx.close()
 
-    influx_client = InfluxClient(write_v1, query_v1, close_v1)
+    databases = None
     if test_write:
-        influx_client.write([])
+        write_v1([])
 
     if test_read:
-        influx_client.query(TEST_QUERY_V1)
+        databases = [db["name"] for db in query_v1(TEST_QUERY_V1)]
 
-    return influx_client
+    return InfluxClient(databases, write_v1, query_v1, close_v1)
 
 
 def setup(hass, config):

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -331,7 +331,7 @@ def get_influx_connection(conf, test_write=False, test_read=False):
             """Close V2 influx client."""
             influx.close()
 
-        buckets = None
+        buckets = []
         if test_write:
             # Try to write [] to influx. If we can connect and creds are valid
             # Then invalid inputs is returned. Anything else is a broken config
@@ -410,7 +410,7 @@ def get_influx_connection(conf, test_write=False, test_read=False):
         """Close the V1 Influx client."""
         influx.close()
 
-    databases = None
+    databases = []
     if test_write:
         write_v1([])
 

--- a/homeassistant/components/influxdb/const.py
+++ b/homeassistant/components/influxdb/const.py
@@ -76,7 +76,7 @@ BATCH_BUFFER_SIZE = 100
 LANGUAGE_INFLUXQL = "influxQL"
 LANGUAGE_FLUX = "flux"
 TEST_QUERY_V1 = "SHOW DATABASES;"
-TEST_QUERY_V2 = f"buckets() {DEFAULT_FUNCTION_FLUX}"
+TEST_QUERY_V2 = "buckets()"
 CODE_INVALID_INPUTS = 400
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
@@ -98,6 +98,14 @@ CLIENT_ERROR_V1 = (
     "InfluxDB database is not accessible due to '%s'. "
     "Please check that the database, username and password are correct and "
     "that the specified user has the correct permissions set."
+)
+NO_BUCKET_ERROR = (
+    "InfluxDB bucket '%s' cannot be found. "
+    "Check the name is correct and the token has access to it."
+)
+NO_DATABASE_ERROR = (
+    "InfluxDB database '%s' cannot be found. "
+    "Check the name is correct and the user has access to it."
 )
 WRITE_ERROR = "Could not write '%s' to influx due to '%s'."
 QUERY_ERROR = (

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -551,3 +551,38 @@ async def test_connection_error_at_startup(
     async_fire_time_changed(hass, new_time)
     await hass.async_block_till_done()
     assert hass.states.get(expected_sensor) is not None
+
+
+@pytest.mark.parametrize(
+    "mock_client, config_ext, queries, set_query_mock",
+    [
+        (
+            DEFAULT_API_VERSION,
+            {"database": "bad_db"},
+            BASE_V1_QUERY,
+            _set_query_mock_v1,
+        ),
+        (
+            API_VERSION_2,
+            {
+                "api_version": API_VERSION_2,
+                "organization": "org",
+                "token": "token",
+                "bucket": "bad_bucket",
+            },
+            BASE_V2_QUERY,
+            _set_query_mock_v2,
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_data_repository_not_found(
+    hass, caplog, mock_client, config_ext, queries, set_query_mock,
+):
+    """Test sensor is not setup when bucket not available."""
+    set_query_mock(mock_client)
+    await _setup(hass, config_ext, queries, [])
+    assert hass.states.get("sensor.test") is None
+    assert (
+        len([record for record in caplog.records if record.levelname == "ERROR"]) == 1
+    )


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to https://github.com/home-assistant/core/pull/37315

Prior to recent refactor (https://github.com/home-assistant/core/pull/37232) the Influx sensor code was creating and testing an Influx connection per sensor and not initializing the sensor if the test failed. Post refactor one connection was made and shared for all sensors so the startup test was done before any sensors were created. This meant that sensors could get setup with an invalid bucket (v2) or database (v1) and then fail repeatedly in the update loop.

Since the test queries used now (`buckets()` for V2 and `SHOW DATABASES;` for V1) return us the list of buckets and dbs that the user can see, we will use that output to validate each sensor before creating it. If the sensor lists a bucket/db that does not exist or cannot be seen by the current user then we log an error and skip setting up that sensor just like before. A test was also added to validate this new behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
- platform: influxdb
   queries:
     name: Foo
     database: NOT_A_VALID_DB
     where: '"name" = ''foo'''
     measurement: '"°C"'
     field: value
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
