### PR TITLE
Replace asynctest with tests.async_mock

### DIFF
--- a/tests/components/acmeda/test_config_flow.py
+++ b/tests/components/acmeda/test_config_flow.py
@@ -1,6 +1,5 @@
 """Define tests for the Acmeda config flow."""
 import aiopulse
-from asynctest.mock import patch
 import pytest
 
 from homeassistant import data_entry_flow
@@ -8,6 +7,7 @@ from homeassistant.components.acmeda.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 DUMMY_HOST1 = "127.0.0.1"

--- a/tests/components/avri/test_config_flow.py
+++ b/tests/components/avri/test_config_flow.py
@@ -1,8 +1,8 @@
 """Test the Avri config flow."""
-from asynctest import patch
-
 from homeassistant import config_entries, setup
 from homeassistant.components.avri.const import DOMAIN
+
+from tests.async_mock import patch
 
 
 async def test_form(hass):

--- a/tests/components/awair/test_config_flow.py
+++ b/tests/components/awair/test_config_flow.py
@@ -1,6 +1,5 @@
 """Define tests for the Awair config flow."""
 
-from asynctest import patch
 from python_awair.exceptions import AuthError, AwairError
 
 from homeassistant import data_entry_flow
@@ -10,6 +9,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 
 from .const import CONFIG, DEVICES_FIXTURE, NO_DEVICES_FIXTURE, UNIQUE_ID, USER_FIXTURE
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/flick_electric/test_config_flow.py
+++ b/tests/components/flick_electric/test_config_flow.py
@@ -1,13 +1,13 @@
 """Test the Flick Electric config flow."""
 import asyncio
 
-from asynctest import patch
 from pyflick.authentication import AuthException
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.flick_electric.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 CONF = {CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"}

--- a/tests/components/guardian/conftest.py
+++ b/tests/components/guardian/conftest.py
@@ -1,6 +1,7 @@
 """Define fixtures for Elexa Guardian tests."""
-from asynctest import patch
 import pytest
+
+from tests.async_mock import patch
 
 
 @pytest.fixture()

--- a/tests/components/guardian/test_config_flow.py
+++ b/tests/components/guardian/test_config_flow.py
@@ -1,6 +1,5 @@
 """Define tests for the Elexa Guardian config flow."""
 from aioguardian.errors import GuardianError
-from asynctest import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.guardian import CONF_UID, DOMAIN
@@ -11,6 +10,7 @@ from homeassistant.components.guardian.config_flow import (
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1,11 +1,10 @@
 """Test the HomeKit config flow."""
-from asynctest import patch
-
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.homekit.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_NAME, CONF_PORT
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -2,7 +2,6 @@
 import os
 from typing import Dict
 
-from asynctest import MagicMock
 import pytest
 
 from homeassistant.components import zeroconf
@@ -62,7 +61,7 @@ from homeassistant.util import json as json_util
 
 from .util import PATH_HOMEKIT, async_init_entry, async_init_integration
 
-from tests.async_mock import ANY, AsyncMock, Mock, patch
+from tests.async_mock import ANY, AsyncMock, MagicMock, Mock, patch
 from tests.common import MockConfigEntry, mock_device_registry, mock_registry
 from tests.components.homekit.common import patch_debounce
 

--- a/tests/components/homekit/util.py
+++ b/tests/components/homekit/util.py
@@ -1,11 +1,10 @@
 """Test util for the homekit integration."""
 
-from asynctest import patch
-
 from homeassistant.components.homekit.const import DOMAIN
 from homeassistant.const import CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 PATH_HOMEKIT = "homeassistant.components.homekit"

--- a/tests/components/juicenet/test_config_flow.py
+++ b/tests/components/juicenet/test_config_flow.py
@@ -1,12 +1,12 @@
 """Test the JuiceNet config flow."""
 import aiohttp
-from asynctest import patch
-from asynctest.mock import MagicMock
 from pyjuicenet import TokenError
 
 from homeassistant import config_entries, setup
 from homeassistant.components.juicenet.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
+
+from tests.async_mock import MagicMock, patch
 
 
 def _mock_juicenet_return_value(get_devices=None):

--- a/tests/components/panasonic_viera/test_init.py
+++ b/tests/components/panasonic_viera/test_init.py
@@ -1,6 +1,4 @@
 """Test the Panasonic Viera setup process."""
-from asynctest import patch
-
 from homeassistant.components.panasonic_viera.const import (
     CONF_APP_ID,
     CONF_ENCRYPTION_KEY,
@@ -13,7 +11,7 @@ from homeassistant.config_entries import ENTRY_STATE_NOT_LOADED
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import Mock
+from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
 
 MOCK_CONFIG_DATA = {

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Logitech Squeezebox config flow."""
-from asynctest import patch
 from pysqueezebox import Server
 
 from homeassistant import config_entries
@@ -17,6 +16,7 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 HOST = "1.1.1.1"

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the UPB Control config flow."""
 
-from asynctest import MagicMock, PropertyMock, patch
-
 from homeassistant import config_entries, setup
 from homeassistant.components.upb.const import DOMAIN
+
+from tests.async_mock import MagicMock, PropertyMock, patch
 
 
 def mocked_upb(sync_complete=True, config_ok=True):

--- a/tests/components/wiffi/test_config_flow.py
+++ b/tests/components/wiffi/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the wiffi integration config flow."""
 import errno
 
-from asynctest import patch
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
@@ -13,6 +12,7 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 MOCK_CONFIG = {CONF_PORT: 8765}

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -5,7 +5,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 from aiohttp.test_utils import TestClient
-from asynctest import MagicMock
 import pytest
 import requests_mock
 from withings_api.common import NotifyAppli, NotifyListProfile, NotifyListResponse
@@ -18,6 +17,7 @@ from homeassistant.components.withings.common import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2Implementation
 
+from tests.async_mock import MagicMock
 from tests.common import MockConfigEntry
 from tests.components.withings.common import (
     ComponentFactory,

--- a/tests/components/zerproc/test_config_flow.py
+++ b/tests/components/zerproc/test_config_flow.py
@@ -1,9 +1,10 @@
 """Test the zerproc config flow."""
-from asynctest import patch
 import pyzerproc
 
 from homeassistant import config_entries, setup
 from homeassistant.components.zerproc.config_flow import DOMAIN
+
+from tests.async_mock import patch
 
 
 async def test_flow_success(hass):

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -1,5 +1,4 @@
 """Test the zerproc lights."""
-from asynctest import patch
 import pytest
 import pyzerproc
 
@@ -24,6 +23,7 @@ from homeassistant.const import (
 )
 import homeassistant.util.dt as dt_util
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
On Python 3.8+ we shouldn't use asynctest. I had already fixed most tests in the past but looks like some sneaked in again. Replacing it again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
