### PR TITLE
Drop rfxtrx dummy connection

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -36,7 +36,6 @@ CONF_FIRE_EVENT = "fire_event"
 CONF_DATA_BITS = "data_bits"
 CONF_AUTOMATIC_ADD = "automatic_add"
 CONF_SIGNAL_REPETITIONS = "signal_repetitions"
-CONF_DUMMY = "dummy"
 CONF_DEBUG = "debug"
 CONF_OFF_DELAY = "off_delay"
 SIGNAL_EVENT = f"{DOMAIN}_event"
@@ -94,7 +93,6 @@ DEVICE_SCHEMA = vol.Schema(
 BASE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
-        vol.Optional(CONF_DUMMY, default=False): cv.boolean,
         vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
         vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
     }
@@ -158,13 +156,8 @@ def setup(hass, config):
     host = config[DOMAIN].get(CONF_HOST)
     port = config[DOMAIN].get(CONF_PORT)
     debug = config[DOMAIN][CONF_DEBUG]
-    dummy_connection = config[DOMAIN][CONF_DUMMY]
 
-    if dummy_connection:
-        rfx_object = rfxtrxmod.Connect(
-            device, None, debug=debug, transport_protocol=rfxtrxmod.DummyTransport2,
-        )
-    elif port is not None:
+    if port is not None:
         # If port is set then we create a TCP connection
         rfx_object = rfxtrxmod.Connect(
             (host, port),

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -14,13 +14,7 @@ async def test_one(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "devices": {"0b1100cd0213c7f230010f71": {}},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f230010f71": {}}}},
     )
     await hass.async_block_till_done()
 
@@ -38,7 +32,6 @@ async def test_one_pt2262(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0913000022670e013970": {
                         "data_bits": 4,
@@ -74,7 +67,6 @@ async def test_several(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0b1100cd0213c7f230010f71": {},
                     "0b1100100118cdea02010f70": {},
@@ -109,7 +101,6 @@ async def test_discover(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "automatic_add": True,
                 "devices": {
                     "0b1100cd0213c7f230010f71": {},
@@ -141,7 +132,6 @@ async def test_off_delay(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {"0b1100100118cdea02010f70": {"off_delay": 5}},
             }
         },

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -11,13 +11,7 @@ async def test_one_cover(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "devices": {"0b1400cd0213c7f20d010f51": {}},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "devices": {"0b1400cd0213c7f20d010f51": {}}}},
     )
     await hass.async_block_till_done()
 
@@ -60,7 +54,6 @@ async def test_several_covers(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0b1400cd0213c7f20d010f51": {},
                     "0A1400ADF394AB010D0060": {},
@@ -90,9 +83,7 @@ async def test_several_covers(hass, rfxtrx):
 async def test_discover_covers(hass, rfxtrx):
     """Test with discovery of covers."""
     assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
+        hass, "rfxtrx", {"rfxtrx": {"device": "abcd", "automatic_add": True}}
     )
     await hass.async_block_till_done()
     await hass.async_start()

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -16,7 +16,6 @@ async def test_valid_config(hass):
             "rfxtrx": {
                 "device": "/dev/serial/by-id/usb"
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                "dummy": True,
             }
         },
     )
@@ -31,7 +30,6 @@ async def test_valid_config2(hass):
             "rfxtrx": {
                 "device": "/dev/serial/by-id/usb"
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                "dummy": True,
                 "debug": True,
             }
         },
@@ -64,7 +62,6 @@ async def test_fire_event(hass):
             "rfxtrx": {
                 "device": "/dev/serial/by-id/usb"
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                "dummy": True,
                 "automatic_add": True,
                 "devices": {
                     "0b1100cd0213c7f210010f51": {rfxtrx.CONF_FIRE_EVENT: True},

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -13,13 +13,7 @@ async def test_one_light(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "devices": {"0b1100cd0213c7f210020f51": {}},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210020f51": {}}}},
     )
     await hass.async_block_till_done()
 
@@ -97,7 +91,6 @@ async def test_several_lights(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0b1100cd0213c7f230020f71": {},
                     "0b1100100118cdea02020f70": {},
@@ -133,7 +126,6 @@ async def test_repetitions(hass, rfxtrx, repetitions):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}
                 },
@@ -153,9 +145,7 @@ async def test_repetitions(hass, rfxtrx, repetitions):
 async def test_discover_light(hass, rfxtrx):
     """Test with discovery of lights."""
     assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
+        hass, "rfxtrx", {"rfxtrx": {"device": "abcd", "automatic_add": True}},
     )
     await hass.async_block_till_done()
     await hass.async_start()

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -20,13 +20,7 @@ async def test_one_sensor(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "devices": {"0a52080705020095220269": {}},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "devices": {"0a52080705020095220269": {}}}},
     )
     await hass.async_block_till_done()
 
@@ -45,13 +39,7 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "devices": {"0a52080705020095220269": {}},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "devices": {"0a52080705020095220269": {}}}},
     )
     await hass.async_block_till_done()
 
@@ -97,7 +85,6 @@ async def test_several_sensors(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0a52080705020095220269": {},
                     "0a520802060100ff0e0269": {},
@@ -139,9 +126,7 @@ async def test_several_sensors(hass, rfxtrx):
 async def test_discover_sensor(hass, rfxtrx):
     """Test with discovery of sensor."""
     assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
+        hass, "rfxtrx", {"rfxtrx": {"device": "abcd", "automatic_add": True}},
     )
     await hass.async_block_till_done()
     await hass.async_start()
@@ -244,7 +229,6 @@ async def test_update_of_sensors(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0a52080705020095220269": {},
                     "0a520802060100ff0e0269": {},

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -13,13 +13,7 @@ async def test_one_switch(hass, rfxtrx):
     assert await async_setup_component(
         hass,
         "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "dummy": True,
-                "devices": {"0b1100cd0213c7f210010f51": {}},
-            }
-        },
+        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210010f51": {}}}},
     )
     await hass.async_block_till_done()
 
@@ -56,7 +50,6 @@ async def test_several_switches(hass, rfxtrx):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0b1100cd0213c7f230010f71": {},
                     "0b1100100118cdea02010f70": {},
@@ -92,7 +85,6 @@ async def test_repetitions(hass, rfxtrx, repetitions):
         {
             "rfxtrx": {
                 "device": "abcd",
-                "dummy": True,
                 "devices": {
                     "0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}
                 },
@@ -112,9 +104,7 @@ async def test_repetitions(hass, rfxtrx, repetitions):
 async def test_discover_switch(hass, rfxtrx):
     """Test with discovery of switches."""
     assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "dummy": True, "automatic_add": True}},
+        hass, "rfxtrx", {"rfxtrx": {"device": "abcd", "automatic_add": True}},
     )
     await hass.async_block_till_done()
     await hass.async_start()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop usage of drummy connection in library. We fully mock it during tests, and it's a cpu hog in library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
