### PR TITLE
Fix songpal already configured check in config flow

### DIFF
--- a/homeassistant/components/songpal/config_flow.py
+++ b/homeassistant/components/songpal/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import callback
 
 from .const import CONF_ENDPOINT, DOMAIN  # pylint: disable=unused-import
 
@@ -74,7 +75,7 @@ class SongpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_init(self, user_input=None):
         """Handle a flow start."""
         # Check if already configured
-        if self._endpoint_already_configured():
+        if self._async_endpoint_already_configured():
             return self.async_abort(reason="already_configured")
 
         if user_input is None:
@@ -145,7 +146,8 @@ class SongpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_init(user_input)
 
-    def _endpoint_already_configured(self):
+    @callback
+    def _async_endpoint_already_configured(self):
         """See if we already have an endpoint matching user input configured."""
         for entry in self._async_current_entries():
             if entry.data.get(CONF_ENDPOINT) == self.conf.endpoint:

--- a/homeassistant/components/songpal/config_flow.py
+++ b/homeassistant/components/songpal/config_flow.py
@@ -147,7 +147,7 @@ class SongpalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _endpoint_already_configured(self):
         """See if we already have an endpoint matching user input configured."""
-        existing_endpoints = [
-            entry.data[CONF_ENDPOINT] for entry in self._async_current_entries()
-        ]
-        return self.conf.endpoint in existing_endpoints
+        for entry in self._async_current_entries():
+            if entry.data.get(CONF_ENDPOINT) == self.conf.endpoint:
+                return True
+        return False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a discovered device is ignored, there will be a config entry with empty data, which causes `KeyError` when checking for already configured endpoints. This PR fixes this problem.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37744
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
