### PR TITLE
Switch async_track_state_change to the faster async_track_state_change_event part 2

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -32,7 +32,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.loader import bind_hass
 
@@ -499,7 +499,7 @@ class Group(Entity):
         This method must be run in the event loop.
         """
         if self._async_unsub_state_changed is None:
-            self._async_unsub_state_changed = async_track_state_change(
+            self._async_unsub_state_changed = async_track_state_change_event(
                 self.hass, self.tracking, self._async_state_changed_listener
             )
 
@@ -528,7 +528,7 @@ class Group(Entity):
             self._async_unsub_state_changed()
             self._async_unsub_state_changed = None
 
-    async def _async_state_changed_listener(self, entity_id, old_state, new_state):
+    async def _async_state_changed_listener(self, event):
         """Respond to a member state changing.
 
         This method must be run in the event loop.
@@ -537,7 +537,7 @@ class Group(Entity):
         if self._async_unsub_state_changed is None:
             return
 
-        self._async_update_group_state(new_state)
+        self._async_update_group_state(event.data.get("new_state"))
         self.async_write_ha_state()
 
     @property

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -41,7 +41,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import State, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs
@@ -95,12 +95,14 @@ class CoverGroup(CoverEntity):
         }
 
     @callback
+    def _update_supported_features_event(self, event):
+        self.update_supported_features(
+            event.data.get("entity_id"), event.data.get("new_state")
+        )
+
+    @callback
     def update_supported_features(
-        self,
-        entity_id: str,
-        old_state: Optional[State],
-        new_state: Optional[State],
-        update_state: bool = True,
+        self, entity_id: str, new_state: Optional[State], update_state: bool = True,
     ) -> None:
         """Update dictionaries with supported features."""
         if not new_state:
@@ -147,11 +149,9 @@ class CoverGroup(CoverEntity):
         """Register listeners."""
         for entity_id in self._entities:
             new_state = self.hass.states.get(entity_id)
-            self.update_supported_features(
-                entity_id, None, new_state, update_state=False
-            )
-        async_track_state_change(
-            self.hass, self._entities, self.update_supported_features
+            self.update_supported_features(entity_id, new_state, update_state=False)
+        async_track_state_change_event(
+            self.hass, self._entities, self._update_supported_features_event
         )
         await self.async_update()
 

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -38,7 +38,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, State, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util import color as color_util
 
@@ -100,14 +100,12 @@ class LightGroup(light.LightEntity):
         """Register callbacks."""
 
         @callback
-        def async_state_changed_listener(
-            entity_id: str, old_state: State, new_state: State
-        ):
+        def async_state_changed_listener(*_):
             """Handle child updates."""
             self.async_schedule_update_ha_state(True)
 
         assert self.hass is not None
-        self._async_unsub_state_changed = async_track_state_change(
+        self._async_unsub_state_changed = async_track_state_change_event(
             self.hass, self._entity_ids, async_state_changed_listener
         )
         await self.async_update()


### PR DESCRIPTION
I'm slowly switching these over so `async_track_state_change_event` gets used in new code instead of `async_track_state_change` when possible since code tends to get copied.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Calling async_track_state_change_event directly is faster than async_track_state_change (see #37251) since async_track_state_change is a wrapper around async_track_state_change_event now

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
