### PR TITLE
Rewrite rfxtrx init logic to do away with global object

### DIFF
--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -74,7 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Binary Sensor platform to RFXtrx."""
     sensors = []
 
-    device_ids = []
+    device_ids = set()
     device_bits = {}
 
     pt2262_devices = []
@@ -88,7 +88,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_id = get_device_id(event.device, data_bits=entity.get(CONF_DATA_BITS))
         if device_id in device_ids:
             continue
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         if event.device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
             find_possible_pt2262_device(pt2262_devices, event.device.id_string)
@@ -118,7 +118,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_id = get_device_id(event.device, data_bits=data_bits)
         if device_id in device_ids:
             return
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         _LOGGER.info(
             "Added binary sensor (Device ID: %s Class: %s Sub: %s)",

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -13,30 +13,28 @@ from homeassistant.const import (
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
     CONF_DEVICE_CLASS,
+    CONF_DEVICES,
     CONF_NAME,
 )
 from homeassistant.helpers import config_validation as cv, event as evt
-from homeassistant.util import slugify
 
 from . import (
-    ATTR_NAME,
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
-    CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_OFF_DELAY,
-    RFX_DEVICES,
     SIGNAL_EVENT,
     find_possible_pt2262_device,
     fire_command_event,
+    get_device_id,
     get_pt2262_cmd,
-    get_pt2262_device,
     get_pt2262_deviceid,
     get_rfx_object,
 )
-from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
+from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST, DEVICE_PACKET_TYPE_LIGHTING4
 
 _LOGGER = logging.getLogger(__name__)
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -61,28 +59,40 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
+def _get_device_data_bits(device, device_bits):
+    """Deduce data bits for device based on a cache of device bits."""
+    data_bits = None
+    if device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
+        for id_masked, bits in device_bits.items():
+            if get_pt2262_deviceid(device.id_string, bits) == id_masked:
+                data_bits = bits
+                break
+    return data_bits
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Binary Sensor platform to RFXtrx."""
     sensors = []
 
+    device_ids = []
+    device_bits = {}
+
+    pt2262_devices = []
+
     for packet_id, entity in config[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
-        device_id = slugify(event.device.id_string.lower())
-
-        if device_id in RFX_DEVICES:
+        if event is None:
+            _LOGGER.error("Invalid device: %s", packet_id)
             continue
 
-        if entity.get(CONF_DATA_BITS) is not None:
-            _LOGGER.debug(
-                "Masked device id: %s",
-                get_pt2262_deviceid(device_id, entity.get(CONF_DATA_BITS)),
-            )
+        device_id = get_device_id(event.device, data_bits=entity.get(CONF_DATA_BITS))
+        if device_id in device_ids:
+            continue
+        device_ids.append(device_id)
 
-        _LOGGER.debug(
-            "Add %s rfxtrx.binary_sensor (class %s)",
-            entity[ATTR_NAME],
-            entity.get(CONF_DEVICE_CLASS),
-        )
+        if event.device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
+            find_possible_pt2262_device(pt2262_devices, event.device.id_string)
+            pt2262_devices.append(event.device.id_string)
 
         device = RfxtrxBinarySensor(
             event.device,
@@ -95,7 +105,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             entity.get(CONF_COMMAND_OFF),
         )
         sensors.append(device)
-        RFX_DEVICES[device_id] = device
 
     add_entities(sensors)
 
@@ -104,35 +113,28 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if not isinstance(event, rfxtrxmod.ControlEvent):
             return
 
-        device_id = slugify(event.device.id_string.lower())
+        data_bits = _get_device_data_bits(event.device, device_bits)
 
-        sensor = RFX_DEVICES.get(device_id, get_pt2262_device(device_id))
+        device_id = get_device_id(event.device, data_bits=data_bits)
+        if device_id in device_ids:
+            return
+        device_ids.append(device_id)
 
-        if sensor is None:
-            # Add the entity if not exists and automatic_add is True
-            if not config[CONF_AUTOMATIC_ADD]:
-                return
-
-            if event.device.packettype == 0x13:
-                poss_dev = find_possible_pt2262_device(device_id)
-                if poss_dev is not None:
-                    poss_id = slugify(poss_dev.event.device.id_string.lower())
-                    _LOGGER.debug("Found possible matching device ID: %s", poss_id)
-
-            pkt_id = "".join(f"{x:02x}" for x in event.data)
-            sensor = RfxtrxBinarySensor(event.device, pkt_id, event=event)
-            RFX_DEVICES[device_id] = sensor
-            add_entities([sensor])
-            _LOGGER.info(
-                "Added binary sensor %s (Device ID: %s Class: %s Sub: %s)",
-                pkt_id,
-                slugify(event.device.id_string.lower()),
-                event.device.__class__.__name__,
-                event.device.subtype,
-            )
+        _LOGGER.info(
+            "Added binary sensor (Device ID: %s Class: %s Sub: %s)",
+            event.device.id_string.lower(),
+            event.device.__class__.__name__,
+            event.device.subtype,
+        )
+        pkt_id = "".join(f"{x:02x}" for x in event.data)
+        sensor = RfxtrxBinarySensor(
+            event.device, pkt_id, data_bits=data_bits, event=event
+        )
+        add_entities([sensor])
 
     # Subscribe to main RFXtrx events
-    hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, binary_sensor_update)
+    if config[CONF_AUTOMATIC_ADD]:
+        hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, binary_sensor_update)
 
 
 class RfxtrxBinarySensor(BinarySensorEntity):
@@ -158,22 +160,13 @@ class RfxtrxBinarySensor(BinarySensorEntity):
         self._device_class = device_class
         self._off_delay = off_delay
         self._state = False
-        self.is_lighting4 = device.packettype == 0x13
         self.delay_listener = None
         self._data_bits = data_bits
         self._cmd_on = cmd_on
         self._cmd_off = cmd_off
 
-        if data_bits is not None:
-            self._masked_id = get_pt2262_deviceid(device.id_string.lower(), data_bits)
-            self._unique_id = (
-                f"{device.packettype:x}_{device.subtype:x}_{self._masked_id}"
-            )
-        else:
-            self._masked_id = None
-            self._unique_id = (
-                f"{device.packettype:x}_{device.subtype:x}_{device.id_string}"
-            )
+        self._device_id = get_device_id(device, data_bits=data_bits)
+        self._unique_id = "_".join(x for x in self._device_id)
 
         if event:
             self._apply_event(event)
@@ -192,11 +185,6 @@ class RfxtrxBinarySensor(BinarySensorEntity):
     def name(self):
         """Return the device name."""
         return self._name
-
-    @property
-    def masked_id(self):
-        """Return the masked device id (isolated address bits)."""
-        return self._masked_id
 
     @property
     def data_bits(self):
@@ -263,20 +251,15 @@ class RfxtrxBinarySensor(BinarySensorEntity):
 
     def _apply_event(self, event):
         """Apply command from rfxtrx."""
-        if self.is_lighting4:
+        if event.device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
             self._apply_event_lighting4(event)
         else:
             self._apply_event_standard(event)
 
     def _handle_event(self, event):
         """Check if event applies to me and update."""
-        if self._masked_id:
-            masked_id = get_pt2262_deviceid(event.device.id_string, self._data_bits)
-            if masked_id != self._masked_id:
-                return
-        else:
-            if event.device.id_string != self._device.id_string:
-                return
+        if get_device_id(event.device, data_bits=self._data_bits) != self._device_id:
+            return
 
         _LOGGER.debug(
             "Binary sensor update (Device ID: %s Class: %s Sub: %s)",

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -14,3 +14,4 @@ COMMAND_OFF_LIST = [
     "Down",
     "Close (inline relay)",
 ]
+DEVICE_PACKET_TYPE_LIGHTING4 = 0x13

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -45,7 +45,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx cover."""
-    device_ids = []
+    device_ids = set()
 
     entities = []
     for packet_id, entity_info in config[CONF_DEVICES].items():
@@ -57,7 +57,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_id = get_device_id(event.device)
         if device_id in device_ids:
             continue
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
         entity = RfxtrxCover(
@@ -79,7 +79,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_id = get_device_id(event.device)
         if device_id in device_ids:
             return
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         _LOGGER.info(
             "Added cover (Device ID: %s Class: %s Sub: %s)",

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -1,23 +1,25 @@
 """Support for RFXtrx covers."""
+import logging
+
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.components.cover import PLATFORM_SCHEMA, CoverEntity
-from homeassistant.const import CONF_NAME, STATE_OPEN
+from homeassistant.const import ATTR_STATE, CONF_DEVICES, CONF_NAME, STATE_OPEN
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (
+    ATTR_FIRE_EVENT,
     CONF_AUTOMATIC_ADD,
-    CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxDevice,
     fire_command_event,
-    get_devices_from_config,
-    get_new_device,
+    get_device_id,
+    get_rfx_object,
 )
 from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 
@@ -38,11 +40,32 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx cover."""
-    covers = get_devices_from_config(config, RfxtrxCover)
-    add_entities(covers)
+    device_ids = []
+
+    entities = []
+    for packet_id, entity_info in config[CONF_DEVICES].items():
+        event = get_rfx_object(packet_id)
+        if event is None:
+            _LOGGER.error("Invalid device: %s", packet_id)
+            continue
+
+        device_id = get_device_id(event.device)
+        if device_id in device_ids:
+            continue
+        device_ids.append(device_id)
+
+        datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
+        entity = RfxtrxCover(
+            entity_info[CONF_NAME], event.device, datas, config[CONF_SIGNAL_REPETITIONS]
+        )
+        entities.append(entity)
+
+    add_entities(entities)
 
     def cover_update(event):
         """Handle cover updates from the RFXtrx gateway."""
@@ -53,12 +76,28 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ):
             return
 
-        new_device = get_new_device(event, config, RfxtrxCover)
-        if new_device:
-            add_entities([new_device])
+        device_id = get_device_id(event.device)
+        if device_id in device_ids:
+            return
+        device_ids.append(device_id)
+
+        _LOGGER.info(
+            "Added cover (Device ID: %s Class: %s Sub: %s)",
+            event.device.id_string.lower(),
+            event.device.__class__.__name__,
+            event.device.subtype,
+        )
+
+        pkt_id = "".join(f"{x:02x}" for x in event.data)
+        datas = {ATTR_STATE: False, ATTR_FIRE_EVENT: False}
+        entity = RfxtrxCover(
+            pkt_id, event.device, datas, DEFAULT_SIGNAL_REPETITIONS, event=event
+        )
+        add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, cover_update)
+    if config[CONF_AUTOMATIC_ADD]:
+        hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, cover_update)
 
 
 class RfxtrxCover(RfxtrxDevice, CoverEntity, RestoreEntity):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -10,21 +10,21 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS,
     LightEntity,
 )
-from homeassistant.const import CONF_NAME, STATE_ON
+from homeassistant.const import ATTR_STATE, CONF_DEVICES, CONF_NAME, STATE_ON
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (
+    ATTR_FIRE_EVENT,
     CONF_AUTOMATIC_ADD,
-    CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxDevice,
     fire_command_event,
-    get_devices_from_config,
-    get_new_device,
+    get_device_id,
+    get_rfx_object,
 )
 from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 
@@ -52,8 +52,29 @@ SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
-    lights = get_devices_from_config(config, RfxtrxLight)
-    add_entities(lights)
+    device_ids = []
+
+    # Add switch from config file
+    entities = []
+    for packet_id, entity_info in config[CONF_DEVICES].items():
+        event = get_rfx_object(packet_id)
+        if event is None:
+            _LOGGER.error("Invalid device: %s", packet_id)
+            continue
+
+        device_id = get_device_id(event.device)
+        if device_id in device_ids:
+            continue
+        device_ids.append(device_id)
+
+        datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
+        entity = RfxtrxLight(
+            entity_info[CONF_NAME], event.device, datas, config[CONF_SIGNAL_REPETITIONS]
+        )
+
+        entities.append(entity)
+
+    add_entities(entities)
 
     def light_update(event):
         """Handle light updates from the RFXtrx gateway."""
@@ -63,12 +84,29 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ):
             return
 
-        new_device = get_new_device(event, config, RfxtrxLight)
-        if new_device:
-            add_entities([new_device])
+        device_id = get_device_id(event.device)
+        if device_id in device_ids:
+            return
+        device_ids.append(device_id)
+
+        _LOGGER.debug(
+            "Added light (Device ID: %s Class: %s Sub: %s)",
+            event.device.id_string.lower(),
+            event.device.__class__.__name__,
+            event.device.subtype,
+        )
+
+        pkt_id = "".join(f"{x:02x}" for x in event.data)
+        datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: False}
+        entity = RfxtrxLight(
+            pkt_id, event.device, datas, DEFAULT_SIGNAL_REPETITIONS, event=event
+        )
+
+        add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, light_update)
+    if config[CONF_AUTOMATIC_ADD]:
+        hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, light_update)
 
 
 class RfxtrxLight(RfxtrxDevice, LightEntity, RestoreEntity):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -52,7 +52,7 @@ SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
-    device_ids = []
+    device_ids = set()
 
     # Add switch from config file
     entities = []
@@ -65,7 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_id = get_device_id(event.device)
         if device_id in device_ids:
             continue
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
         entity = RfxtrxLight(
@@ -87,7 +87,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_id = get_device_id(event.device)
         if device_id in device_ids:
             return
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         _LOGGER.debug(
             "Added light (Device ID: %s Class: %s Sub: %s)",

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -42,7 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
-    data_ids = []
+    data_ids = set()
 
     entities = []
     for packet_id, entity_info in config[CONF_DEVICES].items():
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             data_id = (*device_id, data_type)
             if data_id in data_ids:
                 continue
-            data_ids.append(data_id)
+            data_ids.add(data_id)
 
             entity = RfxtrxSensor(
                 event.device,
@@ -84,7 +84,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             data_id = (*device_id, data_type)
             if data_id in data_ids:
                 continue
-            data_ids.append(data_id)
+            data_ids.add(data_id)
 
             _LOGGER.debug(
                 "Added sensor (Device ID: %s Class: %s Sub: %s)",

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -5,21 +5,17 @@ from RFXtrx import SensorEvent
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, CONF_NAME
+from homeassistant.const import ATTR_ENTITY_ID, CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import slugify
 
 from . import (
-    ATTR_DATA_TYPE,
-    ATTR_FIRE_EVENT,
     CONF_AUTOMATIC_ADD,
     CONF_DATA_TYPE,
-    CONF_DEVICES,
     CONF_FIRE_EVENT,
     DATA_TYPES,
-    RFX_DEVICES,
     SIGNAL_EVENT,
+    get_device_id,
     get_rfx_object,
 )
 
@@ -46,64 +42,63 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
-    sensors = []
+    data_ids = []
+
+    entities = []
     for packet_id, entity_info in config[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
-        device_id = "sensor_{}".format(slugify(event.device.id_string.lower()))
-        if device_id in RFX_DEVICES:
+        if event is None:
+            _LOGGER.error("Invalid device: %s", packet_id)
             continue
-        _LOGGER.info("Add %s rfxtrx.sensor", entity_info[ATTR_NAME])
 
-        sub_sensors = {}
-        data_types = entity_info[ATTR_DATA_TYPE]
-        if not data_types:
-            data_types = [""]
-            for data_type in DATA_TYPES:
-                if data_type in event.values:
-                    data_types = [data_type]
-                    break
-        for _data_type in data_types:
-            new_sensor = RfxtrxSensor(
+        if entity_info[CONF_DATA_TYPE]:
+            data_types = entity_info[CONF_DATA_TYPE]
+        else:
+            data_types = list(set(event.values) & set(DATA_TYPES))
+
+        device_id = get_device_id(event.device)
+        for data_type in data_types:
+            data_id = (*device_id, data_type)
+            if data_id in data_ids:
+                continue
+            data_ids.append(data_id)
+
+            entity = RfxtrxSensor(
                 event.device,
-                entity_info[ATTR_NAME],
-                _data_type,
-                entity_info[ATTR_FIRE_EVENT],
+                entity_info[CONF_NAME],
+                data_type,
+                entity_info[CONF_FIRE_EVENT],
             )
-            sensors.append(new_sensor)
-            sub_sensors[_data_type] = new_sensor
-        RFX_DEVICES[device_id] = sub_sensors
-    add_entities(sensors)
+            entities.append(entity)
+
+    add_entities(entities)
 
     def sensor_update(event):
         """Handle sensor updates from the RFXtrx gateway."""
         if not isinstance(event, SensorEvent):
             return
 
-        device_id = f"sensor_{slugify(event.device.id_string.lower())}"
-
-        if device_id in RFX_DEVICES:
-            return
-
-        # Add entity if not exist and the automatic_add is True
-        if not config[CONF_AUTOMATIC_ADD]:
-            return
-
         pkt_id = "".join(f"{x:02x}" for x in event.data)
-        _LOGGER.info("Automatic add rfxtrx.sensor: %s", pkt_id)
+        device_id = get_device_id(event.device)
+        for data_type in set(event.values) & set(DATA_TYPES):
+            data_id = (*device_id, data_type)
+            if data_id in data_ids:
+                continue
+            data_ids.append(data_id)
 
-        data_type = ""
-        for _data_type in DATA_TYPES:
-            if _data_type in event.values:
-                data_type = _data_type
-                break
-        new_sensor = RfxtrxSensor(event.device, pkt_id, data_type, event=event)
-        sub_sensors = {}
-        sub_sensors[new_sensor.data_type] = new_sensor
-        RFX_DEVICES[device_id] = sub_sensors
-        add_entities([new_sensor])
+            _LOGGER.debug(
+                "Added sensor (Device ID: %s Class: %s Sub: %s)",
+                event.device.id_string.lower(),
+                event.device.__class__.__name__,
+                event.device.subtype,
+            )
+
+            entity = RfxtrxSensor(event.device, pkt_id, data_type, event=event)
+            add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, sensor_update)
+    if config[CONF_AUTOMATIC_ADD]:
+        hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, sensor_update)
 
 
 class RfxtrxSensor(Entity):
@@ -117,9 +112,8 @@ class RfxtrxSensor(Entity):
         self.should_fire_event = should_fire_event
         self.data_type = data_type
         self._unit_of_measurement = DATA_TYPES.get(data_type, "")
-        self._unique_id = (
-            f"{device.packettype:x}_{device.subtype:x}_{device.id_string}_{data_type}"
-        )
+        self._device_id = get_device_id(device)
+        self._unique_id = "_".join(x for x in (*self._device_id, data_type))
 
         if event:
             self._apply_event(event)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -45,7 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the RFXtrx platform."""
-    device_ids = []
+    device_ids = set()
 
     # Add switch from config file
     entities = []
@@ -58,7 +58,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         device_id = get_device_id(event.device)
         if device_id in device_ids:
             continue
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
         entity = RfxtrxSwitch(
@@ -80,7 +80,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         device_id = get_device_id(event.device)
         if device_id in device_ids:
             return
-        device_ids.append(device_id)
+        device_ids.add(device_id)
 
         _LOGGER.info(
             "Added switch (Device ID: %s Class: %s Sub: %s)",

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -5,21 +5,21 @@ import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
-from homeassistant.const import CONF_NAME, STATE_ON
+from homeassistant.const import ATTR_STATE, CONF_DEVICES, CONF_NAME, STATE_ON
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (
+    ATTR_FIRE_EVENT,
     CONF_AUTOMATIC_ADD,
-    CONF_DEVICES,
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxDevice,
     fire_command_event,
-    get_devices_from_config,
-    get_new_device,
+    get_device_id,
+    get_rfx_object,
 )
 from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 
@@ -45,9 +45,28 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the RFXtrx platform."""
+    device_ids = []
+
     # Add switch from config file
-    switches = get_devices_from_config(config, RfxtrxSwitch)
-    add_entities_callback(switches)
+    entities = []
+    for packet_id, entity_info in config[CONF_DEVICES].items():
+        event = get_rfx_object(packet_id)
+        if event is None:
+            _LOGGER.error("Invalid device: %s", packet_id)
+            continue
+
+        device_id = get_device_id(event.device)
+        if device_id in device_ids:
+            continue
+        device_ids.append(device_id)
+
+        datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
+        entity = RfxtrxSwitch(
+            entity_info[CONF_NAME], event.device, datas, config[CONF_SIGNAL_REPETITIONS]
+        )
+        entities.append(entity)
+
+    add_entities_callback(entities)
 
     def switch_update(event):
         """Handle sensor updates from the RFXtrx gateway."""
@@ -58,12 +77,28 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         ):
             return
 
-        new_device = get_new_device(event, config, RfxtrxSwitch)
-        if new_device:
-            add_entities_callback([new_device])
+        device_id = get_device_id(event.device)
+        if device_id in device_ids:
+            return
+        device_ids.append(device_id)
+
+        _LOGGER.info(
+            "Added switch (Device ID: %s Class: %s Sub: %s)",
+            event.device.id_string.lower(),
+            event.device.__class__.__name__,
+            event.device.subtype,
+        )
+
+        pkt_id = "".join(f"{x:02x}" for x in event.data)
+        datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: False}
+        entity = RfxtrxSwitch(
+            pkt_id, event.device, datas, DEFAULT_SIGNAL_REPETITIONS, event=event
+        )
+        add_entities_callback([entity])
 
     # Subscribe to main RFXtrx events
-    hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, switch_update)
+    if config[CONF_AUTOMATIC_ADD]:
+        hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, switch_update)
 
 
 class RfxtrxSwitch(RfxtrxDevice, SwitchEntity, RestoreEntity):

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -59,8 +59,6 @@ async def rfxtrx_cleanup():
     ):
         yield
 
-    rfxtrx_core.RFX_DEVICES.clear()
-
 
 @pytest.fixture(name="rfxtrx")
 async def rfxtrx_fixture(hass):

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -187,5 +187,5 @@ async def test_fire_event_sensor(hass):
     hass.bus.async_listen("signal_received", record_event)
 
     await _signal_event(hass, "0a520802060101ff0f0269")
-    assert 1 == len(calls)
-    assert calls[0].data == {"entity_id": "sensor.test_temperature"}
+    assert 5 == len(calls)
+    assert any(call.data == {"entity_id": "sensor.test_temperature"} for call in calls)

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -141,7 +141,7 @@ async def test_fire_event(hass):
     assert state
     assert state.state == "on"
 
-    assert 1 == len(calls)
+    assert len(calls) == 1
     assert calls[0].data == {"entity_id": "switch.test", "state": "on"}
 
 
@@ -187,5 +187,5 @@ async def test_fire_event_sensor(hass):
     hass.bus.async_listen("signal_received", record_event)
 
     await _signal_event(hass, "0a520802060101ff0f0269")
-    assert 5 == len(calls)
+    assert len(calls) == 5
     assert any(call.data == {"entity_id": "sensor.test_temperature"} for call in calls)

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -57,7 +57,7 @@ async def test_default_config(hass, rfxtrx):
         )
         await hass.async_block_till_done()
 
-    assert 0 == len(rfxtrx_core.RFX_DEVICES)
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_one_light(hass, rfxtrx):

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -55,11 +55,38 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.test_temperature")
+    base_id = "sensor.test"
+    base_name = "Test"
+
+    state = hass.states.get(f"{base_id}_temperature")
     assert state
     assert state.state == "unknown"
-    assert state.attributes.get("friendly_name") == "Test Temperature"
+    assert state.attributes.get("friendly_name") == f"{base_name} Temperature"
     assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
+
+    state = hass.states.get(f"{base_id}_humidity")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == f"{base_name} Humidity"
+    assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
+
+    state = hass.states.get(f"{base_id}_humidity_status")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == f"{base_name} Humidity status"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_rssi_numeric")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == f"{base_name} Rssi numeric"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_battery_numeric")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == f"{base_name} Battery numeric"
+    assert state.attributes.get("unit_of_measurement") == ""
 
 
 async def test_several_sensors(hass, rfxtrx):
@@ -113,61 +140,94 @@ async def test_discover_sensor(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
+    # 1
     await _signal_event(hass, "0a520801070100b81b0279")
-    state = hass.states.get("sensor.0a520801070100b81b0279_temperature")
+    base_id = "sensor.0a520801070100b81b0279"
+
+    state = hass.states.get(f"{base_id}_humidity")
+    assert state
+    assert state.state == "27"
+    assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
+
+    state = hass.states.get(f"{base_id}_humidity_status")
+    assert state
+    assert state.state == "normal"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_rssi_numeric")
+    assert state
+    assert state.state == "7"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_temperature")
     assert state
     assert state.state == "18.4"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "0a520801070100b81b0279 Temperature",
-            "unit_of_measurement": TEMP_CELSIUS,
-            "Humidity status": "normal",
-            "Temperature": 18.4,
-            "Rssi numeric": 7,
-            "Humidity": 27,
-            "Battery numeric": 9,
-            "Humidity status numeric": 2,
-        }.items()
-    )
+    assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
+    state = hass.states.get(f"{base_id}_battery_numeric")
+    assert state
+    assert state.state == "9"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    # 2
     await _signal_event(hass, "0a52080405020095240279")
-    state = hass.states.get("sensor.0a52080405020095240279_temperature")
+    base_id = "sensor.0a52080405020095240279"
+    state = hass.states.get(f"{base_id}_humidity")
+
+    assert state
+    assert state.state == "36"
+    assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
+
+    state = hass.states.get(f"{base_id}_humidity_status")
+    assert state
+    assert state.state == "normal"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_rssi_numeric")
+    assert state
+    assert state.state == "7"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_temperature")
     assert state
     assert state.state == "14.9"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "0a52080405020095240279 Temperature",
-            "unit_of_measurement": TEMP_CELSIUS,
-            "Humidity status": "normal",
-            "Temperature": 14.9,
-            "Rssi numeric": 7,
-            "Humidity": 36,
-            "Battery numeric": 9,
-            "Humidity status numeric": 2,
-        }.items()
-    )
+    assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
+    state = hass.states.get(f"{base_id}_battery_numeric")
+    assert state
+    assert state.state == "9"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    # 1 Update
     await _signal_event(hass, "0a52085e070100b31b0279")
-    state = hass.states.get("sensor.0a520801070100b81b0279_temperature")
+    base_id = "sensor.0a520801070100b81b0279"
+
+    state = hass.states.get(f"{base_id}_humidity")
+    assert state
+    assert state.state == "27"
+    assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
+
+    state = hass.states.get(f"{base_id}_humidity_status")
+    assert state
+    assert state.state == "normal"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_rssi_numeric")
+    assert state
+    assert state.state == "7"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    state = hass.states.get(f"{base_id}_temperature")
     assert state
     assert state.state == "17.9"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "0a520801070100b81b0279 Temperature",
-            "unit_of_measurement": TEMP_CELSIUS,
-            "Humidity status": "normal",
-            "Temperature": 17.9,
-            "Rssi numeric": 7,
-            "Humidity": 27,
-            "Battery numeric": 9,
-            "Humidity status numeric": 2,
-        }.items()
-    )
+    assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
-    assert len(hass.states.async_all()) == 2
+    state = hass.states.get(f"{base_id}_battery_numeric")
+    assert state
+    assert state.state == "9"
+    assert state.attributes.get("unit_of_measurement") == ""
+
+    assert len(hass.states.async_all()) == 10
 
 
 async def test_discover_sensor_noautoadd(hass, rfxtrx):
@@ -215,35 +275,14 @@ async def test_update_of_sensors(hass, rfxtrx):
     state = hass.states.get("sensor.test_temperature")
     assert state
     assert state.state == "unknown"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "Test Temperature",
-            "unit_of_measurement": TEMP_CELSIUS,
-        }.items()
-    )
 
     state = hass.states.get("sensor.bath_temperature")
     assert state
     assert state.state == "unknown"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "Bath Temperature",
-            "unit_of_measurement": TEMP_CELSIUS,
-        }.items()
-    )
 
     state = hass.states.get("sensor.bath_humidity")
     assert state
     assert state.state == "unknown"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "Bath Humidity",
-            "unit_of_measurement": UNIT_PERCENTAGE,
-        }.items()
-    )
 
     assert len(hass.states.async_all()) == 3
 
@@ -253,52 +292,13 @@ async def test_update_of_sensors(hass, rfxtrx):
     state = hass.states.get("sensor.test_temperature")
     assert state
     assert state.state == "13.3"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "Test Temperature",
-            "unit_of_measurement": TEMP_CELSIUS,
-            "Battery numeric": 9,
-            "Temperature": 13.3,
-            "Humidity": 34,
-            "Humidity status": "normal",
-            "Humidity status numeric": 2,
-            "Rssi numeric": 6,
-        }.items()
-    )
 
     state = hass.states.get("sensor.bath_temperature")
     assert state
     assert state.state == "51.1"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "Bath Temperature",
-            "unit_of_measurement": TEMP_CELSIUS,
-            "Battery numeric": 9,
-            "Temperature": 51.1,
-            "Humidity": 15,
-            "Humidity status": "normal",
-            "Humidity status numeric": 2,
-            "Rssi numeric": 6,
-        }.items()
-    )
 
     state = hass.states.get("sensor.bath_humidity")
     assert state
     assert state.state == "15"
-    assert (
-        state.attributes.items()
-        >= {
-            "friendly_name": "Bath Humidity",
-            "unit_of_measurement": UNIT_PERCENTAGE,
-            "Battery numeric": 9,
-            "Temperature": 51.1,
-            "Humidity": 15,
-            "Humidity status": "normal",
-            "Humidity status numeric": 2,
-            "Rssi numeric": 6,
-        }.items()
-    )
 
     assert len(hass.states.async_all()) == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This re-writes the entity setup code to do away with global state as well as remove the built in stealing of entities between platforms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
rfxtrx:
  device: /dev/tty.usbserial-A11D14EO
  dummy: false
  debug: true

switch:
  - platform: rfxtrx
    automatic_add: true

light:
  - platform: rfxtrx
    automatic_add: true
  - platform: demo

sensor:
  platform: rfxtrx
  automatic_add: true

binary_sensor:
  platform: rfxtrx
  automatic_add: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #37539
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
