### PR TITLE
Improve handling of template platforms when entity extraction fails

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -40,8 +40,11 @@ def extract_entities(
             else:
                 invalid_templates.append(template_name.replace("_template", ""))
 
+        entity_ids = list(entity_ids)
+
         if invalid_templates:
-            entity_ids = MATCH_ALL
+            if not entity_ids:
+                entity_ids = MATCH_ALL
             _LOGGER.warning(
                 "Template %s '%s' has no entity ids configured to track nor"
                 " were we able to extract the entities to track from the %s "
@@ -51,8 +54,6 @@ def extract_entities(
                 device_name,
                 ", ".join(invalid_templates),
             )
-        else:
-            entity_ids = list(entity_ids)
     else:
         entity_ids = manual_entity_ids
 

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -32,7 +32,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.script import Script
 
 _LOGGER = logging.getLogger(__name__)
@@ -204,15 +204,16 @@ class AlarmControlPanelTemplate(AlarmControlPanelEntity):
         """Register callbacks."""
 
         @callback
-        def template_alarm_state_listener(entity, old_state, new_state):
+        def template_alarm_state_listener(event):
             """Handle target device state changes."""
             self.async_schedule_update_ha_state(True)
 
         @callback
         def template_alarm_control_panel_startup(event):
             """Update template on startup."""
-            if self._template is not None:
-                async_track_state_change(
+            if self._template is not None and self._entities != MATCH_ALL:
+                # Track state change only for valid templates
+                async_track_state_change_event(
                     self.hass, self._entities, template_alarm_state_listener
                 )
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -24,7 +24,10 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.event import async_track_same_state, async_track_state_change
+from homeassistant.helpers.event import (
+    async_track_same_state,
+    async_track_state_change_event,
+)
 
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
@@ -148,7 +151,7 @@ class BinarySensorTemplate(BinarySensorEntity):
         """Register callbacks."""
 
         @callback
-        def template_bsensor_state_listener(entity, old_state, new_state):
+        def template_bsensor_state_listener(event):
             """Handle the target device state changes."""
             self.async_check_state()
 
@@ -157,7 +160,7 @@ class BinarySensorTemplate(BinarySensorEntity):
             """Update template on startup."""
             if self._entities != MATCH_ALL:
                 # Track state change only for valid templates
-                async_track_state_change(
+                async_track_state_change_event(
                     self.hass, self._entities, template_bsensor_state_listener
                 )
 

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     CONF_OPTIMISTIC,
     CONF_VALUE_TEMPLATE,
     EVENT_HOMEASSISTANT_START,
+    MATCH_ALL,
     STATE_CLOSED,
     STATE_OPEN,
 )
@@ -35,7 +36,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.script import Script
 
 from . import extract_entities, initialise_templates
@@ -226,16 +227,18 @@ class CoverTemplate(CoverEntity):
         """Register callbacks."""
 
         @callback
-        def template_cover_state_listener(entity, old_state, new_state):
+        def template_cover_state_listener(event):
             """Handle target device state changes."""
             self.async_schedule_update_ha_state(True)
 
         @callback
         def template_cover_startup(event):
             """Update template on startup."""
-            async_track_state_change(
-                self.hass, self._entities, template_cover_state_listener
-            )
+            if self._entities != MATCH_ALL:
+                # Track state change only for valid templates
+                async_track_state_change_event(
+                    self.hass, self._entities, template_cover_state_listener
+                )
 
             self.async_schedule_update_ha_state(True)
 

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     CONF_FRIENDLY_NAME,
     CONF_VALUE_TEMPLATE,
     EVENT_HOMEASSISTANT_START,
+    MATCH_ALL,
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
@@ -313,16 +314,18 @@ class TemplateFan(FanEntity):
         """Register callbacks."""
 
         @callback
-        def template_fan_state_listener(entity, old_state, new_state):
+        def template_fan_state_listener(event):
             """Handle target device state changes."""
             self.async_schedule_update_ha_state(True)
 
         @callback
         def template_fan_startup(event):
             """Update template on startup."""
-            self.hass.helpers.event.async_track_state_change(
-                self._entities, template_fan_state_listener
-            )
+            if self._entities != MATCH_ALL:
+                # Track state change only for valid templates
+                self.hass.helpers.event.async_track_state_change_event(
+                    self._entities, template_fan_state_listener
+                )
 
             self.async_schedule_update_ha_state(True)
 

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.script import Script
 
 from . import extract_entities, initialise_templates
@@ -102,7 +102,7 @@ class TemplateLock(LockEntity):
         """Register callbacks."""
 
         @callback
-        def template_lock_state_listener(entity, old_state, new_state):
+        def template_lock_state_listener(event):
             """Handle target device state changes."""
             self.async_schedule_update_ha_state(True)
 
@@ -111,7 +111,7 @@ class TemplateLock(LockEntity):
             """Update template on startup."""
             if self._state_entities != MATCH_ALL:
                 # Track state change only for valid templates
-                async_track_state_change(
+                async_track_state_change_event(
                     self._hass, self._state_entities, template_lock_state_listener
                 )
             self.async_schedule_update_ha_state(True)

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 
 from . import extract_entities, initialise_templates
 from .const import CONF_AVAILABILITY_TEMPLATE
@@ -154,7 +154,7 @@ class SensorTemplate(Entity):
         """Register callbacks."""
 
         @callback
-        def template_sensor_state_listener(entity, old_state, new_state):
+        def template_sensor_state_listener(event):
             """Handle device state changes."""
             self.async_schedule_update_ha_state(True)
 
@@ -163,7 +163,7 @@ class SensorTemplate(Entity):
             """Update template on startup."""
             if self._entities != MATCH_ALL:
                 # Track state change only for valid templates
-                async_track_state_change(
+                async_track_state_change_event(
                     self.hass, self._entities, template_sensor_state_listener
                 )
 

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_SWITCHES,
     CONF_VALUE_TEMPLATE,
     EVENT_HOMEASSISTANT_START,
+    MATCH_ALL,
     STATE_OFF,
     STATE_ON,
 )
@@ -23,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.script import Script
 
@@ -147,16 +148,18 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
 
         # set up event listening
         @callback
-        def template_switch_state_listener(entity, old_state, new_state):
+        def template_switch_state_listener(event):
             """Handle target device state changes."""
             self.async_schedule_update_ha_state(True)
 
         @callback
         def template_switch_startup(event):
             """Update template on startup."""
-            async_track_state_change(
-                self.hass, self._entities, template_switch_state_listener
-            )
+            if self._entities != MATCH_ALL:
+                # Track state change only for valid templates
+                async_track_state_change_event(
+                    self.hass, self._entities, template_switch_state_listener
+                )
 
             self.async_schedule_update_ha_state(True)
 

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -341,7 +341,7 @@ class TemplateVacuum(StateVacuumEntity):
         """Register callbacks."""
 
         @callback
-        def template_vacuum_state_listener(entity, old_state, new_state):
+        def template_vacuum_state_listener(event):
             """Handle target device state changes."""
             self.async_schedule_update_ha_state(True)
 
@@ -350,7 +350,7 @@ class TemplateVacuum(StateVacuumEntity):
             """Update template on startup."""
             if self._entities != MATCH_ALL:
                 # Track state changes only for valid templates
-                self.hass.helpers.event.async_track_state_change(
+                self.hass.helpers.event.async_track_state_change_event(
                     self._entities, template_vacuum_state_listener
                 )
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -622,9 +622,10 @@ async def test_no_update_template_match_all(hass, caplog):
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.all_state").state == "on"
-    assert hass.states.get("binary_sensor.all_icon").state == "on"
-    assert hass.states.get("binary_sensor.all_entity_picture").state == "on"
-    assert hass.states.get("binary_sensor.all_attribute").state == "on"
+    # Will now process because we have one valid template
+    assert hass.states.get("binary_sensor.all_icon").state == "off"
+    assert hass.states.get("binary_sensor.all_entity_picture").state == "off"
+    assert hass.states.get("binary_sensor.all_attribute").state == "off"
 
     await hass.helpers.entity_component.async_update_entity("binary_sensor.all_state")
     await hass.helpers.entity_component.async_update_entity("binary_sensor.all_icon")

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -618,10 +618,11 @@ async def test_no_template_match_all(hass, caplog):
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.invalid_state").state == "2"
-    assert hass.states.get("sensor.invalid_icon").state == "startup"
-    assert hass.states.get("sensor.invalid_entity_picture").state == "startup"
-    assert hass.states.get("sensor.invalid_friendly_name").state == "startup"
-    assert hass.states.get("sensor.invalid_attribute").state == "startup"
+    # Will now process because we have at least one valid template
+    assert hass.states.get("sensor.invalid_icon").state == "hello"
+    assert hass.states.get("sensor.invalid_entity_picture").state == "hello"
+    assert hass.states.get("sensor.invalid_friendly_name").state == "hello"
+    assert hass.states.get("sensor.invalid_attribute").state == "hello"
 
     await hass.helpers.entity_component.async_update_entity("sensor.invalid_state")
     await hass.helpers.entity_component.async_update_entity("sensor.invalid_icon")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Most of the the template platforms would check for
extract_entities failing to extract entities and avoid
setting up a state change listner for MATCH_ALL after
extract_entities had warned that it could not extract
the entities and updates would need to be done manually.
This protection has been extended to all template platforms.

Alter the behavior of extract_entities to return the
successfully extracted entities if one or more templates
fail extraction instead of returning MATCH_ALL and getting
rejected by the platform itself.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
