### PR TITLE
Fix zone cleaning and raise config entry not ready when needed

### DIFF
--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import Throttle
 
@@ -103,6 +104,7 @@ async def async_setup_entry(hass, entry):
         await hass.async_add_executor_job(hub.update_robots)
     except NeatoRobotException:
         _LOGGER.debug("Failed to connect to Neato API")
+        raise ConfigEntryNotReady
         return False
 
     for component in ("camera", "vacuum", "switch", "sensor"):
@@ -154,6 +156,7 @@ class NeatoHub:
                 _LOGGER.error("Invalid credentials")
             else:
                 _LOGGER.error("Unable to connect to Neato API")
+                raise ConfigEntryNotReady
             self.logged_in = False
             return
 

--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -107,7 +107,7 @@ async def async_setup_entry(hass, entry):
         raise ConfigEntryNotReady
 
     for component in ("camera", "vacuum", "switch", "sensor"):
-        hass.async_create_task(
+        hass.async_add_job(
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
 

--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -92,9 +92,8 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up config entry."""
-    hass.data[NEATO_LOGIN] = NeatoHub(hass, entry.data, Account)
+    hub = NeatoHub(hass, entry.data, Account)
 
-    hub = hass.data[NEATO_LOGIN]
     await hass.async_add_executor_job(hub.login)
     if not hub.logged_in:
         _LOGGER.debug("Failed to login to Neato API")
@@ -105,6 +104,8 @@ async def async_setup_entry(hass, entry):
     except NeatoRobotException:
         _LOGGER.debug("Failed to connect to Neato API")
         raise ConfigEntryNotReady
+
+    hass.data[NEATO_LOGIN] = hub
 
     for component in ("camera", "vacuum", "switch", "sensor"):
         hass.async_add_job(

--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -105,7 +105,6 @@ async def async_setup_entry(hass, entry):
     except NeatoRobotException:
         _LOGGER.debug("Failed to connect to Neato API")
         raise ConfigEntryNotReady
-        return False
 
     for component in ("camera", "vacuum", "switch", "sensor"):
         hass.async_create_task(

--- a/homeassistant/components/neato/const.py
+++ b/homeassistant/components/neato/const.py
@@ -9,7 +9,7 @@ NEATO_MAP_DATA = "neato_map_data"
 NEATO_PERSISTENT_MAPS = "neato_persistent_maps"
 NEATO_ROBOTS = "neato_robots"
 
-SCAN_INTERVAL_MINUTES = 5
+SCAN_INTERVAL_MINUTES = 1
 
 SERVICE_NEATO_CUSTOM_CLEANING = "custom_cleaning"
 

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -341,6 +341,7 @@ class NeatoConnectedVacuum(StateVacuumEntity):
             info["manufacturer"] = self._robot_stats["battery"]["vendor"]
             info["model"] = self._robot_stats["model"]
             info["sw_version"] = self._robot_stats["firmware"]
+        return info
 
     def start(self):
         """Start cleaning or resume cleaning."""

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -152,7 +152,7 @@ class NeatoConnectedVacuum(StateVacuumEntity):
         self._clean_error_time = None
         self._launched_from = None
         self._battery_level = None
-        self._robot_boundaries = {}
+        self._robot_boundaries = []
         self._robot_stats = None
 
     def update(self):
@@ -242,7 +242,7 @@ class NeatoConnectedVacuum(StateVacuumEntity):
         ):
             allmaps = self._robot_maps[self._robot_serial]
             _LOGGER.debug("Found the following maps for '%s': %s", self._name, allmaps)
-            self._robot_boundaries = {}  # Reset boundaries before refreshing boundaries
+            self._robot_boundaries = []  # Reset boundaries before refreshing boundaries
             for maps in allmaps:
                 try:
                     robot_boundaries = self.robot.get_map_boundaries(maps["id"]).json()
@@ -256,12 +256,7 @@ class NeatoConnectedVacuum(StateVacuumEntity):
                     maps["name"],
                     robot_boundaries,
                 )
-                if self._robot_boundaries == {}:
-                    self._robot_boundaries = robot_boundaries
-                else:
-                    self._robot_boundaries["data"]["boundaries"] += robot_boundaries[
-                        "data"
-                    ]["boundaries"]
+                self._robot_boundaries += robot_boundaries["data"]["boundaries"]
                 _LOGGER.debug(
                     "List of boundaries for '%s': %s",
                     self._name,
@@ -395,7 +390,7 @@ class NeatoConnectedVacuum(StateVacuumEntity):
         """Zone cleaning service call."""
         boundary_id = None
         if zone is not None:
-            for boundary in self._robot_boundaries["data"]["boundaries"]:
+            for boundary in self._robot_boundaries:
                 if zone in boundary["name"]:
                     boundary_id = boundary["id"]
             if boundary_id is None:

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -241,14 +241,32 @@ class NeatoConnectedVacuum(StateVacuumEntity):
             and self._robot_maps[self._robot_serial]
         ):
             allmaps = self._robot_maps[self._robot_serial]
+            _LOGGER.debug("Found the following maps for '%s': %s", self._name, allmaps)
+            self._robot_boundaries = {}  # Reset boundaries before refreshing boundaries
             for maps in allmaps:
                 try:
-                    self._robot_boundaries = self.robot.get_map_boundaries(
-                        maps["id"]
-                    ).json()
+                    robot_boundaries = self.robot.get_map_boundaries(maps["id"]).json()
                 except NeatoRobotException as ex:
                     _LOGGER.error("Could not fetch map boundaries: %s", ex)
-                    self._robot_boundaries = {}
+                    return
+
+                _LOGGER.debug(
+                    "Boundaries for robot '%s' in map '%s': %s",
+                    self._name,
+                    maps["name"],
+                    robot_boundaries,
+                )
+                if self._robot_boundaries == {}:
+                    self._robot_boundaries = robot_boundaries
+                else:
+                    self._robot_boundaries["data"]["boundaries"] += robot_boundaries[
+                        "data"
+                    ]["boundaries"]
+                _LOGGER.debug(
+                    "List of boundaries for '%s': %s",
+                    self._name,
+                    self._robot_boundaries,
+                )
 
     @property
     def name(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Raise config entry not ready during certain situations where the cloud is not responding properly.  Neatos cloud had issues the other day when I was testing some other fix and this allowed the integration to reconnect successfully.

Reduce scan interval as the cloud calls have relaxed over time with the improvements the integration has received.  We also have a feature request for this too: https://community.home-assistant.io/t/increase-neato-update-interval/193973

Fix zone cleaning in cases where a user had multiple floorplans.  The old code would overwrite the variable each time a new map was retrieved so now we are adding the boundaries to the proper list.  I also added some debug statements to help debug any issues in the future.

Fix device registry, I noticed during testing the vacuum entity was not added to the device so we had some missing information.  My production instance does not have this issue so I suspect it happened after we added the config flow to neato.

Also had a couple other users test these changes successfully both on discord and the forums: https://community.home-assistant.io/t/issue-with-neato-botvac-zones/167722/46?u=dshokouhi

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
neato:
  username: username
  password: password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36022 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
