### PR TITLE
Do no crash Luftdaten on additional data returned by the API

### DIFF
--- a/homeassistant/components/luftdaten/sensor.py
+++ b/homeassistant/components/luftdaten/sensor.py
@@ -30,7 +30,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     sensors = []
     for sensor_type in luftdaten.sensor_conditions:
-        name, icon, unit = SENSORS[sensor_type]
+        try:
+            name, icon, unit = SENSORS[sensor_type]
+        except KeyError:
+            _LOGGER.debug("Unknown sensor value type: %s", sensor_type)
+            continue
+
         sensors.append(
             LuftdatenSensor(
                 luftdaten, sensor_type, name, icon, unit, entry.data[CONF_SHOW_ON_MAP]


### PR DESCRIPTION
## Proposed change
Some particle sensors used for Luftdaten sensors will provide additional particle size measurements. E.g. the PMS7003 sensor also reports PM1 values, which will be reported by the API using `P0` as value type. Because this value is not known by the integration, the python code will fail with a `KeyError` exception during setup.

Besides this fix making the interaction with the sensor.community API more stable, it might also be useful to also support the PM1 values. I could try to add that to this pull request, if necessary.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
Configuration was done via the Integrations UI. My sensor has the ID [23240](https://data.sensor.community/airrohr/v1/sensor/23240/).

```yaml
# Example configuration.yaml

```

## Additional information
I haven't opened an issue for this beforehand, so I can't link to one.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
