### PR TITLE
Feature/izone temperature precision

### DIFF
--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -254,11 +254,6 @@ class ControllerDevice(ClimateEntity):
         return PRECISION_TENTHS
 
     @property
-    def setpoint_precision(self) -> float:
-        """Return the precision of setpoint values."""
-        return PRECISION_HALVES
-
-    @property
     def device_state_attributes(self):
         """Return the optional state attributes."""
         return {
@@ -272,7 +267,7 @@ class ControllerDevice(ClimateEntity):
                 self.hass,
                 self._controller.temp_setpoint,
                 self.temperature_unit,
-                self.setpoint_precision,
+                PRECISION_HALVES,
             ),
         }
 

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_EXCLUDE,
     PRECISION_HALVES,
+    PRECISION_TENTHS,
     TEMP_CELSIUS,
 )
 from homeassistant.core import callback
@@ -250,6 +251,11 @@ class ControllerDevice(ClimateEntity):
     @property
     def precision(self) -> float:
         """Return the precision of the system."""
+        return PRECISION_TENTHS
+
+    @property
+    def setpoint_precision(self) -> float:
+        """Return the precision of setpoint values."""
         return PRECISION_HALVES
 
     @property
@@ -266,7 +272,7 @@ class ControllerDevice(ClimateEntity):
                 self.hass,
                 self._controller.temp_setpoint,
                 self.temperature_unit,
-                self.precision,
+                self.setpoint_precision,
             ),
         }
 
@@ -494,7 +500,7 @@ class ZoneDevice(ClimateEntity):
     @property
     def precision(self):
         """Return the precision of the system."""
-        return PRECISION_HALVES
+        return PRECISION_TENTHS
 
     @property
     def hvac_mode(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change precision of reported current and supply temperature for iZone air conditioner control to use tenths precision instead of halves, similar to the iZone control panels and native app. (Keep the set point / target temperature at halves.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Not really a full feature, but just a minor improvement in precision.

The current precision for all temperature values is set to halves, which gives large jumps in graphs and is not consistent with the native iZone panel and phone apps, which use one decimal place. The actual reported temperature in the API has the additional details.

Note that set point (target) temperature must be set in halves, and this is kept. The change improves the detail of reported temperature.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
