### PR TITLE
Support empty output of MQTT binary_sensor value_template

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -189,17 +189,30 @@ class MqttBinarySensor(
                 payload = value_template.async_render_with_possible_json_value(
                     payload, variables={"entity_id": self.entity_id}
                 )
+                if not payload:  # No output from template, ignore
+                    _LOGGER.debug(
+                        "Empty template output for entity: %s with state topic: %s. Payload: '%s', with value template '%s'",
+                        self._config[CONF_NAME],
+                        self._config[CONF_STATE_TOPIC],
+                        msg.payload,
+                        value_template,
+                    )
+                    return
+
             if payload == self._config[CONF_PAYLOAD_ON]:
                 self._state = True
             elif payload == self._config[CONF_PAYLOAD_OFF]:
                 self._state = False
             else:  # Payload is not for this entity
-                _LOGGER.warning(
-                    "No matching payload found for entity: %s with state topic: %s. Payload: %s, with value template %s",
+                template_info = ""
+                if value_template is not None:
+                    template_info = f", template output: '{payload}', with value template '{str(value_template)}'"
+                _LOGGER.info(
+                    "No matching payload found for entity: %s with state topic: %s. Payload: '%s'%s",
                     self._config[CONF_NAME],
                     self._config[CONF_STATE_TOPIC],
-                    payload,
-                    value_template,
+                    msg.payload,
+                    template_info,
                 )
                 return
 

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -189,7 +189,7 @@ class MqttBinarySensor(
                 payload = value_template.async_render_with_possible_json_value(
                     payload, variables={"entity_id": self.entity_id}
                 )
-                if not payload:  # No output from template, ignore
+                if not payload.strip():  # No output from template, ignore
                     _LOGGER.debug(
                         "Empty template output for entity: %s with state topic: %s. Payload: '%s', with value template '%s'",
                         self._config[CONF_NAME],

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -259,6 +259,39 @@ async def test_setting_sensor_value_via_mqtt_message_and_template(hass, mqtt_moc
     assert state.state == STATE_OFF
 
 
+async def test_setting_sensor_value_via_mqtt_message_empty_template(
+    hass, mqtt_mock, caplog
+):
+    """Test the setting of the value via MQTT."""
+    assert await async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            binary_sensor.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "test-topic",
+                "payload_on": "ON",
+                "payload_off": "OFF",
+                "value_template": '{%if value == "ABC"%}ON{%endif%}',
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "test-topic", "DEF")
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+    assert "Empty template output" in caplog.text
+
+    async_fire_mqtt_message(hass, "test-topic", "ABC")
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+
 async def test_valid_device_class(hass, mqtt_mock):
     """Test the setting of a valid sensor class."""
     assert await async_setup_component(

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -259,6 +259,43 @@ async def test_setting_sensor_value_via_mqtt_message_and_template(hass, mqtt_moc
     assert state.state == STATE_OFF
 
 
+async def test_setting_sensor_value_via_mqtt_message_and_template2(
+    hass, mqtt_mock, caplog
+):
+    """Test the setting of the value via MQTT."""
+    assert await async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            binary_sensor.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "test-topic",
+                "payload_on": "ON",
+                "payload_off": "OFF",
+                "value_template": "{{value | upper}}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "test-topic", "on")
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    async_fire_mqtt_message(hass, "test-topic", "off")
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "test-topic", "illegal")
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+    assert "template output: 'ILLEGAL'" in caplog.text
+
+
 async def test_setting_sensor_value_via_mqtt_message_empty_template(
     hass, mqtt_mock, caplog
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support empty output of MQTT binary_sensor value_template

This is useful when the subscribed topic may contain data for other entities.

The kind of template below where the entity's state is copied will work for other entity types, but doesn't work for binary_sensor because the output must be `ON` or `OFF`, but the binary_sensor's state may be `UNAVAILABLE` etc.
This came to light after merging PR #36479 + #37230 
```yaml
value_template: >-
      {% if value_json.RfReceived.Data == '545CE9' %}
        {{'ON'}}
      {% else %}
        {{states('binary_sensor.garage_main_motion_sensor') | upper}}
      {% endif %}
```

With this PR, support a template rendering an empty output:
```yaml
value_template: >-
      {% if value_json.RfReceived.Data == '545CE9' %}
        {{'ON'}}
      {% endif %}
```
An empty output of the template will be ignored, but it will be logged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #37347
- Link to documentation pull request: #TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
