### PR TITLE
Fix acmeda syn/async cover methods

### DIFF
--- a/homeassistant/components/acmeda/cover.py
+++ b/homeassistant/components/acmeda/cover.py
@@ -61,7 +61,7 @@ class AcmedaCover(AcmedaBase, CoverEntity):
         None is unknown, 0 is closed, 100 is fully open.
         """
         position = None
-        if self.roller.type == 7 or self.roller.type == 10:
+        if self.roller.type in [7, 10]:
             position = 100 - self.roller.closed_percent
         return position
 
@@ -86,37 +86,36 @@ class AcmedaCover(AcmedaBase, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        is_closed = self.roller.closed_percent == 100
-        return is_closed
+        return self.roller.closed_percent == 100
 
-    async def close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs):
         """Close the roller."""
         await self.roller.move_down()
 
-    async def open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs):
         """Open the roller."""
         await self.roller.move_up()
 
-    async def stop_cover(self, **kwargs):
+    async def async_stop_cover(self, **kwargs):
         """Stop the roller."""
         await self.roller.move_stop()
 
-    async def set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs):
         """Move the roller shutter to a specific position."""
         await self.roller.move_to(100 - kwargs[ATTR_POSITION])
 
-    async def close_cover_tilt(self, **kwargs):
+    async def async_close_cover_tilt(self, **kwargs):
         """Close the roller."""
         await self.roller.move_down()
 
-    async def open_cover_tilt(self, **kwargs):
+    async def async_open_cover_tilt(self, **kwargs):
         """Open the roller."""
         await self.roller.move_up()
 
-    async def stop_cover_tilt(self, **kwargs):
+    async def async_stop_cover_tilt(self, **kwargs):
         """Stop the roller."""
         await self.roller.move_stop()
 
-    async def set_cover_tilt(self, **kwargs):
+    async def async_set_cover_tilt(self, **kwargs):
         """Tilt the roller shutter to a specific position."""
         await self.roller.move_to(100 - kwargs[ATTR_POSITION])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes a couple of sync functions overridden as async.
This PR changes it to override the async versions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
