### PR TITLE
Revert "Updated influxdb-client dependency to 1.8.0"

### DIFF
--- a/homeassistant/components/influxdb/manifest.json
+++ b/homeassistant/components/influxdb/manifest.json
@@ -2,6 +2,6 @@
   "domain": "influxdb",
   "name": "InfluxDB",
   "documentation": "https://www.home-assistant.io/integrations/influxdb",
-  "requirements": ["influxdb==5.2.3", "influxdb-client==1.8.0"],
+  "requirements": ["influxdb==5.2.3", "influxdb-client==1.6.0"],
   "codeowners": ["@fabaff", "@mdegat01"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -793,7 +793,7 @@ ihcsdk==2.7.0
 incomfort-client==0.4.0
 
 # homeassistant.components.influxdb
-influxdb-client==1.8.0
+influxdb-client==1.6.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -371,7 +371,7 @@ huawei-lte-api==1.4.12
 iaqualink==0.3.4
 
 # homeassistant.components.influxdb
-influxdb-client==1.8.0
+influxdb-client==1.6.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3


### PR DESCRIPTION
Reverts home-assistant/core#37396

See https://github.com/influxdata/influxdb-client-python/issues/122 for details on why. Essentially there is no way to do a connection test on v1.8.0, no exceptions are returned for write errors. Will continue to follow-up there but in the meantime, we need to return to 1.6.0.