### PR TITLE
Downgrading the python-gammu requirement from 3.0 to 2.11 temporarily

### DIFF
--- a/homeassistant/components/sms/manifest.json
+++ b/homeassistant/components/sms/manifest.json
@@ -3,6 +3,6 @@
   "name": "SMS notifications via GSM-modem",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sms",
-  "requirements": ["python-gammu==3.0"],
+  "requirements": ["python-gammu==2.11"],
   "codeowners": ["@ocalvo"]
 }


### PR DESCRIPTION
For trying to solve temporarily this issue: https://github.com/home-assistant/docker/issues/119

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

N/A


## Proposed change

Downgraging to the python-gammu 2.11, the one with Gammu 1.39, that allows incoming sms to work properly.

## Type of change

- [x] Dependency **down**grade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

N/A

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/docker/issues/119
- This PR is related to issue:  https://github.com/home-assistant/docker/issues/119
- Link to documentation pull request: N/A

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
