### PR TITLE
Use the shared zeroconf instance for homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -63,7 +63,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         self.controller = None
         self.finish_pairing = None
 
-    async def _async_setup(self):
+    async def _async_setup_controller(self):
         """Create the controller."""
         zeroconf_instance = await zeroconf.async_get_instance(self.hass)
         self.controller = aiohomekit.Controller(zeroconf_instance=zeroconf_instance)
@@ -82,7 +82,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             return await self.async_step_pair()
 
         if self.controller is None:
-            await self._async_setup()
+            await self._async_setup_controller()
 
         all_hosts = await self.controller.discover_ip()
 
@@ -111,7 +111,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         await self.async_set_unique_id(unique_id)
 
         if self.controller is None:
-            await self._async_setup()
+            await self._async_setup_controller()
 
         devices = await self.controller.discover_ip(max_seconds=5)
         for device in devices:
@@ -239,7 +239,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         errors = {}
         if self.controller is None:
-            await self._async_setup()
+            await self._async_setup_controller()
 
         if pair_info:
             code = pair_info["pairing_code"]

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.44"],
+  "requirements": ["aiohomekit[IP]==0.2.45"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k"]

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.43"],
+  "requirements": ["aiohomekit[IP]==0.2.44"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k"]

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.41"],
+  "requirements": ["aiohomekit[IP]==0.2.43"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k"]

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "requirements": ["aiohomekit[IP]==0.2.41"],
   "zeroconf": ["_hap._tcp.local."],
+  "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioguardian==1.0.1
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.44
+aiohomekit[IP]==0.2.45
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioguardian==1.0.1
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.41
+aiohomekit[IP]==0.2.43
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioguardian==1.0.1
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.43
+aiohomekit[IP]==0.2.44
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ aioguardian==1.0.1
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.44
+aiohomekit[IP]==0.2.45
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ aioguardian==1.0.1
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.43
+aiohomekit[IP]==0.2.44
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ aioguardian==1.0.1
 aioharmony==0.2.5
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.41
+aiohomekit[IP]==0.2.43
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Should fix the cpu issue reported here
https://community.home-assistant.io/t/python3-high-cpu-usage/160012/26?u=bdraco

aiohomekit 0.2.45 supports using the shared zeroconf instance and significantly reduces the time needed to initialize configuration of new homekit controller devices.

Requires https://github.com/Jc2k/aiohomekit/pull/6
Requires https://github.com/Jc2k/aiohomekit/pull/7
Requires https://github.com/Jc2k/aiohomekit/pull/8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
