### PR TITLE
Bump aiohomekit to 0.2.41

### DIFF
--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.38"],
+  "requirements": ["aiohomekit[IP]==0.2.41"],
   "zeroconf": ["_hap._tcp.local."],
   "codeowners": ["@Jc2k"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioguardian==1.0.0
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.38
+aiohomekit[IP]==0.2.41
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ aioguardian==1.0.0
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.38
+aiohomekit[IP]==0.2.41
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump aiohomekit to 0.2.41 to fix rounding behaviour.

Floats (such as temperature) should be clamped according to the minStep metadata of the device. For example, if the target temperature has a min of `20` and a minStep of `.5` then `21.324` should round to `21.5`.

Most devices are tolerant of the current behaviour but the Honeywell T6 Pro is not. This is especially problematic when the Home Assistant user is not using Celsius as only some temperatures convert cleanly.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37083
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works. - the tests are upstream in aiohomekit, though.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
