### PR TITLE
Ozw climate fixes

### DIFF
--- a/homeassistant/components/ozw/climate.py
+++ b/homeassistant/components/ozw/climate.py
@@ -182,7 +182,7 @@ class ZWaveClimateEntity(ZWaveDeviceEntity, ClimateEntity):
     @property
     def hvac_modes(self):
         """Return the list of available hvac operation modes."""
-        return list(self._hvac_modes.keys())
+        return list(self._hvac_modes)
 
     @property
     def fan_mode(self):
@@ -227,7 +227,7 @@ class ZWaveClimateEntity(ZWaveDeviceEntity, ClimateEntity):
     @property
     def preset_modes(self):
         """Return the list of available preset operation modes."""
-        return list(self._hvac_presets.keys())
+        return list(self._hvac_presets)
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/ozw/climate.py
+++ b/homeassistant/components/ozw/climate.py
@@ -99,11 +99,13 @@ HVAC_CURRENT_MAPPINGS = {
 
 
 # Map Z-Wave HVAC Mode to Home Assistant value
+# Note: We treat "auto" as "heat_cool" as most Z-Wave devices
+# report auto_changeover as auto without schedule support.
 ZW_HVAC_MODE_MAPPINGS = {
     ThermostatMode.OFF: HVAC_MODE_OFF,
     ThermostatMode.HEAT: HVAC_MODE_HEAT,
     ThermostatMode.COOL: HVAC_MODE_COOL,
-    ThermostatMode.AUTO: HVAC_MODE_AUTO,
+    ThermostatMode.AUTO: HVAC_MODE_HEAT_COOL,
     ThermostatMode.AUXILIARY: HVAC_MODE_HEAT,
     ThermostatMode.FAN: HVAC_MODE_FAN_ONLY,
     ThermostatMode.FURNANCE: HVAC_MODE_HEAT,
@@ -212,19 +214,19 @@ class ZWaveClimateEntity(ZWaveDeviceEntity, ClimateEntity):
     @property
     def preset_mode(self):
         """Return preset operation ie. eco, away."""
-        # Z-Wave uses mode-values > 10 for presets
-        if self.values.mode.value[VALUE_SELECTED_ID] > 10:
+        # Z-Wave uses mode-values > 3 for presets
+        if self.values.mode.value[VALUE_SELECTED_ID] > 3:
             return self.values.mode.value[VALUE_SELECTED_LABEL]
         return PRESET_NONE
 
     @property
     def preset_modes(self):
         """Return the list of available preset operation modes."""
-        # Z-Wave uses mode-values > 10 for presets
+        # Z-Wave uses mode-values > 3 for presets
         return [PRESET_NONE] + [
             val[VALUE_LABEL]
             for val in self.values.mode.value[VALUE_LIST]
-            if val[VALUE_ID] > 10
+            if val[VALUE_ID] > 3
         ]
 
     @property

--- a/tests/components/ozw/test_climate.py
+++ b/tests/components/ozw/test_climate.py
@@ -10,9 +10,9 @@ from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     CURRENT_HVAC_IDLE,
-    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
 )
 
@@ -32,7 +32,7 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
         HVAC_MODE_OFF,
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
-        HVAC_MODE_AUTO,
+        HVAC_MODE_HEAT_COOL,
     ]
     assert state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 23.1
@@ -60,7 +60,7 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
     await hass.services.async_call(
         "climate",
         "set_hvac_mode",
-        {"entity_id": "climate.ct32_thermostat_mode", "hvac_mode": HVAC_MODE_AUTO},
+        {"entity_id": "climate.ct32_thermostat_mode", "hvac_mode": HVAC_MODE_HEAT_COOL},
         blocking=True,
     )
     assert len(sent_messages) == 2
@@ -106,7 +106,7 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
     await hass.async_block_till_done()
     state = hass.states.get("climate.ct32_thermostat_mode")
     assert state is not None
-    assert state.state == HVAC_MODE_AUTO
+    assert state.state == HVAC_MODE_HEAT_COOL
     assert state.attributes.get(ATTR_TEMPERATURE) is None
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 21.1
     assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 25.6


### PR DESCRIPTION
## Proposed change
Auto mode in the Z-Wave world is not considered the same in the Hass world. After this change, Zwave's auto mode is translated into heat/cool mode in Hass as discussed here: https://github.com/home-assistant/core/issues/35957

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes #35957
- This PR is related to issue: #35957
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

