### PR TITLE
Add rfxtrx ability to send a raw command to device

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
-from .const import DEVICE_PACKET_TYPE_LIGHTING4
+from .const import ATTR_EVENT, DEVICE_PACKET_TYPE_LIGHTING4, SERVICE_SEND
 
 DOMAIN = "rfxtrx"
 
@@ -83,6 +83,16 @@ DATA_TYPES = OrderedDict(
 _LOGGER = logging.getLogger(__name__)
 DATA_RFXOBJECT = "rfxobject"
 
+
+def _bytearray_string(data):
+    val = cv.string(data)
+    try:
+        return bytearray.fromhex(val)
+    except ValueError:
+        raise vol.Invalid("Data must be a hex string with multiple of two characters")
+
+
+SERVICE_SEND_SCHEMA = vol.Schema({ATTR_EVENT: _bytearray_string})
 
 DEVICE_SCHEMA = vol.Schema(
     {
@@ -175,6 +185,12 @@ def setup(hass, config):
     load_platform(hass, "cover", DOMAIN, config[DOMAIN], config)
     load_platform(hass, "binary_sensor", DOMAIN, config[DOMAIN], config)
     load_platform(hass, "sensor", DOMAIN, config[DOMAIN], config)
+
+    def send(call):
+        event = call.data[ATTR_EVENT]
+        rfx_object.transport.send(event)
+
+    hass.services.async_register(DOMAIN, SERVICE_SEND, send, schema=SERVICE_SEND_SCHEMA)
 
     return True
 

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -14,4 +14,9 @@ COMMAND_OFF_LIST = [
     "Down",
     "Close (inline relay)",
 ]
+
+ATTR_EVENT = "event"
+
+SERVICE_SEND = "send"
+
 DEVICE_PACKET_TYPE_LIGHTING4 = 0x13

--- a/homeassistant/components/rfxtrx/services.yaml
+++ b/homeassistant/components/rfxtrx/services.yaml
@@ -1,0 +1,6 @@
+send:
+  description: Sends a raw event on radio.
+  fields:
+    event:
+      description: A hexadecimal string to send.
+      example: "0b11009e00e6116202020070"

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,12 +1,12 @@
 """The tests for the Rfxtrx component."""
 
-from tests.async_mock import call
-
 from homeassistant.components import rfxtrx
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
 
 from . import _signal_event
+
+from tests.async_mock import call
 
 
 async def test_valid_config(hass):

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,5 +1,7 @@
 """The tests for the Rfxtrx component."""
 
+from unittest.mock import call
+
 from homeassistant.components import rfxtrx
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
@@ -131,3 +133,19 @@ async def test_fire_event_sensor(hass):
         == {"entity_id": "sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_temperature"}
         for call in calls
     )
+
+
+async def test_send(hass, rfxtrx):
+    """Test configuration."""
+    assert await async_setup_component(
+        hass, "rfxtrx", {"rfxtrx": {"device": "/dev/null"}}
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "rfxtrx", "send", {"event": "0a520802060101ff0f0269"}, blocking=True
+    )
+
+    rfxtrx.transport.send.calls == [
+        call(bytearray(b"\x0a\x52\x08\x02\x06\x01\x01\xff\x0f\x02\x69"))
+    ]

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the Rfxtrx component."""
 
-from unittest.mock import call
+from tests.async_mock import call
 
 from homeassistant.components import rfxtrx
 from homeassistant.core import callback


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a service to send a raw event packet using rfxtrx to support sending chimes and other codes not directly represented by entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13976

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
