### PR TITLE
Reduce time to run zha discover tests

### DIFF
--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -34,18 +34,20 @@ class FakeEndpoint:
         self.device_type = None
         self.request = AsyncMock(return_value=[0])
 
-    def add_input_cluster(self, cluster_id):
+    def add_input_cluster(self, cluster_id, _patch_cluster=True):
         """Add an input cluster."""
         cluster = zigpy.zcl.Cluster.from_id(self, cluster_id, is_server=True)
-        patch_cluster(cluster)
+        if _patch_cluster:
+            patch_cluster(cluster)
         self.in_clusters[cluster_id] = cluster
         if hasattr(cluster, "ep_attribute"):
             setattr(self, cluster.ep_attribute, cluster)
 
-    def add_output_cluster(self, cluster_id):
+    def add_output_cluster(self, cluster_id, _patch_cluster=True):
         """Add an output cluster."""
         cluster = zigpy.zcl.Cluster.from_id(self, cluster_id, is_server=False)
-        patch_cluster(cluster)
+        if _patch_cluster:
+            patch_cluster(cluster)
         self.out_clusters[cluster_id] = cluster
 
     reply = AsyncMock(return_value=[0])

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -101,6 +101,7 @@ def zigpy_device_mock(zigpy_app_controller):
         model="FakeModel",
         node_descriptor=b"\x02@\x807\x10\x7fd\x00\x00*d\x00\x00",
         nwk=0xB79C,
+        patch_cluster=True,
     ):
         """Make a fake device using the specified cluster classes."""
         device = FakeDevice(
@@ -116,10 +117,10 @@ def zigpy_device_mock(zigpy_app_controller):
                 endpoint.profile_id = profile_id
 
             for cluster_id in ep.get("in_clusters", []):
-                endpoint.add_input_cluster(cluster_id)
+                endpoint.add_input_cluster(cluster_id, _patch_cluster=patch_cluster)
 
             for cluster_id in ep.get("out_clusters", []):
-                endpoint.add_output_cluster(cluster_id)
+                endpoint.add_output_cluster(cluster_id, _patch_cluster=patch_cluster)
 
         return device
 
@@ -187,6 +188,7 @@ def zha_device_mock(hass, zigpy_device_mock):
         manufacturer="mock manufacturer",
         model="mock model",
         node_desc=b"\x02@\x807\x10\x7fd\x00\x00*d\x00\x00",
+        patch_cluster=True,
     ):
         if endpoints is None:
             endpoints = {
@@ -202,9 +204,18 @@ def zha_device_mock(hass, zigpy_device_mock):
                 },
             }
         zigpy_device = zigpy_device_mock(
-            endpoints, ieee, manufacturer, model, node_desc
+            endpoints, ieee, manufacturer, model, node_desc, patch_cluster=patch_cluster
         )
         zha_device = zha_core_device.ZHADevice(hass, zigpy_device, MagicMock())
         return zha_device
 
     return _zha_device
+
+
+@pytest.fixture
+def hass_disable_services(hass):
+    """Mock service register."""
+    with patch.object(hass.services, "async_register"), patch.object(
+        hass.services, "has_service", return_value=True
+    ):
+        yield hass


### PR DESCRIPTION
With the tests broken up in https://github.com/home-assistant/core/pull/37419 zha discover comes to the top of whichever group runs it in the slow test list.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Most of the time was registering services and patching
the clusters which are never called in these tests

```
2020-07-03T16:31:45.7205440Z 2.77s teardown tests/components/zha/test_discover.py::test_group_probe_cleanup_called[pyloop]
2020-07-03T16:31:45.7205930Z 2.06s call     tests/components/verisure/test_lock.py::test_verisure_default_code[pyloop]
2020-07-03T16:31:45.7206586Z 1.79s teardown tests/components/zha/test_discover.py::test_discover_endpoint[pyloop-device_info55]
2020-07-03T16:31:45.7207422Z 1.77s teardown tests/components/zha/test_discover.py::test_discover_endpoint[pyloop-device_info22]
2020-07-03T16:31:45.7208006Z 1.70s teardown tests/components/zha/test_discover.py::test_discover_endpoint[pyloop-device_info90]
2020-07-03T16:31:45.7208558Z 1.69s teardown tests/components/zha/test_discover.py::test_devices[zha_device_restored-pyloop-device86]
2020-07-03T16:31:45.7209087Z 1.69s teardown tests/components/zha/test_discover.py::test_discover_endpoint[pyloop-device_info26]
2020-07-03T16:31:45.7209610Z 1.68s teardown tests/components/zha/test_discover.py::test_discover_endpoint[pyloop-device_info14]
2020-07-03T16:31:45.7210254Z 1.68s teardown tests/components/zha/test_discover.py::test_discover_endpoint[pyloop-device_info71]
2020-07-03T16:31:45.7210776Z 1.66s teardown tests/components/zha/test_discover.py::test_discover_endpoint[pyloop-device_info33]
```

Before = 531.30s
After = 367.10s



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
