### PR TITLE
RFC: Add validator integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -491,6 +491,7 @@ homeassistant/components/upnp/* @StevenLooman
 homeassistant/components/uptimerobot/* @ludeeus
 homeassistant/components/usgs_earthquakes_feed/* @exxamalte
 homeassistant/components/utility_meter/* @dgomes
+homeassistant/components/validator/* @home-assistant/core
 homeassistant/components/velbus/* @Cereal2nd @brefra
 homeassistant/components/velux/* @Julius2342
 homeassistant/components/vera/* @vangorra

--- a/homeassistant/components/sensor/validator.py
+++ b/homeassistant/components/sensor/validator.py
@@ -1,0 +1,36 @@
+"""Validate the sensor integration."""
+from typing import cast
+
+from homeassistant.components import validator
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, State
+
+from . import DOMAIN
+
+
+async def async_validate_entities(
+    hass: HomeAssistant, report: validator.Report
+) -> None:
+    """Validate sensor entities."""
+    for entity_id in hass.states.async_entity_ids(DOMAIN):
+        state = cast(State, hass.states.get(entity_id))
+        report.async_validate_base_attributes(state)
+        report.async_validate_supported_features(state, {})  # no supported features
+
+        if ATTR_UNIT_OF_MEASUREMENT not in state.attributes or state.state in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        ):
+            continue
+
+        try:
+            float(state.state)
+        except ValueError:
+            report.async_add_warning(
+                entity_id,
+                f"State with a unit of measurement should be numeric. Got '{state.state}'",
+            )

--- a/homeassistant/components/validator/__init__.py
+++ b/homeassistant/components/validator/__init__.py
@@ -1,0 +1,148 @@
+"""The Validator integration."""
+import dataclasses as dc
+from typing import Any, Dict, List, Union
+
+import voluptuous as vol
+from voluptuous.humanize import humanize_error
+
+from homeassistant.components import persistent_notification
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_BATTERY_LEVEL,
+    ATTR_FRIENDLY_NAME,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_UNIT_OF_MEASUREMENT,
+    EVENT_HOMEASSISTANT_STARTED,
+)
+from homeassistant.core import Event, HomeAssistant, ServiceCall, State, callback
+from homeassistant.helpers.integration_platform import (
+    async_process_integration_platforms,
+)
+
+DOMAIN = "validator"
+
+ATTRIBUTE_VALIDATE_DICT = Dict[str, Any]
+
+BASE_VALIDATOR: ATTRIBUTE_VALIDATE_DICT = {
+    ATTR_FRIENDLY_NAME: vol.Maybe(str),
+    ATTR_SUPPORTED_FEATURES: vol.Maybe(int),
+    ATTR_BATTERY_LEVEL: vol.Maybe(int),
+    ATTR_ATTRIBUTION: vol.Maybe(str),
+    ATTR_UNIT_OF_MEASUREMENT: vol.Maybe(str),
+}
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Validator component."""
+
+    async def do_validate(call_or_evt: Union[ServiceCall, Event]):
+        await validate(
+            hass,
+            # During startup do not report if all entities valid
+            report_if_valid=isinstance(call_or_evt, ServiceCall),
+        )
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, do_validate)
+    hass.services.async_register(DOMAIN, "validate", do_validate)
+    return True
+
+
+async def validate(hass: HomeAssistant, *, report_if_valid=True) -> None:
+    """Validate integrations."""
+    report = Report()
+
+    # Run all validate platforms
+    async def _async_process_platform(hass: HomeAssistant, domain: str, platform: Any):
+        """Process a platform."""
+
+        if hasattr(platform, "async_validate_entities"):
+            await platform.async_validate_entities(hass, report)
+
+    unsub = await async_process_integration_platforms(
+        hass, DOMAIN, _async_process_platform
+    )
+    unsub()
+
+    title = "Validator Report"
+
+    if len(report.entities) == 0:
+        if report_if_valid:
+            persistent_notification.async_create(
+                hass, "No invalid entities found!", title, DOMAIN
+            )
+        return
+
+    parts = [
+        f"Found {len(report.entities)} invalid entit{'y' if len(report.entities) == 1 else 'ies'}."
+    ]
+
+    for entity_id, errors in report.entities.items():
+        parts.append(f"\n**{entity_id}**")
+        parts.extend(f"- {err}" for err in errors)
+
+    persistent_notification.async_create(hass, "\n".join(parts), title, DOMAIN)
+
+
+@dc.dataclass
+class Report:
+    """Class to track warnings for entities."""
+
+    entities: Dict[str, List[str]] = dc.field(default_factory=dict, init=False)
+
+    @callback
+    def async_validate_base_attributes(self, state: State) -> None:
+        """Validate the base attributes."""
+        self._async_validate_dict(state.entity_id, state.attributes, BASE_VALIDATOR)
+
+    @callback
+    def async_validate_supported_features(
+        self,
+        state: State,
+        supported_feature_validators: Dict[int, ATTRIBUTE_VALIDATE_DICT],
+    ):
+        """Validate supported features."""
+        allowed_supported_features = 0
+
+        for feat in supported_feature_validators:
+            allowed_supported_features |= feat
+
+        supported_features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+
+        extra_features = abs(
+            (allowed_supported_features & supported_features)
+            - allowed_supported_features
+        )
+
+        if extra_features != 0:
+            self.async_add_warning(
+                state.entity_id, f"Unsupported feature flags found: {extra_features}"
+            )
+
+        for feat, validators in supported_feature_validators.items():
+            if feat & supported_features == 0:
+                continue
+
+            self._async_validate_dict(state.entity_id, state.attributes, validators)
+
+    @callback
+    def async_add_warning(self, entity_id: str, warning: str):
+        """Record a warning."""
+        self.entities.setdefault(entity_id, []).append(warning)
+
+    @callback
+    def _async_validate_dict(
+        self,
+        entity_id: str,
+        to_validate: Dict[str, Any],
+        validators: ATTRIBUTE_VALIDATE_DICT,
+    ) -> None:
+        """Validate a dictionary."""
+        for key, validator in validators.items():
+            key_value = to_validate.get(key)
+            try:
+                validator(key_value)
+            except vol.Invalid as ex:
+                self.async_add_warning(
+                    entity_id,
+                    f"Invalid value for {key}: {humanize_error(key_value, ex)}",
+                )

--- a/homeassistant/components/validator/__init__.py
+++ b/homeassistant/components/validator/__init__.py
@@ -1,7 +1,7 @@
 """The Validator integration."""
-import dataclasses as dc
 from typing import Any, Dict, List, Union
 
+import attr
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
@@ -21,7 +21,9 @@ from homeassistant.helpers.integration_platform import (
 
 DOMAIN = "validator"
 
+# pylint: disable=invalid-name
 ATTRIBUTE_VALIDATE_DICT = Dict[str, Any]
+# pylint: enable=invalid-name
 
 BASE_VALIDATOR: ATTRIBUTE_VALIDATE_DICT = {
     ATTR_FRIENDLY_NAME: vol.Maybe(str),
@@ -83,11 +85,11 @@ async def validate(hass: HomeAssistant, *, report_if_valid=True) -> None:
     persistent_notification.async_create(hass, "\n".join(parts), title, DOMAIN)
 
 
-@dc.dataclass
+@attr.s
 class Report:
     """Class to track warnings for entities."""
 
-    entities: Dict[str, List[str]] = dc.field(default_factory=dict, init=False)
+    entities: Dict[str, List[str]] = attr.ib(factory=dict, init=False)
 
     @callback
     def async_validate_base_attributes(self, state: State) -> None:

--- a/homeassistant/components/validator/manifest.json
+++ b/homeassistant/components/validator/manifest.json
@@ -1,0 +1,7 @@
+{
+  "domain": "validator",
+  "name": "Validator",
+  "config_flow": false,
+  "documentation": "https://www.home-assistant.io/integrations/validator",
+  "codeowners": ["@home-assistant/core"]
+}

--- a/homeassistant/components/validator/services.yaml
+++ b/homeassistant/components/validator/services.yaml
@@ -1,0 +1,2 @@
+validate:
+  description: Validate that the system data is correct.

--- a/tests/components/sensor/test_validator.py
+++ b/tests/components/sensor/test_validator.py
@@ -1,0 +1,19 @@
+"""Test sensor validation."""
+from homeassistant.components.sensor.validator import async_validate_entities
+from homeassistant.components.validator import Report
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
+
+
+async def test_validate_entities(hass):
+    """Test validate entities."""
+    hass.states.async_set(
+        "sensor.invalid_state", "hello", {ATTR_UNIT_OF_MEASUREMENT: "C"}
+    )
+    hass.states.async_set("sensor.valid_int", "3", {ATTR_UNIT_OF_MEASUREMENT: "C"})
+    hass.states.async_set("sensor.valid_float", "15.6", {ATTR_UNIT_OF_MEASUREMENT: "C"})
+    report = Report()
+    await async_validate_entities(hass, report)
+    assert len(report.entities) == 1
+    assert report.entities.get("sensor.invalid_state", []) == [
+        "State with a unit of measurement should be numeric. Got 'hello'"
+    ]

--- a/tests/components/validator/__init__.py
+++ b/tests/components/validator/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Validator integration."""

--- a/tests/components/validator/test_init.py
+++ b/tests/components/validator/test_init.py
@@ -1,0 +1,69 @@
+"""Test validator integration."""
+import voluptuous as vol
+
+from homeassistant.components import validator
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_BATTERY_LEVEL,
+    ATTR_FRIENDLY_NAME,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_UNIT_OF_MEASUREMENT,
+)
+from homeassistant.core import State
+
+
+async def test_validate_base_attributes():
+    """Test validating base attributes."""
+    report = validator.Report()
+    report.async_validate_base_attributes(
+        State(
+            "light.kitchen",
+            "on",
+            {
+                ATTR_FRIENDLY_NAME: True,
+                ATTR_SUPPORTED_FEATURES: "invalid mock type",
+                ATTR_BATTERY_LEVEL: "invalid mock type",
+                ATTR_ATTRIBUTION: True,
+                ATTR_UNIT_OF_MEASUREMENT: True,
+            },
+        )
+    )
+    assert report.entities.get("light.kitchen", []) == [
+        "Invalid value for friendly_name: not a valid value. Got True",
+        "Invalid value for supported_features: not a valid value. Got 'invalid mock type'",
+        "Invalid value for battery_level: not a valid value. Got 'invalid mock type'",
+        "Invalid value for attribution: not a valid value. Got True",
+        "Invalid value for unit_of_measurement: not a valid value. Got True",
+    ]
+
+    report = validator.Report()
+    report.async_validate_base_attributes(State("light.kitchen", "on",))
+    assert report.entities.get("light.kitchen", []) == []
+
+
+async def test_validate_supported_features():
+    """Test validating supported features."""
+    report = validator.Report()
+    support_feature_1 = 1
+    support_feature_2 = 2
+    support_feature_3 = 4
+    supported_feature_validator = {
+        support_feature_1: {},
+        support_feature_2: {},
+        support_feature_3: {
+            "fan_mode": vol.Any("on", "off"),
+            "fan_modes": vol.Schema([str]),
+        },
+    }
+
+    report.async_validate_supported_features(
+        State("light.kitchen", "on", {ATTR_SUPPORTED_FEATURES: 8}),
+        supported_feature_validator,
+    )
+    assert report.entities.get("light.kitchen", []) == [
+        "Unsupported feature flags found: 7",
+    ]
+
+    # report = validator.Report()
+    # report.async_validate_base_attributes(State("light.kitchen", "on",))
+    # assert report.entities.get("light.kitchen", []) == []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new validator integration. It will validate that all entities published by integrations actually follow our abstraction rules. This is important or else it breaks things like our frontend, Google, Alexa, HomeKit or any other system that relies on our abstraction.

This integration works by providing basic infrastructure for validation and reporting. It's up to each integration to implement a `validator` platform.

![image](https://user-images.githubusercontent.com/1444314/86973653-ce77d080-c129-11ea-8a94-ad7c276bbe3a.png)

To do:
 - [ ] Add scaffold script

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
