### PR TITLE
Add OZW support for set_config_parameter service

### DIFF
--- a/homeassistant/components/ozw/const.py
+++ b/homeassistant/components/ozw/const.py
@@ -25,6 +25,8 @@ PLATFORMS = [
 TOPIC_OPENZWAVE = "OpenZWave"
 
 # Common Attributes
+ATTR_CONFIG_PARAMETER = "parameter"
+ATTR_CONFIG_VALUE = "value"
 ATTR_INSTANCE_ID = "instance_id"
 ATTR_SECURE = "secure"
 ATTR_NODE_ID = "node_id"
@@ -36,6 +38,7 @@ ATTR_SCENE_VALUE_LABEL = "scene_value_label"
 # Service specific
 SERVICE_ADD_NODE = "add_node"
 SERVICE_REMOVE_NODE = "remove_node"
+SERVICE_SET_CONFIG_PARAMETER = "set_config_parameter"
 
 # Home Assistant Events
 EVENT_SCENE_ACTIVATED = f"{DOMAIN}.scene_activated"

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -83,7 +83,7 @@ class ZWaveServices:
                         str(selection),
                     )
                     return
-                elif value.type == ValueType.LIST:
+                if value.type == ValueType.LIST:
                     # accept either string from the list value OR the int value
                     if isinstance(selection, int):
                         if selection <= value.max:
@@ -121,11 +121,11 @@ class ZWaveServices:
                                     param,
                                 )
                                 break
-                elif value.type == ValueType.BUTTON:
+                if value.type == ValueType.BUTTON:
                     # Unsupported at this time
                     _LOGGER.info("Button type not supported yet")
                     return
-                elif value.type == ValueType.INT:
+                if value.type == ValueType.INT:
                     if selection <= value.max:
                         value.send_value(int(selection))
                         _LOGGER.info(

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -99,24 +99,21 @@ class ZWaveServices:
                             "Invalid value %s for parameter %s", str(selection), param,
                         )
                         break
-                    else:
-                        # iterate list labels to get value
-                        for selected in value.value["List"]:
-                            if selected["Label"] == selection:
-                                value.send_value(int(selected["Value"]))
-                                _LOGGER.info(
-                                    "Setting configuration parameter %s on Node %s with list selection %s",
-                                    param,
-                                    node_id,
-                                    str(selection),
-                                )
-                                return
-                            _LOGGER.error(
-                                "Invalid value %s for parameter %s",
-                                str(selection),
+                    # iterate list labels to get value
+                    for selected in value.value["List"]:
+                        if selected["Label"] == selection:
+                            value.send_value(int(selected["Value"]))
+                            _LOGGER.info(
+                                "Setting configuration parameter %s on Node %s with list selection %s",
                                 param,
+                                node_id,
+                                str(selection),
                             )
-                            break
+                            return
+                        _LOGGER.error(
+                            "Invalid value %s for parameter %s", str(selection), param,
+                        )
+                        break
                 if value.type == ValueType.BUTTON:
                     # Unsupported at this time
                     _LOGGER.info("Button type not supported yet")

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -1,9 +1,15 @@
 """Methods and classes related to executing Z-Wave commands and publishing these to hass."""
+import logging
+
+from openzwavemqtt.const import CommandClass, ValueType
 import voluptuous as vol
 
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 
 from . import const
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ZWaveServices:
@@ -36,6 +42,107 @@ class ZWaveServices:
                 {vol.Optional(const.ATTR_INSTANCE_ID, default=1): vol.Coerce(int)}
             ),
         )
+
+        self._hass.services.async_register(
+            const.DOMAIN,
+            const.SERVICE_SET_CONFIG_PARAMETER,
+            self.async_set_config_parameter,
+            schema=vol.Schema(
+                {
+                    vol.Optional(const.ATTR_INSTANCE_ID, default=1): vol.Coerce(int),
+                    vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),
+                    vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Coerce(int),
+                    vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
+                        vol.Coerce(int), cv.string
+                    ),
+                }
+            ),
+        )
+
+    @callback
+    def async_set_config_parameter(self, service):
+        """Set a config parameter to a node."""
+        instance_id = service.data[const.ATTR_INSTANCE_ID]
+        node_id = service.data[const.ATTR_NODE_ID]
+        param = service.data[const.ATTR_CONFIG_PARAMETER]
+        selection = service.data[const.ATTR_CONFIG_VALUE]
+
+        node = self._manager.get_instance(instance_id).get_node(node_id).values()
+
+        for value in node:
+            if (
+                value.command_class == CommandClass.CONFIGURATION
+                and value.index == param
+            ):
+                if value.type == ValueType.BOOL:
+                    value.send_value(str(selection == "True"))
+                    _LOGGER.info(
+                        "Setting configuration parameter %s on Node %s with bool selection %s",
+                        param,
+                        node_id,
+                        str(selection),
+                    )
+                    return
+                elif value.type == ValueType.LIST:
+                    # accept either string from the list value OR the int value
+                    if isinstance(selection, int):
+                        if selection <= value.max:
+                            value.send_value(int(selection))
+                            _LOGGER.info(
+                                "Setting configuration parameter %s on Node %s with list selection %s",
+                                param,
+                                node_id,
+                                str(selection),
+                            )
+                            return
+                        else:
+                            _LOGGER.error(
+                                "Invalid value %s for parameter %s",
+                                str(selection),
+                                param,
+                            )
+                            break
+                    else:
+                        # iterate list labels to get value
+                        for selected in value.value["List"]:
+                            if selected["Label"] == selection:
+                                value.send_value(int(selected["Value"]))
+                                _LOGGER.info(
+                                    "Setting configuration parameter %s on Node %s with list selection %s",
+                                    param,
+                                    node_id,
+                                    str(selection),
+                                )
+                                return
+                            else:
+                                _LOGGER.error(
+                                    "Invalid value %s for parameter %s",
+                                    str(selection),
+                                    param,
+                                )
+                                break
+                elif value.type == ValueType.BUTTON:
+                    # Unsupported at this time
+                    _LOGGER.info("Button type not supported yet")
+                    return
+                elif value.type == ValueType.INT:
+                    if selection <= value.max:
+                        value.send_value(int(selection))
+                        _LOGGER.info(
+                            "Setting configuration parameter %s on Node %s with selection %s",
+                            param,
+                            node_id,
+                            selection,
+                        )
+                        return
+                    else:
+                        _LOGGER.error(
+                            "Invalid value %s for parameter %s, maximum value of %s",
+                            str(selection),
+                            param,
+                            value.max,
+                        )
+                        break
 
     @callback
     def async_add_node(self, service):

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -91,7 +91,7 @@ class ZWaveServices:
                             value.min,
                             value.max,
                         )
-                        break
+                        return
                     payload = int(selection)
 
                 # iterate list labels to get value
@@ -104,7 +104,7 @@ class ZWaveServices:
                     _LOGGER.error(
                         "Invalid value %s for parameter %s", selection, param,
                     )
-                    break
+                    return
 
             if value.type == ValueType.BUTTON:
                 # Unsupported at this time
@@ -123,7 +123,7 @@ class ZWaveServices:
                         value.min,
                         value.max,
                     )
-                    break
+                    return
                 payload = int(selection)
 
             value.send_value(payload)  # send the payload

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -76,6 +76,7 @@ class ZWaveServices:
                 or value.index != param
             ):
                 continue
+
             if value.type == ValueType.BOOL:
                 payload = selection == "True"
 
@@ -109,7 +110,11 @@ class ZWaveServices:
                 # Unsupported at this time
                 _LOGGER.info("Button type not supported yet")
                 return
-            if value.type == ValueType.INT:
+
+            if value.type == ValueType.STRING:
+                payload = selection
+
+            if value.type == ValueType.INT or value.type == ValueType.BYTE:
                 if selection > value.max or selection < value.min:
                     _LOGGER.error(
                         "Value %s out of range for parameter %s (Min: %s Max: %s)",

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -95,13 +95,10 @@ class ZWaveServices:
                                 str(selection),
                             )
                             return
-                        else:
-                            _LOGGER.error(
-                                "Invalid value %s for parameter %s",
-                                str(selection),
-                                param,
-                            )
-                            break
+                        _LOGGER.error(
+                            "Invalid value %s for parameter %s", str(selection), param,
+                        )
+                        break
                     else:
                         # iterate list labels to get value
                         for selected in value.value["List"]:
@@ -114,13 +111,12 @@ class ZWaveServices:
                                     str(selection),
                                 )
                                 return
-                            else:
-                                _LOGGER.error(
-                                    "Invalid value %s for parameter %s",
-                                    str(selection),
-                                    param,
-                                )
-                                break
+                            _LOGGER.error(
+                                "Invalid value %s for parameter %s",
+                                str(selection),
+                                param,
+                            )
+                            break
                 if value.type == ValueType.BUTTON:
                     # Unsupported at this time
                     _LOGGER.info("Button type not supported yet")
@@ -135,14 +131,13 @@ class ZWaveServices:
                             selection,
                         )
                         return
-                    else:
-                        _LOGGER.error(
-                            "Invalid value %s for parameter %s, maximum value of %s",
-                            str(selection),
-                            param,
-                            value.max,
-                        )
-                        break
+                    _LOGGER.error(
+                        "Invalid value %s for parameter %s, maximum value of %s",
+                        str(selection),
+                        param,
+                        value.max,
+                    )
+                    break
 
     @callback
     def async_add_node(self, service):

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -85,7 +85,7 @@ class ZWaveServices:
                     if selection > value.max or selection < value.min:
                         _LOGGER.error(
                             "Value %s out of range for parameter %s (Min: %s Max: %s)",
-                            str(selection),
+                            selection,
                             param,
                             value.min,
                             value.max,
@@ -101,7 +101,7 @@ class ZWaveServices:
 
                 if payload is None:
                     _LOGGER.error(
-                        "Invalid value %s for parameter %s", str(selection), param,
+                        "Invalid value %s for parameter %s", selection, param,
                     )
                     break
 
@@ -113,7 +113,7 @@ class ZWaveServices:
                 if selection > value.max or selection < value.min:
                     _LOGGER.error(
                         "Value %s out of range for parameter %s (Min: %s Max: %s)",
-                        str(selection),
+                        selection,
                         param,
                         value.min,
                         value.max,
@@ -126,8 +126,9 @@ class ZWaveServices:
                 "Setting configuration parameter %s on Node %s with value %s",
                 param,
                 node_id,
-                str(payload),
+                payload,
             )
+            return
 
     @callback
     def async_add_node(self, service):

--- a/homeassistant/components/ozw/services.yaml
+++ b/homeassistant/components/ozw/services.yaml
@@ -12,3 +12,18 @@ remove_node:
   fields:
     instance_id:
       description: (Optional) The OZW Instance/Controller to use, defaults to 1.
+
+set_config_parameter:
+  description: Set a config parameter to a node on the Z-Wave network.
+  fields:
+    node_id:
+      description: Node id of the device to set config parameter to (integer).
+      example: 10
+    parameter:
+      description: Parameter number to set (integer).
+      example: 8
+    value:
+      description: Value to set for parameter. (String value for list and bool parameters, integer for others).
+      example: 50268673
+    instance_id:
+      description: (Optional) The OZW Instance/Controller to use, defaults to 1.

--- a/tests/components/ozw/test_services.py
+++ b/tests/components/ozw/test_services.py
@@ -50,7 +50,7 @@ async def test_services(hass, lock_data, sent_messages, lock_msg, caplog):
         blocking=True,
     )
     assert len(sent_messages) == 3
-    assert "Invalid value 12 for parameter 1" in caplog.text
+    assert "Value 12 out of range for parameter 1" in caplog.text
 
     # Test set_config_parameter invalid list string
     await hass.services.async_call(
@@ -70,7 +70,4 @@ async def test_services(hass, lock_data, sent_messages, lock_msg, caplog):
         blocking=True,
     )
     assert len(sent_messages) == 3
-    assert (
-        "Invalid value 2147483657 for parameter 6, maximum value of 2147483647"
-        in caplog.text
-    )
+    assert "Value 12 out of range for parameter 1" in caplog.text

--- a/tests/components/ozw/test_services.py
+++ b/tests/components/ozw/test_services.py
@@ -1,0 +1,76 @@
+"""Test Z-Wave Services."""
+from .common import setup_ozw
+
+
+async def test_services(hass, lock_data, sent_messages, lock_msg, caplog):
+    """Test services on lock."""
+    await setup_ozw(hass, fixture=lock_data)
+
+    # Test set_config_parameter list by label
+    await hass.services.async_call(
+        "ozw",
+        "set_config_parameter",
+        {"node_id": 10, "parameter": 1, "value": "Disabled"},
+        blocking=True,
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": 0, "ValueIDKey": 281475154706452}
+
+    # Test set_config_parameter list by index int
+    await hass.services.async_call(
+        "ozw",
+        "set_config_parameter",
+        {"node_id": 10, "parameter": 1, "value": 0},
+        blocking=True,
+    )
+    assert len(sent_messages) == 2
+    msg = sent_messages[1]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": 0, "ValueIDKey": 281475154706452}
+
+    # Test set_config_parameter int
+    await hass.services.async_call(
+        "ozw",
+        "set_config_parameter",
+        {"node_id": 10, "parameter": 6, "value": 0},
+        blocking=True,
+    )
+    assert len(sent_messages) == 3
+    msg = sent_messages[2]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": 0, "ValueIDKey": 1688850038259731}
+
+    # Test set_config_parameter invalid list int
+    await hass.services.async_call(
+        "ozw",
+        "set_config_parameter",
+        {"node_id": 10, "parameter": 1, "value": 12},
+        blocking=True,
+    )
+    assert len(sent_messages) == 3
+    assert "Invalid value 12 for parameter 1" in caplog.text
+
+    # Test set_config_parameter invalid list string
+    await hass.services.async_call(
+        "ozw",
+        "set_config_parameter",
+        {"node_id": 10, "parameter": 1, "value": "Blah"},
+        blocking=True,
+    )
+    assert len(sent_messages) == 3
+    assert "Invalid value Blah for parameter 1" in caplog.text
+
+    # Test set_config_parameter int out of range
+    await hass.services.async_call(
+        "ozw",
+        "set_config_parameter",
+        {"node_id": 10, "parameter": 6, "value": 2147483657},
+        blocking=True,
+    )
+    assert len(sent_messages) == 3
+    assert (
+        "Invalid value 2147483657 for parameter 6, maximum value of 2147483647"
+        in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds `ozw.set_config_parameter` service to allow device specific configurations such as LED notifications.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13949

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
