### PR TITLE
Fix Daikin ACs turn_on service

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -222,7 +222,9 @@ class DaikinClimate(ClimateEntity):
     @property
     def preset_mode(self):
         """Return the preset_mode."""
-        device_preset_mode = self._api.device.represent(HA_ATTR_TO_DAIKIN[ATTR_PRESET_MODE])[1]
+        device_preset_mode = self._api.device.represent(
+            HA_ATTR_TO_DAIKIN[ATTR_PRESET_MODE]
+        )[1]
         if device_preset_mode == HA_PRESET_TO_DAIKIN[PRESET_AWAY]:
             return PRESET_AWAY
         return PRESET_NONE

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -222,10 +222,8 @@ class DaikinClimate(ClimateEntity):
     @property
     def preset_mode(self):
         """Return the preset_mode."""
-        if (
-            self._api.device.represent(HA_ATTR_TO_DAIKIN[ATTR_PRESET_MODE])[1]
-            == HA_PRESET_TO_DAIKIN[PRESET_AWAY]
-        ):
+        device_preset_mode = self._api.device.represent(HA_ATTR_TO_DAIKIN[ATTR_PRESET_MODE])[1]
+        if device_preset_mode == HA_PRESET_TO_DAIKIN[PRESET_AWAY]:
             return PRESET_AWAY
         return PRESET_NONE
 
@@ -247,7 +245,9 @@ class DaikinClimate(ClimateEntity):
 
     async def async_turn_on(self):
         """Turn device on."""
-        await self._api.device.set({})
+        await self._api.device.set(
+            {HA_ATTR_TO_DAIKIN[ATTR_HVAC_MODE]: HA_STATE_TO_DAIKIN[HVAC_MODE_HEAT_COOL]}
+        )
 
     async def async_turn_off(self):
         """Turn device off."""


### PR DESCRIPTION
Make sure Daikin ACs turn on on turn_on service

Set Daikin ACs HVAC_MODE to auto on turn_on, instead of empty dict.

Fix hanging identation in code.


## Breaking change
Not applicable.


## Proposed change
Currently turn_on service is ineffective for Daikin ACs as we send down an empty dict. With the change we set the HVAC_MODE to auto on turn on, so it will actually turn on the AC.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
Not applicable.

## Additional information
- This PR fixes or closes issue: fixes #37758
- This PR is related to issue:  #37758
- Link to documentation pull request: Not applicable.

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
