### PR TITLE
Add `ignore_attributes` option to influxdb

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -145,9 +145,7 @@ def validate_version_specific_config(conf: Dict) -> Dict:
 _CUSTOMIZE_ENTITY_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
-        vol.Optional(CONF_IGNORE_ATTRIBUTES, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
+        vol.Optional(CONF_IGNORE_ATTRIBUTES): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 
@@ -191,7 +189,7 @@ def _generate_event_to_json(conf: Dict) -> Callable[[Dict], str]:
     tags_attributes = conf.get(CONF_TAGS_ATTRIBUTES)
     default_measurement = conf.get(CONF_DEFAULT_MEASUREMENT)
     override_measurement = conf.get(CONF_OVERRIDE_MEASUREMENT)
-    global_ignore_attributes = set(conf.get(CONF_IGNORE_ATTRIBUTES))
+    global_ignore_attributes = set(conf[CONF_IGNORE_ATTRIBUTES])
     component_config = EntityValues(
         conf[CONF_COMPONENT_CONFIG],
         conf[CONF_COMPONENT_CONFIG_DOMAIN],

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -51,6 +51,7 @@ from .const import (
     CONF_DB_NAME,
     CONF_DEFAULT_MEASUREMENT,
     CONF_HOST,
+    CONF_IGNORE_ATTRIBUTES,
     CONF_ORG,
     CONF_OVERRIDE_MEASUREMENT,
     CONF_PASSWORD,
@@ -142,7 +143,12 @@ def validate_version_specific_config(conf: Dict) -> Dict:
 
 
 _CUSTOMIZE_ENTITY_SCHEMA = vol.Schema(
-    {vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string}
+    {
+        vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
+        vol.Optional(CONF_IGNORE_ATTRIBUTES, default=[]): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+    }
 )
 
 _INFLUX_BASE_SCHEMA = INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA.extend(
@@ -152,6 +158,9 @@ _INFLUX_BASE_SCHEMA = INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA.extend(
         vol.Optional(CONF_OVERRIDE_MEASUREMENT): cv.string,
         vol.Optional(CONF_TAGS, default={}): vol.Schema({cv.string: cv.string}),
         vol.Optional(CONF_TAGS_ATTRIBUTES, default=[]): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(CONF_IGNORE_ATTRIBUTES, default=[]): vol.All(
             cv.ensure_list, [cv.string]
         ),
         vol.Optional(CONF_COMPONENT_CONFIG, default={}): vol.Schema(
@@ -182,6 +191,7 @@ def _generate_event_to_json(conf: Dict) -> Callable[[Dict], str]:
     tags_attributes = conf.get(CONF_TAGS_ATTRIBUTES)
     default_measurement = conf.get(CONF_DEFAULT_MEASUREMENT)
     override_measurement = conf.get(CONF_OVERRIDE_MEASUREMENT)
+    global_ignore_attributes = set(conf.get(CONF_IGNORE_ATTRIBUTES))
     component_config = EntityValues(
         conf[CONF_COMPONENT_CONFIG],
         conf[CONF_COMPONENT_CONFIG_DOMAIN],
@@ -211,9 +221,8 @@ def _generate_event_to_json(conf: Dict) -> Callable[[Dict], str]:
                 _include_state = True
 
         include_uom = True
-        measurement = component_config.get(state.entity_id).get(
-            CONF_OVERRIDE_MEASUREMENT
-        )
+        entity_config = component_config.get(state.entity_id)
+        measurement = entity_config.get(CONF_OVERRIDE_MEASUREMENT)
         if measurement in (None, ""):
             if override_measurement:
                 measurement = override_measurement
@@ -241,10 +250,14 @@ def _generate_event_to_json(conf: Dict) -> Callable[[Dict], str]:
         if _include_value:
             json[INFLUX_CONF_FIELDS][INFLUX_CONF_VALUE] = _state_as_value
 
+        ignore_attributes = set(entity_config.get(CONF_IGNORE_ATTRIBUTES, []))
+        ignore_attributes.update(global_ignore_attributes)
         for key, value in state.attributes.items():
             if key in tags_attributes:
                 json[INFLUX_CONF_TAGS][key] = value
-            elif key != CONF_UNIT_OF_MEASUREMENT or include_uom:
+            elif (
+                key != CONF_UNIT_OF_MEASUREMENT or include_uom
+            ) and key not in ignore_attributes:
                 # If the key is already in fields
                 if key in json[INFLUX_CONF_FIELDS]:
                     key = f"{key}_"

--- a/homeassistant/components/influxdb/const.py
+++ b/homeassistant/components/influxdb/const.py
@@ -28,6 +28,7 @@ CONF_COMPONENT_CONFIG = "component_config"
 CONF_COMPONENT_CONFIG_GLOB = "component_config_glob"
 CONF_COMPONENT_CONFIG_DOMAIN = "component_config_domain"
 CONF_RETRY_COUNT = "max_retries"
+CONF_IGNORE_ATTRIBUTES = "ignore_attributes"
 
 CONF_LANGUAGE = "language"
 CONF_QUERIES = "queries"

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1077,6 +1077,94 @@ async def test_event_listener_component_override_measurement(
     ],
     indirect=["mock_client", "get_mock_call"],
 )
+async def test_event_listener_ignore_attributes(
+    hass, mock_client, config_ext, get_write_api, get_mock_call
+):
+    """Test the event listener with overridden measurements."""
+    config = {
+        "ignore_attributes": ["ignore"],
+        "component_config": {
+            "sensor.fake_humidity": {"ignore_attributes": ["id_ignore"]}
+        },
+        "component_config_glob": {
+            "binary_sensor.*motion": {"ignore_attributes": ["glob_ignore"]}
+        },
+        "component_config_domain": {
+            "climate": {"ignore_attributes": ["domain_ignore"]}
+        },
+    }
+    config.update(config_ext)
+    handler_method = await _setup(hass, mock_client, config, get_write_api)
+
+    test_components = [
+        {
+            "domain": "sensor",
+            "id": "fake_humidity",
+            "attrs": {"glob_ignore": 1, "domain_ignore": 1},
+        },
+        {
+            "domain": "binary_sensor",
+            "id": "fake_motion",
+            "attrs": {"id_ignore": 1, "domain_ignore": 1},
+        },
+        {
+            "domain": "climate",
+            "id": "fake_thermostat",
+            "attrs": {"id_ignore": 1, "glob_ignore": 1},
+        },
+    ]
+    for comp in test_components:
+        entity_id = f"{comp['domain']}.{comp['id']}"
+        state = MagicMock(
+            state=1,
+            domain=comp["domain"],
+            entity_id=entity_id,
+            object_id=comp["id"],
+            attributes={
+                "ignore": 1,
+                "id_ignore": 1,
+                "glob_ignore": 1,
+                "domain_ignore": 1,
+            },
+        )
+        event = MagicMock(data={"new_state": state}, time_fired=12345)
+        fields = {"value": 1}
+        fields.update(comp["attrs"])
+        body = [
+            {
+                "measurement": entity_id,
+                "tags": {"domain": comp["domain"], "entity_id": comp["id"]},
+                "time": 12345,
+                "fields": fields,
+            }
+        ]
+        handler_method(event)
+        hass.data[influxdb.DOMAIN].block_till_done()
+
+        write_api = get_write_api(mock_client)
+        assert write_api.call_count == 1
+        assert write_api.call_args == get_mock_call(body)
+        write_api.reset_mock()
+
+
+@pytest.mark.parametrize(
+    "mock_client, config_ext, get_write_api, get_mock_call",
+    [
+        (
+            influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            _get_write_api_mock_v1,
+            influxdb.DEFAULT_API_VERSION,
+        ),
+        (
+            influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
+            _get_write_api_mock_v2,
+            influxdb.API_VERSION_2,
+        ),
+    ],
+    indirect=["mock_client", "get_mock_call"],
+)
 async def test_event_listener_scheduled_write(
     hass, mock_client, config_ext, get_write_api, get_mock_call
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As I've been using Influx 2.0 now that it is live in HA I've noticed that my usage with Influx 2.0 is on the high side, pushing the limits of the free plan. Since Influx's cloud service is a pay-by-usage service that means additional controls are required in order to keep usage in check. I don't really think my HA usage is unusual either, I currently have 650 entities and I filter out a good amount of them. If my usage is high here I think a lot of people will run into this issue trying to use this capability.

Exploring my data I noticed there's a lot of wasted writes for attributes that don't need to be tracked. The way Influx 2.0 works is for every attribute you don't mark as a tag you end up with a separate table for that attribute and each entity that has it. A row is then recorded in that table each time the state of the entity changes, along with the keys of the table (the entity ID, the domain, the measurement and each attribute marked as a tag). There are many attributes simply never or rarely ever change (like customization attributes for instance) and there's really no reason to track them. Tracking them is just wasted usage and space, plus the additional useless tables increase the complexity of queries.

Therefore I think adding the ability to ignore attributes is a good and simple way of providing users with the ability to keep usage in check here. It's not just for Influx 2.0 either. Although I believe this is less of an issue with Influx 1.0, the extra attributes do still create noise and complicate queries.

What I added is pretty simple, a global `ignore_attributes` list as well as an `ignore_attributes` option in the `component_config` options for more fine-grained control. I also added a test for the new capability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
influxdb:
  api_version: 2
  token: !secret influxdb_token
  organization: !secret influxdb_org
  include:
    entities:
    - sensor.haio_version
    - sensor.hassio_version
  ignore_attributes:
  - 'release_title'
  component_config:
    sensor.haio_version:
      ignore_attributes:
      - semantic_version
  component_config_domain:
    sensor:
      ignore_attributes:
      - beta
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13981

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
