### PR TITLE
Allow the ONVIF PullPoint subscription to be restarted when the camera reboots

### DIFF
--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -1,8 +1,13 @@
 """ONVIF event abstraction."""
+import asyncio
 import datetime as dt
 from typing import Callable, Dict, List, Optional, Set
 
-from aiohttp.client_exceptions import ServerDisconnectedError
+from aiohttp.client_exceptions import (
+    ClientConnectorError,
+    ClientOSError,
+    ServerDisconnectedError,
+)
 from onvif import ONVIFCamera, ONVIFService
 from zeep.exceptions import Fault
 
@@ -15,6 +20,13 @@ from .models import Event
 from .parsers import PARSERS
 
 UNHANDLED_TOPICS = set()
+SUBSCRIPTION_ERRORS = (
+    ClientConnectorError,
+    ClientOSError,
+    Fault,
+    ServerDisconnectedError,
+    asyncio.TimeoutError,
+)
 
 
 class EventManager:
@@ -44,11 +56,7 @@ class EventManager:
         """Listen for data updates."""
         # This is the first listener, set up polling.
         if not self._listeners:
-            self._unsub_refresh = async_track_point_in_utc_time(
-                self.hass,
-                self.async_pull_messages,
-                dt_util.utcnow() + dt.timedelta(seconds=1),
-            )
+            self.schedule_pull()
 
         self._listeners.append(update_callback)
 
@@ -89,18 +97,54 @@ class EventManager:
             )
 
             self.started = True
+            return True
 
-        return self.started
+        return False
 
     async def async_stop(self) -> None:
         """Unsubscribe from events."""
         self._listeners = []
+        self.started = False
 
         if not self._subscription:
             return
 
         await self._subscription.Unsubscribe()
         self._subscription = None
+
+    async def async_restart(self, _now: dt = None) -> None:
+        """Restart the subscription assuming the camera rebooted."""
+        if not self.started:
+            return
+
+        if self._subscription:
+            try:
+                await self._subscription.Unsubscribe()
+            except SUBSCRIPTION_ERRORS:
+                pass  # Ignored. The subscription may no longer exist.
+            self._subscription = None
+
+        try:
+            restarted = await self.async_start()
+        except SUBSCRIPTION_ERRORS:
+            restarted = False
+
+        if not restarted:
+            LOGGER.warning(
+                "Failed to restart ONVIF PullPoint subscription for '%s'. Retrying...",
+                self.unique_id,
+            )
+            # Try again in a minute
+            self._unsub_refresh = async_track_point_in_utc_time(
+                self.hass,
+                self.async_restart,
+                dt_util.utcnow() + dt.timedelta(seconds=60),
+            )
+        elif self._listeners:
+            LOGGER.info(
+                "Restarted ONVIF PullPoint subscription for '%s'", self.unique_id
+            )
+            self.schedule_pull()
 
     async def async_renew(self) -> None:
         """Renew subscription."""
@@ -111,6 +155,14 @@ class EventManager:
             (dt_util.utcnow() + dt.timedelta(days=1)).replace(microsecond=0).isoformat()
         )
         await self._subscription.Renew(termination_time)
+
+    def schedule_pull(self) -> None:
+        """Schedule async_pull_messages to run."""
+        self._unsub_refresh = async_track_point_in_utc_time(
+            self.hass,
+            self.async_pull_messages,
+            dt_util.utcnow() + dt.timedelta(seconds=1),
+        )
 
     async def async_pull_messages(self, _now: dt = None) -> None:
         """Pull messages from device."""
@@ -127,14 +179,19 @@ class EventManager:
                     dt_util.as_utc(response.TerminationTime) - dt_util.utcnow()
                 ).total_seconds() < 7200:
                     await self.async_renew()
+            except SUBSCRIPTION_ERRORS:
+                LOGGER.warning(
+                    "Failed to fetch ONVIF PullPoint subscription messages for '%s'",
+                    self.unique_id,
+                )
+                # Treat errors as if the camera restarted. Assume that the pullpoint
+                # subscription is no longer valid.
+                self._unsub_refresh = None
+                await self.async_restart()
+                return
 
-                # Parse response
-                await self.async_parse_messages(response.NotificationMessage)
-
-            except ServerDisconnectedError:
-                pass
-            except Fault:
-                pass
+            # Parse response
+            await self.async_parse_messages(response.NotificationMessage)
 
             # Update entities
             for update_callback in self._listeners:
@@ -142,11 +199,7 @@ class EventManager:
 
         # Reschedule another pull
         if self._listeners:
-            self._unsub_refresh = async_track_point_in_utc_time(
-                self.hass,
-                self.async_pull_messages,
-                dt_util.utcnow() + dt.timedelta(seconds=1),
-            )
+            self.schedule_pull()
 
     # pylint: disable=protected-access
     async def async_parse_messages(self, messages) -> None:

--- a/homeassistant/components/onvif/manifest.json
+++ b/homeassistant/components/onvif/manifest.json
@@ -2,7 +2,7 @@
   "domain": "onvif",
   "name": "ONVIF",
   "documentation": "https://www.home-assistant.io/integrations/onvif",
-  "requirements": ["onvif-zeep-async==0.4.0", "WSDiscovery==2.0.0"],
+  "requirements": ["onvif-zeep-async==0.5.0", "WSDiscovery==2.0.0"],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@hunterjm"],
   "config_flow": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -996,7 +996,7 @@ oemthermostat==1.1
 onkyo-eiscp==1.2.7
 
 # homeassistant.components.onvif
-onvif-zeep-async==0.4.0
+onvif-zeep-async==0.5.0
 
 # homeassistant.components.opengarage
 open-garage==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -467,7 +467,7 @@ numpy==1.19.0
 oauth2client==4.0.0
 
 # homeassistant.components.onvif
-onvif-zeep-async==0.4.0
+onvif-zeep-async==0.5.0
 
 # homeassistant.components.openerz
 openerz-api==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I noticed that when my camera reboots the onvif component stops receiving motion events from the camera. For my Amcrest cameras this results in the following exception:

```
2020-07-08 11:33:49 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/onvif/event.py", line 122, in async_pull_messages
    response = await pullpoint.PullMessages(req)
  File "/usr/local/lib/python3.7/site-packages/zeep/asyncio/bindings.py", line 13, in send
    options["address"], envelope, http_headers
  File "/usr/local/lib/python3.7/site-packages/zeep/asyncio/transport.py", line 107, in post_xml
    response = await self.post(address, message, headers)
  File "/usr/local/lib/python3.7/site-packages/zeep/asyncio/transport.py", line 95, in post
    proxy=self.proxy,
  File "/usr/local/lib/python3.7/site-packages/aiohttp/client.py", line 504, in _request
    await resp.start(conn)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/client_reqrep.py", line 860, in start
    self._continue = None
  File "/usr/local/lib/python3.7/site-packages/aiohttp/helpers.py", line 586, in __exit__
    raise asyncio.TimeoutError from None
concurrent.futures._base.TimeoutError
```

`async_pull_messages` is never scheduled to run again when this happens.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR may also be related to #36336 but the stack trace I see is different from that issue.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
