### PR TITLE
Fix smappee supported configurations and device class for voltage sensors

### DIFF
--- a/homeassistant/components/smappee/sensor.py
+++ b/homeassistant/components/smappee/sensor.py
@@ -88,48 +88,48 @@ VOLTAGE_SENSORS = {
         "mdi:flash",
         VOLT,
         "phase_voltage_a",
-        ["ONE", "TWO", "THREE_STAR", "THREE_DELTA"],
         None,
+        ["ONE", "TWO", "THREE_STAR", "THREE_DELTA"],
     ],
     "phase_voltages_b": [
         "Phase voltages - B",
         "mdi:flash",
         VOLT,
         "phase_voltage_b",
-        ["TWO", "THREE_STAR", "THREE_DELTA"],
         None,
+        ["TWO", "THREE_STAR", "THREE_DELTA"],
     ],
     "phase_voltages_c": [
         "Phase voltages - C",
         "mdi:flash",
         VOLT,
         "phase_voltage_c",
-        ["THREE_STAR"],
         None,
+        ["THREE_STAR"],
     ],
     "line_voltages_a": [
         "Line voltages - A",
         "mdi:flash",
         VOLT,
         "line_voltage_a",
-        ["ONE", "TWO", "THREE_STAR", "THREE_DELTA"],
         None,
+        ["ONE", "TWO", "THREE_STAR", "THREE_DELTA"],
     ],
     "line_voltages_b": [
         "Line voltages - B",
         "mdi:flash",
         VOLT,
         "line_voltage_b",
-        ["TWO", "THREE_STAR", "THREE_DELTA"],
         None,
+        ["TWO", "THREE_STAR", "THREE_DELTA"],
     ],
     "line_voltages_c": [
         "Line voltages - C",
         "mdi:flash",
         VOLT,
         "line_voltage_c",
-        ["THREE_STAR", "THREE_DELTA"],
         None,
+        ["THREE_STAR", "THREE_DELTA"],
     ],
 }
 
@@ -182,7 +182,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         # Add phase- and line voltages
         for sensor_name, sensor in VOLTAGE_SENSORS.items():
-            if service_location.phase_type in sensor[4]:
+            if service_location.phase_type in sensor[5]:
                 entities.append(
                     SmappeeSensor(
                         smappee_base=smappee_base,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Smappee sensors set the device class to a list.  This prevented HomeKit from starting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
smappee:
    client_id: 1234
    client_secret: 5678
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/37489, fixes https://github.com/home-assistant/core/issues/37573
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
