### PR TITLE
Simplify vizio unique ID check since only IP and device class are needed

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -180,14 +180,8 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._data = None
         self._apps = {}
 
-    async def _create_entry_if_unique(
-        self, input_dict: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Create entry if ID is unique.
-
-        If it is, create entry. If it isn't, abort config flow.
-        """
+    async def _create_entry(self, input_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Create vizio config entry."""
         # Remove extra keys that will not be used by entry setup
         input_dict.pop(CONF_APPS_TO_INCLUDE_OR_EXCLUDE, None)
         input_dict.pop(CONF_INCLUDE_OR_EXCLUDE, None)
@@ -245,7 +239,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         errors["base"] = "cannot_connect"
 
                     if not errors:
-                        return await self._create_entry_if_unique(user_input)
+                        return await self._create_entry(user_input)
                 # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
                 elif self._must_show_form and self.context["source"] == SOURCE_IMPORT:
                     # Import should always display the config form if CONF_ACCESS_TOKEN
@@ -431,7 +425,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _pairing_complete(self, step_id: str) -> Dict[str, Any]:
         """Handle config flow completion."""
         if not self._must_show_form:
-            return await self._create_entry_if_unique(self._data)
+            return await self._create_entry(self._data)
 
         self._must_show_form = False
         return self.async_show_form(

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -220,6 +220,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     unique_id=unique_id, raise_on_progress=True
                 )
                 # If device was discovered, abort if existing entry found, otherwise display an error
+                # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
                 if self.context["source"] == SOURCE_ZEROCONF:
                     self._abort_if_unique_id_configured()
                 elif existing_entry:

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "VIZIO SmartCast",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.1.50"],
+  "requirements": ["pyvizio==0.1.51"],
   "codeowners": ["@raman325"],
   "config_flow": true,
   "zeroconf": ["_viziocast._tcp.local."],

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "VIZIO SmartCast",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.1.49"],
+  "requirements": ["pyvizio==0.1.50"],
   "codeowners": ["@raman325"],
   "config_flow": true,
   "zeroconf": ["_viziocast._tcp.local."],

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -296,7 +296,7 @@ class VizioDevice(MediaPlayerEntity):
             new_value,
         )
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Register callbacks when entity is added."""
         # Register callback for when config entry is updated.
         self._async_unsub_listeners.append(
@@ -312,7 +312,7 @@ class VizioDevice(MediaPlayerEntity):
             )
         )
 
-    async def async_will_remove_from_hass(self):
+    async def async_will_remove_from_hass(self) -> None:
         """Disconnect callbacks when entity is removed."""
         for listener in self._async_unsub_listeners:
             listener()
@@ -325,7 +325,7 @@ class VizioDevice(MediaPlayerEntity):
         return self._available
 
     @property
-    def state(self) -> str:
+    def state(self) -> Optional[str]:
         """Return the state of the device."""
         return self._state
 
@@ -340,7 +340,7 @@ class VizioDevice(MediaPlayerEntity):
         return self._icon
 
     @property
-    def volume_level(self) -> float:
+    def volume_level(self) -> Optional[float]:
         """Return the volume level of the device."""
         return self._volume_level
 
@@ -350,7 +350,7 @@ class VizioDevice(MediaPlayerEntity):
         return self._is_volume_muted
 
     @property
-    def source(self) -> str:
+    def source(self) -> Optional[str]:
         """Return current input of the device."""
         if self._current_app is not None and self._current_input in INPUT_APPS:
             return self._current_app

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -30,7 +30,7 @@
     "error": {
       "complete_pairing_failed": "Unable to complete pairing. Ensure the PIN you provided is correct and the TV is still powered and connected to the network before resubmitting.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "existing_config_entry_found": "An existing `vizio` config entry with the same serial number has already been configured. You must delete the existing entry in order to configure this one."
+      "existing_config_entry_found": "An existing [%key:component::vizio::config::step::user::title%] config entry with the same serial number has already been configured. You must delete the existing entry in order to configure this one."
     },
     "abort": {
       "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -28,10 +28,9 @@
       }
     },
     "error": {
-      "host_exists": "[%key:component::vizio::config::step::user::title%] with specified host already configured.",
-      "name_exists": "[%key:component::vizio::config::step::user::title%] with specified name already configured.",
       "complete_pairing_failed": "Unable to complete pairing. Ensure the PIN you provided is correct and the TV is still powered and connected to the network before resubmitting.",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "existing_config_entry_found": "An existing `vizio` config entry with the same serial number has already been configured. You must delete the existing entry in order to configure this one."
     },
     "abort": {
       "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1822,7 +1822,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.49
+pyvizio==0.1.50
 
 # homeassistant.components.velux
 pyvlx==0.2.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1822,7 +1822,7 @@ pyversasense==0.0.6
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.50
+pyvizio==0.1.51
 
 # homeassistant.components.velux
 pyvlx==0.2.16

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -827,7 +827,7 @@ pyvera==0.3.9
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.50
+pyvizio==0.1.51
 
 # homeassistant.components.volumio
 pyvolumio==0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -827,7 +827,7 @@ pyvera==0.3.9
 pyvesync==1.1.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.49
+pyvizio==0.1.50
 
 # homeassistant.components.volumio
 pyvolumio==0.1

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -47,15 +47,32 @@ def skip_notifications_fixture():
         yield
 
 
+@pytest.fixture(name="vizio_get_unique_id", autouse=True)
+def vizio_get_unique_id_fixture():
+    """Mock get vizio unique ID."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
+        return_value=UNIQUE_ID,
+    ):
+        yield
+
+
+@pytest.fixture(name="vizio_no_unique_id")
+def vizio_no_unique_id_fixture():
+    """Mock no vizio unique ID returrned."""
+    with patch(
+        "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.fixture(name="vizio_connect")
 def vizio_connect_fixture():
     """Mock valid vizio device and entry setup."""
     with patch(
         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
         return_value=True,
-    ), patch(
-        "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
-        return_value=UNIQUE_ID,
     ):
         yield
 

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -51,7 +51,6 @@ from .const import (
     NAME2,
     UNIQUE_ID,
     VOLUME_STEP,
-    ZEROCONF_HOST,
 )
 
 from tests.common import MockConfigEntry
@@ -223,7 +222,10 @@ async def test_user_host_already_configured(
 ) -> None:
     """Test host is already configured during user setup."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
+        domain=DOMAIN,
+        data=MOCK_SPEAKER_CONFIG,
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
+        unique_id=UNIQUE_ID,
     )
     entry.add_to_hass(hass)
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
@@ -234,61 +236,15 @@ async def test_user_host_already_configured(
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_HOST: "host_exists"}
+    assert result["errors"] == {CONF_HOST: "existing_config_entry_found"}
 
 
-async def test_user_host_already_configured_no_port(
+async def test_user_serial_number_already_exists(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,
     vizio_bypass_setup: pytest.fixture,
 ) -> None:
-    """Test host is already configured during user setup when existing entry has no port."""
-    # Mock entry without port so we can test that the same entry WITH a port will fail
-    no_port_entry = MOCK_SPEAKER_CONFIG.copy()
-    no_port_entry[CONF_HOST] = no_port_entry[CONF_HOST].split(":")[0]
-    entry = MockConfigEntry(
-        domain=DOMAIN, data=no_port_entry, options={CONF_VOLUME_STEP: VOLUME_STEP}
-    )
-    entry.add_to_hass(hass)
-    fail_entry = MOCK_SPEAKER_CONFIG.copy()
-    fail_entry[CONF_NAME] = "newtestname"
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_HOST: "host_exists"}
-
-
-async def test_user_name_already_configured(
-    hass: HomeAssistantType,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
-    """Test name is already configured during user setup."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
-    )
-    entry.add_to_hass(hass)
-
-    fail_entry = MOCK_SPEAKER_CONFIG.copy()
-    fail_entry[CONF_HOST] = "0.0.0.0"
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_NAME: "name_exists"}
-
-
-async def test_user_esn_already_exists(
-    hass: HomeAssistantType,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
-    """Test ESN is already configured with different host and name during user setup."""
+    """Test serial_number is already configured with different host and name during user setup."""
     # Set up new entry
     MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
@@ -303,14 +259,26 @@ async def test_user_esn_already_exists(
         DOMAIN, context={"source": SOURCE_USER}, data=fail_entry
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "existing_config_entry_found"}
 
 
 async def test_user_error_on_could_not_connect(
+    hass: HomeAssistantType, vizio_no_unique_id: pytest.fixture
+) -> None:
+    """Test with could_not_connect during user setup due to no connectivity."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "cannot_connect"}
+
+
+async def test_user_error_on_could_not_connect_invalid_token(
     hass: HomeAssistantType, vizio_cant_connect: pytest.fixture
 ) -> None:
-    """Test with could_not_connect during user_setup."""
+    """Test with could_not_connect during user setup due to invalid token."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
     )
@@ -683,6 +651,7 @@ async def test_import_error(
         domain=DOMAIN,
         data=vol.Schema(VIZIO_SCHEMA)(MOCK_SPEAKER_CONFIG),
         options={CONF_VOLUME_STEP: VOLUME_STEP},
+        unique_id=UNIQUE_ID,
     )
     entry.add_to_hass(hass)
     fail_entry = MOCK_SPEAKER_CONFIG.copy()
@@ -763,10 +732,14 @@ async def test_zeroconf_flow_already_configured(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,
     vizio_bypass_setup: pytest.fixture,
+    vizio_guess_device_type: pytest.fixture,
 ) -> None:
     """Test entity is already configured during zeroconf setup."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, options={CONF_VOLUME_STEP: VOLUME_STEP}
+        domain=DOMAIN,
+        data=MOCK_SPEAKER_CONFIG,
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
+        unique_id=UNIQUE_ID,
     )
     entry.add_to_hass(hass)
 
@@ -778,7 +751,7 @@ async def test_zeroconf_flow_already_configured(
 
     # Flow should abort because device is already setup
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured_device"
+    assert result["reason"] == "already_configured"
 
 
 async def test_zeroconf_dupe_fail(
@@ -842,7 +815,7 @@ async def test_zeroconf_abort_when_ignored(
         data=MOCK_SPEAKER_CONFIG,
         options={CONF_VOLUME_STEP: VOLUME_STEP},
         source=SOURCE_IGNORE,
-        unique_id=ZEROCONF_HOST,
+        unique_id=UNIQUE_ID,
     )
     entry.add_to_hass(hass)
 
@@ -860,12 +833,16 @@ async def test_zeroconf_flow_already_configured_hostname(
     vizio_connect: pytest.fixture,
     vizio_bypass_setup: pytest.fixture,
     vizio_hostname_check: pytest.fixture,
+    vizio_guess_device_type: pytest.fixture,
 ) -> None:
     """Test entity is already configured during zeroconf setup when existing entry uses hostname."""
     config = MOCK_SPEAKER_CONFIG.copy()
     config[CONF_HOST] = "hostname"
     entry = MockConfigEntry(
-        domain=DOMAIN, data=config, options={CONF_VOLUME_STEP: VOLUME_STEP}
+        domain=DOMAIN,
+        data=config,
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
+        unique_id=UNIQUE_ID,
     )
     entry.add_to_hass(hass)
 
@@ -877,7 +854,7 @@ async def test_zeroconf_flow_already_configured_hostname(
 
     # Flow should abort because device is already setup
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured_device"
+    assert result["reason"] == "already_configured"
 
 
 async def test_import_flow_already_configured_hostname(


### PR DESCRIPTION
## Proposed change
When I originally implemented `config_flow`, I was under the impression that I needed an auth token before I can get the `unique_id` of a `vizio` device. I recently discovered that I only actually need the `host` and `device_class` to get the `unique_id` which means I can set it much earlier and detect for a duplicate sooner. As a result, I can remove duplicate logic and slightly simplify the config flow. I also added two missing typehints that I found and fixed some other typehints that `pylance` found errors for.

EDIT: The update to `pyvizio` was to remove the auth token as a parameter from the `get_unique_id` function.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
