### PR TITLE
Ensure async_setup is mocked in geonetnz intergration tests

### DIFF
--- a/tests/components/geonetnz_quakes/test_config_flow.py
+++ b/tests/components/geonetnz_quakes/test_config_flow.py
@@ -1,6 +1,8 @@
 """Define tests for the GeoNet NZ Quakes config flow."""
 from datetime import timedelta
 
+from asynctest import patch
+
 from homeassistant import data_entry_flow
 from homeassistant.components.geonetnz_quakes import (
     CONF_MINIMUM_MAGNITUDE,
@@ -49,9 +51,12 @@ async def test_step_import(hass):
         CONF_MINIMUM_MAGNITUDE: 2.5,
     }
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "import"}, data=conf
-    )
+    with patch(
+        "homeassistant.components.geonetnz_quakes.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.geonetnz_quakes.async_setup", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "import"}, data=conf
+        )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
@@ -71,9 +76,12 @@ async def test_step_user(hass):
     hass.config.longitude = 174.7
     conf = {CONF_RADIUS: 25, CONF_MMI: 4}
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}, data=conf
-    )
+    with patch(
+        "homeassistant.components.geonetnz_quakes.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.geonetnz_quakes.async_setup", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}, data=conf
+        )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {

--- a/tests/components/geonetnz_quakes/test_config_flow.py
+++ b/tests/components/geonetnz_quakes/test_config_flow.py
@@ -1,8 +1,6 @@
 """Define tests for the GeoNet NZ Quakes config flow."""
 from datetime import timedelta
 
-from asynctest import patch
-
 from homeassistant import data_entry_flow
 from homeassistant.components.geonetnz_quakes import (
     CONF_MINIMUM_MAGNITUDE,
@@ -16,6 +14,8 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_UNIT_SYSTEM,
 )
+
+from tests.async_mock import patch
 
 
 async def test_duplicate_error(hass, config_entry):

--- a/tests/components/geonetnz_volcano/test_config_flow.py
+++ b/tests/components/geonetnz_volcano/test_config_flow.py
@@ -1,8 +1,6 @@
 """Define tests for the GeoNet NZ Volcano config flow."""
 from datetime import timedelta
 
-from asynctest import patch
-
 from homeassistant import data_entry_flow
 from homeassistant.components.geonetnz_volcano import config_flow
 from homeassistant.const import (
@@ -12,6 +10,8 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_UNIT_SYSTEM,
 )
+
+from tests.async_mock import patch
 
 
 async def test_duplicate_error(hass, config_entry):

--- a/tests/components/geonetnz_volcano/test_config_flow.py
+++ b/tests/components/geonetnz_volcano/test_config_flow.py
@@ -1,6 +1,8 @@
 """Define tests for the GeoNet NZ Volcano config flow."""
 from datetime import timedelta
 
+from asynctest import patch
+
 from homeassistant import data_entry_flow
 from homeassistant.components.geonetnz_volcano import config_flow
 from homeassistant.const import (
@@ -48,7 +50,12 @@ async def test_step_import(hass):
     flow = config_flow.GeonetnzVolcanoFlowHandler()
     flow.hass = hass
 
-    result = await flow.async_step_import(import_config=conf)
+    with patch(
+        "homeassistant.components.geonetnz_volcano.async_setup_entry", return_value=True
+    ), patch(
+        "homeassistant.components.geonetnz_volcano.async_setup", return_value=True
+    ):
+        result = await flow.async_step_import(import_config=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {
@@ -69,7 +76,12 @@ async def test_step_user(hass):
     flow = config_flow.GeonetnzVolcanoFlowHandler()
     flow.hass = hass
 
-    result = await flow.async_step_user(user_input=conf)
+    with patch(
+        "homeassistant.components.geonetnz_volcano.async_setup_entry", return_value=True
+    ), patch(
+        "homeassistant.components.geonetnz_volcano.async_setup", return_value=True
+    ):
+        result = await flow.async_step_user(user_input=conf)
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "-41.2, 174.7"
     assert result["data"] == {


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
async_setup was not mocked out.

```
2020-07-03T16:26:32.6774537Z 1.48s teardown tests/components/geonetnz_quakes/test_config_flow.py::test_step_user[pyloop]
2020-07-03T16:26:32.6774706Z 1.37s teardown tests/components/geonetnz_quakes/test_config_flow.py::test_step_import[pyloop]
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
