### PR TITLE
Fix undesired power toggling

### DIFF
--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -3,6 +3,6 @@
   "name": "Sony PlayStation 4",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ps4",
-  "requirements": ["pyps4-2ndscreen==1.1.0"],
+  "requirements": ["pyps4-2ndscreen==1.1.1"],
   "codeowners": ["@ktnrg45"]
 }

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -453,6 +453,10 @@ class PS4Device(MediaPlayerEntity):
         """Turn on the media player."""
         self._ps4.wakeup()
 
+    async def async_toggle(self):
+        """Toggle media player."""
+        await self._ps4.toggle()
+
     async def async_media_pause(self):
         """Send keypress ps to return to menu."""
         await self.async_send_remote_control("ps")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1546,7 +1546,7 @@ pypjlink2==1.2.1
 pypoint==1.1.2
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.1.0
+pyps4-2ndscreen==1.1.1
 
 # homeassistant.components.qvr_pro
 pyqvrpro==0.52

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -708,7 +708,7 @@ pyotp==2.3.0
 pypoint==1.1.2
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.1.0
+pyps4-2ndscreen==1.1.1
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -379,6 +379,22 @@ async def test_turn_off(hass):
     assert len(mock_call.mock_calls) == 1
 
 
+async def test_toggle(hass):
+    """Test that toggle service calls function."""
+    mock_entity_id = await setup_mock_component(hass)
+    mock_func = "{}{}".format(
+        "homeassistant.components.ps4.media_player.", "pyps4.Ps4Async.toggle"
+    )
+
+    with patch(mock_func) as mock_call:
+        await hass.services.async_call(
+            "media_player", "toggle", {ATTR_ENTITY_ID: mock_entity_id}
+        )
+        await hass.async_block_till_done()
+
+    assert len(mock_call.mock_calls) == 1
+
+
 async def test_media_pause(hass):
     """Test that media pause service calls function."""
     mock_entity_id = await setup_mock_component(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pyps4-2ndscreen to 1.1.1. to fix undesired toggling for turn_on/turn_off due to aggresssive error handling
Add defined toggle to ps4.media_player

Release notes:

1.1.1: https://github.com/ktnrg45/pyps4-2ndscreen/releases/tag/1.1.1
Compare: https://github.com/ktnrg45/pyps4-2ndscreen/compare/1.1.0...1.1.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37332
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
