### PR TITLE
Use the main event loop for homekit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -500,7 +500,7 @@ class HomeKit:
         self._async_register_bridge(dev_reg)
         await self.hass.async_add_executor_job(self._start, bridged_states)
         _LOGGER.debug("Driver start for %s", self._name)
-        self.hass.add_job(self.driver._do_start)
+        self.hass.add_job(self.driver.start_service)
         self.status = STATUS_RUNNING
 
     @callback
@@ -580,7 +580,7 @@ class HomeKit:
             return
         self.status = STATUS_STOPPED
         _LOGGER.debug("Driver stop for %s", self._name)
-        self.hass.add_job(self.driver._do_stop)
+        await self.driver.async_stop()
         for acc in self.bridge.accessories.values():
             acc.async_stop()
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -389,6 +389,7 @@ class HomeKit:
             self.hass,
             self._entry_id,
             self._name,
+            loop=self.hass.loop,
             address=ip_addr,
             port=self._port,
             persist_file=persist_file,
@@ -498,6 +499,9 @@ class HomeKit:
 
         self._async_register_bridge(dev_reg)
         await self.hass.async_add_executor_job(self._start, bridged_states)
+        _LOGGER.debug("Driver start for %s", self._name)
+        self.hass.add_job(self.driver._do_start)
+        self.status = STATUS_RUNNING
 
     @callback
     def _async_register_bridge(self, dev_reg):
@@ -570,17 +574,13 @@ class HomeKit:
                 self.bridge.xhm_uri(),
             )
 
-        _LOGGER.debug("Driver start for %s", self._name)
-        self.hass.add_job(self.driver.start)
-        self.status = STATUS_RUNNING
-
     async def async_stop(self, *args):
         """Stop the accessory driver."""
         if self.status != STATUS_RUNNING:
             return
         self.status = STATUS_STOPPED
         _LOGGER.debug("Driver stop for %s", self._name)
-        self.hass.add_job(self.driver.stop)
+        self.hass.add_job(self.driver._do_stop)
         for acc in self.bridge.accessories.values():
             acc.async_stop()
 

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
   "requirements": [
-    "HAP-python==2.9.1",
+    "HAP-python==2.9.2",
     "fnvhash==0.1.0",
     "PyQRCode==1.2.1",
     "base36==0.1.1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -36,7 +36,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==2.9.1
+HAP-python==2.9.2
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -4,7 +4,7 @@
 -r requirements_test.txt
 
 # homeassistant.components.homekit
-HAP-python==2.9.1
+HAP-python==2.9.2
 
 # homeassistant.components.plugwise
 Plugwise_Smile==1.1.0

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -210,6 +210,7 @@ async def test_homekit_setup(hass, hk_driver):
         hass,
         entry.entry_id,
         BRIDGE_NAME,
+        loop=hass.loop,
         address=IP_ADDRESS,
         port=DEFAULT_PORT,
         persist_file=path,
@@ -251,6 +252,7 @@ async def test_homekit_setup_ip_address(hass, hk_driver):
         hass,
         entry.entry_id,
         BRIDGE_NAME,
+        loop=hass.loop,
         address="172.0.0.0",
         port=DEFAULT_PORT,
         persist_file=path,
@@ -288,6 +290,7 @@ async def test_homekit_setup_advertise_ip(hass, hk_driver):
         hass,
         entry.entry_id,
         BRIDGE_NAME,
+        loop=hass.loop,
         address="0.0.0.0",
         port=DEFAULT_PORT,
         persist_file=path,
@@ -494,7 +497,7 @@ async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start"
+        "pyhap.accessory_driver.AccessoryDriver._do_start"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -527,7 +530,7 @@ async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start"
+        "pyhap.accessory_driver.AccessoryDriver._do_start"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -574,7 +577,7 @@ async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, debounce_p
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory",
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start"
+        "pyhap.accessory_driver.AccessoryDriver._do_start"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -610,8 +613,6 @@ async def test_homekit_stop(hass):
     homekit.bridge = Mock()
     homekit.bridge.accessories = {}
 
-    await async_init_integration(hass)
-
     assert homekit.status == STATUS_READY
     await homekit.async_stop()
     await hass.async_block_till_done()
@@ -621,13 +622,13 @@ async def test_homekit_stop(hass):
     homekit.status = STATUS_STOPPED
     await homekit.async_stop()
     await hass.async_block_till_done()
-    assert homekit.driver.stop.called is False
+    assert homekit.driver._do_stop.called is False
 
     # Test if driver is started
     homekit.status = STATUS_RUNNING
     await homekit.async_stop()
     await hass.async_block_till_done()
-    assert homekit.driver.stop.called is True
+    assert homekit.driver._do_stop.called is True
 
 
 async def test_homekit_reset_accessories(hass):
@@ -655,7 +656,7 @@ async def test_homekit_reset_accessories(hass):
     ), patch("pyhap.accessory.Bridge.add_accessory") as mock_add_accessory, patch(
         "pyhap.accessory_driver.AccessoryDriver.config_changed"
     ) as hk_driver_config_changed, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start"
+        "pyhap.accessory_driver.AccessoryDriver._do_start"
     ):
         await async_init_entry(hass, entry)
 
@@ -702,7 +703,7 @@ async def test_homekit_too_many_accessories(hass, hk_driver):
 
     hass.states.async_set("light.demo", "on")
 
-    with patch("pyhap.accessory_driver.AccessoryDriver.start"), patch(
+    with patch("pyhap.accessory_driver.AccessoryDriver._do_start"), patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ), patch("homeassistant.components.homekit._LOGGER.warning") as mock_warn, patch(
         f"{PATH_HOMEKIT}.show_setup_message"
@@ -916,7 +917,7 @@ async def test_raise_config_entry_not_ready(hass):
         await hass.async_block_till_done()
 
 
-async def test_homekit_uses_system_zeroconf(hass, mock_zeroconf):
+async def test_homekit_uses_system_zeroconf(hass, hk_driver, mock_zeroconf):
     """Test HomeKit uses system zeroconf."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -925,15 +926,11 @@ async def test_homekit_uses_system_zeroconf(hass, mock_zeroconf):
     )
     system_zc = await zeroconf.async_get_instance(hass)
 
-    with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory"), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
-    ), patch("pyhap.accessory_driver.AccessoryDriver.add_accessory"), patch(
-        "pyhap.accessory_driver.AccessoryDriver.start"
-    ):
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-        assert hass.data[DOMAIN][entry.entry_id][HOMEKIT].driver.advertiser == system_zc
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.data[DOMAIN][entry.entry_id][HOMEKIT].driver.advertiser == system_zc
+    await hass.async_block_till_done()
 
 
 def _write_data(path: str, data: Dict) -> None:

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -497,7 +497,7 @@ async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver._do_start"
+        "pyhap.accessory_driver.AccessoryDriver.start_service"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -530,7 +530,7 @@ async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver._do_start"
+        "pyhap.accessory_driver.AccessoryDriver.start_service"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -577,7 +577,7 @@ async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, debounce_p
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory",
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver._do_start"
+        "pyhap.accessory_driver.AccessoryDriver.start_service"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -610,6 +610,7 @@ async def test_homekit_stop(hass):
         entry_id=entry.entry_id,
     )
     homekit.driver = Mock()
+    homekit.driver.async_stop = AsyncMock()
     homekit.bridge = Mock()
     homekit.bridge.accessories = {}
 
@@ -622,13 +623,13 @@ async def test_homekit_stop(hass):
     homekit.status = STATUS_STOPPED
     await homekit.async_stop()
     await hass.async_block_till_done()
-    assert homekit.driver._do_stop.called is False
+    assert homekit.driver.async_stop.called is False
 
     # Test if driver is started
     homekit.status = STATUS_RUNNING
     await homekit.async_stop()
     await hass.async_block_till_done()
-    assert homekit.driver._do_stop.called is True
+    assert homekit.driver.async_stop.called is True
 
 
 async def test_homekit_reset_accessories(hass):
@@ -656,7 +657,7 @@ async def test_homekit_reset_accessories(hass):
     ), patch("pyhap.accessory.Bridge.add_accessory") as mock_add_accessory, patch(
         "pyhap.accessory_driver.AccessoryDriver.config_changed"
     ) as hk_driver_config_changed, patch(
-        "pyhap.accessory_driver.AccessoryDriver._do_start"
+        "pyhap.accessory_driver.AccessoryDriver.start_service"
     ):
         await async_init_entry(hass, entry)
 
@@ -703,7 +704,7 @@ async def test_homekit_too_many_accessories(hass, hk_driver):
 
     hass.states.async_set("light.demo", "on")
 
-    with patch("pyhap.accessory_driver.AccessoryDriver._do_start"), patch(
+    with patch("pyhap.accessory_driver.AccessoryDriver.start_service"), patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ), patch("homeassistant.components.homekit._LOGGER.warning") as mock_warn, patch(
         f"{PATH_HOMEKIT}.show_setup_message"


### PR DESCRIPTION
~~Waiting for https://github.com/ikalchev/HAP-python/pull/270~~ .. now bumped to 2.9.2

~~May conflict with https://github.com/home-assistant/core/pull/37253~~

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the main event loop for homekit.  This change shaves off one thread per homekit bridge.

Update HAP-python to 2.9.2 which includes Paulus' changes and a bugfix for single byte reads


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
