### PR TITLE
Improve dlib integration functionality

### DIFF
--- a/homeassistant/components/dlib_face_detect/manifest.json
+++ b/homeassistant/components/dlib_face_detect/manifest.json
@@ -2,6 +2,6 @@
   "domain": "dlib_face_detect",
   "name": "Dlib Face Detect",
   "documentation": "https://www.home-assistant.io/integrations/dlib_face_detect",
-  "requirements": ["face_recognition==1.2.3"],
+  "requirements": ["face_recognition==1.3.0"],
   "codeowners": []
 }

--- a/homeassistant/components/dlib_face_identify/image_processing.py
+++ b/homeassistant/components/dlib_face_identify/image_processing.py
@@ -1,6 +1,9 @@
 """Component that will help set the Dlib face detect processing."""
+import asyncio
+import imghdr
 import io
 import logging
+import os
 
 # pylint: disable=import-error
 import face_recognition
@@ -14,44 +17,121 @@ from homeassistant.components.image_processing import (
     PLATFORM_SCHEMA,
     ImageProcessingFaceEntity,
 )
-from homeassistant.core import split_entity_id
+from homeassistant.core import callback, split_entity_id
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_NAME = "name"
+ATTR_DISTANCE = "distance"
 CONF_FACES = "faces"
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_FACES): {cv.string: cv.isfile},
+        vol.Required(CONF_FACES): vol.Any({cv.string: cv.isfile}, cv.isdir),
         vol.Optional(CONF_CONFIDENCE, default=0.6): vol.Coerce(float),
     }
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Dlib Face detection platform."""
     entities = []
+
+    face_encodings_task = hass.async_create_task(
+        async_generate_encodings(hass, config[CONF_FACES])
+    )
+
     for camera in config[CONF_SOURCE]:
-        entities.append(
-            DlibFaceIdentifyEntity(
-                camera[CONF_ENTITY_ID],
-                config[CONF_FACES],
-                camera.get(CONF_NAME),
-                config[CONF_CONFIDENCE],
-            )
+
+        entity = DlibFaceIdentifyEntity(
+            camera[CONF_ENTITY_ID],
+            face_encodings_task,
+            camera.get(CONF_NAME),
+            config[CONF_CONFIDENCE],
         )
 
-    add_entities(entities)
+        entities.append(entity)
+
+    async_add_entities(entities)
+
+
+async def async_generate_encodings(hass, faces):
+    """Generate face encodings."""
+    face_encodings = {}
+
+    if isinstance(faces, str):
+
+        immediate_subfolders = [n.name for n in os.scandir(faces) if n.is_dir()]
+
+        for person_subfolder in immediate_subfolders:
+
+            current_folder = os.path.join(faces, person_subfolder)
+
+            face_encodings[person_subfolder] = []
+
+            for face_file in [
+                i.path for i in os.scandir(current_folder) if i.is_file()
+            ]:
+
+                if imghdr.what(face_file) is None:
+                    continue
+
+                try:
+                    image = await hass.async_add_executor_job(
+                        face_recognition.load_image_file, face_file
+                    )
+                    encodings_list = await hass.async_add_executor_job(
+                        face_recognition.face_encodings, image
+                    )
+
+                    if len(encodings_list) > 1:
+                        _LOGGER.error(
+                            "Failed to parse %s. More than one face detected in image.",
+                            face_file,
+                        )
+                    else:
+                        face_encodings[person_subfolder].append(encodings_list[0])
+
+                except IndexError as err:
+                    _LOGGER.error("Failed to parse %s. Error: %s", face_file, err)
+
+    else:
+
+        for face_name, face_file in faces.items():
+            try:
+                image = await hass.async_add_executor_job(
+                    face_recognition.load_image_file, face_file
+                )
+
+                encodings_list = await hass.async_add_executor_job(
+                    face_recognition.face_encodings, image
+                )
+
+                if len(encodings_list) > 1:
+                    _LOGGER.error(
+                        "Failed to parse %s. More than one face detected in image.",
+                        face_file,
+                    )
+                else:
+
+                    if face_name in face_encodings:
+                        face_encodings[face_name].append(encodings_list[0])
+                    else:
+                        face_encodings[face_name] = [encodings_list[0]]
+
+            except IndexError as err:
+                _LOGGER.error("Failed to parse %s. Error: %s", face_file, err)
+
+    return face_encodings
 
 
 class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
     """Dlib Face API entity for identify."""
 
-    def __init__(self, camera_entity, faces, name, tolerance):
+    def __init__(self, camera_entity, face_encodings_task, name, tolerance):
         """Initialize Dlib face identify entry."""
-
         super().__init__()
 
         self._camera = camera_entity
@@ -62,14 +142,22 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
             self._name = f"Dlib Face {split_entity_id(camera_entity)[1]}"
 
         self._faces = {}
-        for face_name, face_file in faces.items():
-            try:
-                image = face_recognition.load_image_file(face_file)
-                self._faces[face_name] = face_recognition.face_encodings(image)[0]
-            except IndexError as err:
-                _LOGGER.error("Failed to parse %s. Error: %s", face_file, err)
+
+        face_encodings_task.add_done_callback(self.async_encodings_ready)
 
         self._tolerance = tolerance
+
+    @callback
+    def async_encodings_ready(self, future):
+        """Update known face encodings when the task has finished."""
+        try:
+            encodings = future.result()
+
+            for name, face_encoding_list in encodings.items():
+                self._faces[name] = face_encoding_list
+
+        except asyncio.InvalidStateError:
+            _LOGGER.error("Generating known face encodings failed.")
 
     @property
     def camera_entity(self):
@@ -83,21 +171,43 @@ class DlibFaceIdentifyEntity(ImageProcessingFaceEntity):
 
     def process_image(self, image):
         """Process image."""
-
         fak_file = io.BytesIO(image)
         fak_file.name = "snapshot.jpg"
         fak_file.seek(0)
 
         image = face_recognition.load_image_file(fak_file)
+
         unknowns = face_recognition.face_encodings(image)
 
         found = []
         for unknown_face in unknowns:
-            for name, face in self._faces.items():
-                result = face_recognition.compare_faces(
-                    [face], unknown_face, tolerance=self._tolerance
+
+            closest_match = None
+            smallest_average_distance = None
+
+            for name, known_encodings in self._faces.items():
+
+                distances = face_recognition.face_distance(
+                    known_encodings, unknown_face
                 )
-                if result[0]:
-                    found.append({ATTR_NAME: name})
+                average_distance = 0
+
+                for i in distances:
+                    average_distance += i
+
+                average_distance = average_distance / len(known_encodings)
+
+                if average_distance < self._tolerance:
+                    if (
+                        smallest_average_distance is None
+                        or average_distance < smallest_average_distance
+                    ):
+                        smallest_average_distance = average_distance
+                        closest_match = name
+
+            if closest_match is not None:
+                found.append(
+                    {ATTR_DISTANCE: smallest_average_distance, ATTR_NAME: closest_match}
+                )
 
         self.process_faces(found, len(unknowns))

--- a/homeassistant/components/dlib_face_identify/manifest.json
+++ b/homeassistant/components/dlib_face_identify/manifest.json
@@ -2,6 +2,6 @@
   "domain": "dlib_face_identify",
   "name": "Dlib Face Identify",
   "documentation": "https://www.home-assistant.io/integrations/dlib_face_identify",
-  "requirements": ["face_recognition==1.2.3"],
+  "requirements": ["face_recognition==1.3.0"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -573,7 +573,7 @@ evohome-async==0.3.5.post1
 
 # homeassistant.components.dlib_face_detect
 # homeassistant.components.dlib_face_identify
-# face_recognition==1.2.3
+# face_recognition==1.3.0
 
 # homeassistant.components.fastdotcom
 fastdotcom==0.0.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improves current dlib face identify integration:

- Enables having multiple training images per identity.

- Enables maintaining known faces by organizing the face images to folders according to identity.

- Makes the setup more async friendly and enables using the integration on platforms like Raspberry pi. Previously the setup-function would regularly timeout on a Raspberry Pi as the face encodings were calculated in the setup routine non-asynchronously and repeatedly for each image processing entity. Now a separate task is created for calculating the face encodings and the known encodings are only calculated once for all entities. Of course, the face_recognition library is only a python wrapper for dlib which isn't async friendly so having a large library of known faces will still slow the start up down somewhat. 



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
image_processing:
 - platform: dlib_face_identify
   confidence: 0.5
   source:
    - entity_id: camera.example_camera
   faces:
     /config/faces/

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13952

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
