### PR TITLE
Fix braviatv authentication refresh

### DIFF
--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -55,7 +55,8 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.braviarc.connect, pin, CLIENTID_PREFIX, NICKNAME
         )
 
-        if not self.braviarc.is_connected():
+        connected = await self.hass.async_add_executor_job(self.braviarc.is_connected)
+        if not connected:
             raise CannotConnect()
 
         system_info = await self.hass.async_add_executor_job(
@@ -161,7 +162,8 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         self.braviarc = self.hass.data[DOMAIN][self.config_entry.entry_id][BRAVIARC]
-        if not self.braviarc.is_connected():
+        connected = await self.hass.async_add_executor_job(self.braviarc.is_connected)
+        if not connected:
             await self.hass.async_add_executor_job(
                 self.braviarc.connect, self.pin, CLIENTID_PREFIX, NICKNAME
             )

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["bravia-tv==1.0.5"],
+  "requirements": ["bravia-tv==1.0.6"],
   "codeowners": ["@bieniu"],
   "config_flow": true
 }

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -148,33 +148,31 @@ class BraviaTVDevice(MediaPlayerEntity):
         self._device_info = device_info
         self._ignored_sources = ignored_sources
         self._state_lock = asyncio.Lock()
-        self._need_refresh = True
 
     async def async_update(self):
         """Update TV info."""
         if self._state_lock.locked():
             return
 
-        if self._state == STATE_OFF:
-            self._need_refresh = True
-
         power_status = await self.hass.async_add_executor_job(
             self._braviarc.get_power_status
         )
-        if power_status == "active":
-            if self._need_refresh:
+
+        if power_status != "off":
+            connected = await self.hass.async_add_executor_job(
+                self._braviarc.is_connected
+            )
+            if not connected:
                 try:
                     connected = await self.hass.async_add_executor_job(
                         self._braviarc.connect, self._pin, CLIENTID_PREFIX, NICKNAME
                     )
                 except NoIPControl:
                     _LOGGER.error("IP Control is disabled in the TV settings")
-                self._need_refresh = False
-            else:
-                connected = self._braviarc.is_connected()
             if not connected:
-                return
+                power_status = "off"
 
+        if power_status == "active":
             self._state = STATE_ON
             if (
                 await self._async_refresh_volume()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -375,7 +375,7 @@ bomradarloop==0.1.4
 boto3==1.9.252
 
 # homeassistant.components.braviatv
-bravia-tv==1.0.5
+bravia-tv==1.0.6
 
 # homeassistant.components.broadlink
 broadlink==0.14.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -177,7 +177,7 @@ blinkpy==0.15.0
 bomradarloop==0.1.4
 
 # homeassistant.components.braviatv
-bravia-tv==1.0.5
+bravia-tv==1.0.6
 
 # homeassistant.components.broadlink
 broadlink==0.14.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
 The purpose of this change is to fix #36498. Specifically this PR does the following:
- Bumps bravia-tv lib to 1.0.6 ([change log](https://github.com/dcnielsen90/python-bravia-tv/compare/v1.0.5...v1.0.6)) which fixes is_connected() to actually return True only when API is connected, instead of just returning whether or not cookies are cached (regardless if they actually worked).
- Wrap is_connected() because it now performs io.
- Remove unnecessary logic to refresh cookies. Now that is_connected() works, the bravia instance only needs to be reconnected when is_connected is False and TV is not off.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

No changes to implementation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36498
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
