### PR TITLE
Actually fix Guardian entity services

### DIFF
--- a/homeassistant/components/guardian/manifest.json
+++ b/homeassistant/components/guardian/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/guardian",
   "requirements": [
-    "aioguardian==1.0.0"
+    "aioguardian==1.0.1"
   ],
   "ssdp": [],
   "zeroconf": [

--- a/homeassistant/components/guardian/services.yaml
+++ b/homeassistant/components/guardian/services.yaml
@@ -4,36 +4,31 @@ disable_ap:
   fields:
     entity_id:
       description: The Guardian valve controller to affect.
-    area_id:
-      description: The area to affect.
+      example: switch.guardian_abcde_valve
 enable_ap:
   description: Enable the device's onboard access point.
   fields:
     entity_id:
       description: The Guardian valve controller to affect.
-    area_id:
-      description: The area to affect.
+      example: switch.guardian_abcde_valve
 reboot:
   description: Reboot the device.
   fields:
     entity_id:
       description: The Guardian valve controller to affect.
-    area_id:
-      description: The area to affect.
+      example: switch.guardian_abcde_valve
 reset_valve_diagnostics:
   description: Fully (and irrecoverably) reset all valve diagnostics.
   fields:
     entity_id:
       description: The Guardian valve controller to affect.
-    area_id:
-      description: The area to affect.
+      example: switch.guardian_abcde_valve
 upgrade_firmware:
   description: Upgrade the device firmware.
   fields:
     entity_id:
       description: The Guardian valve controller to affect.
-    area_id:
-      description: The area to affect.
+      example: switch.guardian_abcde_valve
     url:
       description: (optional) The URL of the server hosting the firmware file.
       example: https://repo.guardiancloud.services/gvc/fw

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -31,16 +31,6 @@ SERVICE_REBOOT = "reboot"
 SERVICE_RESET_VALVE_DIAGNOSTICS = "reset_valve_diagnostics"
 SERVICE_UPGRADE_FIRMWARE = "upgrade_firmware"
 
-SERVICE_UPGRADE_FIRMWARE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_URL, default=DEFAULT_FIRMWARE_UPGRADE_URL): cv.url,
-        vol.Optional(CONF_PORT, default=DEFAULT_FIRMWARE_UPGRADE_PORT): cv.port,
-        vol.Optional(
-            CONF_FILENAME, default=DEFAULT_FIRMWARE_UPGRADE_FILENAME
-        ): cv.string,
-    }
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: Callable
@@ -49,13 +39,19 @@ async def async_setup_entry(
     platform = entity_platform.current_platform.get()
 
     for service_name, schema, method in [
-        (SERVICE_DISABLE_AP, None, "async_disable_ap"),
-        (SERVICE_ENABLE_AP, None, "async_enable_ap"),
-        (SERVICE_REBOOT, None, "async_reboot"),
-        (SERVICE_RESET_VALVE_DIAGNOSTICS, None, "async_reset_valve_diagnostics"),
+        (SERVICE_DISABLE_AP, {}, "async_disable_ap"),
+        (SERVICE_ENABLE_AP, {}, "async_enable_ap"),
+        (SERVICE_REBOOT, {}, "async_reboot"),
+        (SERVICE_RESET_VALVE_DIAGNOSTICS, {}, "async_reset_valve_diagnostics"),
         (
             SERVICE_UPGRADE_FIRMWARE,
-            SERVICE_UPGRADE_FIRMWARE_SCHEMA,
+            {
+                vol.Optional(CONF_URL, default=DEFAULT_FIRMWARE_UPGRADE_URL): cv.url,
+                vol.Optional(CONF_PORT, default=DEFAULT_FIRMWARE_UPGRADE_PORT): cv.port,
+                vol.Optional(
+                    CONF_FILENAME, default=DEFAULT_FIRMWARE_UPGRADE_FILENAME
+                ): cv.string,
+            },
             "async_upgrade_firmware",
         ),
     ]:

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -2,11 +2,6 @@
 from typing import Callable, Dict
 
 from aioguardian import Client
-from aioguardian.commands.system import (
-    DEFAULT_FIRMWARE_UPGRADE_FILENAME,
-    DEFAULT_FIRMWARE_UPGRADE_PORT,
-    DEFAULT_FIRMWARE_UPGRADE_URL,
-)
 from aioguardian.errors import GuardianError
 import voluptuous as vol
 
@@ -46,11 +41,9 @@ async def async_setup_entry(
         (
             SERVICE_UPGRADE_FIRMWARE,
             {
-                vol.Optional(CONF_URL, default=DEFAULT_FIRMWARE_UPGRADE_URL): cv.url,
-                vol.Optional(CONF_PORT, default=DEFAULT_FIRMWARE_UPGRADE_PORT): cv.port,
-                vol.Optional(
-                    CONF_FILENAME, default=DEFAULT_FIRMWARE_UPGRADE_FILENAME
-                ): cv.string,
+                vol.Optional(CONF_URL): cv.url,
+                vol.Optional(CONF_PORT): cv.port,
+                vol.Optional(CONF_FILENAME): cv.string,
             },
             "async_upgrade_firmware",
         ),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,7 +179,7 @@ aiofreepybox==0.0.8
 aioftp==0.12.0
 
 # homeassistant.components.guardian
-aioguardian==1.0.0
+aioguardian==1.0.1
 
 # homeassistant.components.harmony
 aioharmony==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -85,7 +85,7 @@ aioesphomeapi==2.6.1
 aiofreepybox==0.0.8
 
 # homeassistant.components.guardian
-aioguardian==1.0.0
+aioguardian==1.0.1
 
 # homeassistant.components.harmony
 aioharmony==0.2.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on https://github.com/home-assistant/core/pull/37659, this PR actually fixes the schemas for the Guardian entity services to ensure that proper `entity_id` or `area_id` values are passed.

While here, the PR also bumps `aioguardian` to 1.0.1. Changelog: https://github.com/bachya/aioguardian/releases/tag/1.0.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
