### PR TITLE
Fix bugs updating state of `hdmi_cec` switch

### DIFF
--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -389,6 +389,15 @@ class CecDevice(Entity):
         self.schedule_update_ha_state(True)
 
     @property
+    def should_poll(self):
+        """
+        Return false.
+
+        CecDevice.update() is called by the HDMI network when there is new data.
+        """
+        return False
+
+    @property
     def name(self):
         """Return the name of the device."""
         return (

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -353,7 +353,7 @@ def setup(hass: HomeAssistant, base_config):
     return True
 
 
-class CecDevice(Entity):
+class CecEntity(Entity):
     """Representation of a HDMI CEC device entity."""
 
     def __init__(self, device, logical) -> None:
@@ -393,7 +393,7 @@ class CecDevice(Entity):
         """
         Return false.
 
-        CecDevice.update() is called by the HDMI network when there is new data.
+        CecEntity.update() is called by the HDMI network when there is new data.
         """
         return False
 

--- a/homeassistant/components/hdmi_cec/media_player.py
+++ b/homeassistant/components/hdmi_cec/media_player.py
@@ -43,7 +43,7 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 
-from . import ATTR_NEW, CecDevice
+from . import ATTR_NEW, CecEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,12 +61,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         add_entities(entities, True)
 
 
-class CecPlayerDevice(CecDevice, MediaPlayerEntity):
+class CecPlayerDevice(CecEntity, MediaPlayerEntity):
     """Representation of a HDMI device as a Media player."""
 
     def __init__(self, device, logical) -> None:
         """Initialize the HDMI device."""
-        CecDevice.__init__(self, device, logical)
+        CecEntity.__init__(self, device, logical)
         self.entity_id = f"{DOMAIN}.hdmi_{hex(self._logical_address)[2:]}"
 
     def send_keypress(self, key):

--- a/homeassistant/components/hdmi_cec/media_player.py
+++ b/homeassistant/components/hdmi_cec/media_player.py
@@ -57,11 +57,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         entities = []
         for device in discovery_info[ATTR_NEW]:
             hdmi_device = hass.data.get(device)
-            entities.append(CecPlayerDevice(hdmi_device, hdmi_device.logical_address))
+            entities.append(CecPlayerEntity(hdmi_device, hdmi_device.logical_address))
         add_entities(entities, True)
 
 
-class CecPlayerDevice(CecEntity, MediaPlayerEntity):
+class CecPlayerEntity(CecEntity, MediaPlayerEntity):
     """Representation of a HDMI device as a Media player."""
 
     def __init__(self, device, logical) -> None:

--- a/homeassistant/components/hdmi_cec/switch.py
+++ b/homeassistant/components/hdmi_cec/switch.py
@@ -34,11 +34,13 @@ class CecSwitchDevice(CecDevice, SwitchEntity):
         """Turn device on."""
         self._device.turn_on()
         self._state = STATE_ON
+        self.async_write_ha_state()
 
     def turn_off(self, **kwargs) -> None:
         """Turn device off."""
         self._device.turn_off()
         self._state = STATE_OFF
+        self.async_write_ha_state()
 
     def toggle(self, **kwargs):
         """Toggle the entity."""
@@ -47,6 +49,7 @@ class CecSwitchDevice(CecDevice, SwitchEntity):
             self._state = STATE_OFF
         else:
             self._state = STATE_ON
+        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/hdmi_cec/switch.py
+++ b/homeassistant/components/hdmi_cec/switch.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_STANDBY
 
-from . import ATTR_NEW, CecDevice
+from . import ATTR_NEW, CecEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,12 +22,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         add_entities(entities, True)
 
 
-class CecSwitchDevice(CecDevice, SwitchEntity):
+class CecSwitchDevice(CecEntity, SwitchEntity):
     """Representation of a HDMI device as a Switch."""
 
     def __init__(self, device, logical) -> None:
         """Initialize the HDMI device."""
-        CecDevice.__init__(self, device, logical)
+        CecEntity.__init__(self, device, logical)
         self.entity_id = f"{DOMAIN}.hdmi_{hex(self._logical_address)[2:]}"
 
     def turn_on(self, **kwargs) -> None:

--- a/homeassistant/components/hdmi_cec/switch.py
+++ b/homeassistant/components/hdmi_cec/switch.py
@@ -38,7 +38,7 @@ class CecSwitchDevice(CecDevice, SwitchEntity):
     def turn_off(self, **kwargs) -> None:
         """Turn device off."""
         self._device.turn_off()
-        self._state = STATE_ON
+        self._state = STATE_OFF
 
     def toggle(self, **kwargs):
         """Toggle the entity."""

--- a/homeassistant/components/hdmi_cec/switch.py
+++ b/homeassistant/components/hdmi_cec/switch.py
@@ -18,11 +18,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         entities = []
         for device in discovery_info[ATTR_NEW]:
             hdmi_device = hass.data.get(device)
-            entities.append(CecSwitchDevice(hdmi_device, hdmi_device.logical_address))
+            entities.append(CecSwitchEntity(hdmi_device, hdmi_device.logical_address))
         add_entities(entities, True)
 
 
-class CecSwitchDevice(CecEntity, SwitchEntity):
+class CecSwitchEntity(CecEntity, SwitchEntity):
     """Representation of a HDMI device as a Switch."""
 
     def __init__(self, device, logical) -> None:
@@ -34,13 +34,13 @@ class CecSwitchDevice(CecEntity, SwitchEntity):
         """Turn device on."""
         self._device.turn_on()
         self._state = STATE_ON
-        self.async_write_ha_state()
+        self.schedule_update_ha_state(force_refresh=False)
 
     def turn_off(self, **kwargs) -> None:
         """Turn device off."""
         self._device.turn_off()
         self._state = STATE_OFF
-        self.async_write_ha_state()
+        self.schedule_update_ha_state(force_refresh=False)
 
     def toggle(self, **kwargs):
         """Toggle the entity."""
@@ -49,7 +49,7 @@ class CecSwitchDevice(CecEntity, SwitchEntity):
             self._state = STATE_OFF
         else:
             self._state = STATE_ON
-        self.async_write_ha_state()
+        self.schedule_update_ha_state(force_refresh=False)
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Fixes slow responsiveness in updating the state of an `hdmi_cec` `switch`.

There was a simply typo in the `hdmi_cec` `switch` platform. Setting turning the device `off` updated the status to `on`. 

In addition, these entities were polling, even though their status is actually updated through a callback from the `pycec` module when there is new data. This meant that the stale cached status was overwriting the status set when the switch was toggled.

Also updated `CecDevice` to `CecEntity` to match current terms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
