### PR TITLE
Support multiple MQTT availability topics

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -88,6 +88,8 @@ CONF_TLS_INSECURE = "tls_insecure"
 CONF_TLS_VERSION = "tls_version"
 
 CONF_COMMAND_TOPIC = "command_topic"
+CONF_TOPIC = "topic"
+CONF_AVAILABILITY = "availability"
 CONF_AVAILABILITY_TOPIC = "availability_topic"
 CONF_PAYLOAD_AVAILABLE = "payload_available"
 CONF_PAYLOAD_NOT_AVAILABLE = "payload_not_available"
@@ -203,7 +205,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 SCHEMA_BASE = {vol.Optional(CONF_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA}
 
-MQTT_AVAILABILITY_SCHEMA = vol.Schema(
+MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_AVAILABILITY_TOPIC): valid_subscribe_topic,
         vol.Optional(
@@ -213,6 +215,30 @@ MQTT_AVAILABILITY_SCHEMA = vol.Schema(
             CONF_PAYLOAD_NOT_AVAILABLE, default=DEFAULT_PAYLOAD_NOT_AVAILABLE
         ): cv.string,
     }
+)
+
+MQTT_AVAILABILITY_LIST_SCHEMA = vol.Schema(
+    {
+        CONF_AVAILABILITY: vol.All(
+            cv.ensure_list,
+            [
+                {
+                    vol.Optional(CONF_TOPIC): valid_subscribe_topic,
+                    vol.Optional(
+                        CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_PAYLOAD_NOT_AVAILABLE,
+                        default=DEFAULT_PAYLOAD_NOT_AVAILABLE,
+                    ): cv.string,
+                }
+            ],
+        ),
+    }
+)
+
+MQTT_AVAILABILITY_SCHEMA = MQTT_AVAILABILITY_SINGLE_SCHEMA.extend(
+    MQTT_AVAILABILITY_LIST_SCHEMA.schema
 )
 
 MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(
@@ -985,8 +1011,7 @@ class MqttAvailability(Entity):
         """Initialize the availability mixin."""
         self._availability_sub_state = None
         self._available = False
-
-        self._avail_config = config
+        self._availability_setup_from_config(config)
 
     async def async_added_to_hass(self) -> None:
         """Subscribe MQTT events."""
@@ -1000,8 +1025,26 @@ class MqttAvailability(Entity):
 
     async def availability_discovery_update(self, config: dict):
         """Handle updated discovery message."""
-        self._avail_config = config
+        self._availability_setup_from_config(config)
         await self._availability_subscribe_topics()
+
+    def _availability_setup_from_config(self, config):
+        """(Re)Setup."""
+        self._avail_topics = {}
+        if CONF_AVAILABILITY_TOPIC in config:
+            self._avail_topics[config[CONF_AVAILABILITY_TOPIC]] = {
+                CONF_PAYLOAD_AVAILABLE: config[CONF_PAYLOAD_AVAILABLE],
+                CONF_PAYLOAD_NOT_AVAILABLE: config[CONF_PAYLOAD_NOT_AVAILABLE],
+            }
+
+        if CONF_AVAILABILITY in config:
+            for avail in config[CONF_AVAILABILITY]:
+                self._avail_topics[avail[CONF_TOPIC]] = {
+                    CONF_PAYLOAD_AVAILABLE: avail[CONF_PAYLOAD_AVAILABLE],
+                    CONF_PAYLOAD_NOT_AVAILABLE: avail[CONF_PAYLOAD_NOT_AVAILABLE],
+                }
+
+        self._avail_config = config
 
     async def _availability_subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -1010,23 +1053,24 @@ class MqttAvailability(Entity):
         @log_messages(self.hass, self.entity_id)
         def availability_message_received(msg: Message) -> None:
             """Handle a new received MQTT availability message."""
-            if msg.payload == self._avail_config[CONF_PAYLOAD_AVAILABLE]:
+            topic = msg.topic
+            if msg.payload == self._avail_topics[topic][CONF_PAYLOAD_AVAILABLE]:
                 self._available = True
-            elif msg.payload == self._avail_config[CONF_PAYLOAD_NOT_AVAILABLE]:
+            elif msg.payload == self._avail_topics[topic][CONF_PAYLOAD_NOT_AVAILABLE]:
                 self._available = False
 
             self.async_write_ha_state()
 
+        topics = {}
+        for topic in self._avail_topics:
+            topics[f"availability_{topic}"] = {
+                "topic": topic,
+                "msg_callback": availability_message_received,
+                "qos": self._avail_config[CONF_QOS],
+            }
+
         self._availability_sub_state = await async_subscribe_topics(
-            self.hass,
-            self._availability_sub_state,
-            {
-                "availability_topic": {
-                    "topic": self._avail_config.get(CONF_AVAILABILITY_TOPIC),
-                    "msg_callback": availability_message_received,
-                    "qos": self._avail_config[CONF_QOS],
-                }
-            },
+            self.hass, self._availability_sub_state, topics,
         )
 
     @callback
@@ -1044,10 +1088,9 @@ class MqttAvailability(Entity):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        availability_topic = self._avail_config.get(CONF_AVAILABILITY_TOPIC)
         if not self.hass.data[DATA_MQTT].connected:
             return False
-        return availability_topic is None or self._available
+        return not self._avail_topics or self._available
 
 
 async def cleanup_device_registry(hass, device_id):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -207,7 +207,7 @@ SCHEMA_BASE = {vol.Optional(CONF_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA}
 
 MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_AVAILABILITY_TOPIC): valid_subscribe_topic,
+        vol.Exclusive(CONF_AVAILABILITY_TOPIC, "availability"): valid_subscribe_topic,
         vol.Optional(
             CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
         ): cv.string,
@@ -219,7 +219,7 @@ MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
 
 MQTT_AVAILABILITY_LIST_SCHEMA = vol.Schema(
     {
-        CONF_AVAILABILITY: vol.All(
+        vol.Exclusive(CONF_AVAILABILITY, "availability"): vol.All(
             cv.ensure_list,
             [
                 {

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -7,6 +7,7 @@ ABBREVIATIONS = {
     "aux_cmd_t": "aux_command_topic",
     "aux_stat_tpl": "aux_state_template",
     "aux_stat_t": "aux_state_topic",
+    "avty": "availability",
     "avty_t": "availability_topic",
     "away_mode_cmd_t": "away_mode_command_topic",
     "away_mode_stat_tpl": "away_mode_state_template",

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -175,7 +175,7 @@ async def help_test_default_availability_list_single(
     state_topic=None,
     state_message=None,
 ):
-    """Test availability by default payload with defined topic.
+    """Test availability list and availability_topic are mutually exclusive.
 
     This is a test helper for the MqttAvailability mixin.
     """

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -165,6 +165,37 @@ async def help_test_default_availability_list_payload(
         assert state.state != STATE_UNAVAILABLE
 
 
+async def help_test_default_availability_list_single(
+    hass,
+    mqtt_mock,
+    caplog,
+    domain,
+    config,
+    no_assumed_state=False,
+    state_topic=None,
+    state_message=None,
+):
+    """Test availability by default payload with defined topic.
+
+    This is a test helper for the MqttAvailability mixin.
+    """
+    # Add availability settings to config
+    config = copy.deepcopy(config)
+    config[domain]["availability"] = [
+        {"topic": "availability-topic1"},
+    ]
+    config[domain]["availability_topic"] = "availability-topic"
+    assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{domain}.test")
+    assert state is None
+    assert (
+        "Invalid config for [sensor.mqtt]: two or more values in the same group of exclusion 'availability'"
+        in caplog.text
+    )
+
+
 async def help_test_custom_availability_payload(
     hass,
     mqtt_mock,

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -104,6 +104,67 @@ async def help_test_default_availability_payload(
         assert state.state != STATE_UNAVAILABLE
 
 
+async def help_test_default_availability_list_payload(
+    hass,
+    mqtt_mock,
+    domain,
+    config,
+    no_assumed_state=False,
+    state_topic=None,
+    state_message=None,
+):
+    """Test availability by default payload with defined topic.
+
+    This is a test helper for the MqttAvailability mixin.
+    """
+    # Add availability settings to config
+    config = copy.deepcopy(config)
+    config[domain]["availability"] = [
+        {"topic": "availability-topic1"},
+        {"topic": "availability-topic2"},
+    ]
+    assert await async_setup_component(hass, domain, config,)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    async_fire_mqtt_message(hass, "availability-topic1", "online")
+
+    state = hass.states.get(f"{domain}.test")
+    assert state.state != STATE_UNAVAILABLE
+    if no_assumed_state:
+        assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, "availability-topic1", "offline")
+
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    async_fire_mqtt_message(hass, "availability-topic2", "online")
+
+    state = hass.states.get(f"{domain}.test")
+    assert state.state != STATE_UNAVAILABLE
+    if no_assumed_state:
+        assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, "availability-topic2", "offline")
+
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    if state_topic:
+        async_fire_mqtt_message(hass, state_topic, state_message)
+
+        state = hass.states.get(f"{domain}.test")
+        assert state.state == STATE_UNAVAILABLE
+
+        async_fire_mqtt_message(hass, "availability-topic1", "online")
+
+        state = hass.states.get(f"{domain}.test")
+        assert state.state != STATE_UNAVAILABLE
+
+
 async def help_test_custom_availability_payload(
     hass,
     mqtt_mock,
@@ -150,6 +211,88 @@ async def help_test_custom_availability_payload(
 
         state = hass.states.get(f"{domain}.test")
         assert state.state != STATE_UNAVAILABLE
+
+
+async def help_test_discovery_update_availability(
+    hass,
+    mqtt_mock,
+    domain,
+    config,
+    no_assumed_state=False,
+    state_topic=None,
+    state_message=None,
+):
+    """Test update of discovered MQTTAvailability.
+
+    This is a test helper for the MQTTAvailability mixin.
+    """
+    # Add availability settings to config
+    config1 = copy.deepcopy(config)
+    config1[domain]["availability_topic"] = "availability-topic1"
+    config2 = copy.deepcopy(config)
+    config2[domain]["availability"] = [
+        {"topic": "availability-topic2"},
+        {"topic": "availability-topic3"},
+    ]
+    config3 = copy.deepcopy(config)
+    config3[domain]["availability_topic"] = "availability-topic4"
+    data1 = json.dumps(config1[domain])
+    data2 = json.dumps(config2[domain])
+    data3 = json.dumps(config3[domain])
+
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    await async_start(hass, "homeassistant", entry)
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data1)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    async_fire_mqtt_message(hass, "availability-topic1", "online")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state != STATE_UNAVAILABLE
+
+    async_fire_mqtt_message(hass, "availability-topic1", "offline")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    # Change availability_topic
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data2)
+    await hass.async_block_till_done()
+
+    # Verify we are no longer subscribing to the old topic
+    async_fire_mqtt_message(hass, "availability-topic1", "online")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    # Verify we are subscribing to the new topic
+    async_fire_mqtt_message(hass, "availability-topic2", "online")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state != STATE_UNAVAILABLE
+
+    # Verify we are subscribing to the new topic
+    async_fire_mqtt_message(hass, "availability-topic3", "offline")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    # Change availability_topic
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data3)
+    await hass.async_block_till_done()
+
+    # Verify we are no longer subscribing to the old topic
+    async_fire_mqtt_message(hass, "availability-topic2", "online")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    # Verify we are no longer subscribing to the old topic
+    async_fire_mqtt_message(hass, "availability-topic3", "online")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state == STATE_UNAVAILABLE
+
+    # Verify we are subscribing to the new topic
+    async_fire_mqtt_message(hass, "availability-topic4", "online")
+    state = hass.states.get(f"{domain}.test")
+    assert state.state != STATE_UNAVAILABLE
 
 
 async def help_test_setting_attribute_via_mqtt_json_message(

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -17,6 +17,7 @@ from .test_common import (
     help_test_availability_without_topic,
     help_test_custom_availability_payload,
     help_test_default_availability_list_payload,
+    help_test_default_availability_list_single,
     help_test_default_availability_payload,
     help_test_discovery_broken,
     help_test_discovery_removal,
@@ -259,6 +260,13 @@ async def test_default_availability_list_payload(hass, mqtt_mock):
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_list_payload(
         hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+async def test_default_availability_list_single(hass, mqtt_mock, caplog):
+    """Test availability by default payload with defined topic."""
+    await help_test_default_availability_list_single(
+        hass, mqtt_mock, caplog, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -264,7 +264,7 @@ async def test_default_availability_list_payload(hass, mqtt_mock):
 
 
 async def test_default_availability_list_single(hass, mqtt_mock, caplog):
-    """Test availability by default payload with defined topic."""
+    """Test availability list and availability_topic are mutually exclusive."""
     await help_test_default_availability_list_single(
         hass, mqtt_mock, caplog, sensor.DOMAIN, DEFAULT_CONFIG
     )

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -16,11 +16,13 @@ from .test_common import (
     help_test_availability_when_connection_lost,
     help_test_availability_without_topic,
     help_test_custom_availability_payload,
+    help_test_default_availability_list_payload,
     help_test_default_availability_payload,
     help_test_discovery_broken,
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_availability,
     help_test_entity_debug_info,
     help_test_entity_debug_info_max_messages,
     help_test_entity_debug_info_message,
@@ -253,9 +255,23 @@ async def test_default_availability_payload(hass, mqtt_mock):
     )
 
 
+async def test_default_availability_list_payload(hass, mqtt_mock):
+    """Test availability by default payload with defined topic."""
+    await help_test_default_availability_list_payload(
+        hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG
+    )
+
+
 async def test_custom_availability_payload(hass, mqtt_mock):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
+        hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+async def test_discovery_update_availability(hass, mqtt_mock):
+    """Test availability discovery update."""
+    await help_test_discovery_update_availability(
         hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support multiple MQTT availability topics.
The use case is for gateways such as zigbee2mqtt where it's useful to be able to indicate:
- Availability based on zigbee2mqtt connected or not connected to broker for all devices
- Availability for each connected to device

With this PR, it's possible to configure:
```yaml
availability:
 - topic: <zigbee2mqtt_will_topic>
 - topic: <individual_device_availability_topic>
```

The gatweay can now:
- Publish `online` or `offline` to the device-specific availability topics when connection with the device is established or lost.
- Set an MQTT will to publish `offline` to the gateway's availability  topic
- Optionally publish, `offline` to the gateway's availability   topic when shutting down (only needed if `disconnect` is sent to MQTT broker)
- NOT publish `online` to the gateway's availability topic when the gateways connects to MQTT as it would set all devices as available

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
availability:
 - topic: zigbee2mqtt/status
 - topic: device1234/status
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
