### PR TITLE
Make sure groups are initialized before template sensors

### DIFF
--- a/homeassistant/components/template/manifest.json
+++ b/homeassistant/components/template/manifest.json
@@ -3,5 +3,6 @@
   "name": "Template",
   "documentation": "https://www.home-assistant.io/integrations/template",
   "codeowners": ["@PhracturedBlue", "@tetienne"],
-  "quality_scale": "internal"
+  "quality_scale": "internal",
+  "after_dependencies": ["group"]
 }

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -479,7 +479,7 @@ async def test_creating_sensor_loads_group(hass):
         )
         await hass.async_block_till_done()
 
-    assert ["group", "sensor.template"] == order
+    assert order == ["group", "sensor.template"]
 
 
 async def test_available_template_with_entities(hass):

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1,15 +1,16 @@
 """The test for the Template sensor platform."""
-from asyncio import sleep
+from asyncio import Event
 from unittest.mock import patch
 
 from homeassistant.bootstrap import async_from_config_dict
 from homeassistant.const import (
+    EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_START,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.setup import async_setup_component, setup_component
+from homeassistant.setup import ATTR_COMPONENT, async_setup_component, setup_component
 
 from tests.common import assert_setup_component, get_test_home_assistant
 
@@ -445,11 +446,12 @@ class TestTemplateSensor:
 async def test_creating_sensor_loads_group(hass):
     """Test setting up template sensor loads group component first."""
     order = []
+    after_dep_event = Event()
 
     async def async_setup_group(hass, config):
         # Make sure group takes longer to load, so that it won't
         # be loaded first by chance
-        await sleep(0.1)
+        await after_dep_event.wait()
 
         order.append("group")
         return True
@@ -459,6 +461,12 @@ async def test_creating_sensor_loads_group(hass):
     ):
         order.append("sensor.template")
         return True
+
+    async def set_after_dep_event(event):
+        if event.data[ATTR_COMPONENT] == "sensor":
+            after_dep_event.set()
+
+    hass.bus.async_listen(EVENT_COMPONENT_LOADED, set_after_dep_event)
 
     with patch(
         "homeassistant.components.group.async_setup", new=async_setup_group,

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -462,15 +462,14 @@ async def test_creating_sensor_loads_group(hass):
 
     with patch(
         "homeassistant.components.group.async_setup", new=async_setup_group,
+    ), patch(
+        "homeassistant.components.template.sensor.async_setup_platform",
+        new=async_setup_template,
     ):
-        with patch(
-            "homeassistant.components.template.sensor.async_setup_platform",
-            new=async_setup_template,
-        ):
-            await async_from_config_dict(
-                {"sensor": {"platform": "template", "sensors": {}}, "group": {}}, hass
-            )
-            await hass.async_block_till_done()
+        await async_from_config_dict(
+            {"sensor": {"platform": "template", "sensors": {}}, "group": {}}, hass
+        )
+        await hass.async_block_till_done()
 
     assert ["group", "sensor.template"] == order
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Make sure groups are initialized before template sensors, so that users may use the `expand` function in templates to expand groups and have HA listen for changes to group members.

Follow-up of #36786
Fixes #35872

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
input_boolean:
  switch_1:
    name: "Switch 1"
  switch_2:
    name: "Switch 2"

group:
  input_booleans:
    name: "All boolean inputs"
    entities:
      - input_boolean.switch_1
      - input_boolean.switch_2


sensor:
  - platform: template
    sensors:
      length_sensor:
        value_template: "{{ expand('group.input_booleans') | selectattr('state', 'eq', 'on') | list | length }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35872 #36137
- This PR is related to issue: #35398 #36786

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
