### PR TITLE
Vizio: when checking new host against existing config entry hosts, make check hostname aware

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -212,8 +212,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # If source is ignore bypass host and name check and continue through loop
                 if entry.source == SOURCE_IGNORE:
                     continue
-
-                if _host_is_same(entry.data[CONF_HOST], user_input[CONF_HOST]):
+                if await self.hass.async_add_executor_job(
+                    _host_is_same, entry.data[CONF_HOST], user_input[CONF_HOST]
+                ):
                     errors[CONF_HOST] = "host_exists"
 
                 if entry.data[CONF_NAME] == user_input[CONF_NAME]:
@@ -290,7 +291,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if entry.source == SOURCE_IGNORE:
                 continue
 
-            if _host_is_same(entry.data[CONF_HOST], import_config[CONF_HOST]):
+            if await self.hass.async_add_executor_job(
+                _host_is_same, entry.data[CONF_HOST], import_config[CONF_HOST]
+            ):
                 updated_options = {}
                 updated_data = {}
                 remove_apps = False
@@ -364,7 +367,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if entry.source == SOURCE_IGNORE:
                 continue
 
-            if _host_is_same(entry.data[CONF_HOST], discovery_info[CONF_HOST]):
+            if await self.hass.async_add_executor_job(
+                _host_is_same, entry.data[CONF_HOST], discovery_info[CONF_HOST]
+            ):
                 return self.async_abort(reason="already_configured_device")
 
         # Set default name to discovered device name by stripping zeroconf service

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -310,11 +310,9 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if not import_config.get(CONF_APPS):
                         remove_apps = True
                     else:
-                        updated_data[CONF_APPS] = import_config[CONF_APPS]
                         updated_options[CONF_APPS] = import_config[CONF_APPS]
 
                 if entry.data.get(CONF_VOLUME_STEP) != import_config[CONF_VOLUME_STEP]:
-                    updated_data[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
                     updated_options[CONF_VOLUME_STEP] = import_config[CONF_VOLUME_STEP]
 
                 if updated_options or updated_data or remove_apps:
@@ -328,6 +326,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if updated_data:
                         new_data.update(updated_data)
 
+                    # options are stored in entry options and data so update both
                     if updated_options:
                         new_data.update(updated_options)
                         new_options.update(updated_options)

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -110,7 +110,7 @@ async def async_setup_entry(
         _LOGGER.warning("Failed to connect to %s", host)
         raise PlatformNotReady
 
-    entity = VizioDevice(config_entry, device, name, device_class,)
+    entity = VizioDevice(config_entry, device, name, device_class)
 
     async_add_entities([entity], update_before_add=True)
 

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -16,6 +16,7 @@ from .const import (
     RESPONSE_TOKEN,
     UNIQUE_ID,
     VERSION,
+    ZEROCONF_HOST,
     MockCompletePairingResponse,
     MockStartPairingResponse,
 )
@@ -181,5 +182,15 @@ def vizio_update_with_apps_fixture(vizio_update: pytest.fixture):
     ), patch(
         "homeassistant.components.vizio.media_player.VizioAsync.get_current_app_config",
         return_value=CURRENT_APP_CONFIG,
+    ):
+        yield
+
+
+@pytest.fixture(name="vizio_hostname_check")
+def vizio_hostname_check():
+    """Mock vizio hostname resolution."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.socket.gethostbyname",
+        return_value=ZEROCONF_HOST,
     ):
         yield

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -853,3 +853,55 @@ async def test_zeroconf_abort_when_ignored(
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_flow_already_configured_hostname(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
+    vizio_hostname_check: pytest.fixture,
+) -> None:
+    """Test entity is already configured during zeroconf setup when existing entry uses hostname."""
+    config = MOCK_SPEAKER_CONFIG.copy()
+    config[CONF_HOST] = "hostname"
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=config, options={CONF_VOLUME_STEP: VOLUME_STEP}
+    )
+    entry.add_to_hass(hass)
+
+    # Try rediscovering same device
+    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+    )
+
+    # Flow should abort because device is already setup
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured_device"
+
+
+async def test_import_flow_already_configured_hostname(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_setup: pytest.fixture,
+    vizio_hostname_check: pytest.fixture,
+) -> None:
+    """Test entity is already configured during import setup when existing entry uses hostname."""
+    config = MOCK_SPEAKER_CONFIG.copy()
+    config[CONF_HOST] = "hostname"
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=config, options={CONF_VOLUME_STEP: VOLUME_STEP}
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
+    )
+
+    # Flow should abort because device was updated
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "updated_entry"
+
+    assert entry.data[CONF_HOST] == HOST


### PR DESCRIPTION
## Proposed change
I discovered through discussion of #36265 that if a user uses a hostname instead of an IP address when configuring a config entry, discovery may not realize the host already existed and will notify the user of a new entry. This change makes it so that the host check is hostname aware and resolves hostnames as part of the check. This also impacts the user and import config flows because they will also do the same check, which is safe because it achieves the original intent of the host check. ~I also added a change to ensure that when updating an existing config entry via import, the `data` gets properly updated so that the config entry doesn't continue to get updated or checked for updates on future HA restarts.~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #36265
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
