### PR TITLE
Update influxdb-client dependency to 1.8.0, fix test write for InfluxDB v2

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -333,10 +333,10 @@ def get_influx_connection(conf, test_write=False, test_read=False):
 
         buckets = []
         if test_write:
-            # Try to write [] to influx. If we can connect and creds are valid
+            # Try to write b'' to influx. If we can connect and creds are valid
             # Then invalid inputs is returned. Anything else is a broken config
             try:
-                write_v2([])
+                write_v2(b'')
             except ValueError:
                 pass
             write_api = influx.write_api(write_options=ASYNCHRONOUS)

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -333,10 +333,10 @@ def get_influx_connection(conf, test_write=False, test_read=False):
 
         buckets = []
         if test_write:
-            # Try to write b'' to influx. If we can connect and creds are valid
+            # Try to write b"" to influx. If we can connect and creds are valid
             # Then invalid inputs is returned. Anything else is a broken config
             try:
-                write_v2(b'')
+                write_v2(b"")
             except ValueError:
                 pass
             write_api = influx.write_api(write_options=ASYNCHRONOUS)

--- a/homeassistant/components/influxdb/manifest.json
+++ b/homeassistant/components/influxdb/manifest.json
@@ -2,6 +2,6 @@
   "domain": "influxdb",
   "name": "InfluxDB",
   "documentation": "https://www.home-assistant.io/integrations/influxdb",
-  "requirements": ["influxdb==5.2.3", "influxdb-client==1.6.0"],
+  "requirements": ["influxdb==5.2.3", "influxdb-client==1.8.0"],
   "codeowners": ["@fabaff", "@mdegat01"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -793,7 +793,7 @@ ihcsdk==2.7.0
 incomfort-client==0.4.0
 
 # homeassistant.components.influxdb
-influxdb-client==1.6.0
+influxdb-client==1.8.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -371,7 +371,7 @@ huawei-lte-api==1.4.12
 iaqualink==0.3.4
 
 # homeassistant.components.influxdb
-influxdb-client==1.6.0
+influxdb-client==1.8.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3


### PR DESCRIPTION
## Proposed change
- Update InfluxDB v2 client to 1.8.0
- Fixed testing writes for InfluxDB v2


## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
influxdb:
  api_version: "2"
  organization: my_org
  token: my_token

sensor:
- platform: influxdb
  api_version: "2"
  organization: my_org
  token: my_token
  queries:
    range_start: "-1d"
    bucket: Glances Bucket
    name: "Average CPU temp today"
    query: "filter(fn: (r) => r._field == \"value\" and r.entity_id == \"glances_cpu_temperature\")"
    group_function: mean
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/37697

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
