### PR TITLE
Updated influxdb-client dependency to 1.8.0

### DIFF
--- a/homeassistant/components/influxdb/manifest.json
+++ b/homeassistant/components/influxdb/manifest.json
@@ -2,6 +2,6 @@
   "domain": "influxdb",
   "name": "InfluxDB",
   "documentation": "https://www.home-assistant.io/integrations/influxdb",
-  "requirements": ["influxdb==5.2.3", "influxdb-client==1.6.0"],
+  "requirements": ["influxdb==5.2.3", "influxdb-client==1.8.0"],
   "codeowners": ["@fabaff", "@mdegat01"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -789,7 +789,7 @@ ihcsdk==2.7.0
 incomfort-client==0.4.0
 
 # homeassistant.components.influxdb
-influxdb-client==1.6.0
+influxdb-client==1.8.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -365,7 +365,7 @@ huawei-lte-api==1.4.12
 iaqualink==0.3.4
 
 # homeassistant.components.influxdb
-influxdb-client==1.6.0
+influxdb-client==1.8.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updating the library for the V2 client. Not much change but there was a bugfix that allows you to do `.write([])` without getting a `400` error. This allows me to clean up the test write on startup a bit. Currently the code is doing `.write([])` and then if a `400` error is received that is considered a success since it meant the credentials succeeded but the input was invalid. Now with this bugfix that workaround can be removed. Any exception will be considered an error state, as it should be.

In additions to confirming the tests pass, I also setup a local HA reading and writing from my InfluxDB 2.0 instance to confirm there's no issues when the library is in use and not mocked. Confirmed it worked without issue.

Update is from v1.6.0 to v1.8.0 of the library. Changelog is here: https://github.com/influxdata/influxdb-client-python/releases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
influxdb:
  api_version: "2"
  organization: my_org
  token: my_token

sensor:
- platform: influxdb
  api_version: "2"
  organization: my_org
  token: my_token
  queries:
    range_start: "-1d"
    bucket: Glances Bucket
    name: "Average CPU temp today"
    query: "filter(fn: (r) => r._field == \"value\" and r.entity_id == \"glances_cpu_temperature\")"
    group_function: mean
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
