### PR TITLE
Add generic unavailable and last_updated metrics for prometheus

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -154,7 +154,7 @@ class PrometheusMetrics:
 
         handler = f"_handle_{domain}"
 
-        if hasattr(self, handler):
+        if hasattr(self, handler) and state.state != STATE_UNAVAILABLE:
             getattr(self, handler)(state)
 
         labels = self._labels(state)
@@ -163,17 +163,19 @@ class PrometheusMetrics:
         )
         state_change.labels(**labels).inc()
 
-        unavailable = self._metric(
-            "unavailable",
+        entity_available = self._metric(
+            "entity_available",
             self.prometheus_cli.Gauge,
-            "Entity is in the unavailable state",
+            "Entity is available (not in the unavailable state)",
         )
-        unavailable.labels(**labels).set(float(state.state == STATE_UNAVAILABLE))
+        entity_available.labels(**labels).set(float(state.state != STATE_UNAVAILABLE))
 
-        last_updated = self._metric(
-            "last_updated", self.prometheus_cli.Gauge, "The last_updated timestamp"
+        last_updated_time_seconds = self._metric(
+            "last_updated_time_seconds",
+            self.prometheus_cli.Gauge,
+            "The last_updated timestamp",
         )
-        last_updated.labels(**labels).set(state.last_updated.timestamp())
+        last_updated_time_seconds.labels(**labels).set(state.last_updated.timestamp())
 
     def _handle_attributes(self, state):
         for key, value in state.attributes.items():

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -171,13 +171,13 @@ async def test_view(hass, hass_client):
     )
 
     assert (
-        'unavailable{domain="sensor",'
+        'entity_available{domain="sensor",'
         'entity="sensor.radio_energy",'
-        'friendly_name="Radio Energy"} 0.0' in body
+        'friendly_name="Radio Energy"} 1.0' in body
     )
 
     assert (
-        'last_updated{domain="sensor",'
+        'last_updated_time_seconds{domain="sensor",'
         'entity="sensor.radio_energy",'
         'friendly_name="Radio Energy"} 86400.0' in body
     )

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -1,9 +1,9 @@
 """The tests for the Prometheus exporter."""
 from dataclasses import dataclass
+import datetime
 
 import pytest
 
-from homeassistant import setup
 from homeassistant.components import climate, humidifier, sensor
 from homeassistant.components.demo.sensor import DemoSensor
 import homeassistant.components.prometheus as prometheus
@@ -16,6 +16,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import split_entity_id
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 import tests.async_mock as mock
 
@@ -30,21 +31,18 @@ class FilterTest:
     should_pass: bool
 
 
-@pytest.fixture
-async def prometheus_client(loop, hass, hass_client):
+async def prometheus_client(hass, hass_client):
     """Initialize an hass_client with Prometheus component."""
     await async_setup_component(hass, prometheus.DOMAIN, {prometheus.DOMAIN: {}})
 
-    await setup.async_setup_component(
-        hass, sensor.DOMAIN, {"sensor": [{"platform": "demo"}]}
-    )
+    await async_setup_component(hass, sensor.DOMAIN, {"sensor": [{"platform": "demo"}]})
 
-    await setup.async_setup_component(
+    await async_setup_component(
         hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
     )
     await hass.async_block_till_done()
 
-    await setup.async_setup_component(
+    await async_setup_component(
         hass, humidifier.DOMAIN, {"humidifier": [{"platform": "demo"}]}
     )
 
@@ -60,7 +58,11 @@ async def prometheus_client(loop, hass, hass_client):
     )
     sensor2.hass = hass
     sensor2.entity_id = "sensor.radio_energy"
-    await sensor2.async_update_ha_state()
+    with mock.patch(
+        "homeassistant.util.dt.utcnow",
+        return_value=datetime.datetime(1970, 1, 2, tzinfo=dt_util.UTC),
+    ):
+        await sensor2.async_update_ha_state()
 
     sensor3 = DemoSensor(
         None, "Electricity price", 0.123, None, f"SEK/{ENERGY_KILO_WATT_HOUR}", None
@@ -89,9 +91,10 @@ async def prometheus_client(loop, hass, hass_client):
     return await hass_client()
 
 
-async def test_view(prometheus_client):  # pylint: disable=redefined-outer-name
+async def test_view(hass, hass_client):
     """Test prometheus metrics view."""
-    resp = await prometheus_client.get(prometheus.API_ENDPOINT)
+    client = await prometheus_client(hass, hass_client)
+    resp = await client.get(prometheus.API_ENDPOINT)
 
     assert resp.status == 200
     assert resp.headers["content-type"] == "text/plain"
@@ -165,6 +168,18 @@ async def test_view(prometheus_client):  # pylint: disable=redefined-outer-name
         'power_kwh{domain="sensor",'
         'entity="sensor.radio_energy",'
         'friendly_name="Radio Energy"} 14.0' in body
+    )
+
+    assert (
+        'unavailable{domain="sensor",'
+        'entity="sensor.radio_energy",'
+        'friendly_name="Radio Energy"} 0.0' in body
+    )
+
+    assert (
+        'last_updated{domain="sensor",'
+        'entity="sensor.radio_energy",'
+        'friendly_name="Radio Energy"} 86400.0' in body
     )
 
     assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exposing the last update time and (un)available state to Prometheus allows for monitoring and alerting for entities that are offline or that haven't been updated in the expected interval.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #32112
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io