### PR TITLE
Make Modbus hub name mandatory

### DIFF
--- a/homeassistant/components/flexit/climate.py
+++ b/homeassistant/components/flexit/climate.py
@@ -11,7 +11,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
-from homeassistant.components.modbus.const import CONF_HUB, DEFAULT_HUB, MODBUS_DOMAIN
+from homeassistant.components.modbus.const import CONF_HUB, MODBUS_DOMAIN
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_NAME,
@@ -23,7 +23,7 @@ import homeassistant.helpers.config_validation as cv
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
+        vol.Required(CONF_HUB): cv.string,
         vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=32)),
         vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string,
     }

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -28,7 +28,6 @@ from .const import (
     CONF_BYTESIZE,
     CONF_PARITY,
     CONF_STOPBITS,
-    DEFAULT_HUB,
     MODBUS_DOMAIN as DOMAIN,
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
@@ -37,7 +36,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-BASE_SCHEMA = vol.Schema({vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string})
+BASE_SCHEMA = vol.Schema({vol.Required(CONF_NAME): cv.string})
 
 SERIAL_SCHEMA = BASE_SCHEMA.extend(
     {
@@ -69,7 +68,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema(
     {
-        vol.Optional(ATTR_HUB, default=DEFAULT_HUB): cv.string,
+        vol.Required(ATTR_HUB): cv.string,
         vol.Required(ATTR_UNIT): cv.positive_int,
         vol.Required(ATTR_ADDRESS): cv.positive_int,
         vol.Required(ATTR_VALUE): vol.Any(
@@ -80,7 +79,7 @@ SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema(
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema(
     {
-        vol.Optional(ATTR_HUB, default=DEFAULT_HUB): cv.string,
+        vol.Required(ATTR_HUB): cv.string,
         vol.Required(ATTR_UNIT): cv.positive_int,
         vol.Required(ATTR_ADDRESS): cv.positive_int,
         vol.Required(ATTR_STATE): cv.boolean,

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -22,7 +22,6 @@ from .const import (
     CONF_HUB,
     CONF_INPUT_TYPE,
     CONF_INPUTS,
-    DEFAULT_HUB,
     MODBUS_DOMAIN,
 )
 
@@ -38,9 +37,9 @@ PLATFORM_SCHEMA = vol.All(
                     vol.Schema(
                         {
                             vol.Required(CONF_ADDRESS): cv.positive_int,
+                            vol.Required(CONF_HUB): cv.string,
                             vol.Required(CONF_NAME): cv.string,
                             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-                            vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
                             vol.Optional(CONF_SLAVE): cv.positive_int,
                             vol.Optional(
                                 CONF_INPUT_TYPE, default=CALL_TYPE_COIL

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -40,7 +40,6 @@ from .const import (
     DATA_TYPE_FLOAT,
     DATA_TYPE_INT,
     DATA_TYPE_UINT,
-    DEFAULT_HUB,
     MODBUS_DOMAIN,
 )
 
@@ -50,6 +49,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_CURRENT_TEMP): cv.positive_int,
+        vol.Required(CONF_HUB): cv.string,
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_SLAVE): cv.positive_int,
         vol.Required(CONF_TARGET_TEMP): cv.positive_int,
@@ -60,7 +60,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT): vol.In(
             [DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT]
         ),
-        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
         vol.Optional(CONF_PRECISION, default=1): cv.positive_int,
         vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
         vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -17,7 +17,6 @@ CONF_OFFSET = "offset"
 CONF_COILS = "coils"
 
 # integration names
-DEFAULT_HUB = "default"
 MODBUS_DOMAIN = "modbus"
 
 # data types

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -36,7 +36,6 @@ from .const import (
     DATA_TYPE_INT,
     DATA_TYPE_STRING,
     DATA_TYPE_UINT,
-    DEFAULT_HUB,
     MODBUS_DOMAIN,
 )
 
@@ -66,6 +65,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_REGISTERS): [
             {
+                vol.Required(CONF_HUB): cv.string,
                 vol.Required(CONF_NAME): cv.string,
                 vol.Required(CONF_REGISTER): cv.positive_int,
                 vol.Optional(CONF_COUNT, default=1): cv.positive_int,
@@ -79,7 +79,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     ]
                 ),
                 vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-                vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
                 vol.Optional(CONF_OFFSET, default=0): number,
                 vol.Optional(CONF_PRECISION, default=0): cv.positive_int,
                 vol.Optional(

--- a/homeassistant/components/modbus/services.yaml
+++ b/homeassistant/components/modbus/services.yaml
@@ -11,7 +11,7 @@ write_coil:
       description: Address of the modbus unit.
       example: 21
     hub:
-      description: Optional Modbus hub name. A hub with the name 'default' is used if not specified.
+      description: Modbus hub name.
       example: "hub1"
 write_register:
   description: Write to a modbus holding register.
@@ -26,5 +26,5 @@ write_register:
       description: Value (single value or array) to write.
       example: "0 or [4,0]"
     hub:
-      description: Optional Modbus hub name. A hub with the name 'default' is used if not specified.
+      description: Modbus hub name.
       example: "hub1"

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -31,7 +31,6 @@ from .const import (
     CONF_STATE_ON,
     CONF_VERIFY_REGISTER,
     CONF_VERIFY_STATE,
-    DEFAULT_HUB,
     MODBUS_DOMAIN,
 )
 
@@ -42,9 +41,9 @@ REGISTERS_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_COMMAND_OFF): cv.positive_int,
         vol.Required(CONF_COMMAND_ON): cv.positive_int,
+        vol.Required(CONF_HUB): cv.string,
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_REGISTER): cv.positive_int,
-        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
         vol.Optional(CONF_REGISTER_TYPE, default=CALL_TYPE_REGISTER_HOLDING): vol.In(
             [CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT]
         ),
@@ -59,9 +58,9 @@ REGISTERS_SCHEMA = vol.Schema(
 COILS_SCHEMA = vol.Schema(
     {
         vol.Required(CALL_TYPE_COIL): cv.positive_int,
+        vol.Required(CONF_HUB): cv.string,
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_SLAVE): cv.positive_int,
-        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
     }
 )
 

--- a/homeassistant/components/stiebel_eltron/__init__.py
+++ b/homeassistant/components/stiebel_eltron/__init__.py
@@ -5,7 +5,7 @@ import logging
 from pystiebeleltron import pystiebeleltron
 import voluptuous as vol
 
-from homeassistant.components.modbus.const import CONF_HUB, DEFAULT_HUB, MODBUS_DOMAIN
+from homeassistant.components.modbus.const import CONF_HUB, MODBUS_DOMAIN
 from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
@@ -17,8 +17,8 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
+                vol.Required(CONF_HUB): cv.string,
                 vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string,
-                vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
             }
         )
     },

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -10,7 +10,6 @@ from homeassistant.components.modbus.const import (
     CONF_REGISTER,
     CONF_REGISTER_TYPE,
     CONF_REGISTERS,
-    DEFAULT_HUB,
     MODBUS_DOMAIN as DOMAIN,
 )
 from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_SCAN_INTERVAL
@@ -18,6 +17,8 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import MockModule, async_fire_time_changed, mock_integration
+
+HUB_NAME = "hub"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,8 +28,8 @@ def mock_hub(hass):
     """Mock hub."""
     mock_integration(hass, MockModule(DOMAIN))
     hub = mock.MagicMock()
-    hub.name = "hub"
-    hass.data[DOMAIN] = {DEFAULT_HUB: hub}
+    hub.name = HUB_NAME
+    hass.data[DOMAIN] = {HUB_NAME: hub}
     return hub
 
 

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.modbus.const import (
     CALL_TYPE_REGISTER_INPUT,
     CONF_COUNT,
     CONF_DATA_TYPE,
+    CONF_HUB,
     CONF_OFFSET,
     CONF_PRECISION,
     CONF_REGISTER_TYPE,
@@ -18,7 +19,7 @@ from homeassistant.components.modbus.const import (
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 
-from .conftest import run_test
+from .conftest import HUB_NAME, run_test
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ async def test_simple_word_register(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -44,7 +46,9 @@ async def test_simple_word_register(hass, mock_hub):
 
 async def test_optional_conf_keys(hass, mock_hub):
     """Test handling of optional configuration keys."""
-    register_config = {}
+    register_config = {
+        CONF_HUB: HUB_NAME,
+    }
     await run_test(
         hass,
         mock_hub,
@@ -63,6 +67,7 @@ async def test_offset(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 13,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -82,6 +87,7 @@ async def test_scale_and_offset(hass, mock_hub):
         CONF_SCALE: 3,
         CONF_OFFSET: 13,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -101,6 +107,7 @@ async def test_ints_can_have_precision(hass, mock_hub):
         CONF_SCALE: 3,
         CONF_OFFSET: 13,
         CONF_PRECISION: 4,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -120,6 +127,7 @@ async def test_floats_get_rounded_correctly(hass, mock_hub):
         CONF_SCALE: 1.5,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -139,6 +147,7 @@ async def test_parameters_as_strings(hass, mock_hub):
         CONF_SCALE: "1.5",
         CONF_OFFSET: "5",
         CONF_PRECISION: "1",
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -158,6 +167,7 @@ async def test_floating_point_scale(hass, mock_hub):
         CONF_SCALE: 2.4,
         CONF_OFFSET: 0,
         CONF_PRECISION: 2,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -177,6 +187,7 @@ async def test_floating_point_offset(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: -10.3,
         CONF_PRECISION: 1,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -196,6 +207,7 @@ async def test_signed_two_word_register(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -215,6 +227,7 @@ async def test_unsigned_two_word_register(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -232,6 +245,7 @@ async def test_reversed(hass, mock_hub):
         CONF_COUNT: 2,
         CONF_DATA_TYPE: DATA_TYPE_UINT,
         CONF_REVERSE_ORDER: True,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -251,6 +265,7 @@ async def test_four_word_register(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -270,6 +285,7 @@ async def test_four_word_register_precision_is_intact_with_int_params(hass, mock
         CONF_SCALE: 2,
         CONF_OFFSET: 3,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -289,6 +305,7 @@ async def test_four_word_register_precision_is_lost_with_float_params(hass, mock
         CONF_SCALE: 2.0,
         CONF_OFFSET: 3.0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -309,6 +326,7 @@ async def test_two_word_input_register(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -329,6 +347,7 @@ async def test_two_word_holding_register(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -349,6 +368,7 @@ async def test_float_data_type(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 5,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,
@@ -369,6 +389,7 @@ async def test_string_data_type(hass, mock_hub):
         CONF_SCALE: 1,
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
+        CONF_HUB: HUB_NAME,
     }
     await run_test(
         hass,


### PR DESCRIPTION
This pull request enforces hub name as a mandatory parameter. At the moment it's entirely optional, which introduces ambiguity.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Modbus hub name was optional. With this change, user has to specify a hub name
to avoid ambiguity in the configuration:
- Set `name` parameter for each Modbus hub
- Set `hub` parameter for each Modbus entity, telling which hub to use

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Here's an example config:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: 127.0.0.1
    port: 5020
  - name: hub2
    type: tcp
    host: 127.0.0.1
    port: 5021

binary_sensor:
  - platform: modbus
    inputs:
      - name: Sensor1
        hub: hub1
        slave: 1
        address: 100
```

To better describe my point, let me show you the following several scenarios:
- If we omit the `hub` parameter from the `binary_sensor`, this parameter will be set to `default`. Such a hub doesn't exist. Home Assistant throws an exception at some point while trying to access a `default` hub. We could add a code, which will set up an alias for the first hub in a list, but I think it's better to make the parameter mandatory instead
- If we don't specify a name for `hub1` and `hub2`, we end up with a non-working configuration. Both hubs are called `default`
- By making the name mandatory, user has to name each hub and reference it in each Modbus entity. This approach should help avoiding configuration errors. Home Assistant config validator doesn't catch such errors - it would be only possible with cross-validation in place to validate configs between entities (i.e., if `binary_sensor` doesn't specify a hub, there should at least one Modbus hub with a default name. Otherwise, the config is invalid).

All examples in the documentation already specify a hub name. Users who copy and paste the sample documentation most likely use the name parameter already. However, if they're calling Modbus services `write_coil` and `write_register` from the automation, they will need to adapt their automation rules to also specify a hub.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#13920

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
