### PR TITLE
0.112.2

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -117,6 +117,12 @@ async def async_setup(hass, config):
         domain = service.data.get(ATTR_DOMAIN)
         entity_id = service.data.get(ATTR_ENTITY_ID)
 
+        if entity_id is None and domain is None:
+            # If there is no entity_id or
+            # domain, the event will get filtered
+            # away so we use the "logbook" domain
+            domain = DOMAIN
+
         message.hass = hass
         message = message.async_render()
         async_log_entry(hass, name, message, domain, entity_id)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -476,10 +476,14 @@ async def async_setup_entry(hass, entry):
     if conf is None:
         conf = CONFIG_SCHEMA({DOMAIN: dict(entry.data)})[DOMAIN]
     elif any(key in conf for key in entry.data):
-        _LOGGER.warning(
+        shared_keys = conf.keys() & entry.data.keys()
+        override = {k: entry.data[k] for k in shared_keys}
+        if CONF_PASSWORD in override:
+            override[CONF_PASSWORD] = "********"
+        _LOGGER.info(
             "Data in your configuration entry is going to override your "
             "configuration.yaml: %s",
-            entry.data,
+            override,
         )
 
     conf = _merge_config(entry, conf)

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -81,7 +81,9 @@ def _create_index(engine, table_name, index_name):
     try:
         index.create(engine)
     except OperationalError as err:
-        if "already exists" not in str(err).lower():
+        lower_err_str = str(err).lower()
+
+        if "already exists" not in lower_err_str and "duplicate" not in lower_err_str:
             raise
 
         _LOGGER.warning(

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -3,6 +3,6 @@
   "name": "Tesla",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
-  "requirements": ["teslajsonpy==0.9.0"],
+  "requirements": ["teslajsonpy==0.9.2"],
   "codeowners": ["@zabuldon", "@alandtse"]
 }

--- a/homeassistant/components/tile/manifest.json
+++ b/homeassistant/components/tile/manifest.json
@@ -3,6 +3,6 @@
   "name": "Tile",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tile",
-  "requirements": ["pytile==3.0.6"],
+  "requirements": ["pytile==4.0.0"],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Miio",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.9.45", "python-miio==0.5.1"],
+  "requirements": ["construct==2.9.45", "python-miio==0.5.2.1"],
   "codeowners": ["@rytilahti", "@syssi"],
   "zeroconf": ["_miio._udp.local."]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 112
-PATCH_VERSION = "1"
+PATCH_VERSION = "2"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1778,7 +1778,7 @@ python_opendata_transport==0.2.1
 pythonegardia==1.0.40
 
 # homeassistant.components.tile
-pytile==3.0.6
+pytile==4.0.0
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2094,7 +2094,7 @@ temperusb==1.5.3
 tesla-powerwall==0.2.11
 
 # homeassistant.components.tesla
-teslajsonpy==0.9.0
+teslajsonpy==0.9.2
 
 # homeassistant.components.thermoworks_smoke
 thermoworks_smoke==0.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1712,7 +1712,7 @@ python-juicenet==1.0.1
 # python-lirc==1.2.3
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.1
+python-miio==0.5.2.1
 
 # homeassistant.components.mpd
 python-mpd2==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -775,7 +775,7 @@ python-velbus==2.0.43
 python_awair==0.1.1
 
 # homeassistant.components.tile
-pytile==3.0.6
+pytile==4.0.0
 
 # homeassistant.components.traccar
 pytraccar==0.9.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -748,7 +748,7 @@ python-izone==1.1.2
 python-juicenet==1.0.1
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.1
+python-miio==0.5.2.1
 
 # homeassistant.components.nest
 python-nest==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -890,7 +890,7 @@ tellduslive==0.10.11
 tesla-powerwall==0.2.11
 
 # homeassistant.components.tesla
-teslajsonpy==0.9.0
+teslajsonpy==0.9.2
 
 # homeassistant.components.toon
 toonapi==0.1.0

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -77,7 +77,15 @@ class TestComponentLogbook(unittest.TestCase):
             },
             True,
         )
-
+        self.hass.services.call(
+            logbook.DOMAIN,
+            "log",
+            {
+                logbook.ATTR_NAME: "This entry",
+                logbook.ATTR_MESSAGE: "has no domain or entity_id",
+            },
+            True,
+        )
         # Logbook entry service call results in firing an event.
         # Our service call will unblock when the event listeners have been
         # scheduled. This means that they may not have been processed yet.
@@ -92,15 +100,21 @@ class TestComponentLogbook(unittest.TestCase):
                 dt_util.utcnow() + timedelta(hours=1),
             )
         )
-        assert len(events) == 1
+        assert len(events) == 2
 
-        assert len(calls) == 1
+        assert len(calls) == 2
+        first_call = calls[-2]
+
+        assert first_call.data.get(logbook.ATTR_NAME) == "Alarm"
+        assert first_call.data.get(logbook.ATTR_MESSAGE) == "is triggered"
+        assert first_call.data.get(logbook.ATTR_DOMAIN) == "switch"
+        assert first_call.data.get(logbook.ATTR_ENTITY_ID) == "switch.test_switch"
+
         last_call = calls[-1]
 
-        assert last_call.data.get(logbook.ATTR_NAME) == "Alarm"
-        assert last_call.data.get(logbook.ATTR_MESSAGE) == "is triggered"
-        assert last_call.data.get(logbook.ATTR_DOMAIN) == "switch"
-        assert last_call.data.get(logbook.ATTR_ENTITY_ID) == "switch.test_switch"
+        assert last_call.data.get(logbook.ATTR_NAME) == "This entry"
+        assert last_call.data.get(logbook.ATTR_MESSAGE) == "has no domain or entity_id"
+        assert last_call.data.get(logbook.ATTR_DOMAIN) == "logbook"
 
     def test_service_call_create_log_book_entry_no_message(self):
         """Test if service call create log book entry without message."""


### PR DESCRIPTION
- Don't print MQTT credentials to log (@emontnemery - #37364)
- Handle index already existing on db migration with MySQLdb backend (@bdraco - #37384)
- Ensure entries appear when using the logbook.log service without a domain/entity_id (@bdraco - #37388)
- Bump pytile to 4.0.0 (@bachya - #37398)
- Bump python-miio to 0.5.2.1 (@rytilahti - #37422)
- Bump teslajsonpy to 0.9.2 (@alandtse - #37434)