### PR TITLE
Add bond cover assumed state and local polling

### DIFF
--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -1,5 +1,4 @@
 """Support for Bond covers."""
-import logging
 from typing import Any, Callable, Dict, List, Optional
 
 from bond import BOND_DEVICE_TYPE_MOTORIZED_SHADES, Bond
@@ -13,13 +12,11 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
 from .utils import BondDevice, get_bond_devices
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[List[Entity]], None],
+    async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:
     """Set up Bond cover devices."""
     bond: Bond = hass.data[DOMAIN][entry.entry_id]
@@ -32,7 +29,7 @@ async def async_setup_entry(
         if device.type == BOND_DEVICE_TYPE_MOTORIZED_SHADES
     ]
 
-    async_add_entities(covers)
+    async_add_entities(covers, True)
 
 
 class BondCover(CoverEntity):
@@ -42,6 +39,7 @@ class BondCover(CoverEntity):
         """Create HA entity representing Bond cover."""
         self._bond = bond
         self._device = device
+        self._closed: Optional[bool] = None
 
     @property
     def device_class(self) -> Optional[str]:
@@ -64,9 +62,25 @@ class BondCover(CoverEntity):
         return {ATTR_NAME: self.name, "identifiers": {(DOMAIN, self._device.device_id)}}
 
     @property
+    def assumed_state(self) -> bool:
+        """Let HA know this entity relies on an assumed state tracked by Bond."""
+        return True
+
+    @property
+    def should_poll(self) -> bool:
+        """Let HA know it should periodically poll this entity for state changes."""
+        return True
+
+    def update(self):
+        """Fetch assumed state of the cover from the hub using API."""
+        state: dict = self._bond.getDeviceState(self._device.device_id)
+        cover_open = state.get("open", None)
+        self._closed = True if cover_open == 0 else False if cover_open == 1 else None
+
+    @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        return None
+        return self._closed
 
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -66,15 +66,10 @@ class BondCover(CoverEntity):
         """Let HA know this entity relies on an assumed state tracked by Bond."""
         return True
 
-    @property
-    def should_poll(self) -> bool:
-        """Let HA know it should periodically poll this entity for state changes."""
-        return True
-
     def update(self):
         """Fetch assumed state of the cover from the hub using API."""
         state: dict = self._bond.getDeviceState(self._device.device_id)
-        cover_open = state.get("open", None)
+        cover_open = state.get("open")
         self._closed = True if cover_open == 0 else False if cover_open == 1 else None
 
     @property

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -1,14 +1,11 @@
 """Tests for the Bond cover device."""
+from datetime import timedelta
 import logging
 
 from bond import BOND_DEVICE_TYPE_MOTORIZED_SHADES
 
 from homeassistant import core
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
-from homeassistant.components.homeassistant import (
-    DOMAIN as HA_DOMAIN,
-    SERVICE_UPDATE_ENTITY,
-)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
@@ -16,8 +13,9 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
 )
 from homeassistant.helpers.entity_registry import EntityRegistry
-from homeassistant.setup import async_setup_component
+from homeassistant.util import utcnow
 
+from ...common import async_fire_time_changed
 from .common import setup_platform
 
 from tests.async_mock import patch
@@ -116,7 +114,6 @@ async def test_stop_cover(hass: core.HomeAssistant):
 async def test_update_reports_open_cover(hass: core.HomeAssistant):
     """Tests that update command sets correct state when Bond API reports cover is open."""
 
-    await async_setup_component(hass, HA_DOMAIN, {})
     with patch(
         "homeassistant.components.bond.Bond.getDeviceIds", return_value=TEST_DEVICE_IDS
     ), patch(
@@ -129,12 +126,7 @@ async def test_update_reports_open_cover(hass: core.HomeAssistant):
     with patch(
         "homeassistant.components.bond.Bond.getDeviceState", return_value={"open": 1}
     ):
-        await hass.services.async_call(
-            HA_DOMAIN,
-            SERVICE_UPDATE_ENTITY,
-            {ATTR_ENTITY_ID: "cover.name_1"},
-            blocking=True,
-        )
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
 
     assert hass.states.get("cover.name_1").state == "open"
@@ -143,7 +135,6 @@ async def test_update_reports_open_cover(hass: core.HomeAssistant):
 async def test_update_reports_closed_cover(hass: core.HomeAssistant):
     """Tests that update command sets correct state when Bond API reports cover is closed."""
 
-    await async_setup_component(hass, HA_DOMAIN, {})
     with patch(
         "homeassistant.components.bond.Bond.getDeviceIds", return_value=TEST_DEVICE_IDS
     ), patch(
@@ -156,12 +147,7 @@ async def test_update_reports_closed_cover(hass: core.HomeAssistant):
     with patch(
         "homeassistant.components.bond.Bond.getDeviceState", return_value={"open": 0}
     ):
-        await hass.services.async_call(
-            HA_DOMAIN,
-            SERVICE_UPDATE_ENTITY,
-            {ATTR_ENTITY_ID: "cover.name_1"},
-            blocking=True,
-        )
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
 
     assert hass.states.get("cover.name_1").state == "closed"

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -15,10 +15,10 @@ from homeassistant.const import (
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
-from ...common import async_fire_time_changed
 from .common import setup_platform
 
 from tests.async_mock import patch
+from tests.common import async_fire_time_changed
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Informing HA that Bond integration covers have assumed state tracked by Bond hub, implement polling for state

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
