### PR TITLE
Fix Plex client controls when connected via plex.tv resource

### DIFF
--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -318,6 +318,8 @@ class PlexServer:
                 _LOGGER.debug("plex.tv resource connection successful: %s", client)
             except NotFound:
                 _LOGGER.error("plex.tv resource connection failed: %s", resource.name)
+            else:
+                client.proxyThroughServer(value=False, server=self._plex_server)
 
             self._plextv_device_cache[client_id] = client
             return client

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -229,6 +229,10 @@ class MockPlexClient:
         """Mock the version attribute."""
         return "1.0"
 
+    def proxyThroughServer(self, value=True, server=None):
+        """Mock the proxyThroughServer method."""
+        pass
+
     def playMedia(self, item):
         """Mock the playMedia method."""
         pass


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the ability to control Plex clients when they're found via plex.tv resources instead of the Plex server. A Plex server must be explicitly assigned to allow playing media to these clients.

Example backtrace of problems:
```
  File "/home/homeassistant/.pyenv/versions/3.8.3/envs/prod383/lib/python3.8/site-packages/homeassistant/components/plex/media_player.py", line 588, in play_media
    self.device.playMedia(playqueue)
  File "/home/homeassistant/.pyenv/versions/3.8.3/envs/prod383/lib/python3.8/site-packages/plexapi/client.py", line 473, in playMedia
    raise Unsupported('A server must be specified before using this command.')
plexapi.exceptions.Unsupported: A server must be specified before using this command.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
