### PR TITLE
Add support for the DataUpdateCoordinator to not automatically update

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -30,7 +30,7 @@ class DataUpdateCoordinator:
         logger: logging.Logger,
         *,
         name: str,
-        update_interval: timedelta,
+        update_interval: Optional[timedelta] = None,
         update_method: Optional[Callable[[], Awaitable]] = None,
         request_refresh_debouncer: Optional[Debouncer] = None,
     ):
@@ -91,6 +91,9 @@ class DataUpdateCoordinator:
     @callback
     def _schedule_refresh(self) -> None:
         """Schedule a refresh."""
+        if self.update_interval is None:
+            return
+
         if self._unsub_refresh:
             self._unsub_refresh()
             self._unsub_refresh = None

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -15,9 +15,8 @@ from tests.common import async_fire_time_changed
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def crd(hass):
-    """Coordinator mock."""
+def get_crd(hass, update_interval):
+    """Make coordinator mocks."""
     calls = 0
 
     async def refresh():
@@ -30,9 +29,24 @@ def crd(hass):
         LOGGER,
         name="test",
         update_method=refresh,
-        update_interval=timedelta(seconds=10),
+        update_interval=update_interval,
     )
     return crd
+
+
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=10)
+
+
+@pytest.fixture
+def crd(hass):
+    """Coordinator mock with default update interval."""
+    return get_crd(hass, DEFAULT_UPDATE_INTERVAL)
+
+
+@pytest.fixture
+def crd_without_update_interval(hass):
+    """Coordinator mock that never automatically updates."""
+    return get_crd(hass, None)
 
 
 async def test_async_refresh(crd):
@@ -68,6 +82,20 @@ async def test_async_refresh(crd):
 
 async def test_request_refresh(crd):
     """Test request refresh for update coordinator."""
+    assert crd.data is None
+    await crd.async_request_refresh()
+    assert crd.data == 1
+    assert crd.last_update_success is True
+
+    # Second time we hit the debonuce
+    await crd.async_request_refresh()
+    assert crd.data == 1
+    assert crd.last_update_success is True
+
+
+async def test_request_refresh_no_auto_update(crd_without_update_interval):
+    """Test request refresh for update coordinator without automatic update."""
+    crd = crd_without_update_interval
     assert crd.data is None
     await crd.async_request_refresh()
     assert crd.data == 1
@@ -149,6 +177,37 @@ async def test_update_interval(hass, crd):
 
     # Test we stop updating after we lose last subscriber
     assert crd.data == 2
+
+
+async def test_update_interval_not_present(hass, crd_without_update_interval):
+    """Test update never happens with no update interval."""
+    crd = crd_without_update_interval
+    # Test we don't update without subscriber with no update interval
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+    assert crd.data is None
+
+    # Add subscriber
+    update_callback = Mock()
+    crd.async_add_listener(update_callback)
+
+    # Test twice we don't update with subscriber with no update interval
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+    assert crd.data is None
+
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+    assert crd.data is None
+
+    # Test removing listener
+    crd.async_remove_listener(update_callback)
+
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    # Test we stop don't update after we lose last subscriber
+    assert crd.data is None
 
 
 async def test_refresh_recover(crd, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for the DataUpdateCoordinator to accept a `refresh_interval=None` and then not schedule updates. Manual updates are still allowed. This is needed to support situations like https://github.com/home-assistant/core/pull/37708

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
None

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/37708, https://github.com/home-assistant/core/issues/37658

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
