### PR TITLE
Upgrade sonarr to 0.2.3

### DIFF
--- a/homeassistant/components/sonarr/manifest.json
+++ b/homeassistant/components/sonarr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonarr",
   "documentation": "https://www.home-assistant.io/integrations/sonarr",
   "codeowners": ["@ctalkington"],
-  "requirements": ["sonarr==0.2.2"],
+  "requirements": ["sonarr==0.2.3"],
   "config_flow": true,
   "quality_scale": "silver"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2009,7 +2009,7 @@ somecomfort==0.5.2
 somfy-mylink-synergy==1.0.6
 
 # homeassistant.components.sonarr
-sonarr==0.2.2
+sonarr==0.2.3
 
 # homeassistant.components.marytts
 speak2mary==1.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -862,7 +862,7 @@ solaredge==0.0.2
 somecomfort==0.5.2
 
 # homeassistant.components.sonarr
-sonarr==0.2.2
+sonarr==0.2.3
 
 # homeassistant.components.marytts
 speak2mary==1.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

This change now handle when diskspace information is not available in sonarr, without this fix this causes connection to fail.

Release notes: https://github.com/ctalkington/python-sonarr/releases/tag/0.2.3
Changes: https://github.com/ctalkington/python-sonarr/compare/0.2.2...0.2.3

## Type of change
- [ x] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml

```

## Additional information
## Checklist

- [x ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum