### PR TITLE
Add sudo: option to nmap_tracker (for Mac OS, not needed on Linux)

### DIFF
--- a/homeassistant/components/nmap_tracker/device_tracker.py
+++ b/homeassistant/components/nmap_tracker/device_tracker.py
@@ -116,7 +116,9 @@ class NmapDeviceScanner(DeviceScanner):
             options += f" --exclude {','.join(exclude_hosts)}"
 
         try:
-            result = scanner.scan(hosts=" ".join(self.hosts), arguments=options, sudo=sudo)
+            result = scanner.scan(
+                hosts=" ".join(self.hosts), arguments=options, sudo=sudo
+            )
         except PortScannerError:
             return False
 

--- a/homeassistant/components/nmap_tracker/device_tracker.py
+++ b/homeassistant/components/nmap_tracker/device_tracker.py
@@ -23,6 +23,7 @@ CONF_EXCLUDE = "exclude"
 CONF_HOME_INTERVAL = "home_interval"
 CONF_OPTIONS = "scan_options"
 DEFAULT_OPTIONS = "-F --host-timeout 5s"
+CONF_SUDO = "sudo"
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -31,6 +32,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_HOME_INTERVAL, default=0): cv.positive_int,
         vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_OPTIONS, default=DEFAULT_OPTIONS): cv.string,
+        vol.Optional(CONF_SUDO, default=False): cv.boolean,
     }
 )
 
@@ -56,6 +58,7 @@ class NmapDeviceScanner(DeviceScanner):
         self.exclude = config[CONF_EXCLUDE]
         minutes = config[CONF_HOME_INTERVAL]
         self._options = config[CONF_OPTIONS]
+        self._sudo = config[CONF_SUDO]
         self.home_interval = timedelta(minutes=minutes)
 
         _LOGGER.debug("Scanner initialized")
@@ -95,6 +98,7 @@ class NmapDeviceScanner(DeviceScanner):
         scanner = PortScanner()
 
         options = self._options
+        sudo = self._sudo
 
         if self.home_interval:
             boundary = dt_util.now() - self.home_interval
@@ -112,7 +116,7 @@ class NmapDeviceScanner(DeviceScanner):
             options += f" --exclude {','.join(exclude_hosts)}"
 
         try:
-            result = scanner.scan(hosts=" ".join(self.hosts), arguments=options)
+            result = scanner.scan(hosts=" ".join(self.hosts), arguments=options, sudo=sudo)
         except PortScannerError:
             return False
 


### PR DESCRIPTION

## Proposed change
This commit adds the option for setting a `sudo: true` flag for the nmap tracker. For Linux, the recommended way to take advantage of root permissions is via `setcap`. However, this isn't an option on Mac OS, and so this PR offers a fallback of running nmap as root.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
  - platform: nmap_tracker
    hosts: 192.168.1.0/24
    scan_options: "-sn"
    sudo: true
```

## Additional information
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/13946

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
