### PR TITLE
Switch tests to use hass objects instead of direct

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -175,6 +175,8 @@ def get_rfx_object(packetid):
         obj = rfxtrxmod.StatusEvent(pkt)
     else:
         obj = rfxtrxmod.ControlEvent(pkt)
+
+    obj.data = binarypacket
     return obj
 
 

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -93,7 +93,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             entity.get(CONF_COMMAND_ON),
             entity.get(CONF_COMMAND_OFF),
         )
-        device.hass = hass
         sensors.append(device)
         RFX_DEVICES[device_id] = device
 
@@ -121,7 +120,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
             pkt_id = "".join(f"{x:02x}" for x in event.data)
             sensor = RfxtrxBinarySensor(event, pkt_id)
-            sensor.hass = hass
             RFX_DEVICES[device_id] = sensor
             add_entities([sensor])
             _LOGGER.info(
@@ -271,4 +269,5 @@ class RfxtrxBinarySensor(BinarySensorEntity):
     def update_state(self, state):
         """Update the state of the device."""
         self._state = state
-        self.schedule_update_ha_state()
+        if self.hass:
+            self.schedule_update_ha_state()

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -92,6 +92,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     continue
                 sensor = sensors[data_type]
                 sensor.event = event
+                if sensor.hass:
+                    sensor.schedule_update_ha_state()
                 # Fire event
                 if sensor.should_fire_event:
                     sensor.hass.bus.fire(

--- a/tests/components/rfxtrx/__init__.py
+++ b/tests/components/rfxtrx/__init__.py
@@ -2,5 +2,8 @@
 from homeassistant.components import rfxtrx
 
 
-async def _signal_event(hass, event):
+async def _signal_event(hass, packet_id):
+    event = rfxtrx.get_rfx_object(packet_id)
     await hass.async_add_executor_job(rfxtrx.RECEIVED_EVT_SUBSCRIBERS[0], event)
+    await hass.async_block_till_done()
+    return event

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -68,7 +68,10 @@ async def rfxtrx_fixture(hass):
     """Stub out core rfxtrx to test platform."""
     mock_component(hass, "rfxtrx")
 
-    yield
+    rfxobject = mock.MagicMock()
+    hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxobject
+
+    yield rfxobject
 
     # These test don't listen for stop to do cleanup.
     if rfxtrx_core.DATA_RFXOBJECT in hass.data:

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -1,0 +1,123 @@
+"""The tests for the Rfxtrx sensor platform."""
+from homeassistant.setup import async_setup_component
+
+from . import _signal_event
+
+
+async def test_default_config(hass, rfxtrx):
+    """Test with 0 sensor."""
+    await async_setup_component(
+        hass, "binary_sensor", {"binary_sensor": {"platform": "rfxtrx", "devices": {}}}
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+
+
+async def test_one(hass, rfxtrx):
+    """Test with 1 sensor."""
+    await async_setup_component(
+        hass,
+        "binary_sensor",
+        {
+            "binary_sensor": {
+                "platform": "rfxtrx",
+                "devices": {"0a52080705020095220269": {"name": "Test"}},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "Test"
+
+
+async def test_several(hass, rfxtrx):
+    """Test with 3."""
+    await async_setup_component(
+        hass,
+        "binary_sensor",
+        {
+            "binary_sensor": {
+                "platform": "rfxtrx",
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {"name": "Test"},
+                    "0b1100100118cdea02010f70": {"name": "Bath"},
+                    "0b1100101118cdea02010f70": {"name": "Living"},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "Test"
+
+    state = hass.states.get("binary_sensor.bath")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "Bath"
+
+    state = hass.states.get("binary_sensor.living")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "Living"
+
+
+async def test_discover(hass, rfxtrx):
+    """Test with discovery."""
+    await async_setup_component(
+        hass,
+        "binary_sensor",
+        {"binary_sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+    )
+    await hass.async_block_till_done()
+
+    await _signal_event(hass, "0b1100100118cdea02010f70")
+    state = hass.states.get("binary_sensor.0b1100100118cdea02010f70")
+    assert state
+    assert state.state == "on"
+
+    await _signal_event(hass, "0b1100100118cdeb02010f70")
+    state = hass.states.get("binary_sensor.0b1100100118cdeb02010f70")
+    assert state
+    assert state.state == "on"
+
+    # Trying to add a sensor
+    await _signal_event(hass, "0a52085e070100b31b0279")
+    state = hass.states.get("sensor.0a52085e070100b31b0279")
+    assert state is None
+
+    # Trying to add a light
+    await _signal_event(hass, "0b1100100118cdea02010f70")
+    state = hass.states.get("light.0b1100100118cdea02010f70")
+    assert state is None
+
+    # Trying to add a rollershutter
+    await _signal_event(hass, "0a1400adf394ab020e0060")
+    state = hass.states.get("cover.0a1400adf394ab020e0060")
+    assert state is None
+
+
+async def test_discover_noautoadd(hass, rfxtrx):
+    """Test with discovery of switch when auto add is False."""
+    await async_setup_component(
+        hass,
+        "binary_sensor",
+        {
+            "binary_sensor": {
+                "platform": "rfxtrx",
+                "automatic_add": False,
+                "devices": {},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Trying to add switch
+    await _signal_event(hass, "0b1100100118cdea02010f70")
+    assert hass.states.async_all() == []

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -34,6 +34,45 @@ async def test_one(hass, rfxtrx):
     assert state.attributes.get("friendly_name") == "Test"
 
 
+async def test_one_pt2262(hass, rfxtrx):
+    """Test with 1 sensor."""
+    await async_setup_component(
+        hass,
+        "binary_sensor",
+        {
+            "binary_sensor": {
+                "platform": "rfxtrx",
+                "devices": {
+                    "0913000022670e013970": {
+                        "name": "Test",
+                        "data_bits": 4,
+                        "command_on": 0xE,
+                        "command_off": 0x7,
+                    }
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state
+    assert state.state == "off"  # probably aught to be unknown
+    assert state.attributes.get("friendly_name") == "Test"
+
+    await _signal_event(hass, "0913000022670e013970")
+    state = hass.states.get("binary_sensor.test")
+    assert state
+    assert state.state == "on"
+    assert state.attributes.get("friendly_name") == "Test"
+
+    await _signal_event(hass, "09130000226707013d70")
+    state = hass.states.get("binary_sensor.test")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "Test"
+
+
 async def test_several(hass, rfxtrx):
     """Test with 3."""
     await async_setup_component(

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -130,23 +130,17 @@ async def test_fire_event(hass):
         calls.append(event)
 
     hass.bus.async_listen(rfxtrx.EVENT_BUTTON_PRESSED, record_event)
-    await hass.async_block_till_done()
-    entity = rfxtrx.RFX_DEVICES["213c7f2_16"]
-    entity.update_state(False, 0)
-    assert "Test" == entity.name
-    assert "off" == entity.state
-    assert entity.should_fire_event
 
-    event = rfxtrx.get_rfx_object("0b1100cd0213c7f210010f51")
-    event.data = bytearray(
-        [0x0B, 0x11, 0x00, 0x10, 0x01, 0x18, 0xCD, 0xEA, 0x01, 0x01, 0x0F, 0x70]
-    )
-    await _signal_event(hass, event)
-    await hass.async_block_till_done()
+    state = hass.states.get("switch.test")
+    assert state
+    assert state.state == "off"
 
-    assert event.values["Command"] == "On"
-    assert "on" == entity.state
-    assert hass.states.get("switch.test").state == "on"
+    await _signal_event(hass, "0b1100cd0213c7f210010f51")
+
+    state = hass.states.get("switch.test")
+    assert state
+    assert state.state == "on"
+
     assert 1 == len(calls)
     assert calls[0].data == {"entity_id": "switch.test", "state": "on"}
 
@@ -191,11 +185,7 @@ async def test_fire_event_sensor(hass):
         calls.append(event)
 
     hass.bus.async_listen("signal_received", record_event)
-    await hass.async_block_till_done()
-    event = rfxtrx.get_rfx_object("0a520802060101ff0f0269")
-    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
-    await _signal_event(hass, event)
 
-    await hass.async_block_till_done()
+    await _signal_event(hass, "0a520802060101ff0f0269")
     assert 1 == len(calls)
     assert calls[0].data == {"entity_id": "sensor.test_temperature"}

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -1,5 +1,4 @@
 """The tests for the Rfxtrx sensor platform."""
-from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.const import TEMP_CELSIUS, UNIT_PERCENTAGE
 from homeassistant.setup import async_setup_component
 
@@ -13,7 +12,7 @@ async def test_default_config(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_one_sensor(hass, rfxtrx):
@@ -35,11 +34,11 @@ async def test_one_sensor(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    assert 1 == len(rfxtrx_core.RFX_DEVICES)
-    entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-    assert "Test Temperature" == entity.name
-    assert TEMP_CELSIUS == entity.unit_of_measurement
-    assert entity.state is None
+    state = hass.states.get("sensor.test_temperature")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == "Test Temperature"
+    assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
 
 async def test_one_sensor_no_datatype(hass, rfxtrx):
@@ -56,11 +55,11 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    assert 1 == len(rfxtrx_core.RFX_DEVICES)
-    entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-    assert "Test Temperature" == entity.name
-    assert TEMP_CELSIUS == entity.unit_of_measurement
-    assert entity.state is None
+    state = hass.states.get("sensor.test_temperature")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == "Test Temperature"
+    assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
 
 async def test_several_sensors(hass, rfxtrx):
@@ -86,27 +85,23 @@ async def test_several_sensors(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    assert 2 == len(rfxtrx_core.RFX_DEVICES)
-    device_num = 0
-    for id in rfxtrx_core.RFX_DEVICES:
-        if id == "sensor_06_01":
-            device_num = device_num + 1
-            assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
-            _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-            _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
-            assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
-            assert "Bath" == _entity_hum.__str__()
-            assert _entity_hum.state is None
-            assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
-            assert "Bath" == _entity_temp.__str__()
-        elif id == "sensor_05_02":
-            device_num = device_num + 1
-            entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-            assert entity.state is None
-            assert TEMP_CELSIUS == entity.unit_of_measurement
-            assert "Test" == entity.__str__()
+    state = hass.states.get("sensor.test_temperature")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == "Test Temperature"
+    assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
-    assert 2 == device_num
+    state = hass.states.get("sensor.bath_temperature")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == "Bath Temperature"
+    assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
+
+    state = hass.states.get("sensor.bath_humidity")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == "Bath Humidity"
+    assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
 
 
 async def test_discover_sensor(hass, rfxtrx):
@@ -118,59 +113,61 @@ async def test_discover_sensor(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    event = rfxtrx_core.get_rfx_object("0a520801070100b81b0279")
-    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
-    await _signal_event(hass, event)
+    await _signal_event(hass, "0a520801070100b81b0279")
+    state = hass.states.get("sensor.0a520801070100b81b0279_temperature")
+    assert state
+    assert state.state == "18.4"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "0a520801070100b81b0279 Temperature",
+            "unit_of_measurement": TEMP_CELSIUS,
+            "Humidity status": "normal",
+            "Temperature": 18.4,
+            "Rssi numeric": 7,
+            "Humidity": 27,
+            "Battery numeric": 9,
+            "Humidity status numeric": 2,
+        }.items()
+    )
 
-    entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
-    assert 1 == len(rfxtrx_core.RFX_DEVICES)
-    assert {
-        "Humidity status": "normal",
-        "Temperature": 18.4,
-        "Rssi numeric": 7,
-        "Humidity": 27,
-        "Battery numeric": 9,
-        "Humidity status numeric": 2,
-    } == entity.device_state_attributes
-    assert "0a520801070100b81b0279" == entity.__str__()
+    await _signal_event(hass, "0a52080405020095240279")
+    state = hass.states.get("sensor.0a52080405020095240279_temperature")
+    assert state
+    assert state.state == "14.9"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "0a52080405020095240279 Temperature",
+            "unit_of_measurement": TEMP_CELSIUS,
+            "Humidity status": "normal",
+            "Temperature": 14.9,
+            "Rssi numeric": 7,
+            "Humidity": 36,
+            "Battery numeric": 9,
+            "Humidity status numeric": 2,
+        }.items()
+    )
 
-    await _signal_event(hass, event)
-    assert 1 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, "0a52085e070100b31b0279")
+    state = hass.states.get("sensor.0a520801070100b81b0279_temperature")
+    assert state
+    assert state.state == "17.9"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "0a520801070100b81b0279 Temperature",
+            "unit_of_measurement": TEMP_CELSIUS,
+            "Humidity status": "normal",
+            "Temperature": 17.9,
+            "Rssi numeric": 7,
+            "Humidity": 27,
+            "Battery numeric": 9,
+            "Humidity status numeric": 2,
+        }.items()
+    )
 
-    event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
-    event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
-    await _signal_event(hass, event)
-    entity = rfxtrx_core.RFX_DEVICES["sensor_05_02"]["Temperature"]
-    assert 2 == len(rfxtrx_core.RFX_DEVICES)
-    assert {
-        "Humidity status": "normal",
-        "Temperature": 14.9,
-        "Rssi numeric": 7,
-        "Humidity": 36,
-        "Battery numeric": 9,
-        "Humidity status numeric": 2,
-    } == entity.device_state_attributes
-    assert "0a52080405020095240279" == entity.__str__()
-
-    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-    await _signal_event(hass, event)
-    entity = rfxtrx_core.RFX_DEVICES["sensor_07_01"]["Temperature"]
-    assert 2 == len(rfxtrx_core.RFX_DEVICES)
-    assert {
-        "Humidity status": "normal",
-        "Temperature": 17.9,
-        "Rssi numeric": 7,
-        "Humidity": 27,
-        "Battery numeric": 9,
-        "Humidity status numeric": 2,
-    } == entity.device_state_attributes
-    assert "0a520801070100b81b0279" == entity.__str__()
-
-    # trying to add a switch
-    event = rfxtrx_core.get_rfx_object("0b1100cd0213c7f210010f70")
-    await _signal_event(hass, event)
-    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    assert len(hass.states.async_all()) == 2
 
 
 async def test_discover_sensor_noautoadd(hass, rfxtrx):
@@ -182,25 +179,14 @@ async def test_discover_sensor_noautoadd(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    event = rfxtrx_core.get_rfx_object("0a520801070100b81b0279")
-    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
+    await _signal_event(hass, "0a520801070100b81b0279")
+    assert len(hass.states.async_all()) == 0
 
-    assert 0 == len(rfxtrx_core.RFX_DEVICES)
-    await _signal_event(hass, event)
-    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, "0a52080405020095240279")
+    assert len(hass.states.async_all()) == 0
 
-    await _signal_event(hass, event)
-    assert 0 == len(rfxtrx_core.RFX_DEVICES)
-
-    event = rfxtrx_core.get_rfx_object("0a52080405020095240279")
-    event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
-    await _signal_event(hass, event)
-    assert 0 == len(rfxtrx_core.RFX_DEVICES)
-
-    event = rfxtrx_core.get_rfx_object("0a52085e070100b31b0279")
-    event.data = bytearray(b"\nR\x08^\x07\x01\x00\xb3\x1b\x02y")
-    await _signal_event(hass, event)
-    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, "0a52085e070100b31b0279")
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_update_of_sensors(hass, rfxtrx):
@@ -226,83 +212,93 @@ async def test_update_of_sensors(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    assert 2 == len(rfxtrx_core.RFX_DEVICES)
-    device_num = 0
-    for id in rfxtrx_core.RFX_DEVICES:
-        if id == "sensor_06_01":
-            device_num = device_num + 1
-            assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
-            _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-            _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
-            assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
-            assert "Bath" == _entity_hum.__str__()
-            assert _entity_temp.state is None
-            assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
-            assert "Bath" == _entity_temp.__str__()
-        elif id == "sensor_05_02":
-            device_num = device_num + 1
-            entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-            assert entity.state is None
-            assert TEMP_CELSIUS == entity.unit_of_measurement
-            assert "Test" == entity.__str__()
+    state = hass.states.get("sensor.test_temperature")
+    assert state
+    assert state.state == "unknown"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "Test Temperature",
+            "unit_of_measurement": TEMP_CELSIUS,
+        }.items()
+    )
 
-    assert 2 == device_num
+    state = hass.states.get("sensor.bath_temperature")
+    assert state
+    assert state.state == "unknown"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "Bath Temperature",
+            "unit_of_measurement": TEMP_CELSIUS,
+        }.items()
+    )
 
-    event = rfxtrx_core.get_rfx_object("0a520802060101ff0f0269")
-    event.data = bytearray(b"\nR\x08\x01\x07\x01\x00\xb8\x1b\x02y")
-    await _signal_event(hass, event)
+    state = hass.states.get("sensor.bath_humidity")
+    assert state
+    assert state.state == "unknown"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "Bath Humidity",
+            "unit_of_measurement": UNIT_PERCENTAGE,
+        }.items()
+    )
 
-    await _signal_event(hass, event)
-    event = rfxtrx_core.get_rfx_object("0a52080705020085220269")
-    event.data = bytearray(b"\nR\x08\x04\x05\x02\x00\x95$\x02y")
-    await _signal_event(hass, event)
+    assert len(hass.states.async_all()) == 3
 
-    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    await _signal_event(hass, "0a520802060101ff0f0269")
+    await _signal_event(hass, "0a52080705020085220269")
 
-    device_num = 0
-    for id in rfxtrx_core.RFX_DEVICES:
-        if id == "sensor_06_01":
-            device_num = device_num + 1
-            assert len(rfxtrx_core.RFX_DEVICES[id]) == 2
-            _entity_temp = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-            _entity_hum = rfxtrx_core.RFX_DEVICES[id]["Humidity"]
-            assert UNIT_PERCENTAGE == _entity_hum.unit_of_measurement
-            assert 15 == _entity_hum.state
-            assert {
-                "Battery numeric": 9,
-                "Temperature": 51.1,
-                "Humidity": 15,
-                "Humidity status": "normal",
-                "Humidity status numeric": 2,
-                "Rssi numeric": 6,
-            } == _entity_hum.device_state_attributes
-            assert "Bath" == _entity_hum.__str__()
+    state = hass.states.get("sensor.test_temperature")
+    assert state
+    assert state.state == "13.3"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "Test Temperature",
+            "unit_of_measurement": TEMP_CELSIUS,
+            "Battery numeric": 9,
+            "Temperature": 13.3,
+            "Humidity": 34,
+            "Humidity status": "normal",
+            "Humidity status numeric": 2,
+            "Rssi numeric": 6,
+        }.items()
+    )
 
-            assert TEMP_CELSIUS == _entity_temp.unit_of_measurement
-            assert 51.1 == _entity_temp.state
-            assert {
-                "Battery numeric": 9,
-                "Temperature": 51.1,
-                "Humidity": 15,
-                "Humidity status": "normal",
-                "Humidity status numeric": 2,
-                "Rssi numeric": 6,
-            } == _entity_temp.device_state_attributes
-            assert "Bath" == _entity_temp.__str__()
-        elif id == "sensor_05_02":
-            device_num = device_num + 1
-            entity = rfxtrx_core.RFX_DEVICES[id]["Temperature"]
-            assert TEMP_CELSIUS == entity.unit_of_measurement
-            assert 13.3 == entity.state
-            assert {
-                "Humidity status": "normal",
-                "Temperature": 13.3,
-                "Rssi numeric": 6,
-                "Humidity": 34,
-                "Battery numeric": 9,
-                "Humidity status numeric": 2,
-            } == entity.device_state_attributes
-            assert "Test" == entity.__str__()
+    state = hass.states.get("sensor.bath_temperature")
+    assert state
+    assert state.state == "51.1"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "Bath Temperature",
+            "unit_of_measurement": TEMP_CELSIUS,
+            "Battery numeric": 9,
+            "Temperature": 51.1,
+            "Humidity": 15,
+            "Humidity status": "normal",
+            "Humidity status numeric": 2,
+            "Rssi numeric": 6,
+        }.items()
+    )
 
-    assert 2 == device_num
-    assert 2 == len(rfxtrx_core.RFX_DEVICES)
+    state = hass.states.get("sensor.bath_humidity")
+    assert state
+    assert state.state == "15"
+    assert (
+        state.attributes.items()
+        >= {
+            "friendly_name": "Bath Humidity",
+            "unit_of_measurement": UNIT_PERCENTAGE,
+            "Battery numeric": 9,
+            "Temperature": 51.1,
+            "Humidity": 15,
+            "Humidity status": "normal",
+            "Humidity status numeric": 2,
+            "Rssi numeric": 6,
+        }.items()
+    )
+
+    assert len(hass.states.async_all()) == 3


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite rfxtrx tests to avoid using global objects and accessing entity objects directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #37271 and if that is merged will have a very minor conflict

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
