### PR TITLE
Allow an extra packet without dts (for Arlo camera streaming)

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -66,6 +66,8 @@ def stream_worker(hass, stream, quit_event):
     first_pts = 0
     # The decoder timestamp of the latest packet we processed
     last_dts = None
+    # Keep track of consecutive packets without a dts to detect end of stream.
+    last_packet_was_without_dts = False
 
     while not quit_event.is_set():
         try:
@@ -73,8 +75,13 @@ def stream_worker(hass, stream, quit_event):
             if packet.dts is None:
                 if first_packet:
                     continue
-                # If we get a "flushing" packet, the stream is done
-                raise StopIteration("No dts in packet")
+                _LOGGER.error("Stream packet without dts detected, skipping...")
+                # Allow a single packet without dts before terminating the stream.
+                if last_packet_was_without_dts:
+                    # If we get a "flushing" packet, the stream is done
+                    raise StopIteration("No dts in consecutive packets")
+                last_packet_was_without_dts = True
+                continue
         except (av.AVError, StopIteration) as ex:
             # End of stream, clear listeners and stop thread
             for fmt, _ in outputs.items():

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -82,6 +82,8 @@ def stream_worker(hass, stream, quit_event):
                     raise StopIteration("No dts in consecutive packets")
                 last_packet_was_without_dts = True
                 continue
+            else:
+                last_packet_was_without_dts = False
         except (av.AVError, StopIteration) as ex:
             # End of stream, clear listeners and stop thread
             for fmt, _ in outputs.items():

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -82,8 +82,7 @@ def stream_worker(hass, stream, quit_event):
                     raise StopIteration("No dts in consecutive packets")
                 last_packet_was_without_dts = True
                 continue
-            else:
-                last_packet_was_without_dts = False
+            last_packet_was_without_dts = False
         except (av.AVError, StopIteration) as ex:
             # End of stream, clear listeners and stop thread
             for fmt, _ in outputs.items():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Kludge fix to allow certain Arlo cameras to stream (e.g. Arlo Q cameras), which appear to steam multiple packets without dts, which causes streaming to reliably fail, without the additional tolerance this PR introduces.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: https://github.com/twrecked/hass-aarlo/issues/151

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
