### PR TITLE
Switch rfxtrx to integration level config

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -35,11 +35,7 @@ DOMAIN = "rfxtrx"
 
 DEFAULT_SIGNAL_REPETITIONS = 1
 
-ATTR_AUTOMATIC_ADD = "automatic_add"
-ATTR_DEVICE = "device"
-ATTR_DEBUG = "debug"
 ATTR_FIRE_EVENT = "fire_event"
-ATTR_DUMMY = "dummy"
 CONF_DATA_BITS = "data_bits"
 CONF_AUTOMATIC_ADD = "automatic_add"
 CONF_SIGNAL_REPETITIONS = "signal_repetitions"
@@ -140,11 +136,11 @@ def setup(hass, config):
         # Callback to HA registered components.
         hass.helpers.dispatcher.dispatcher_send(SIGNAL_EVENT, event)
 
-    device = config[DOMAIN].get(ATTR_DEVICE)
+    device = config[DOMAIN].get(CONF_DEVICE)
     host = config[DOMAIN].get(CONF_HOST)
     port = config[DOMAIN].get(CONF_PORT)
-    debug = config[DOMAIN][ATTR_DEBUG]
-    dummy_connection = config[DOMAIN][ATTR_DUMMY]
+    debug = config[DOMAIN][CONF_DEBUG]
+    dummy_connection = config[DOMAIN][CONF_DUMMY]
 
     if dummy_connection:
         rfx_object = rfxtrxmod.Connect(

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -10,18 +10,13 @@ from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_STATE,
-    CONF_BINARY_SENSORS,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
-    CONF_COVERS,
     CONF_DEVICE,
     CONF_DEVICE_CLASS,
     CONF_DEVICES,
     CONF_HOST,
-    CONF_LIGHTS,
     CONF_PORT,
-    CONF_SENSORS,
-    CONF_SWITCHES,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
     POWER_WATT,
@@ -95,75 +90,26 @@ _LOGGER = logging.getLogger(__name__)
 DATA_RFXOBJECT = "rfxobject"
 
 
-STANDARD_PLATFORM_SCHEMA = vol.Schema(
+DEVICE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_DEVICES, default={}): {
-            cv.string: vol.Schema(
-                {vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean}
-            )
-        },
-        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
-        vol.Optional(
-            CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS
-        ): vol.Coerce(int),
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+        vol.Optional(CONF_OFF_DELAY): vol.Any(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_DATA_BITS): cv.positive_int,
+        vol.Optional(CONF_COMMAND_ON): cv.byte,
+        vol.Optional(CONF_COMMAND_OFF): cv.byte,
+        vol.Optional(CONF_DATA_TYPE, default=[]): vol.All(
+            cv.ensure_list, [vol.In(DATA_TYPES.keys())]
+        ),
     }
-)
-
-SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_DEVICES, default={}): {
-            cv.string: vol.Schema(
-                {
-                    vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-                    vol.Optional(CONF_DATA_TYPE, default=[]): vol.All(
-                        cv.ensure_list, [vol.In(DATA_TYPES.keys())]
-                    ),
-                }
-            )
-        },
-        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
-BINARY_SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_DEVICES, default={}): {
-            cv.string: vol.Schema(
-                {
-                    vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-                    vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-                    vol.Optional(CONF_OFF_DELAY): vol.Any(
-                        cv.time_period, cv.positive_timedelta
-                    ),
-                    vol.Optional(CONF_DATA_BITS): cv.positive_int,
-                    vol.Optional(CONF_COMMAND_ON): cv.byte,
-                    vol.Optional(CONF_COMMAND_OFF): cv.byte,
-                }
-            )
-        },
-        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
-    },
-    extra=vol.ALLOW_EXTRA,
 )
 
 BASE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
         vol.Optional(CONF_DUMMY, default=False): cv.boolean,
-        vol.Optional(
-            CONF_SWITCHES, default=STANDARD_PLATFORM_SCHEMA({})
-        ): STANDARD_PLATFORM_SCHEMA,
-        vol.Optional(
-            CONF_LIGHTS, default=STANDARD_PLATFORM_SCHEMA({})
-        ): STANDARD_PLATFORM_SCHEMA,
-        vol.Optional(
-            CONF_COVERS, default=STANDARD_PLATFORM_SCHEMA({})
-        ): STANDARD_PLATFORM_SCHEMA,
-        vol.Optional(CONF_SENSORS, default=SENSOR_SCHEMA({})): SENSOR_SCHEMA,
-        vol.Optional(
-            CONF_BINARY_SENSORS, default=BINARY_SENSOR_SCHEMA({})
-        ): BINARY_SENSOR_SCHEMA,
+        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
+        vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
     }
 )
 
@@ -232,13 +178,11 @@ def setup(hass, config):
 
     hass.data[DATA_RFXOBJECT] = rfx_object
 
-    load_platform(hass, "switch", DOMAIN, config[DOMAIN][CONF_SWITCHES], config)
-    load_platform(hass, "light", DOMAIN, config[DOMAIN][CONF_LIGHTS], config)
-    load_platform(hass, "cover", DOMAIN, config[DOMAIN][CONF_COVERS], config)
-    load_platform(
-        hass, "binary_sensor", DOMAIN, config[DOMAIN][CONF_BINARY_SENSORS], config
-    )
-    load_platform(hass, "sensor", DOMAIN, config[DOMAIN][CONF_SENSORS], config)
+    load_platform(hass, "switch", DOMAIN, config[DOMAIN], config)
+    load_platform(hass, "light", DOMAIN, config[DOMAIN], config)
+    load_platform(hass, "cover", DOMAIN, config[DOMAIN], config)
+    load_platform(hass, "binary_sensor", DOMAIN, config[DOMAIN], config)
+    load_platform(hass, "sensor", DOMAIN, config[DOMAIN], config)
 
     return True
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -101,6 +101,7 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Optional(CONF_DATA_TYPE, default=[]): vol.All(
             cv.ensure_list, [vol.In(DATA_TYPES.keys())]
         ),
+        vol.Optional(CONF_SIGNAL_REPETITIONS, default=1): cv.positive_int,
     }
 )
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -39,11 +39,9 @@ ATTR_AUTOMATIC_ADD = "automatic_add"
 ATTR_DEVICE = "device"
 ATTR_DEBUG = "debug"
 ATTR_FIRE_EVENT = "fire_event"
-ATTR_DATA_TYPE = "data_type"
 ATTR_DUMMY = "dummy"
 CONF_DATA_BITS = "data_bits"
 CONF_AUTOMATIC_ADD = "automatic_add"
-CONF_DATA_TYPE = "data_type"
 CONF_SIGNAL_REPETITIONS = "signal_repetitions"
 CONF_FIRE_EVENT = "fire_event"
 CONF_DUMMY = "dummy"
@@ -98,9 +96,6 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Optional(CONF_DATA_BITS): cv.positive_int,
         vol.Optional(CONF_COMMAND_ON): cv.byte,
         vol.Optional(CONF_COMMAND_OFF): cv.byte,
-        vol.Optional(CONF_DATA_TYPE, default=[]): vol.All(
-            cv.ensure_list, [vol.In(DATA_TYPES.keys())]
-        ),
         vol.Optional(CONF_SIGNAL_REPETITIONS, default=1): cv.positive_int,
     }
 )

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -99,10 +99,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_ids.add(device_id)
 
         _LOGGER.info(
-            "Added binary sensor (Device ID: %s Class: %s Sub: %s)",
+            "Added binary sensor (Device ID: %s Class: %s Sub: %s Event: %s)",
             event.device.id_string.lower(),
             event.device.__class__.__name__,
             event.device.subtype,
+            "".join(f"{x:02x}" for x in event.data),
         )
         sensor = RfxtrxBinarySensor(event.device, data_bits=data_bits, event=event)
         add_entities([sensor])

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -54,11 +54,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     pt2262_devices = []
 
+    def supported(event):
+        return isinstance(event, rfxtrxmod.ControlEvent)
+
     for packet_id, entity in config[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
             continue
+        if not supported(event):
+            return
 
         device_id = get_device_id(event.device, data_bits=entity.get(CONF_DATA_BITS))
         if device_id in device_ids:
@@ -84,7 +89,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     def binary_sensor_update(event):
         """Call for control updates from the RFXtrx gateway."""
-        if not isinstance(event, rfxtrxmod.ControlEvent):
+        if not supported(event):
             return
 
         data_bits = _get_device_data_bits(event.device, device_bits)

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -45,7 +45,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Binary Sensor platform to RFXtrx."""
     if discovery_info is None:
         return
-    config = discovery_info
 
     sensors = []
 
@@ -57,7 +56,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     def supported(event):
         return isinstance(event, rfxtrxmod.ControlEvent)
 
-    for packet_id, entity in config[CONF_DEVICES].items():
+    for packet_id, entity in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -26,7 +26,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx cover."""
     if discovery_info is None:
         return
-    config = discovery_info
 
     device_ids = set()
 
@@ -34,7 +33,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return event.device.known_to_be_rollershutter
 
     entities = []
-    for packet_id, entity_info in config[CONF_DEVICES].items():
+    for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
@@ -77,7 +76,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if config[CONF_AUTOMATIC_ADD]:
+    if discovery_info[CONF_AUTOMATIC_ADD]:
         hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, cover_update)
 
 

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -48,7 +48,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
-        entity = RfxtrxCover(event.device, datas, config[CONF_SIGNAL_REPETITIONS])
+        entity = RfxtrxCover(event.device, datas, entity_info[CONF_SIGNAL_REPETITIONS])
         entities.append(entity)
 
     add_entities(entities)

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -1,8 +1,6 @@
 """Support for RFXtrx covers."""
 import logging
 
-import RFXtrx as rfxtrxmod
-
 from homeassistant.components.cover import CoverEntity
 from homeassistant.const import ATTR_STATE, CONF_DEVICES, STATE_OPEN
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -33,11 +31,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     device_ids = set()
 
     def supported(event):
-        return (
-            isinstance(event.device, rfxtrxmod.LightingDevice)
-            and not event.device.known_to_be_dimmable
-            and event.device.known_to_be_rollershutter
-        )
+        return event.device.known_to_be_rollershutter
 
     entities = []
     for packet_id, entity_info in config[CONF_DEVICES].items():

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -63,10 +63,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_ids.add(device_id)
 
         _LOGGER.info(
-            "Added cover (Device ID: %s Class: %s Sub: %s)",
+            "Added cover (Device ID: %s Class: %s Sub: %s, Event: %s)",
             event.device.id_string.lower(),
             event.device.__class__.__name__,
             event.device.subtype,
+            "".join(f"{x:02x}" for x in event.data),
         )
 
         datas = {ATTR_STATE: False, ATTR_FIRE_EVENT: False}

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -75,11 +75,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             return
         device_ids.add(device_id)
 
-        _LOGGER.debug(
-            "Added light (Device ID: %s Class: %s Sub: %s)",
+        _LOGGER.info(
+            "Added light (Device ID: %s Class: %s Sub: %s, Event: %s)",
             event.device.id_string.lower(),
             event.device.__class__.__name__,
             event.device.subtype,
+            "".join(f"{x:02x}" for x in event.data),
         )
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: False}

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -2,16 +2,13 @@
 import logging
 
 import RFXtrx as rfxtrxmod
-import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
     LightEntity,
 )
-from homeassistant.const import ATTR_STATE, CONF_DEVICES, CONF_NAME, STATE_ON
-from homeassistant.helpers import config_validation as cv
+from homeassistant.const import ATTR_STATE, CONF_DEVICES, STATE_ON
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (
@@ -30,28 +27,15 @@ from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_DEVICES, default={}): {
-            cv.string: vol.Schema(
-                {
-                    vol.Required(CONF_NAME): cv.string,
-                    vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-                }
-            )
-        },
-        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
-        vol.Optional(
-            CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS
-        ): vol.Coerce(int),
-    }
-)
-
 SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
+    if discovery_info is None:
+        return
+    config = discovery_info
+
     device_ids = set()
 
     # Add switch from config file
@@ -68,9 +52,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
-        entity = RfxtrxLight(
-            entity_info[CONF_NAME], event.device, datas, config[CONF_SIGNAL_REPETITIONS]
-        )
+        entity = RfxtrxLight(event.device, datas, config[CONF_SIGNAL_REPETITIONS])
 
         entities.append(entity)
 
@@ -96,10 +78,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             event.device.subtype,
         )
 
-        pkt_id = "".join(f"{x:02x}" for x in event.data)
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: False}
         entity = RfxtrxLight(
-            pkt_id, event.device, datas, DEFAULT_SIGNAL_REPETITIONS, event=event
+            event.device, datas, DEFAULT_SIGNAL_REPETITIONS, event=event
         )
 
         add_entities([entity])

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -60,7 +60,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
-        entity = RfxtrxLight(event.device, datas, config[CONF_SIGNAL_REPETITIONS])
+        entity = RfxtrxLight(event.device, datas, entity_info[CONF_SIGNAL_REPETITIONS])
 
         entities.append(entity)
 

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -34,7 +34,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
     if discovery_info is None:
         return
-    config = discovery_info
 
     device_ids = set()
 
@@ -46,7 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Add switch from config file
     entities = []
-    for packet_id, entity_info in config[CONF_DEVICES].items():
+    for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
@@ -91,7 +90,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if config[CONF_AUTOMATIC_ADD]:
+    if discovery_info[CONF_AUTOMATIC_ADD]:
         hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, light_update)
 
 

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx sensors."""
 import logging
 
-from RFXtrx import SensorEvent
+from RFXtrx import ControlEvent, SensorEvent
 
 from homeassistant.components.sensor import (
     DEVICE_CLASS_BATTERY,
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     data_ids = set()
 
     def supported(event):
-        return isinstance(event, SensorEvent)
+        return isinstance(event, SensorEvent) or isinstance(event, ControlEvent)
 
     entities = []
     for packet_id, entity_info in discovery_info[CONF_DEVICES].items():

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -97,11 +97,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 continue
             data_ids.add(data_id)
 
-            _LOGGER.debug(
-                "Added sensor (Device ID: %s Class: %s Sub: %s)",
+            _LOGGER.info(
+                "Added sensor (Device ID: %s Class: %s Sub: %s, Event: %s)",
                 event.device.id_string.lower(),
                 event.device.__class__.__name__,
                 event.device.subtype,
+                "".join(f"{x:02x}" for x in event.data),
             )
 
             entity = RfxtrxSensor(event.device, data_type, event=event)

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.entity import Entity
 
 from . import (
     CONF_AUTOMATIC_ADD,
-    CONF_DATA_TYPE,
     CONF_FIRE_EVENT,
     DATA_TYPES,
     SIGNAL_EVENT,
@@ -72,13 +71,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if not supported(event):
             continue
 
-        if entity_info[CONF_DATA_TYPE]:
-            data_types = entity_info[CONF_DATA_TYPE]
-        else:
-            data_types = list(set(event.values) & set(DATA_TYPES))
-
         device_id = get_device_id(event.device)
-        for data_type in data_types:
+        for data_type in set(event.values) & set(DATA_TYPES):
             data_id = (*device_id, data_type)
             if data_id in data_ids:
                 continue

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -57,7 +57,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
     if discovery_info is None:
         return
-    config = discovery_info
 
     data_ids = set()
 
@@ -115,7 +114,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if config[CONF_AUTOMATIC_ADD]:
+    if discovery_info[CONF_AUTOMATIC_ADD]:
         hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, sensor_update)
 
 

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -2,17 +2,14 @@
 import logging
 
 from RFXtrx import SensorEvent
-import voluptuous as vol
 
 from homeassistant.components.sensor import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
-    PLATFORM_SCHEMA,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_DEVICES, CONF_NAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import ATTR_ENTITY_ID, CONF_DEVICES
 from homeassistant.helpers.entity import Entity
 
 from . import (
@@ -26,24 +23,6 @@ from . import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_DEVICES, default={}): {
-            cv.string: vol.Schema(
-                {
-                    vol.Optional(CONF_NAME): cv.string,
-                    vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-                    vol.Optional(CONF_DATA_TYPE, default=[]): vol.All(
-                        cv.ensure_list, [vol.In(DATA_TYPES.keys())]
-                    ),
-                }
-            )
-        },
-        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
-    },
-    extra=vol.ALLOW_EXTRA,
-)
 
 
 def _battery_convert(value):
@@ -76,10 +55,14 @@ CONVERT_FUNCTIONS = {
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the RFXtrx platform."""
+    if discovery_info is None:
+        return
+    config = discovery_info
+
     data_ids = set()
 
     entities = []
-    for packet_id, entity_info in config[CONF_DEVICES].items():
+    for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
@@ -98,10 +81,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             data_ids.add(data_id)
 
             entity = RfxtrxSensor(
-                event.device,
-                entity_info[CONF_NAME],
-                data_type,
-                entity_info[CONF_FIRE_EVENT],
+                event.device, data_type, entity_info[CONF_FIRE_EVENT],
             )
             entities.append(entity)
 
@@ -112,7 +92,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if not isinstance(event, SensorEvent):
             return
 
-        pkt_id = "".join(f"{x:02x}" for x in event.data)
         device_id = get_device_id(event.device)
         for data_type in set(event.values) & set(DATA_TYPES):
             data_id = (*device_id, data_type)
@@ -127,7 +106,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 event.device.subtype,
             )
 
-            entity = RfxtrxSensor(event.device, pkt_id, data_type, event=event)
+            entity = RfxtrxSensor(event.device, data_type, event=event)
             add_entities([entity])
 
     # Subscribe to main RFXtrx events
@@ -138,11 +117,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class RfxtrxSensor(Entity):
     """Representation of a RFXtrx sensor."""
 
-    def __init__(self, device, name, data_type, should_fire_event=False, event=None):
+    def __init__(self, device, data_type, should_fire_event=False, event=None):
         """Initialize the sensor."""
         self.event = None
         self._device = device
-        self._name = name
+        self._name = f"{device.type_string} {device.id_string} {data_type}"
         self.should_fire_event = should_fire_event
         self.data_type = data_type
         self._unit_of_measurement = DATA_TYPES.get(data_type, "")
@@ -180,7 +159,7 @@ class RfxtrxSensor(Entity):
     @property
     def name(self):
         """Get the name of the sensor."""
-        return f"{self._name} {self.data_type}"
+        return self._name
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     data_ids = set()
 
     def supported(event):
-        return isinstance(event, SensorEvent) or isinstance(event, ControlEvent)
+        return isinstance(event, (ControlEvent, SensorEvent))
 
     entities = []
     for packet_id, entity_info in discovery_info[CONF_DEVICES].items():

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -61,11 +61,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     data_ids = set()
 
+    def supported(event):
+        return isinstance(event, SensorEvent)
+
     entities = []
     for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
+            continue
+        if not supported(event):
             continue
 
         if entity_info[CONF_DATA_TYPE]:
@@ -89,7 +94,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     def sensor_update(event):
         """Handle sensor updates from the RFXtrx gateway."""
-        if not isinstance(event, SensorEvent):
+        if not supported(event):
             return
 
         device_id = get_device_id(event.device)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -73,10 +73,11 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         device_ids.add(device_id)
 
         _LOGGER.info(
-            "Added switch (Device ID: %s Class: %s Sub: %s)",
+            "Added switch (Device ID: %s Class: %s Sub: %s, Event: %s)",
             event.device.id_string.lower(),
             event.device.__class__.__name__,
             event.device.subtype,
+            "".join(f"{x:02x}" for x in event.data),
         )
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: False}

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -2,11 +2,9 @@
 import logging
 
 import RFXtrx as rfxtrxmod
-import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
-from homeassistant.const import ATTR_STATE, CONF_DEVICES, CONF_NAME, STATE_ON
-from homeassistant.helpers import config_validation as cv
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import ATTR_STATE, CONF_DEVICES, STATE_ON
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import (
@@ -15,6 +13,7 @@ from . import (
     CONF_FIRE_EVENT,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
+    DOMAIN,
     SIGNAL_EVENT,
     RfxtrxDevice,
     fire_command_event,
@@ -23,28 +22,17 @@ from . import (
 )
 from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 
-_LOGGER = logging.getLogger(__name__)
+DATA_SWITCH = f"{DOMAIN}_switch"
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_DEVICES, default={}): {
-            cv.string: vol.Schema(
-                {
-                    vol.Required(CONF_NAME): cv.string,
-                    vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-                }
-            )
-        },
-        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
-        vol.Optional(
-            CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS
-        ): vol.Coerce(int),
-    }
-)
+_LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the RFXtrx platform."""
+    if discovery_info is None:
+        return
+
+    config = discovery_info
     device_ids = set()
 
     # Add switch from config file
@@ -61,9 +49,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
-        entity = RfxtrxSwitch(
-            entity_info[CONF_NAME], event.device, datas, config[CONF_SIGNAL_REPETITIONS]
-        )
+        entity = RfxtrxSwitch(event.device, datas, config[CONF_SIGNAL_REPETITIONS])
         entities.append(entity)
 
     add_entities_callback(entities)
@@ -89,10 +75,9 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
             event.device.subtype,
         )
 
-        pkt_id = "".join(f"{x:02x}" for x in event.data)
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: False}
         entity = RfxtrxSwitch(
-            pkt_id, event.device, datas, DEFAULT_SIGNAL_REPETITIONS, event=event
+            event.device, datas, DEFAULT_SIGNAL_REPETITIONS, event=event
         )
         add_entities_callback([entity])
 

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -58,7 +58,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         device_ids.add(device_id)
 
         datas = {ATTR_STATE: None, ATTR_FIRE_EVENT: entity_info[CONF_FIRE_EVENT]}
-        entity = RfxtrxSwitch(event.device, datas, config[CONF_SIGNAL_REPETITIONS])
+        entity = RfxtrxSwitch(event.device, datas, entity_info[CONF_SIGNAL_REPETITIONS])
         entities.append(entity)
 
     add_entities_callback(entities)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -35,12 +35,21 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     config = discovery_info
     device_ids = set()
 
+    def supported(event):
+        return (
+            isinstance(event.device, rfxtrxmod.LightingDevice)
+            and not event.device.known_to_be_dimmable
+            and not event.device.known_to_be_rollershutter
+        )
+
     # Add switch from config file
     entities = []
     for packet_id, entity_info in config[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
+            continue
+        if not supported(event):
             continue
 
         device_id = get_device_id(event.device)
@@ -56,11 +65,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
     def switch_update(event):
         """Handle sensor updates from the RFXtrx gateway."""
-        if (
-            not isinstance(event.device, rfxtrxmod.LightingDevice)
-            or event.device.known_to_be_dimmable
-            or event.device.known_to_be_rollershutter
-        ):
+        if not supported(event):
             return
 
         device_id = get_device_id(event.device)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -32,7 +32,6 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     if discovery_info is None:
         return
 
-    config = discovery_info
     device_ids = set()
 
     def supported(event):
@@ -44,7 +43,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
     # Add switch from config file
     entities = []
-    for packet_id, entity_info in config[CONF_DEVICES].items():
+    for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
@@ -87,7 +86,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         add_entities_callback([entity])
 
     # Subscribe to main RFXtrx events
-    if config[CONF_AUTOMATIC_ADD]:
+    if discovery_info[CONF_AUTOMATIC_ADD]:
         hass.helpers.dispatcher.dispatcher_connect(SIGNAL_EVENT, switch_update)
 
 

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -1,75 +1,12 @@
 """Common test tools."""
-import threading
 from unittest import mock
 
-import RFXtrx
 import pytest
 
-from homeassistant.components import rfxtrx as rfxtrx_core
 
-from tests.common import mock_component
-
-
-class FixedDummySerial(RFXtrx._dummySerial):  # pylint: disable=protected-access
-    """Fixed dummy serial that doesn't cause max CPU usage."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self._close_event = threading.Event()
-
-    def read(self, data=None):
-        """Read."""
-        res = super().read(data)
-        if not res and not data:
-            self._close_event.wait(0.1)
-        return res
-
-    def close(self):
-        """Close."""
-        self._close_event.set()
-
-
-class FixedDummyTransport(RFXtrx.DummyTransport):
-    """Fixed dummy transport that maxes CPU."""
-
-    def __init__(self, device="", debug=True):
-        """Init."""
-        super().__init__(device, debug)
-        self._close_event = threading.Event()
-
-    def receive_blocking(self, data=None):
-        """Read."""
-        res = super().receive_blocking(data)
-        if not res:
-            self._close_event.wait(0.1)
-        return res
-
-    def close(self):
-        """Close."""
-        self._close_event.set()
-
-
-@pytest.fixture(autouse=True)
-async def rfxtrx_cleanup():
+@pytest.fixture(autouse=True, name="rfxtrx")
+async def rfxtrx(hass):
     """Fixture that cleans up threads from integration."""
 
-    with mock.patch("RFXtrx._dummySerial", new=FixedDummySerial), mock.patch(
-        "RFXtrx.DummyTransport", new=FixedDummyTransport
-    ):
-        yield
-
-
-@pytest.fixture(name="rfxtrx")
-async def rfxtrx_fixture(hass):
-    """Stub out core rfxtrx to test platform."""
-    mock_component(hass, "rfxtrx")
-
-    rfxobject = mock.MagicMock()
-    hass.data[rfxtrx_core.DATA_RFXOBJECT] = rfxobject
-
-    yield rfxobject
-
-    # These test don't listen for stop to do cleanup.
-    if rfxtrx_core.DATA_RFXOBJECT in hass.data:
-        hass.data[rfxtrx_core.DATA_RFXOBJECT].close_connection()
+    with mock.patch("RFXtrx.Connect") as connect, mock.patch("RFXtrx.DummyTransport2"):
+        yield connect.return_value

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -9,50 +9,46 @@ from . import _signal_event
 from tests.common import async_fire_time_changed
 
 
-async def test_default_config(hass, rfxtrx):
-    """Test with 0 sensor."""
-    await async_setup_component(
-        hass, "binary_sensor", {"binary_sensor": {"platform": "rfxtrx", "devices": {}}}
-    )
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
-
-
 async def test_one(hass, rfxtrx):
     """Test with 1 sensor."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "binary_sensor",
+        "rfxtrx",
         {
-            "binary_sensor": {
-                "platform": "rfxtrx",
-                "devices": {"0a52080705020095220269": {"name": "Test"}},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "binary_sensors": {"devices": {"0a52080705020095220269": {}}},
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Test"
+    assert (
+        state.attributes.get("friendly_name")
+        == "WT260,WT260H,WT440H,WT450,WT450H 05:02"
+    )
 
 
 async def test_one_pt2262(hass, rfxtrx):
     """Test with 1 sensor."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "binary_sensor",
+        "rfxtrx",
         {
-            "binary_sensor": {
-                "platform": "rfxtrx",
-                "devices": {
-                    "0913000022670e013970": {
-                        "name": "Test",
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "binary_sensors": {
+                    "devices": {
+                        "0913000022670e013970": {
+                            "data_bits": 4,
+                            "command_on": 0xE,
+                            "command_off": 0x7,
+                        }
                     }
                 },
             }
@@ -60,136 +56,113 @@ async def test_one_pt2262(hass, rfxtrx):
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.pt2262_22670e")
     assert state
     assert state.state == "off"  # probably aught to be unknown
-    assert state.attributes.get("friendly_name") == "Test"
+    assert state.attributes.get("friendly_name") == "PT2262 22670e"
 
     await _signal_event(hass, "0913000022670e013970")
-    state = hass.states.get("binary_sensor.test")
-    assert state
+    state = hass.states.get("binary_sensor.pt2262_22670e")
     assert state.state == "on"
-    assert state.attributes.get("friendly_name") == "Test"
 
     await _signal_event(hass, "09130000226707013d70")
-    state = hass.states.get("binary_sensor.test")
-    assert state
+    state = hass.states.get("binary_sensor.pt2262_22670e")
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Test"
 
 
 async def test_several(hass, rfxtrx):
     """Test with 3."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "binary_sensor",
+        "rfxtrx",
         {
-            "binary_sensor": {
-                "platform": "rfxtrx",
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {"name": "Test"},
-                    "0b1100100118cdea02010f70": {"name": "Bath"},
-                    "0b1100101118cdea02010f70": {"name": "Living"},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "binary_sensors": {
+                    "devices": {
+                        "0b1100cd0213c7f230010f71": {},
+                        "0b1100100118cdea02010f70": {},
+                        "0b1100101118cdea02010f70": {},
+                    }
                 },
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.ac_213c7f2_48")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Test"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
-    state = hass.states.get("binary_sensor.bath")
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Bath"
+    assert state.attributes.get("friendly_name") == "AC 118cdea:2"
 
-    state = hass.states.get("binary_sensor.living")
+    state = hass.states.get("binary_sensor.ac_1118cdea_2")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Living"
+    assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
 
 async def test_discover(hass, rfxtrx):
     """Test with discovery."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "binary_sensor",
-        {"binary_sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
-    )
-    await hass.async_block_till_done()
-
-    await _signal_event(hass, "0b1100100118cdea02010f70")
-    state = hass.states.get("binary_sensor.0b1100100118cdea02010f70")
-    assert state
-    assert state.state == "on"
-
-    await _signal_event(hass, "0b1100100118cdeb02010f70")
-    state = hass.states.get("binary_sensor.0b1100100118cdeb02010f70")
-    assert state
-    assert state.state == "on"
-
-    # Trying to add a sensor
-    await _signal_event(hass, "0a52085e070100b31b0279")
-    state = hass.states.get("sensor.0a52085e070100b31b0279")
-    assert state is None
-
-    # Trying to add a light
-    await _signal_event(hass, "0b1100100118cdea02010f70")
-    state = hass.states.get("light.0b1100100118cdea02010f70")
-    assert state is None
-
-    # Trying to add a rollershutter
-    await _signal_event(hass, "0a1400adf394ab020e0060")
-    state = hass.states.get("cover.0a1400adf394ab020e0060")
-    assert state is None
-
-
-async def test_discover_noautoadd(hass, rfxtrx):
-    """Test with discovery of switch when auto add is False."""
-    await async_setup_component(
-        hass,
-        "binary_sensor",
+        "rfxtrx",
         {
-            "binary_sensor": {
-                "platform": "rfxtrx",
-                "automatic_add": False,
-                "devices": {},
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    # Trying to add switch
-    await _signal_event(hass, "0b1100100118cdea02010f70")
-    assert hass.states.async_all() == []
-
-
-async def test_off_delay(hass, rfxtrx):
-    """Test with discovery."""
-    await async_setup_component(
-        hass,
-        "binary_sensor",
-        {
-            "binary_sensor": {
-                "platform": "rfxtrx",
-                "automatic_add": True,
-                "devices": {
-                    "0b1100100118cdea02010f70": {"name": "Test", "off_delay": 5}
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "binary_sensors": {
+                    "devices": {
+                        "0b1100cd0213c7f230010f71": {},
+                        "0b1100100118cdea02010f70": {},
+                        "0b1100101118cdea02010f70": {},
+                    },
+                    "automatic_add": True,
                 },
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.test")
+    await _signal_event(hass, "0b1100100118cdea02010f70")
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
+    assert state
+    assert state.state == "on"
+
+    await _signal_event(hass, "0b1100100118cdeb02010f70")
+    state = hass.states.get("binary_sensor.ac_118cdeb_2")
+    assert state
+    assert state.state == "on"
+
+
+async def test_off_delay(hass, rfxtrx):
+    """Test with discovery."""
+    assert await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "binary_sensors": {
+                    "devices": {"0b1100100118cdea02010f70": {"off_delay": 5}}
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
     assert state.state == "off"
 
     await _signal_event(hass, "0b1100100118cdea02010f70")
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
     assert state.state == "on"
 
@@ -197,12 +170,12 @@ async def test_off_delay(hass, rfxtrx):
 
     async_fire_time_changed(hass, base_time + timedelta(seconds=4))
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
     assert state.state == "on"
 
     async_fire_time_changed(hass, base_time + timedelta(seconds=6))
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
     assert state.state == "off"

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -18,19 +18,16 @@ async def test_one(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "binary_sensors": {"devices": {"0a52080705020095220269": {}}},
+                "devices": {"0b1100cd0213c7f230010f71": {}},
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02")
+    state = hass.states.get("binary_sensor.ac_213c7f2_48")
     assert state
     assert state.state == "off"
-    assert (
-        state.attributes.get("friendly_name")
-        == "WT260,WT260H,WT440H,WT450,WT450H 05:02"
-    )
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
 
 async def test_one_pt2262(hass, rfxtrx):
@@ -42,13 +39,11 @@ async def test_one_pt2262(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "binary_sensors": {
-                    "devices": {
-                        "0913000022670e013970": {
-                            "data_bits": 4,
-                            "command_on": 0xE,
-                            "command_off": 0x7,
-                        }
+                "devices": {
+                    "0913000022670e013970": {
+                        "data_bits": 4,
+                        "command_on": 0xE,
+                        "command_off": 0x7,
                     }
                 },
             }
@@ -79,12 +74,10 @@ async def test_several(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "binary_sensors": {
-                    "devices": {
-                        "0b1100cd0213c7f230010f71": {},
-                        "0b1100100118cdea02010f70": {},
-                        "0b1100101118cdea02010f70": {},
-                    }
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {},
+                    "0b1100100118cdea02010f70": {},
+                    "0b1100101118cdea02010f70": {},
                 },
             }
         },
@@ -116,13 +109,11 @@ async def test_discover(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "binary_sensors": {
-                    "devices": {
-                        "0b1100cd0213c7f230010f71": {},
-                        "0b1100100118cdea02010f70": {},
-                        "0b1100101118cdea02010f70": {},
-                    },
-                    "automatic_add": True,
+                "automatic_add": True,
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {},
+                    "0b1100100118cdea02010f70": {},
+                    "0b1100101118cdea02010f70": {},
                 },
             }
         },
@@ -149,9 +140,7 @@ async def test_off_delay(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "binary_sensors": {
-                    "devices": {"0b1100100118cdea02010f70": {"off_delay": 5}}
-                },
+                "devices": {"0b1100100118cdea02010f70": {"off_delay": 5}},
             }
         },
     )

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -1,55 +1,21 @@
 """The tests for the Rfxtrx cover platform."""
 from unittest.mock import call
 
-from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.setup import async_setup_component
 
 from . import _signal_event
-
-from tests.common import assert_setup_component
-
-
-async def test_valid_config(hass, rfxtrx):
-    """Test configuration."""
-    with assert_setup_component(1):
-        assert await async_setup_component(
-            hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {
-                            "name": "Test",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-        await hass.async_block_till_done()
-
-
-async def test_default_config(hass, rfxtrx):
-    """Test with 0 cover."""
-    assert await async_setup_component(
-        hass, "cover", {"cover": {"platform": "rfxtrx", "devices": {}}}
-    )
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
 
 
 async def test_one_cover(hass, rfxtrx):
     """Test with 1 cover."""
     assert await async_setup_component(
         hass,
-        "cover",
+        "rfxtrx",
         {
-            "cover": {
-                "platform": "rfxtrx",
-                "devices": {"0b1400cd0213c7f210010f51": {"name": "Test"}},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "covers": {"devices": {"0b1400cd0213c7f210010f51": {}}},
             }
         },
     )
@@ -58,15 +24,24 @@ async def test_one_cover(hass, rfxtrx):
     assert len(hass.states.async_all()) == 1
 
     await hass.services.async_call(
-        "cover", "open_cover", {"entity_id": "cover.test"}, blocking=True
+        "cover",
+        "open_cover",
+        {"entity_id": "cover.lightwaverf_siemens_0213c7_242"},
+        blocking=True,
     )
 
     await hass.services.async_call(
-        "cover", "close_cover", {"entity_id": "cover.test"}, blocking=True
+        "cover",
+        "close_cover",
+        {"entity_id": "cover.lightwaverf_siemens_0213c7_242"},
+        blocking=True,
     )
 
     await hass.services.async_call(
-        "cover", "stop_cover", {"entity_id": "cover.test"}, blocking=True
+        "cover",
+        "stop_cover",
+        {"entity_id": "cover.lightwaverf_siemens_0213c7_242"},
+        blocking=True,
     )
 
     assert rfxtrx.transport.send.mock_calls == [
@@ -80,35 +55,37 @@ async def test_several_covers(hass, rfxtrx):
     """Test with 3 covers."""
     assert await async_setup_component(
         hass,
-        "cover",
+        "rfxtrx",
         {
-            "cover": {
-                "platform": "rfxtrx",
-                "signal_repetitions": 3,
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {"name": "Test"},
-                    "0b1100100118cdea02010f70": {"name": "Bath"},
-                    "0b1100101118cdea02010f70": {"name": "Living"},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "covers": {
+                    "devices": {
+                        "0b1100cd0213c7f230010f71": {},
+                        "0b1100100118cdea02010f70": {},
+                        "0b1100101118cdea02010f70": {},
+                    }
                 },
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("cover.test")
+    state = hass.states.get("cover.ac_213c7f2_48")
     assert state
     assert state.state == "closed"
-    assert state.attributes.get("friendly_name") == "Test"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
-    state = hass.states.get("cover.bath")
+    state = hass.states.get("cover.ac_118cdea_2")
     assert state
     assert state.state == "closed"
-    assert state.attributes.get("friendly_name") == "Bath"
+    assert state.attributes.get("friendly_name") == "AC 118cdea:2"
 
-    state = hass.states.get("cover.living")
+    state = hass.states.get("cover.ac_1118cdea_2")
     assert state
     assert state.state == "closed"
-    assert state.attributes.get("friendly_name") == "Living"
+    assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
     assert len(hass.states.async_all()) == 3
 
@@ -117,37 +94,23 @@ async def test_discover_covers(hass, rfxtrx):
     """Test with discovery of covers."""
     assert await async_setup_component(
         hass,
-        "cover",
-        {"cover": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "covers": {"automatic_add": True},
+            }
+        },
     )
     await hass.async_block_till_done()
 
     await _signal_event(hass, "0a140002f38cae010f0070")
-    assert len(hass.states.async_all()) == 1
+    state = hass.states.get("cover.lightwaverf_siemens_f38cae_1")
+    assert state
+    assert state.state == "open"
 
     await _signal_event(hass, "0a1400adf394ab020e0060")
-    assert len(hass.states.async_all()) == 2
-
-    # Trying to add a sensor
-    await _signal_event(hass, "0a52085e070100b31b0279")
-    assert len(hass.states.async_all()) == 2
-
-    # Trying to add a light
-    await _signal_event(hass, "0b1100100118cdea02010f70")
-    assert len(hass.states.async_all()) == 2
-
-
-async def test_discover_cover_noautoadd(hass, rfxtrx):
-    """Test with discovery of cover when auto add is False."""
-    assert await async_setup_component(
-        hass,
-        "cover",
-        {"cover": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-    )
-    await hass.async_block_till_done()
-
-    await _signal_event(hass, "0a1400adf394ab010d0060")
-    assert len(hass.states.async_all()) == 0
-
-    await _signal_event(hass, "0a1400adf394ab020e0060")
-    assert len(hass.states.async_all()) == 0
+    state = hass.states.get("cover.lightwaverf_siemens_f394ab_2")
+    assert state
+    assert state.state == "open"

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -15,13 +15,14 @@ async def test_one_cover(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "covers": {"devices": {"0b1400cd0213c7f210010f51": {}}},
+                "devices": {"0b1400cd0213c7f20d010f51": {}},
             }
         },
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")
+    assert state
 
     await hass.services.async_call(
         "cover",
@@ -60,34 +61,30 @@ async def test_several_covers(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "covers": {
-                    "devices": {
-                        "0b1100cd0213c7f230010f71": {},
-                        "0b1100100118cdea02010f70": {},
-                        "0b1100101118cdea02010f70": {},
-                    }
+                "devices": {
+                    "0b1400cd0213c7f20d010f51": {},
+                    "0A1400ADF394AB010D0060": {},
+                    "09190000009ba8010100": {},
                 },
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("cover.ac_213c7f2_48")
+    state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")
     assert state
     assert state.state == "closed"
-    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
+    assert state.attributes.get("friendly_name") == "LightwaveRF, Siemens 0213c7:242"
 
-    state = hass.states.get("cover.ac_118cdea_2")
+    state = hass.states.get("cover.lightwaverf_siemens_f394ab_1")
     assert state
     assert state.state == "closed"
-    assert state.attributes.get("friendly_name") == "AC 118cdea:2"
+    assert state.attributes.get("friendly_name") == "LightwaveRF, Siemens f394ab:1"
 
-    state = hass.states.get("cover.ac_1118cdea_2")
+    state = hass.states.get("cover.rollertrol_009ba8_1")
     assert state
     assert state.state == "closed"
-    assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
-
-    assert len(hass.states.async_all()) == 3
+    assert state.attributes.get("friendly_name") == "RollerTrol 009ba8:1"
 
 
 async def test_discover_covers(hass, rfxtrx):
@@ -95,13 +92,7 @@ async def test_discover_covers(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "covers": {"automatic_add": True},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
     )
     await hass.async_block_till_done()
 

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,45 +1,10 @@
 """The tests for the Rfxtrx component."""
-# pylint: disable=protected-access
-import asyncio
-
-from async_timeout import timeout
 
 from homeassistant.components import rfxtrx
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
 
 from . import _signal_event
-
-from tests.common import assert_setup_component
-
-
-async def test_default_config(hass):
-    """Test configuration."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "/dev/serial/by-id/usb"
-                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                "dummy": True,
-            }
-        },
-    )
-
-    with assert_setup_component(1, "sensor"):
-        await async_setup_component(
-            hass,
-            "sensor",
-            {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
-        )
-
-    # Dummy startup is slow
-    async with timeout(10):
-        while len(hass.data[rfxtrx.DATA_RFXOBJECT].sensors()) < 2:
-            await asyncio.sleep(0.1)
-
-    assert len(hass.data[rfxtrx.DATA_RFXOBJECT].sensors()) == 2
 
 
 async def test_valid_config(hass):
@@ -100,22 +65,11 @@ async def test_fire_event(hass):
                 "device": "/dev/serial/by-id/usb"
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
                 "dummy": True,
-            }
-        },
-    )
-
-    assert await async_setup_component(
-        hass,
-        "switch",
-        {
-            "switch": {
-                "platform": "rfxtrx",
-                "automatic_add": True,
-                "devices": {
-                    "0b1100cd0213c7f210010f51": {
-                        "name": "Test",
-                        rfxtrx.ATTR_FIRE_EVENT: True,
-                    }
+                "switches": {
+                    "automatic_add": True,
+                    "devices": {
+                        "0b1100cd0213c7f210010f51": {rfxtrx.ATTR_FIRE_EVENT: True}
+                    },
                 },
             }
         },
@@ -131,18 +85,18 @@ async def test_fire_event(hass):
 
     hass.bus.async_listen(rfxtrx.EVENT_BUTTON_PRESSED, record_event)
 
-    state = hass.states.get("switch.test")
+    state = hass.states.get("switch.ac_213c7f2_16")
     assert state
     assert state.state == "off"
 
     await _signal_event(hass, "0b1100cd0213c7f210010f51")
 
-    state = hass.states.get("switch.test")
+    state = hass.states.get("switch.ac_213c7f2_16")
     assert state
     assert state.state == "on"
 
     assert len(calls) == 1
-    assert calls[0].data == {"entity_id": "switch.test", "state": "on"}
+    assert calls[0].data == {"entity_id": "switch.ac_213c7f2_16", "state": "on"}
 
 
 async def test_fire_event_sensor(hass):
@@ -155,26 +109,16 @@ async def test_fire_event_sensor(hass):
                 "device": "/dev/serial/by-id/usb"
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
                 "dummy": True,
-            }
-        },
-    )
-
-    await async_setup_component(
-        hass,
-        "sensor",
-        {
-            "sensor": {
-                "platform": "rfxtrx",
-                "automatic_add": True,
-                "devices": {
-                    "0a520802060100ff0e0269": {
-                        "name": "Test",
-                        rfxtrx.ATTR_FIRE_EVENT: True,
-                    }
+                "sensors": {
+                    "automatic_add": True,
+                    "devices": {
+                        "0a520802060100ff0e0269": {rfxtrx.ATTR_FIRE_EVENT: True}
+                    },
                 },
             }
         },
     )
+
     await hass.async_block_till_done()
 
     calls = []
@@ -188,4 +132,8 @@ async def test_fire_event_sensor(hass):
 
     await _signal_event(hass, "0a520802060101ff0f0269")
     assert len(calls) == 5
-    assert any(call.data == {"entity_id": "sensor.test_temperature"} for call in calls)
+    assert any(
+        call.data
+        == {"entity_id": "sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_temperature"}
+        for call in calls
+    )

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -65,12 +65,8 @@ async def test_fire_event(hass):
                 "device": "/dev/serial/by-id/usb"
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
                 "dummy": True,
-                "switches": {
-                    "automatic_add": True,
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {rfxtrx.ATTR_FIRE_EVENT: True}
-                    },
-                },
+                "automatic_add": True,
+                "devices": {"0b1100cd0213c7f210010f51": {rfxtrx.ATTR_FIRE_EVENT: True}},
             }
         },
     )
@@ -95,8 +91,10 @@ async def test_fire_event(hass):
     assert state
     assert state.state == "on"
 
-    assert len(calls) == 1
-    assert calls[0].data == {"entity_id": "switch.ac_213c7f2_16", "state": "on"}
+    assert any(
+        call.data == {"entity_id": "switch.ac_213c7f2_16", "state": "on"}
+        for call in calls
+    )
 
 
 async def test_fire_event_sensor(hass):
@@ -109,12 +107,8 @@ async def test_fire_event_sensor(hass):
                 "device": "/dev/serial/by-id/usb"
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
                 "dummy": True,
-                "sensors": {
-                    "automatic_add": True,
-                    "devices": {
-                        "0a520802060100ff0e0269": {rfxtrx.ATTR_FIRE_EVENT: True}
-                    },
-                },
+                "automatic_add": True,
+                "devices": {"0a520802060100ff0e0269": {rfxtrx.ATTR_FIRE_EVENT: True}},
             }
         },
     )

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -3,127 +3,79 @@ from unittest.mock import call
 
 import pytest
 
-from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.setup import async_setup_component
 
 from . import _signal_event
 
-from tests.common import assert_setup_component
-
-
-async def test_valid_config(hass, rfxtrx):
-    """Test configuration."""
-    with assert_setup_component(1):
-        assert await async_setup_component(
-            hass,
-            "light",
-            {
-                "light": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {
-                            "name": "Test",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-
-        assert await async_setup_component(
-            hass,
-            "light",
-            {
-                "light": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {
-                            "name": "Test",
-                            "signal_repetitions": 3,
-                        }
-                    },
-                }
-            },
-        )
-
-
-async def test_default_config(hass, rfxtrx):
-    """Test with 0 switches."""
-    with assert_setup_component(1):
-        await async_setup_component(
-            hass, "light", {"light": {"platform": "rfxtrx", "devices": {}}}
-        )
-        await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
-
 
 async def test_one_light(hass, rfxtrx):
     """Test with 1 light."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "light",
+        "rfxtrx",
         {
-            "light": {
-                "platform": "rfxtrx",
-                "devices": {"0b1100cd0213c7f210010f51": {"name": "Test"}},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "lights": {"devices": {"0b1100cd0213c7f210010f51": {}}},
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_16")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Test"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:16"
 
     await hass.services.async_call(
-        "light", "turn_on", {"entity_id": "light.test"}, blocking=True
+        "light", "turn_on", {"entity_id": "light.ac_213c7f2_16"}, blocking=True
     )
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_16")
     assert state.state == "on"
     assert state.attributes.get("brightness") == 255
 
     await hass.services.async_call(
-        "light", "turn_off", {"entity_id": "light.test"}, blocking=True
+        "light", "turn_off", {"entity_id": "light.ac_213c7f2_16"}, blocking=True
     )
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_16")
     assert state.state == "off"
     assert state.attributes.get("brightness") is None
 
     await hass.services.async_call(
         "light",
         "turn_on",
-        {"entity_id": "light.test", "brightness": 100},
+        {"entity_id": "light.ac_213c7f2_16", "brightness": 100},
         blocking=True,
     )
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_16")
     assert state.state == "on"
     assert state.attributes.get("brightness") == 100
 
     await hass.services.async_call(
-        "light", "turn_on", {"entity_id": "light.test", "brightness": 10}, blocking=True
+        "light",
+        "turn_on",
+        {"entity_id": "light.ac_213c7f2_16", "brightness": 10},
+        blocking=True,
     )
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_16")
     assert state.state == "on"
     assert state.attributes.get("brightness") == 10
 
     await hass.services.async_call(
         "light",
         "turn_on",
-        {"entity_id": "light.test", "brightness": 255},
+        {"entity_id": "light.ac_213c7f2_16", "brightness": 255},
         blocking=True,
     )
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_16")
     assert state.state == "on"
     assert state.attributes.get("brightness") == 255
 
     await hass.services.async_call(
-        "light", "turn_off", {"entity_id": "light.test"}, blocking=True
+        "light", "turn_off", {"entity_id": "light.ac_213c7f2_16"}, blocking=True
     )
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_16")
     assert state.state == "off"
     assert state.attributes.get("brightness") is None
 
@@ -139,17 +91,19 @@ async def test_one_light(hass, rfxtrx):
 
 async def test_several_lights(hass, rfxtrx):
     """Test with 3 lights."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "light",
+        "rfxtrx",
         {
-            "light": {
-                "platform": "rfxtrx",
-                "signal_repetitions": 3,
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {"name": "Test"},
-                    "0b1100100118cdea02010f70": {"name": "Bath"},
-                    "0b1100101118cdea02010f70": {"name": "Living"},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "lights": {
+                    "devices": {
+                        "0b1100cd0213c7f230010f71": {},
+                        "0b1100100118cdea02010f70": {},
+                        "0b1100101118cdea02010f70": {},
+                    }
                 },
             }
         },
@@ -158,20 +112,20 @@ async def test_several_lights(hass, rfxtrx):
 
     assert len(hass.states.async_all()) == 3
 
-    state = hass.states.get("light.test")
+    state = hass.states.get("light.ac_213c7f2_48")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Test"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
-    state = hass.states.get("light.bath")
+    state = hass.states.get("light.ac_118cdea_2")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Bath"
+    assert state.attributes.get("friendly_name") == "AC 118cdea:2"
 
-    state = hass.states.get("light.living")
+    state = hass.states.get("light.ac_1118cdea_2")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Living"
+    assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
     assert len(hass.states.async_all()) == 3
 
@@ -179,21 +133,24 @@ async def test_several_lights(hass, rfxtrx):
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "light",
+        "rfxtrx",
         {
-            "light": {
-                "platform": "rfxtrx",
-                "signal_repetitions": repetitions,
-                "devices": {"0b1100cd0213c7f230010f71": {"name": "Test"}},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "lights": {
+                    "signal_repetitions": repetitions,
+                    "devices": {"0b1100cd0213c7f230010f71": {}},
+                },
             }
         },
     )
     await hass.async_block_till_done()
 
     await hass.services.async_call(
-        "light", "turn_on", {"entity_id": "light.test"}, blocking=True
+        "light", "turn_on", {"entity_id": "light.ac_213c7f2_48"}, blocking=True
     )
     await hass.async_block_till_done()
 
@@ -202,40 +159,27 @@ async def test_repetitions(hass, rfxtrx, repetitions):
 
 async def test_discover_light(hass, rfxtrx):
     """Test with discovery of lights."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "light",
-        {"light": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "lights": {"automatic_add": True},
+            }
+        },
     )
     await hass.async_block_till_done()
 
     await _signal_event(hass, "0b11009e00e6116202020070")
-    state = hass.states.get("light.0b11009e00e6116202020070")
+    state = hass.states.get("light.ac_0e61162_2")
     assert state
     assert state.state == "on"
-    assert state.attributes.get("friendly_name") == "0b11009e00e6116202020070"
+    assert state.attributes.get("friendly_name") == "AC 0e61162:2"
 
     await _signal_event(hass, "0b1100120118cdea02020070")
-    state = hass.states.get("light.0b1100120118cdea02020070")
+    state = hass.states.get("light.ac_118cdea_2")
     assert state
     assert state.state == "on"
-    assert state.attributes.get("friendly_name") == "0b1100120118cdea02020070"
-
-
-async def test_discover_light_noautoadd(hass, rfxtrx):
-    """Test with discover of light when auto add is False."""
-    await async_setup_component(
-        hass,
-        "light",
-        {"light": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-    )
-    await hass.async_block_till_done()
-
-    await _signal_event(hass, "0b1100120118cdea02020070")
-    assert hass.states.async_all() == []
-
-    await _signal_event(hass, "0b1100120118cdea02010070")
-    assert hass.states.async_all() == []
-
-    await _signal_event(hass, "0b1100120118cdea02020070")
-    assert hass.states.async_all() == []
+    assert state.attributes.get("friendly_name") == "AC 118cdea:2"

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -17,7 +17,7 @@ async def test_one_light(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "lights": {"devices": {"0b1100cd0213c7f210010f51": {}}},
+                "devices": {"0b1100cd0213c7f210020f51": {}},
             }
         },
     )
@@ -98,19 +98,15 @@ async def test_several_lights(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "lights": {
-                    "devices": {
-                        "0b1100cd0213c7f230010f71": {},
-                        "0b1100100118cdea02010f70": {},
-                        "0b1100101118cdea02010f70": {},
-                    }
+                "devices": {
+                    "0b1100cd0213c7f230020f71": {},
+                    "0b1100100118cdea02020f70": {},
+                    "0b1100101118cdea02050f70": {},
                 },
             }
         },
     )
     await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 3
 
     state = hass.states.get("light.ac_213c7f2_48")
     assert state
@@ -127,8 +123,6 @@ async def test_several_lights(hass, rfxtrx):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
-    assert len(hass.states.async_all()) == 3
-
 
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
@@ -140,9 +134,8 @@ async def test_repetitions(hass, rfxtrx, repetitions):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "lights": {
-                    "signal_repetitions": repetitions,
-                    "devices": {"0b1100cd0213c7f230010f71": {}},
+                "devices": {
+                    "0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}
                 },
             }
         },
@@ -162,13 +155,7 @@ async def test_discover_light(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "lights": {"automatic_add": True},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
     )
     await hass.async_block_till_done()
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -17,46 +17,48 @@ async def test_default_config(hass, rfxtrx):
 
 async def test_one_sensor(hass, rfxtrx):
     """Test with 1 sensor."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "sensor",
+        "rfxtrx",
         {
-            "sensor": {
-                "platform": "rfxtrx",
-                "devices": {
-                    "0a52080705020095220269": {
-                        "name": "Test",
-                        "data_type": "Temperature",
-                    }
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "sensors": {
+                    "devices": {"0a52080705020095220269": {"data_type": "Temperature"}}
                 },
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.test_temperature")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02_temperature")
     assert state
     assert state.state == "unknown"
-    assert state.attributes.get("friendly_name") == "Test Temperature"
+    assert (
+        state.attributes.get("friendly_name")
+        == "WT260,WT260H,WT440H,WT450,WT450H 05:02 Temperature"
+    )
     assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
 
 async def test_one_sensor_no_datatype(hass, rfxtrx):
     """Test with 1 sensor."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "sensor",
+        "rfxtrx",
         {
-            "sensor": {
-                "platform": "rfxtrx",
-                "devices": {"0a52080705020095220269": {"name": "Test"}},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "sensors": {"devices": {"0a52080705020095220269": {}}},
             }
         },
     )
     await hass.async_block_till_done()
 
-    base_id = "sensor.test"
-    base_name = "Test"
+    base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02"
+    base_name = "WT260,WT260H,WT440H,WT450,WT450H 05:02"
 
     state = hass.states.get(f"{base_id}_temperature")
     assert state
@@ -91,58 +93,73 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
 
 async def test_several_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "sensor",
+        "rfxtrx",
         {
-            "sensor": {
-                "platform": "rfxtrx",
-                "devices": {
-                    "0a52080705020095220269": {
-                        "name": "Test",
-                        "data_type": "Temperature",
-                    },
-                    "0a520802060100ff0e0269": {
-                        "name": "Bath",
-                        "data_type": ["Temperature", "Humidity"],
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "sensors": {
+                    "devices": {
+                        "0a52080705020095220269": {"data_type": "Temperature"},
+                        "0a520802060100ff0e0269": {
+                            "data_type": ["Temperature", "Humidity"]
+                        },
                     },
                 },
             }
         },
     )
+
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.test_temperature")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02_temperature")
     assert state
     assert state.state == "unknown"
-    assert state.attributes.get("friendly_name") == "Test Temperature"
+    assert (
+        state.attributes.get("friendly_name")
+        == "WT260,WT260H,WT440H,WT450,WT450H 05:02 Temperature"
+    )
     assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
-    state = hass.states.get("sensor.bath_temperature")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_temperature")
     assert state
     assert state.state == "unknown"
-    assert state.attributes.get("friendly_name") == "Bath Temperature"
+    assert (
+        state.attributes.get("friendly_name")
+        == "WT260,WT260H,WT440H,WT450,WT450H 06:01 Temperature"
+    )
     assert state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
 
-    state = hass.states.get("sensor.bath_humidity")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_humidity")
     assert state
     assert state.state == "unknown"
-    assert state.attributes.get("friendly_name") == "Bath Humidity"
+    assert (
+        state.attributes.get("friendly_name")
+        == "WT260,WT260H,WT440H,WT450,WT450H 06:01 Humidity"
+    )
     assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
 
 
 async def test_discover_sensor(hass, rfxtrx):
     """Test with discovery of sensor."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "sensor",
-        {"sensor": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "sensors": {"automatic_add": True},
+            }
+        },
     )
     await hass.async_block_till_done()
 
     # 1
     await _signal_event(hass, "0a520801070100b81b0279")
-    base_id = "sensor.0a520801070100b81b0279"
+    base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_07_01"
 
     state = hass.states.get(f"{base_id}_humidity")
     assert state
@@ -171,7 +188,7 @@ async def test_discover_sensor(hass, rfxtrx):
 
     # 2
     await _signal_event(hass, "0a52080405020095240279")
-    base_id = "sensor.0a52080405020095240279"
+    base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02"
     state = hass.states.get(f"{base_id}_humidity")
 
     assert state
@@ -200,7 +217,7 @@ async def test_discover_sensor(hass, rfxtrx):
 
     # 1 Update
     await _signal_event(hass, "0a52085e070100b31b0279")
-    base_id = "sensor.0a520801070100b81b0279"
+    base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_07_01"
 
     state = hass.states.get(f"{base_id}_humidity")
     assert state
@@ -230,57 +247,37 @@ async def test_discover_sensor(hass, rfxtrx):
     assert len(hass.states.async_all()) == 10
 
 
-async def test_discover_sensor_noautoadd(hass, rfxtrx):
-    """Test with discover of sensor when auto add is False."""
-    await async_setup_component(
-        hass,
-        "sensor",
-        {"sensor": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-    )
-    await hass.async_block_till_done()
-
-    await _signal_event(hass, "0a520801070100b81b0279")
-    assert len(hass.states.async_all()) == 0
-
-    await _signal_event(hass, "0a52080405020095240279")
-    assert len(hass.states.async_all()) == 0
-
-    await _signal_event(hass, "0a52085e070100b31b0279")
-    assert len(hass.states.async_all()) == 0
-
-
 async def test_update_of_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "sensor",
+        "rfxtrx",
         {
-            "sensor": {
-                "platform": "rfxtrx",
-                "devices": {
-                    "0a52080705020095220269": {
-                        "name": "Test",
-                        "data_type": "Temperature",
-                    },
-                    "0a520802060100ff0e0269": {
-                        "name": "Bath",
-                        "data_type": ["Temperature", "Humidity"],
-                    },
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "sensors": {
+                    "devices": {
+                        "0a52080705020095220269": {"data_type": "Temperature"},
+                        "0a520802060100ff0e0269": {
+                            "data_type": ["Temperature", "Humidity"]
+                        },
+                    }
                 },
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.test_temperature")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02_temperature")
     assert state
     assert state.state == "unknown"
 
-    state = hass.states.get("sensor.bath_temperature")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_temperature")
     assert state
     assert state.state == "unknown"
 
-    state = hass.states.get("sensor.bath_humidity")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_humidity")
     assert state
     assert state.state == "unknown"
 
@@ -289,16 +286,14 @@ async def test_update_of_sensors(hass, rfxtrx):
     await _signal_event(hass, "0a520802060101ff0f0269")
     await _signal_event(hass, "0a52080705020085220269")
 
-    state = hass.states.get("sensor.test_temperature")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02_temperature")
     assert state
     assert state.state == "13.3"
 
-    state = hass.states.get("sensor.bath_temperature")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_temperature")
     assert state
     assert state.state == "51.1"
 
-    state = hass.states.get("sensor.bath_humidity")
+    state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_humidity")
     assert state
     assert state.state == "15"
-
-    assert len(hass.states.async_all()) == 3

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -24,9 +24,7 @@ async def test_one_sensor(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "sensors": {
-                    "devices": {"0a52080705020095220269": {"data_type": "Temperature"}}
-                },
+                "devices": {"0a52080705020095220269": {"data_type": "Temperature"}},
             }
         },
     )
@@ -51,7 +49,7 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "sensors": {"devices": {"0a52080705020095220269": {}}},
+                "devices": {"0a52080705020095220269": {}},
             }
         },
     )
@@ -100,12 +98,10 @@ async def test_several_sensors(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "sensors": {
-                    "devices": {
-                        "0a52080705020095220269": {"data_type": "Temperature"},
-                        "0a520802060100ff0e0269": {
-                            "data_type": ["Temperature", "Humidity"]
-                        },
+                "devices": {
+                    "0a52080705020095220269": {"data_type": "Temperature"},
+                    "0a520802060100ff0e0269": {
+                        "data_type": ["Temperature", "Humidity"]
                     },
                 },
             }
@@ -147,13 +143,7 @@ async def test_discover_sensor(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "sensors": {"automatic_add": True},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
     )
     await hass.async_block_till_done()
 
@@ -256,13 +246,11 @@ async def test_update_of_sensors(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "sensors": {
-                    "devices": {
-                        "0a52080705020095220269": {"data_type": "Temperature"},
-                        "0a520802060100ff0e0269": {
-                            "data_type": ["Temperature", "Humidity"]
-                        },
-                    }
+                "devices": {
+                    "0a52080705020095220269": {"data_type": "Temperature"},
+                    "0a520802060100ff0e0269": {
+                        "data_type": ["Temperature", "Humidity"]
+                    },
                 },
             }
         },

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -24,7 +24,7 @@ async def test_one_sensor(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "devices": {"0a52080705020095220269": {"data_type": "Temperature"}},
+                "devices": {"0a52080705020095220269": {}},
             }
         },
     )
@@ -99,10 +99,8 @@ async def test_several_sensors(hass, rfxtrx):
                 "device": "abcd",
                 "dummy": True,
                 "devices": {
-                    "0a52080705020095220269": {"data_type": "Temperature"},
-                    "0a520802060100ff0e0269": {
-                        "data_type": ["Temperature", "Humidity"]
-                    },
+                    "0a52080705020095220269": {},
+                    "0a520802060100ff0e0269": {},
                 },
             }
         },
@@ -247,10 +245,8 @@ async def test_update_of_sensors(hass, rfxtrx):
                 "device": "abcd",
                 "dummy": True,
                 "devices": {
-                    "0a52080705020095220269": {"data_type": "Temperature"},
-                    "0a520802060100ff0e0269": {
-                        "data_type": ["Temperature", "Humidity"]
-                    },
+                    "0a52080705020095220269": {},
+                    "0a520802060100ff0e0269": {},
                 },
             }
         },
@@ -268,8 +264,6 @@ async def test_update_of_sensors(hass, rfxtrx):
     state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_humidity")
     assert state
     assert state.state == "unknown"
-
-    assert len(hass.states.async_all()) == 3
 
     await _signal_event(hass, "0a520802060101ff0f0269")
     await _signal_event(hass, "0a52080705020085220269")

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -3,121 +3,43 @@ from unittest.mock import call
 
 import pytest
 
-from homeassistant.components import rfxtrx as rfxtrx_core
 from homeassistant.setup import async_setup_component
 
 from . import _signal_event
 
-from tests.common import assert_setup_component
-
-
-async def test_valid_config(hass, rfxtrx):
-    """Test configuration."""
-    with assert_setup_component(1):
-        await async_setup_component(
-            hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {
-                            "name": "Test",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-        await hass.async_block_till_done()
-
-
-async def test_valid_config_int_device_id(hass, rfxtrx):
-    """Test configuration."""
-    with assert_setup_component(1):
-        await async_setup_component(
-            hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "devices": {
-                        710000141010170: {
-                            "name": "Test",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-        await hass.async_block_till_done()
-
-
-async def test_invalid_config2(hass, rfxtrx):
-    """Test invalid configuration."""
-    with assert_setup_component(0):
-        await async_setup_component(
-            hass,
-            "switch",
-            {
-                "switch": {
-                    "platform": "rfxtrx",
-                    "automatic_add": True,
-                    "invalid_key": "afda",
-                    "devices": {
-                        "0b1100cd0213c7f210010f51": {
-                            "name": "Test",
-                            rfxtrx_core.ATTR_FIRE_EVENT: True,
-                        }
-                    },
-                }
-            },
-        )
-        await hass.async_block_till_done()
-
-
-async def test_default_config(hass, rfxtrx):
-    """Test with 0 switches."""
-    await async_setup_component(
-        hass, "switch", {"switch": {"platform": "rfxtrx", "devices": {}}}
-    )
-    await hass.async_block_till_done()
-    assert hass.states.async_all() == []
-
 
 async def test_one_switch(hass, rfxtrx):
     """Test with 1 switch."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "switch",
+        "rfxtrx",
         {
-            "switch": {
-                "platform": "rfxtrx",
-                "devices": {"0b1100cd0213c7f210010f51": {"name": "Test"}},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "switches": {"devices": {"0b1100cd0213c7f210010f51": {}}},
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("switch.test")
+    state = hass.states.get("switch.ac_213c7f2_16")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Test"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:16"
 
     await hass.services.async_call(
-        "switch", "turn_on", {"entity_id": "switch.test"}, blocking=True
+        "switch", "turn_on", {"entity_id": "switch.ac_213c7f2_16"}, blocking=True
     )
 
-    state = hass.states.get("switch.test")
+    state = hass.states.get("switch.ac_213c7f2_16")
     assert state.state == "on"
 
     await hass.services.async_call(
-        "switch", "turn_off", {"entity_id": "switch.test"}, blocking=True
+        "switch", "turn_off", {"entity_id": "switch.ac_213c7f2_16"}, blocking=True
     )
 
-    state = hass.states.get("switch.test")
+    state = hass.states.get("switch.ac_213c7f2_16")
     assert state.state == "off"
 
     assert rfxtrx.transport.send.mock_calls == [
@@ -128,57 +50,62 @@ async def test_one_switch(hass, rfxtrx):
 
 async def test_several_switches(hass, rfxtrx):
     """Test with 3 switches."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "switch",
+        "rfxtrx",
         {
-            "switch": {
-                "platform": "rfxtrx",
-                "signal_repetitions": 3,
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {"name": "Test"},
-                    "0b1100100118cdea02010f70": {"name": "Bath"},
-                    "0b1100101118cdea02010f70": {"name": "Living"},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "switches": {
+                    "devices": {
+                        "0b1100cd0213c7f230010f71": {},
+                        "0b1100100118cdea02010f70": {},
+                        "0b1100101118cdea02010f70": {},
+                    }
                 },
             }
         },
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("switch.test")
+    state = hass.states.get("switch.ac_213c7f2_48")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Test"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
-    state = hass.states.get("switch.bath")
+    state = hass.states.get("switch.ac_118cdea_2")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Bath"
+    assert state.attributes.get("friendly_name") == "AC 118cdea:2"
 
-    state = hass.states.get("switch.living")
+    state = hass.states.get("switch.ac_1118cdea_2")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Living"
+    assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
 
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "switch",
+        "rfxtrx",
         {
-            "switch": {
-                "platform": "rfxtrx",
-                "signal_repetitions": repetitions,
-                "devices": {"0b1100cd0213c7f230010f71": {"name": "Test"}},
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "switches": {
+                    "signal_repetitions": repetitions,
+                    "devices": {"0b1100cd0213c7f230010f71": {}},
+                },
             }
         },
     )
     await hass.async_block_till_done()
 
     await hass.services.async_call(
-        "switch", "turn_on", {"entity_id": "switch.test"}, blocking=True
+        "switch", "turn_on", {"entity_id": "switch.ac_213c7f2_48"}, blocking=True
     )
     await hass.async_block_till_done()
 
@@ -187,48 +114,25 @@ async def test_repetitions(hass, rfxtrx, repetitions):
 
 async def test_discover_switch(hass, rfxtrx):
     """Test with discovery of switches."""
-    await async_setup_component(
+    assert await async_setup_component(
         hass,
-        "switch",
-        {"switch": {"platform": "rfxtrx", "automatic_add": True, "devices": {}}},
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "abcd",
+                "dummy": True,
+                "switches": {"automatic_add": True},
+            }
+        },
     )
     await hass.async_block_till_done()
 
     await _signal_event(hass, "0b1100100118cdea02010f70")
-    state = hass.states.get("switch.0b1100100118cdea02010f70")
+    state = hass.states.get("switch.ac_118cdea_2")
     assert state
     assert state.state == "on"
 
     await _signal_event(hass, "0b1100100118cdeb02010f70")
-    state = hass.states.get("switch.0b1100100118cdeb02010f70")
+    state = hass.states.get("switch.ac_118cdeb_2")
     assert state
     assert state.state == "on"
-
-    # Trying to add a sensor
-    await _signal_event(hass, "0a52085e070100b31b0279")
-    state = hass.states.get("sensor.0a52085e070100b31b0279")
-    assert state is None
-
-    # Trying to add a light
-    await _signal_event(hass, "0b1100100118cdea02010f70")
-    state = hass.states.get("light.0b1100100118cdea02010f70")
-    assert state is None
-
-    # Trying to add a rollershutter
-    await _signal_event(hass, "0a1400adf394ab020e0060")
-    state = hass.states.get("cover.0a1400adf394ab020e0060")
-    assert state is None
-
-
-async def test_discover_switch_noautoadd(hass, rfxtrx):
-    """Test with discovery of switch when auto add is False."""
-    await async_setup_component(
-        hass,
-        "switch",
-        {"switch": {"platform": "rfxtrx", "automatic_add": False, "devices": {}}},
-    )
-    await hass.async_block_till_done()
-
-    # Trying to add switch
-    await _signal_event(hass, "0b1100100118cdea02010f70")
-    assert hass.states.async_all() == []

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -17,7 +17,7 @@ async def test_one_switch(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "switches": {"devices": {"0b1100cd0213c7f210010f51": {}}},
+                "devices": {"0b1100cd0213c7f210010f51": {}},
             }
         },
     )
@@ -57,12 +57,10 @@ async def test_several_switches(hass, rfxtrx):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "switches": {
-                    "devices": {
-                        "0b1100cd0213c7f230010f71": {},
-                        "0b1100100118cdea02010f70": {},
-                        "0b1100101118cdea02010f70": {},
-                    }
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {},
+                    "0b1100100118cdea02010f70": {},
+                    "0b1100101118cdea02010f70": {},
                 },
             }
         },
@@ -95,9 +93,8 @@ async def test_repetitions(hass, rfxtrx, repetitions):
             "rfxtrx": {
                 "device": "abcd",
                 "dummy": True,
-                "switches": {
-                    "signal_repetitions": repetitions,
-                    "devices": {"0b1100cd0213c7f230010f71": {}},
+                "devices": {
+                    "0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}
                 },
             }
         },
@@ -117,13 +114,7 @@ async def test_discover_switch(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "switches": {"automatic_add": True},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

- Configuration of rfxtrx devices now must be moved to the integration. See documentation on https://www.home-assistant.io/integrations/rfxtrx/
- Configuration of entity name must now be done inside home assistant
- Multiple entities may be generated for a single device

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop support for platform level configuration of devices and move config to integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
rfxtrx:
  device: /dev/tty.usbserial-blaha
  dummy: false
  debug: true
  devices:
    # switch
    0a52080705020095220269:
      fire_event: True

    # binary sensor
    0913000022670e013b70:
      device_class: opening
      data_bits: 4
      command_on: 0xe
      command_off: 0x7
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13976

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
