### PR TITLE
0.112.3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,7 +59,7 @@ homeassistant/components/blink/* @fronzbot
 homeassistant/components/bmp280/* @belidzs
 homeassistant/components/bmw_connected_drive/* @gerard33 @rikroe
 homeassistant/components/bom/* @maddenp
-homeassistant/components/braviatv/* @robbiet480 @bieniu
+homeassistant/components/braviatv/* @bieniu
 homeassistant/components/broadlink/* @danielhiversen @felipediel
 homeassistant/components/brother/* @bieniu
 homeassistant/components/brunt/* @eavanvalkenburg

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -55,7 +55,8 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.braviarc.connect, pin, CLIENTID_PREFIX, NICKNAME
         )
 
-        if not self.braviarc.is_connected():
+        connected = await self.hass.async_add_executor_job(self.braviarc.is_connected)
+        if not connected:
             raise CannotConnect()
 
         system_info = await self.hass.async_add_executor_job(
@@ -161,7 +162,8 @@ class BraviaTVOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         self.braviarc = self.hass.data[DOMAIN][self.config_entry.entry_id][BRAVIARC]
-        if not self.braviarc.is_connected():
+        connected = await self.hass.async_add_executor_job(self.braviarc.is_connected)
+        if not connected:
             await self.hass.async_add_executor_job(
                 self.braviarc.connect, self.pin, CLIENTID_PREFIX, NICKNAME
             )

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "braviatv",
   "name": "Sony Bravia TV",
   "documentation": "https://www.home-assistant.io/integrations/braviatv",
-  "requirements": ["bravia-tv==1.0.5"],
-  "codeowners": ["@robbiet480", "@bieniu"],
+  "requirements": ["bravia-tv==1.0.6"],
+  "codeowners": ["@bieniu"],
   "config_flow": true
 }

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -148,33 +148,31 @@ class BraviaTVDevice(MediaPlayerEntity):
         self._device_info = device_info
         self._ignored_sources = ignored_sources
         self._state_lock = asyncio.Lock()
-        self._need_refresh = True
 
     async def async_update(self):
         """Update TV info."""
         if self._state_lock.locked():
             return
 
-        if self._state == STATE_OFF:
-            self._need_refresh = True
-
         power_status = await self.hass.async_add_executor_job(
             self._braviarc.get_power_status
         )
-        if power_status == "active":
-            if self._need_refresh:
+
+        if power_status != "off":
+            connected = await self.hass.async_add_executor_job(
+                self._braviarc.is_connected
+            )
+            if not connected:
                 try:
                     connected = await self.hass.async_add_executor_job(
                         self._braviarc.connect, self._pin, CLIENTID_PREFIX, NICKNAME
                     )
                 except NoIPControl:
                     _LOGGER.error("IP Control is disabled in the TV settings")
-                self._need_refresh = False
-            else:
-                connected = self._braviarc.is_connected()
             if not connected:
-                return
+                power_status = "off"
 
+        if power_status == "active":
             self._state = STATE_ON
             if (
                 await self._async_refresh_volume()

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "denonavr"
 
 SUPPORTED_MANUFACTURERS = ["Denon", "DENON", "Marantz"]
+IGNORED_MODELS = ["HEOS 1", "HEOS 3", "HEOS 5", "HEOS 7"]
 
 CONF_SHOW_ALL_SOURCES = "show_all_sources"
 CONF_ZONE2 = "zone2"
@@ -216,6 +217,9 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.model_name = discovery_info[ssdp.ATTR_UPNP_MODEL_NAME].replace("*", "")
         self.serial_number = discovery_info[ssdp.ATTR_UPNP_SERIAL]
         self.host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
+
+        if self.model_name in IGNORED_MODELS:
+            return self.async_abort(reason="not_denonavr_manufacturer")
 
         unique_id = self.construct_unique_id(self.model_name, self.serial_number)
         await self.async_set_unique_id(unique_id)

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -2,7 +2,7 @@
   "domain": "frontend",
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
-  "requirements": ["home-assistant-frontend==20200702.0"],
+  "requirements": ["home-assistant-frontend==20200702.1"],
   "dependencies": [
     "api",
     "auth",

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -431,7 +431,7 @@ class TelevisionMediaPlayer(HomeAccessory):
                 index = self.sources.index(source_name)
                 if self.char_input_source.value != index:
                     self.char_input_source.set_value(index)
-            else:
+            elif hk_state:
                 _LOGGER.warning(
                     "%s: Sources out of sync. Restart Home Assistant", self.entity_id,
                 )

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -280,7 +280,6 @@ class TelevisionMediaPlayer(HomeAccessory):
 
         serv_tv = self.add_preload_service(SERV_TELEVISION, self.chars_tv)
         self.set_primary_service(serv_tv)
-        serv_tv.configure_char(CHAR_CONFIGURED_NAME, value=self.display_name)
         serv_tv.configure_char(CHAR_SLEEP_DISCOVER_MODE, value=True)
         self.char_active = serv_tv.configure_char(
             CHAR_ACTIVE, setter_callback=self.set_on_off

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import time
 
+import sqlalchemy
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import aliased
 import voluptuous as vol
@@ -28,7 +29,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_NAME,
-    ATTR_UNIT_OF_MEASUREMENT,
     CONF_EXCLUDE,
     CONF_INCLUDE,
     EVENT_HOMEASSISTANT_START,
@@ -66,6 +66,8 @@ DOMAIN = "logbook"
 GROUP_BY_MINUTES = 15
 
 EMPTY_JSON_OBJECT = "{}"
+UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
+
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA}, extra=vol.ALLOW_EXTRA
 )
@@ -420,6 +422,15 @@ def _get_events(hass, config, start_day, end_day, entity_id=None):
                     & (States.state != old_state.state)
                 )
             )
+            #
+            # Prefilter out continuous domains that have
+            # ATTR_UNIT_OF_MEASUREMENT as its much faster in sql.
+            #
+            .filter(
+                (Events.event_type != EVENT_STATE_CHANGED)
+                | sqlalchemy.not_(States.domain.in_(CONTINUOUS_DOMAINS))
+                | sqlalchemy.not_(States.attributes.contains(UNIT_OF_MEASUREMENT_JSON))
+            )
             .filter(
                 Events.event_type.in_(ALL_EVENT_TYPES + list(hass.data.get(DOMAIN, {})))
             )
@@ -454,12 +465,6 @@ def _keep_event(hass, event, entities_filter, entity_attr_cache):
         # Do not report on new entities
         # Do not report on entity removal
         if not event.has_old_and_new_state:
-            return False
-
-        if event.domain in CONTINUOUS_DOMAINS and entity_attr_cache.get(
-            entity_id, ATTR_UNIT_OF_MEASUREMENT, event
-        ):
-            # Don't show continuous sensor value changes in the logbook
             return False
     elif event.event_type in HOMEASSISTANT_EVENTS:
         entity_id = f"{HA_DOMAIN}."

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -104,9 +104,9 @@ async def async_start(
             base = payload.pop(TOPIC_BASE)
             for key, value in payload.items():
                 if isinstance(value, str) and value:
-                    if value[0] == TOPIC_BASE and key.endswith("_topic"):
+                    if value[0] == TOPIC_BASE and key.endswith("topic"):
                         payload[key] = f"{base}{value[1:]}"
-                    if value[-1] == TOPIC_BASE and key.endswith("_topic"):
+                    if value[-1] == TOPIC_BASE and key.endswith("topic"):
                         payload[key] = f"{value[:-1]}{base}"
 
         # If present, the node_id will be included in the discovered object id

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -326,6 +326,8 @@ class PlexServer:
                 _LOGGER.debug("plex.tv resource connection successful: %s", client)
             except NotFound:
                 _LOGGER.error("plex.tv resource connection failed: %s", resource.name)
+            else:
+                client.proxyThroughServer(value=False, server=self._plex_server)
 
             self._plextv_device_cache[client_id] = client
             return client

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -386,11 +386,14 @@ class Recorder(threading.Thread):
             if dbevent and event.event_type == EVENT_STATE_CHANGED:
                 try:
                     dbstate = States.from_event(event)
+                    has_new_state = event.data.get("new_state")
                     dbstate.old_state_id = self._old_state_ids.get(dbstate.entity_id)
+                    if not has_new_state:
+                        dbstate.state = None
                     dbstate.event_id = dbevent.event_id
                     self.event_session.add(dbstate)
                     self.event_session.flush()
-                    if "new_state" in event.data:
+                    if has_new_state:
                         self._old_state_ids[dbstate.entity_id] = dbstate.state_id
                     elif dbstate.entity_id in self._old_state_ids:
                         del self._old_state_ids[dbstate.entity_id]

--- a/homeassistant/components/speedtestdotnet/config_flow.py
+++ b/homeassistant/components/speedtestdotnet/config_flow.py
@@ -85,7 +85,7 @@ class SpeedTestOptionsFlowHandler(config_entries.OptionsFlow):
 
         self._servers = self.hass.data[DOMAIN].servers
 
-        server_name = DEFAULT_SERVER
+        server = []
         if self.config_entry.options.get(
             CONF_SERVER_ID
         ) and not self.config_entry.options.get(CONF_SERVER_NAME):
@@ -94,7 +94,7 @@ class SpeedTestOptionsFlowHandler(config_entries.OptionsFlow):
                 for (key, value) in self._servers.items()
                 if value.get("id") == self.config_entry.options[CONF_SERVER_ID]
             ]
-            server_name = server[0] if server else ""
+        server_name = server[0] if server else DEFAULT_SERVER
 
         options = {
             vol.Optional(

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -2,7 +2,8 @@
 import logging
 
 from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.helpers.entity import Entity
+from homeassistant.core import callback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     ATTR_BYTES_RECEIVED,
@@ -11,6 +12,7 @@ from .const import (
     ATTR_SERVER_ID,
     ATTR_SERVER_NAME,
     ATTRIBUTION,
+    CONF_MANUAL,
     DEFAULT_NAME,
     DOMAIN,
     ICON,
@@ -32,7 +34,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(entities)
 
 
-class SpeedtestSensor(Entity):
+class SpeedtestSensor(RestoreEntity):
     """Implementation of a speedtest.net sensor."""
 
     def __init__(self, coordinator, sensor_type):
@@ -41,6 +43,7 @@ class SpeedtestSensor(Entity):
         self.coordinator = coordinator
         self.type = sensor_type
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
+        self._state = None
 
     @property
     def name(self):
@@ -55,14 +58,7 @@ class SpeedtestSensor(Entity):
     @property
     def state(self):
         """Return the state of the device."""
-        state = None
-        if self.type == "ping":
-            state = self.coordinator.data["ping"]
-        elif self.type == "download":
-            state = round(self.coordinator.data["download"] / 10 ** 6, 2)
-        elif self.type == "upload":
-            state = round(self.coordinator.data["upload"] / 10 ** 6, 2)
-        return state
+        return self._state
 
     @property
     def unit_of_measurement(self):
@@ -82,6 +78,8 @@ class SpeedtestSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
+        if not self.coordinator.data:
+            return None
         attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             ATTR_SERVER_NAME: self.coordinator.data["server"]["name"],
@@ -98,10 +96,30 @@ class SpeedtestSensor(Entity):
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        if self.coordinator.config_entry.options[CONF_MANUAL]:
+            state = await self.async_get_last_state()
+            if state:
+                self._state = state.state
 
-        self.async_on_remove(
-            self.coordinator.async_add_listener(self.async_write_ha_state)
-        )
+        @callback
+        def update():
+            """Update state."""
+            self._update_state()
+            self.async_write_ha_state()
+
+        self.async_on_remove(self.coordinator.async_add_listener(update))
+        self._update_state()
+
+    def _update_state(self):
+        """Update sensors state."""
+        if self.coordinator.data:
+            if self.type == "ping":
+                self._state = self.coordinator.data["ping"]
+            elif self.type == "download":
+                self._state = round(self.coordinator.data["download"] / 10 ** 6, 2)
+            elif self.type == "upload":
+                self._state = round(self.coordinator.data["upload"] / 10 ** 6, 2)
 
     async def async_update(self):
         """Request coordinator to update data."""

--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -5,7 +5,7 @@ import requests
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_POWER,
-    BinarySensorDevice,
+    BinarySensorEntity,
 )
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 
@@ -77,7 +77,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     )
 
 
-class ViCareBinarySensor(BinarySensorDevice):
+class ViCareBinarySensor(BinarySensorEntity):
     """Representation of a ViCare sensor."""
 
     def __init__(self, name, api, sensor_type):

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -450,7 +450,7 @@ WITHINGS_ATTRIBUTES = [
         NotifyAppli.BED_IN,
         "In bed",
         "",
-        "mdi:bed",
+        "mdi:hotel",
         BINARY_SENSOR_DOMAIN,
         True,
         UpdateType.WEBHOOK,

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 112
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ defusedxml==0.6.0
 distro==1.5.0
 emoji==0.5.4
 hass-nabucasa==0.34.7
-home-assistant-frontend==20200702.0
+home-assistant-frontend==20200702.1
 importlib-metadata==1.6.0;python_version<'3.8'
 jinja2>=2.11.1
 netdisco==2.7.1

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -186,7 +186,7 @@ async def _logbook_filtering(hass, last_changed, last_updated):
     def yield_events(event):
         for _ in range(10 ** 5):
             # pylint: disable=protected-access
-            if logbook._keep_event(hass, event, entities_filter, entity_attr_cache):
+            if logbook._keep_event(hass, event, entities_filter):
                 yield event
 
     start = timer()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ hole==0.5.1
 holidays==0.10.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20200702.0
+home-assistant-frontend==20200702.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -374,7 +374,7 @@ bomradarloop==0.1.4
 boto3==1.9.252
 
 # homeassistant.components.braviatv
-bravia-tv==1.0.5
+bravia-tv==1.0.6
 
 # homeassistant.components.broadlink
 broadlink==0.14.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -343,7 +343,7 @@ hole==0.5.1
 holidays==0.10.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20200702.0
+home-assistant-frontend==20200702.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -177,7 +177,7 @@ blinkpy==0.15.0
 bomradarloop==0.1.4
 
 # homeassistant.components.braviatv
-bravia-tv==1.0.5
+bravia-tv==1.0.6
 
 # homeassistant.components.broadlink
 broadlink==0.14.0

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -23,6 +23,7 @@ TEST_MAC = "ab:cd:ef:gh"
 TEST_HOST2 = "5.6.7.8"
 TEST_NAME = "Test_Receiver"
 TEST_MODEL = "model5"
+TEST_IGNORED_MODEL = "HEOS 7"
 TEST_RECEIVER_TYPE = "avr-x"
 TEST_SERIALNUMBER = "123456789"
 TEST_MANUFACTURER = "Denon"
@@ -468,6 +469,27 @@ async def test_config_flow_ssdp_missing_info(hass):
 
     assert result["type"] == "abort"
     assert result["reason"] == "not_denonavr_missing"
+
+
+async def test_config_flow_ssdp_ignored_model(hass):
+    """
+    Failed flow initialized by ssdp discovery.
+
+    Model in the ignored models list.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data={
+            ssdp.ATTR_UPNP_MANUFACTURER: TEST_MANUFACTURER,
+            ssdp.ATTR_UPNP_MODEL_NAME: TEST_IGNORED_MODEL,
+            ssdp.ATTR_UPNP_SERIAL: TEST_SERIALNUMBER,
+            ssdp.ATTR_SSDP_LOCATION: TEST_SSDP_LOCATION,
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_denonavr_manufacturer"
 
 
 async def test_options_flow(hass):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -165,83 +165,6 @@ class TestComponentLogbook(unittest.TestCase):
             entries[1], pointC, "bla", domain="sensor", entity_id=entity_id
         )
 
-    def test_exclude_new_entities(self):
-        """Test if events are excluded on first update."""
-        entity_id = "sensor.bla"
-        entity_id2 = "sensor.blu"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        state_on = ha.State(
-            entity_id, "on", {"brightness": 200}, pointA, pointA
-        ).as_dict()
-
-        eventA = self.create_state_changed_event_from_old_new(
-            entity_id, pointA, None, state_on
-        )
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        entities_filter = convert_include_exclude_filter(
-            logbook.CONFIG_SCHEMA({logbook.DOMAIN: {}})[logbook.DOMAIN]
-        )
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_STOP),
-                eventA,
-                eventB,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
-
-        assert len(entries) == 2
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_exclude_removed_entities(self):
-        """Test if events are excluded on last update."""
-        entity_id = "sensor.bla"
-        entity_id2 = "sensor.blu"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        state_on = ha.State(
-            entity_id, "on", {"brightness": 200}, pointA, pointA
-        ).as_dict()
-        eventA = self.create_state_changed_event_from_old_new(
-            None, pointA, state_on, None,
-        )
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        entities_filter = convert_include_exclude_filter(
-            logbook.CONFIG_SCHEMA({logbook.DOMAIN: {}})[logbook.DOMAIN]
-        )
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_STOP),
-                eventA,
-                eventB,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
-
-        assert len(entries) == 2
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
     def test_exclude_events_entity(self):
         """Test if events are filtered if entity is excluded in config."""
         entity_id = "sensor.bla"
@@ -267,7 +190,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -305,7 +228,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -352,7 +275,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB,
                 eventC,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -394,7 +317,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -440,7 +363,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -494,7 +417,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB,
                 eventC,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -551,7 +474,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB1,
                 eventB2,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -625,7 +548,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventC2,
                 eventC3,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -677,7 +600,7 @@ class TestComponentLogbook(unittest.TestCase):
         events = [
             e
             for e in (eventA, eventB)
-            if logbook._keep_event(self.hass, e, entities_filter, entity_attr_cache)
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
 
@@ -1833,6 +1756,83 @@ async def test_filter_continuous_sensor_values(hass, hass_client):
     assert len(response_json) == 2
     assert response_json[0]["entity_id"] == entity_id_test
     assert response_json[1]["entity_id"] == entity_id_third
+
+
+async def test_exclude_new_entities(hass, hass_client):
+    """Test if events are excluded on first update."""
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", {})
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    entity_id = "climate.bla"
+    entity_id2 = "climate.blu"
+
+    hass.states.async_set(entity_id, STATE_OFF)
+    hass.states.async_set(entity_id2, STATE_ON)
+    hass.states.async_set(entity_id2, STATE_OFF)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    await hass.async_add_job(partial(trigger_db_commit, hass))
+    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    client = await hass_client()
+
+    # Today time 00:00:00
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day)
+
+    # Test today entries without filters
+    response = await client.get(f"/api/logbook/{start_date.isoformat()}")
+    assert response.status == 200
+    response_json = await response.json()
+
+    assert len(response_json) == 2
+    assert response_json[0]["entity_id"] == entity_id2
+    assert response_json[1]["domain"] == "homeassistant"
+    assert response_json[1]["message"] == "started"
+
+
+async def test_exclude_removed_entities(hass, hass_client):
+    """Test if events are excluded on last update."""
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", {})
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    entity_id = "climate.bla"
+    entity_id2 = "climate.blu"
+
+    hass.states.async_set(entity_id, STATE_ON)
+    hass.states.async_set(entity_id, STATE_OFF)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    hass.states.async_set(entity_id2, STATE_ON)
+    hass.states.async_set(entity_id2, STATE_OFF)
+
+    hass.states.async_remove(entity_id)
+    hass.states.async_remove(entity_id2)
+
+    await hass.async_add_job(partial(trigger_db_commit, hass))
+    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    client = await hass_client()
+
+    # Today time 00:00:00
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day)
+
+    # Test today entries without filters
+    response = await client.get(f"/api/logbook/{start_date.isoformat()}")
+    assert response.status == 200
+    response_json = await response.json()
+
+    assert len(response_json) == 3
+    assert response_json[0]["entity_id"] == entity_id
+    assert response_json[1]["domain"] == "homeassistant"
+    assert response_json[1]["message"] == "started"
+    assert response_json[2]["entity_id"] == entity_id2
 
 
 class MockLazyEventPartialState(ha.Event):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -20,6 +20,8 @@ from homeassistant.const import (
     ATTR_NAME,
     CONF_DOMAINS,
     CONF_ENTITIES,
+    CONF_EXCLUDE,
+    CONF_INCLUDE,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
     EVENT_STATE_CHANGED,
@@ -254,7 +256,7 @@ class TestComponentLogbook(unittest.TestCase):
         config = logbook.CONFIG_SCHEMA(
             {
                 ha.DOMAIN: {},
-                logbook.DOMAIN: {logbook.CONF_EXCLUDE: {CONF_ENTITIES: [entity_id]}},
+                logbook.DOMAIN: {CONF_EXCLUDE: {CONF_ENTITIES: [entity_id]}},
             }
         )
         entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
@@ -291,9 +293,7 @@ class TestComponentLogbook(unittest.TestCase):
         config = logbook.CONFIG_SCHEMA(
             {
                 ha.DOMAIN: {},
-                logbook.DOMAIN: {
-                    logbook.CONF_EXCLUDE: {CONF_DOMAINS: ["switch", "alexa"]}
-                },
+                logbook.DOMAIN: {CONF_EXCLUDE: {CONF_DOMAINS: ["switch", "alexa"]}},
             }
         )
         entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
@@ -335,7 +335,7 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_EXCLUDE: {
+                    CONF_EXCLUDE: {
                         CONF_DOMAINS: ["switch", "alexa"],
                         CONF_ENTITY_GLOBS: "*.excluded",
                     }
@@ -379,7 +379,7 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_INCLUDE: {
+                    CONF_INCLUDE: {
                         CONF_DOMAINS: ["homeassistant"],
                         CONF_ENTITIES: [entity_id2],
                     }
@@ -427,9 +427,7 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_INCLUDE: {
-                        CONF_DOMAINS: ["homeassistant", "sensor", "alexa"]
-                    }
+                    CONF_INCLUDE: {CONF_DOMAINS: ["homeassistant", "sensor", "alexa"]}
                 },
             }
         )
@@ -479,7 +477,7 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_INCLUDE: {
+                    CONF_INCLUDE: {
                         CONF_DOMAINS: ["homeassistant", "sensor", "alexa"],
                         CONF_ENTITY_GLOBS: ["*.included"],
                     }
@@ -531,11 +529,11 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_INCLUDE: {
+                    CONF_INCLUDE: {
                         CONF_DOMAINS: ["sensor", "homeassistant"],
                         CONF_ENTITIES: ["switch.bla"],
                     },
-                    logbook.CONF_EXCLUDE: {
+                    CONF_EXCLUDE: {
                         CONF_DOMAINS: ["switch"],
                         CONF_ENTITIES: ["sensor.bli"],
                     },
@@ -600,12 +598,12 @@ class TestComponentLogbook(unittest.TestCase):
             {
                 ha.DOMAIN: {},
                 logbook.DOMAIN: {
-                    logbook.CONF_INCLUDE: {
+                    CONF_INCLUDE: {
                         CONF_DOMAINS: ["sensor", "homeassistant"],
                         CONF_ENTITIES: ["switch.bla"],
                         CONF_ENTITY_GLOBS: ["*.included"],
                     },
-                    logbook.CONF_EXCLUDE: {
+                    CONF_EXCLUDE: {
                         CONF_DOMAINS: ["switch"],
                         CONF_ENTITY_GLOBS: ["*.excluded"],
                         CONF_ENTITIES: ["sensor.bli"],
@@ -1631,10 +1629,7 @@ async def test_exclude_described_event(hass, hass_client):
         logbook.DOMAIN,
         {
             logbook.DOMAIN: {
-                logbook.CONF_EXCLUDE: {
-                    CONF_DOMAINS: ["sensor"],
-                    CONF_ENTITIES: [entity_id],
-                }
+                CONF_EXCLUDE: {CONF_DOMAINS: ["sensor"], CONF_ENTITIES: [entity_id]}
             }
         },
     )

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -163,22 +163,6 @@ class TestComponentLogbook(unittest.TestCase):
             entries[1], pointC, "bla", domain="sensor", entity_id=entity_id
         )
 
-    def test_filter_continuous_sensor_values(self):
-        """Test remove continuous sensor events from logbook."""
-        entity_id = "sensor.bla"
-        pointA = dt_util.utcnow()
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-        attributes = {"unit_of_measurement": "foo"}
-        eventA = self.create_state_changed_event(pointA, entity_id, 10, attributes)
-
-        entities_filter = convert_include_exclude_filter(
-            logbook.CONFIG_SCHEMA({logbook.DOMAIN: {}})[logbook.DOMAIN]
-        )
-        assert (
-            logbook._keep_event(self.hass, eventA, entities_filter, entity_attr_cache)
-            is False
-        )
-
     def test_exclude_new_entities(self):
         """Test if events are excluded on first update."""
         entity_id = "sensor.bla"
@@ -1818,6 +1802,42 @@ async def test_logbook_entity_filter_with_automations(hass, hass_client):
     json_dict = await response.json()
     assert len(json_dict) == 1
     assert json_dict[0]["entity_id"] == entity_id_second
+
+
+async def test_filter_continuous_sensor_values(hass, hass_client):
+    """Test remove continuous sensor events from logbook."""
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", {})
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    entity_id_test = "switch.test"
+    hass.states.async_set(entity_id_test, STATE_OFF)
+    hass.states.async_set(entity_id_test, STATE_ON)
+    entity_id_second = "sensor.bla"
+    hass.states.async_set(entity_id_second, STATE_OFF, {"unit_of_measurement": "foo"})
+    hass.states.async_set(entity_id_second, STATE_ON, {"unit_of_measurement": "foo"})
+    entity_id_third = "light.bla"
+    hass.states.async_set(entity_id_third, STATE_OFF, {"unit_of_measurement": "foo"})
+    hass.states.async_set(entity_id_third, STATE_ON, {"unit_of_measurement": "foo"})
+
+    await hass.async_add_job(partial(trigger_db_commit, hass))
+    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    client = await hass_client()
+
+    # Today time 00:00:00
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day)
+
+    # Test today entries without filters
+    response = await client.get(f"/api/logbook/{start_date.isoformat()}")
+    assert response.status == 200
+    response_json = await response.json()
+
+    assert len(response_json) == 2
+    assert response_json[0]["entity_id"] == entity_id_test
+    assert response_json[1]["entity_id"] == entity_id_third
 
 
 class MockLazyEventPartialState(ha.Event):

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -229,6 +229,10 @@ class MockPlexClient:
         """Mock the version attribute."""
         return "1.0"
 
+    def proxyThroughServer(self, value=True, server=None):
+        """Mock the proxyThroughServer method."""
+        pass
+
     def playMedia(self, item):
         """Mock the playMedia method."""
         pass


### PR DESCRIPTION
- Move logbook continuous domain filtering to sql ([@bdraco] - [#37115]) ([logbook docs])
- Ensure logbook performs well when filtering is configured ([@bdraco] - [#37292]) ([logbook docs])
- Ensure removed entities are not displayed in logbook ([@bdraco] - [#37395]) ([logbook docs]) ([recorder docs])
- Stop Speedtest sensors update on startup if manual option is enabled ([@engrbm87] - [#37403]) ([speedtestdotnet docs])
- Fix base topic for 'topic' ([@emontnemery] - [#37475]) ([mqtt docs])
- Fix base class for ViCare binary sensor to remove warning ([@crazyfx1] - [#37478]) ([vicare docs])
- Fix braviatv authentication refresh ([@dcnielsen90] - [#37482]) ([braviatv docs])
- Fix default icon for Withings sleep sensor ([@SeanPM5] - [#37502]) ([withings docs])
- Update frontend to 20200702.1 ([@bramkragten] - [#37566]) ([frontend docs])
- Suppress spurious homekit warning about media player sources when the device is off ([@bdraco] - [#37567]) ([homekit docs])
- Ensure homekit tv names can be saved ([@bdraco] - [#37571]) ([homekit docs])
- Fix Plex client controls when connected via plex.tv resource ([@jjlawren] - [#37572]) ([plex docs])
- Ignore HEOS 1, 3, 5 and 7 for DenonAvr ssdp discovery ([@starkillerOG] - [#37579]) ([denonavr docs])

[#37115]: https://github.com/home-assistant/core/pull/37115
[#37292]: https://github.com/home-assistant/core/pull/37292
[#37395]: https://github.com/home-assistant/core/pull/37395
[#37403]: https://github.com/home-assistant/core/pull/37403
[#37475]: https://github.com/home-assistant/core/pull/37475
[#37478]: https://github.com/home-assistant/core/pull/37478
[#37482]: https://github.com/home-assistant/core/pull/37482
[#37502]: https://github.com/home-assistant/core/pull/37502
[#37566]: https://github.com/home-assistant/core/pull/37566
[#37567]: https://github.com/home-assistant/core/pull/37567
[#37571]: https://github.com/home-assistant/core/pull/37571
[#37572]: https://github.com/home-assistant/core/pull/37572
[#37579]: https://github.com/home-assistant/core/pull/37579
[@SeanPM5]: https://github.com/SeanPM5
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[@crazyfx1]: https://github.com/crazyfx1
[@dcnielsen90]: https://github.com/dcnielsen90
[@emontnemery]: https://github.com/emontnemery
[@engrbm87]: https://github.com/engrbm87
[@jjlawren]: https://github.com/jjlawren
[@starkillerOG]: https://github.com/starkillerOG
[braviatv docs]: https://www.home-assistant.io/integrations/braviatv/
[denonavr docs]: https://www.home-assistant.io/integrations/denonavr/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[logbook docs]: https://www.home-assistant.io/integrations/logbook/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[plex docs]: https://www.home-assistant.io/integrations/plex/
[recorder docs]: https://www.home-assistant.io/integrations/recorder/
[speedtestdotnet docs]: https://www.home-assistant.io/integrations/speedtestdotnet/
[vicare docs]: https://www.home-assistant.io/integrations/vicare/
[withings docs]: https://www.home-assistant.io/integrations/withings/