### PR TITLE
Add mode info attributes to script and automation

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -590,9 +590,8 @@ class ScriptCapabilities(AlexaEntity):
 
     def interfaces(self):
         """Yield the supported interfaces."""
-        can_cancel = bool(self.entity.attributes.get("can_cancel"))
         return [
-            AlexaSceneController(self.entity, supports_deactivation=can_cancel),
+            AlexaSceneController(self.entity, supports_deactivation=True),
             Alexa(self.hass),
         ]
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -31,6 +31,9 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.script import (
+    ATTR_CUR,
+    ATTR_MAX,
+    ATTR_MODE,
     CONF_MAX,
     SCRIPT_MODE_PARALLEL,
     Script,
@@ -276,7 +279,15 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
     @property
     def state_attributes(self):
         """Return the entity state attributes."""
-        return {ATTR_LAST_TRIGGERED: self._last_triggered}
+        attrs = {
+            ATTR_LAST_TRIGGERED: self._last_triggered,
+            ATTR_MODE: self.action_script.script_mode,
+        }
+        if self.action_script.supports_max:
+            attrs[ATTR_MAX] = self.action_script.max_runs
+            if self.is_on:
+                attrs[ATTR_CUR] = self.action_script.runs
+        return attrs
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -9,7 +9,6 @@ from pyhap.const import (
     CATEGORY_SWITCH,
 )
 
-from homeassistant.components.script import ATTR_CAN_CANCEL
 from homeassistant.components.switch import DOMAIN
 from homeassistant.components.vacuum import (
     DOMAIN as VACUUM_DOMAIN,
@@ -111,10 +110,7 @@ class Switch(HomeAccessory):
 
     def is_activate(self, state):
         """Check if entity is activate only."""
-        can_cancel = state.attributes.get(ATTR_CAN_CANCEL)
         if self._domain == "scene":
-            return True
-        if self._domain == "script" and not can_cancel:
             return True
         return False
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -24,6 +24,9 @@ from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.script import (
+    ATTR_CUR,
+    ATTR_MAX,
+    ATTR_MODE,
     CONF_MAX,
     SCRIPT_MODE_SINGLE,
     Script,
@@ -35,7 +38,7 @@ from homeassistant.loader import bind_hass
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "script"
-ATTR_CAN_CANCEL = "can_cancel"
+
 ATTR_LAST_ACTION = "last_action"
 ATTR_LAST_TRIGGERED = "last_triggered"
 ATTR_VARIABLES = "variables"
@@ -272,9 +275,14 @@ class ScriptEntity(ToggleEntity):
     @property
     def state_attributes(self):
         """Return the state attributes."""
-        attrs = {ATTR_LAST_TRIGGERED: self.script.last_triggered}
-        if self.script.can_cancel:
-            attrs[ATTR_CAN_CANCEL] = self.script.can_cancel
+        attrs = {
+            ATTR_LAST_TRIGGERED: self.script.last_triggered,
+            ATTR_MODE: self.script.script_mode,
+        }
+        if self.script.supports_max:
+            attrs[ATTR_MAX] = self.script.max_runs
+            if self.is_on:
+                attrs[ATTR_CUR] = self.script.runs
         if self.script.last_action:
             attrs[ATTR_LAST_ACTION] = self.script.last_action
         return attrs

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -611,12 +611,7 @@ class Script:
     @property
     def supports_max(self) -> bool:
         """Return true if the current mode support max."""
-        if (
-            self.script_mode == SCRIPT_MODE_PARALLEL
-            or self.script_mode == SCRIPT_MODE_QUEUED
-        ):
-            return True
-        return False
+        return self.script_mode in (SCRIPT_MODE_PARALLEL, SCRIPT_MODE_QUEUED)
 
     @property
     def referenced_devices(self):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -310,29 +310,10 @@ async def test_script(hass):
         appliance, "Alexa.SceneController", "Alexa"
     )
     scene_capability = get_capability(capabilities, "Alexa.SceneController")
-    assert not scene_capability["supportsDeactivation"]
-
-    await assert_scene_controller_works("script#test", "script.turn_on", None, hass)
-
-
-async def test_cancelable_script(hass):
-    """Test cancalable script discovery."""
-    device = (
-        "script.test_2",
-        "off",
-        {"friendly_name": "Test script 2", "can_cancel": True},
-    )
-    appliance = await discovery_test(device, hass)
-
-    assert appliance["endpointId"] == "script#test_2"
-    capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.SceneController", "Alexa"
-    )
-    scene_capability = get_capability(capabilities, "Alexa.SceneController")
     assert scene_capability["supportsDeactivation"]
 
     await assert_scene_controller_works(
-        "script#test_2", "script.turn_on", "script.turn_off", hass
+        "script#test", "script.turn_on", "script.turn_off", hass
     )
 
 

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -16,7 +16,6 @@ from homeassistant.components.homekit.type_switches import (
     Switch,
     Valve,
 )
-from homeassistant.components.script import ATTR_CAN_CANCEL
 from homeassistant.components.vacuum import (
     DOMAIN as VACUUM_DOMAIN,
     SERVICE_RETURN_TO_BASE,
@@ -80,7 +79,7 @@ async def test_outlet_set_state(hass, hk_driver, events):
         ("automation.test", {}),
         ("input_boolean.test", {}),
         ("remote.test", {}),
-        ("script.test", {ATTR_CAN_CANCEL: True}),
+        ("script.test", {}),
         ("switch.test", {}),
     ],
 )
@@ -240,19 +239,12 @@ async def test_vacuum_set_state(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] is None
 
 
-@pytest.mark.parametrize(
-    "entity_id, attrs",
-    [
-        ("scene.test", {}),
-        ("script.test", {}),
-        ("script.test", {ATTR_CAN_CANCEL: False}),
-    ],
-)
-async def test_reset_switch(hass, hk_driver, entity_id, attrs, events):
+async def test_reset_switch(hass, hk_driver, events):
     """Test if switch accessory is reset correctly."""
-    domain = split_entity_id(entity_id)[0]
+    domain = "scene"
+    entity_id = "scene.test"
 
-    hass.states.async_set(entity_id, None, attrs)
+    hass.states.async_set(entity_id, None)
     await hass.async_block_till_done()
     acc = Switch(hass, hk_driver, "Switch", entity_id, 2, None)
     await acc.run_handler()
@@ -283,24 +275,3 @@ async def test_reset_switch(hass, hk_driver, entity_id, attrs, events):
     await hass.async_block_till_done()
     assert acc.char_on.value is False
     assert len(events) == 1
-
-
-async def test_reset_switch_reload(hass, hk_driver, events):
-    """Test reset switch after script reload."""
-    entity_id = "script.test"
-
-    hass.states.async_set(entity_id, None)
-    await hass.async_block_till_done()
-    acc = Switch(hass, hk_driver, "Switch", entity_id, 2, None)
-    await acc.run_handler()
-    await hass.async_block_till_done()
-
-    assert acc.activate_only is True
-
-    hass.states.async_set(entity_id, None, {ATTR_CAN_CANCEL: True})
-    await hass.async_block_till_done()
-    assert acc.activate_only is False
-
-    hass.states.async_set(entity_id, None, {ATTR_CAN_CANCEL: False})
-    await hass.async_block_till_done()
-    assert acc.activate_only is True

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -275,3 +275,20 @@ async def test_reset_switch(hass, hk_driver, events):
     await hass.async_block_till_done()
     assert acc.char_on.value is False
     assert len(events) == 1
+
+
+async def test_reset_switch_reload(hass, hk_driver, events):
+    """Test reset switch after script reload."""
+    entity_id = "script.test"
+
+    hass.states.async_set(entity_id, None)
+    await hass.async_block_till_done()
+    acc = Switch(hass, hk_driver, "Switch", entity_id, 2, None)
+    await acc.run_handler()
+    await hass.async_block_till_done()
+
+    assert acc.activate_only is False
+
+    hass.states.async_set(entity_id, None)
+    await hass.async_block_till_done()
+    assert acc.char_on.value is False

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -93,15 +93,12 @@ async def test_firing_event_basic(hass):
     sequence = cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
     script_obj = script.Script(hass, sequence)
 
-    assert script_obj.can_cancel
-
     await script_obj.async_run(context=context)
     await hass.async_block_till_done()
 
     assert len(events) == 1
     assert events[0].context is context
     assert events[0].data.get("hello") == "world"
-    assert script_obj.can_cancel
 
 
 async def test_firing_event_template(hass):
@@ -125,8 +122,6 @@ async def test_firing_event_template(hass):
     )
     script_obj = script.Script(hass, sequence)
 
-    assert script_obj.can_cancel
-
     await script_obj.async_run({"is_world": "yes"}, context=context)
     await hass.async_block_till_done()
 
@@ -145,8 +140,6 @@ async def test_calling_service_basic(hass):
 
     sequence = cv.SCRIPT_SCHEMA({"service": "test.script", "data": {"hello": "world"}})
     script_obj = script.Script(hass, sequence)
-
-    assert script_obj.can_cancel
 
     await script_obj.async_run(context=context)
     await hass.async_block_till_done()
@@ -181,8 +174,6 @@ async def test_calling_service_template(hass):
         }
     )
     script_obj = script.Script(hass, sequence)
-
-    assert script_obj.can_cancel
 
     await script_obj.async_run({"is_world": "yes"}, context=context)
     await hass.async_block_till_done()
@@ -267,8 +258,6 @@ async def test_activating_scene(hass):
     sequence = cv.SCRIPT_SCHEMA({"scene": "scene.hello"})
     script_obj = script.Script(hass, sequence)
 
-    assert script_obj.can_cancel
-
     await script_obj.async_run(context=context)
     await hass.async_block_till_done()
 
@@ -327,8 +316,6 @@ async def test_delay_basic(hass, mock_timeout):
     sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": 5}, "alias": delay_alias})
     script_obj = script.Script(hass, sequence)
     delay_started_flag = async_watch_for_action(script_obj, delay_alias)
-
-    assert script_obj.can_cancel
 
     try:
         hass.async_create_task(script_obj.async_run())
@@ -394,8 +381,6 @@ async def test_delay_template_ok(hass, mock_timeout):
     script_obj = script.Script(hass, sequence)
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
-    assert script_obj.can_cancel
-
     try:
         hass.async_create_task(script_obj.async_run())
         await asyncio.wait_for(delay_started_flag.wait(), 1)
@@ -443,8 +428,6 @@ async def test_delay_template_complex_ok(hass, mock_timeout):
     sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": "{{ 5 }}"}})
     script_obj = script.Script(hass, sequence)
     delay_started_flag = async_watch_for_action(script_obj, "delay")
-
-    assert script_obj.can_cancel
 
     try:
         hass.async_create_task(script_obj.async_run())
@@ -529,8 +512,6 @@ async def test_wait_template_basic(hass):
     )
     script_obj = script.Script(hass, sequence)
     wait_started_flag = async_watch_for_action(script_obj, wait_alias)
-
-    assert script_obj.can_cancel
 
     try:
         hass.states.async_set("switch.test", "on")
@@ -687,8 +668,6 @@ async def test_wait_template_variables(hass):
     script_obj = script.Script(hass, sequence)
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
-    assert script_obj.can_cancel
-
     try:
         hass.states.async_set("switch.test", "on")
         hass.async_create_task(script_obj.async_run({"data": "switch.test"}))
@@ -720,8 +699,6 @@ async def test_condition_basic(hass):
         ]
     )
     script_obj = script.Script(hass, sequence)
-
-    assert script_obj.can_cancel
 
     hass.states.async_set("test.entity", "hello")
     await script_obj.async_run()


### PR DESCRIPTION
## Proposed change
Adds attributes to scripts and automations about the current mode/max/number of running.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
