### PR TITLE
Update Smappee integration with proper solar, voltage and reactive entities

### DIFF
--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/smappee",
   "dependencies": ["http"],
   "requirements": [
-    "pysmappee==0.1.2"
+    "pysmappee==0.1.4"
   ],
   "codeowners": [
     "@bsmappee"

--- a/homeassistant/components/smappee/sensor.py
+++ b/homeassistant/components/smappee/sensor.py
@@ -193,17 +193,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 )
             )
 
-        # Add phase- and line voltages
-        for sensor_name, sensor in VOLTAGE_SENSORS.items():
-            if service_location.phase_type in sensor[5]:
-                entities.append(
-                    SmappeeSensor(
-                        smappee_base=smappee_base,
-                        service_location=service_location,
-                        sensor=sensor_name,
-                        attributes=sensor,
+        # Add phase- and line voltages if available
+        if service_location.has_voltage_values:
+            for sensor_name, sensor in VOLTAGE_SENSORS.items():
+                if service_location.phase_type in sensor[5]:
+                    entities.append(
+                        SmappeeSensor(
+                            smappee_base=smappee_base,
+                            service_location=service_location,
+                            sensor=sensor_name,
+                            attributes=sensor,
+                        )
                     )
-                )
 
         # Add Gas and Water sensors
         for sensor_id, sensor in service_location.sensors.items():

--- a/homeassistant/components/smappee/sensor.py
+++ b/homeassistant/components/smappee/sensor.py
@@ -16,13 +16,6 @@ TREND_SENSORS = {
         "total_power",
         DEVICE_CLASS_POWER,
     ],
-    "total_reactive_power": [
-        "Total consumption - Reactive power",
-        None,
-        POWER_WATT,
-        "total_reactive_power",
-        DEVICE_CLASS_POWER,
-    ],
     "alwayson": [
         "Always on - Active power",
         None,
@@ -58,6 +51,15 @@ TREND_SENSORS = {
         "alwayson_today",
         None,
     ],
+}
+REACTIVE_SENSORS = {
+    "total_reactive_power": [
+        "Total consumption - Reactive power",
+        None,
+        POWER_WATT,
+        "total_reactive_power",
+        DEVICE_CLASS_POWER,
+    ]
 }
 SOLAR_SENSORS = {
     "solar_power": [
@@ -150,6 +152,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     attributes=TREND_SENSORS[sensor],
                 )
             )
+
+        if service_location.has_reactive_value:
+            for reactive_sensor in REACTIVE_SENSORS:
+                entities.append(
+                    SmappeeSensor(
+                        smappee_base=smappee_base,
+                        service_location=service_location,
+                        sensor=reactive_sensor,
+                        attributes=TREND_SENSORS[reactive_sensor],
+                    )
+                )
 
         # Add solar sensors
         if service_location.has_solar_production:

--- a/homeassistant/components/smappee/sensor.py
+++ b/homeassistant/components/smappee/sensor.py
@@ -160,7 +160,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         smappee_base=smappee_base,
                         service_location=service_location,
                         sensor=reactive_sensor,
-                        attributes=TREND_SENSORS[reactive_sensor],
+                        attributes=REACTIVE_SENSORS[reactive_sensor],
                     )
                 )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1620,7 +1620,7 @@ pysignalclirestapi==0.3.4
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.1.2
+pysmappee==0.1.4
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -727,7 +727,7 @@ pysignalclirestapi==0.3.4
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.1.2
+pysmappee==0.1.4
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Readd solar entities for Smappee Solar devices (https://github.com/smappee/pysmappee/issues/1)
* Only create voltage entities for Smappee Infinity series
* Only create reactive entities if local MQTT broker is reachable

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
smappee:
    client_id: 1234
    client_secret: 5678
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/smappee/pysmappee/issues/1
- This PR is related to issue: https://github.com/smappee/pysmappee/issues/1
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
