### PR TITLE
device_tracker: Add changeable zone

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -61,6 +61,7 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
             cv.time_period, cv.positive_timedelta
         ),
         vol.Optional(CONF_NEW_DEVICE_DEFAULTS, default={}): NEW_DEVICE_DEFAULTS_SCHEMA,
+        vol.Optional("location_name"): cv.string,
     }
 )
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE.extend(PLATFORM_SCHEMA.schema)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     ATTR_MAC,
     ATTR_SOURCE_TYPE,
     CONF_CONSIDER_HOME,
+    CONF_LOCATION_NAME,
     CONF_NEW_DEVICE_DEFAULTS,
     CONF_SCAN_INTERVAL,
     CONF_TRACK_NEW,
@@ -61,7 +62,7 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
             cv.time_period, cv.positive_timedelta
         ),
         vol.Optional(CONF_NEW_DEVICE_DEFAULTS, default={}): NEW_DEVICE_DEFAULTS_SCHEMA,
-        vol.Optional("location_name"): cv.string,
+        vol.Optional(CONF_LOCATION_NAME): cv.string,
     }
 )
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE.extend(PLATFORM_SCHEMA.schema)

--- a/homeassistant/components/device_tracker/const.py
+++ b/homeassistant/components/device_tracker/const.py
@@ -25,6 +25,8 @@ DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 
 CONF_NEW_DEVICE_DEFAULTS = "new_device_defaults"
 
+CONF_LOCATION_NAME = "location_name"
+
 ATTR_ATTRIBUTES = "attributes"
 ATTR_BATTERY = "battery"
 ATTR_DEV_ID = "dev_id"

--- a/homeassistant/components/device_tracker/setup.py
+++ b/homeassistant/components/device_tracker/setup.py
@@ -15,6 +15,7 @@ from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    CONF_LOCATION_NAME,
     CONF_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
@@ -140,7 +141,7 @@ def async_setup_scanner_platform(
     This method must be run in the event loop.
     """
     interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
-    location_name = config.get("location_name", None)
+    location_name = config.get(CONF_LOCATION_NAME, None)
     update_lock = asyncio.Lock()
     scanner.hass = hass
 

--- a/homeassistant/components/device_tracker/setup.py
+++ b/homeassistant/components/device_tracker/setup.py
@@ -140,6 +140,7 @@ def async_setup_scanner_platform(
     This method must be run in the event loop.
     """
     interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
+    location_name = config.get("location_name", None)
     update_lock = asyncio.Lock()
     scanner.hass = hass
 
@@ -181,8 +182,13 @@ def async_setup_scanner_platform(
                     **extra_attributes,
                 },
             }
+            zonename = hass.components.zone.ENTITY_ID_HOME
+            if location_name is not None:
+                kwargs["location_name"] = location_name
+                zonename = "zone." + location_name
 
-            zone_home = hass.states.get(hass.components.zone.ENTITY_ID_HOME)
+            zone_home = hass.states.get(zonename)
+
             if zone_home:
                 kwargs["gps"] = [
                     zone_home.attributes[ATTR_LATITUDE],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A device tracker which doesn't report a geo-location only sets state to 'home' or 'not_home'. If the device_trackers are in different zones it might be useful to see in which zone the device is located. The easiest way would be to assign a device_tracker to a zone and set the tracked devices to that zone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
device_tracker:
  - platform: some_platform
    # no location_name, so default value = 'home'
  - platform: some_platform
    location_name: 'office'

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to:
  -  https://community.home-assistant.io/t/device-tracker-associate-a-device-tracker-to-different-zone/63794/7
  -  https://community.home-assistant.io/t/device-tracker-ip-address-of-tracked-devices-as-an-attribute/64353
- Link to documentation pull request: 
will be done if there is interest in this PR

- Things I've considered:
  - If there are 2 different device_tracker platforms you can check for the scanner - field
  - You can check the IP -> network range.
  - My change is light-weight and would make checking the zone much more easily
  - I'm not sure if the config option name 'location_name' is better than 'zone'

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
