### PR TITLE
0.112.5

### DIFF
--- a/homeassistant/components/blink/manifest.json
+++ b/homeassistant/components/blink/manifest.json
@@ -2,7 +2,7 @@
   "domain": "blink",
   "name": "Blink",
   "documentation": "https://www.home-assistant.io/integrations/blink",
-  "requirements": ["blinkpy==0.15.0"],
+  "requirements": ["blinkpy==0.15.1"],
   "codeowners": ["@fronzbot"],
   "config_flow": true
 }

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==71"],
+  "requirements": ["pydeconz==72"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -1021,10 +1021,13 @@ class MqttAvailability(Entity):
         """Subscribe MQTT events."""
         await super().async_added_to_hass()
         await self._availability_subscribe_topics()
-        async_dispatcher_connect(self.hass, MQTT_CONNECTED, self.async_mqtt_connect)
-        async_dispatcher_connect(self.hass, MQTT_DISCONNECTED, self.async_mqtt_connect)
         self.async_on_remove(
             async_dispatcher_connect(self.hass, MQTT_CONNECTED, self.async_mqtt_connect)
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, MQTT_DISCONNECTED, self.async_mqtt_connect
+            )
         )
 
     async def availability_discovery_update(self, config: dict):
@@ -1092,7 +1095,7 @@ class MqttAvailability(Entity):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        if not self.hass.data[DATA_MQTT].connected:
+        if not self.hass.data[DATA_MQTT].connected and not self.hass.is_stopping:
             return False
         return not self._avail_topics or self._available
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -1083,7 +1083,7 @@ class MqttAvailability(Entity):
     @callback
     def async_mqtt_connect(self):
         """Update state on connection/disconnection to MQTT broker."""
-        if self.hass.is_running:
+        if not self.hass.is_stopping:
             self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -88,6 +88,8 @@ CONF_TLS_INSECURE = "tls_insecure"
 CONF_TLS_VERSION = "tls_version"
 
 CONF_COMMAND_TOPIC = "command_topic"
+CONF_TOPIC = "topic"
+CONF_AVAILABILITY = "availability"
 CONF_AVAILABILITY_TOPIC = "availability_topic"
 CONF_PAYLOAD_AVAILABLE = "payload_available"
 CONF_PAYLOAD_NOT_AVAILABLE = "payload_not_available"
@@ -203,9 +205,9 @@ CONFIG_SCHEMA = vol.Schema(
 
 SCHEMA_BASE = {vol.Optional(CONF_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA}
 
-MQTT_AVAILABILITY_SCHEMA = vol.Schema(
+MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_AVAILABILITY_TOPIC): valid_subscribe_topic,
+        vol.Exclusive(CONF_AVAILABILITY_TOPIC, "availability"): valid_subscribe_topic,
         vol.Optional(
             CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
         ): cv.string,
@@ -213,6 +215,30 @@ MQTT_AVAILABILITY_SCHEMA = vol.Schema(
             CONF_PAYLOAD_NOT_AVAILABLE, default=DEFAULT_PAYLOAD_NOT_AVAILABLE
         ): cv.string,
     }
+)
+
+MQTT_AVAILABILITY_LIST_SCHEMA = vol.Schema(
+    {
+        vol.Exclusive(CONF_AVAILABILITY, "availability"): vol.All(
+            cv.ensure_list,
+            [
+                {
+                    vol.Optional(CONF_TOPIC): valid_subscribe_topic,
+                    vol.Optional(
+                        CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_PAYLOAD_NOT_AVAILABLE,
+                        default=DEFAULT_PAYLOAD_NOT_AVAILABLE,
+                    ): cv.string,
+                }
+            ],
+        ),
+    }
+)
+
+MQTT_AVAILABILITY_SCHEMA = MQTT_AVAILABILITY_SINGLE_SCHEMA.extend(
+    MQTT_AVAILABILITY_LIST_SCHEMA.schema
 )
 
 MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(
@@ -989,8 +1015,7 @@ class MqttAvailability(Entity):
         """Initialize the availability mixin."""
         self._availability_sub_state = None
         self._available = False
-
-        self._avail_config = config
+        self._availability_setup_from_config(config)
 
     async def async_added_to_hass(self) -> None:
         """Subscribe MQTT events."""
@@ -1004,8 +1029,26 @@ class MqttAvailability(Entity):
 
     async def availability_discovery_update(self, config: dict):
         """Handle updated discovery message."""
-        self._avail_config = config
+        self._availability_setup_from_config(config)
         await self._availability_subscribe_topics()
+
+    def _availability_setup_from_config(self, config):
+        """(Re)Setup."""
+        self._avail_topics = {}
+        if CONF_AVAILABILITY_TOPIC in config:
+            self._avail_topics[config[CONF_AVAILABILITY_TOPIC]] = {
+                CONF_PAYLOAD_AVAILABLE: config[CONF_PAYLOAD_AVAILABLE],
+                CONF_PAYLOAD_NOT_AVAILABLE: config[CONF_PAYLOAD_NOT_AVAILABLE],
+            }
+
+        if CONF_AVAILABILITY in config:
+            for avail in config[CONF_AVAILABILITY]:
+                self._avail_topics[avail[CONF_TOPIC]] = {
+                    CONF_PAYLOAD_AVAILABLE: avail[CONF_PAYLOAD_AVAILABLE],
+                    CONF_PAYLOAD_NOT_AVAILABLE: avail[CONF_PAYLOAD_NOT_AVAILABLE],
+                }
+
+        self._avail_config = config
 
     async def _availability_subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -1014,23 +1057,24 @@ class MqttAvailability(Entity):
         @log_messages(self.hass, self.entity_id)
         def availability_message_received(msg: Message) -> None:
             """Handle a new received MQTT availability message."""
-            if msg.payload == self._avail_config[CONF_PAYLOAD_AVAILABLE]:
+            topic = msg.topic
+            if msg.payload == self._avail_topics[topic][CONF_PAYLOAD_AVAILABLE]:
                 self._available = True
-            elif msg.payload == self._avail_config[CONF_PAYLOAD_NOT_AVAILABLE]:
+            elif msg.payload == self._avail_topics[topic][CONF_PAYLOAD_NOT_AVAILABLE]:
                 self._available = False
 
             self.async_write_ha_state()
 
+        topics = {}
+        for topic in self._avail_topics:
+            topics[f"availability_{topic}"] = {
+                "topic": topic,
+                "msg_callback": availability_message_received,
+                "qos": self._avail_config[CONF_QOS],
+            }
+
         self._availability_sub_state = await async_subscribe_topics(
-            self.hass,
-            self._availability_sub_state,
-            {
-                "availability_topic": {
-                    "topic": self._avail_config.get(CONF_AVAILABILITY_TOPIC),
-                    "msg_callback": availability_message_received,
-                    "qos": self._avail_config[CONF_QOS],
-                }
-            },
+            self.hass, self._availability_sub_state, topics,
         )
 
     @callback
@@ -1048,10 +1092,9 @@ class MqttAvailability(Entity):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        availability_topic = self._avail_config.get(CONF_AVAILABILITY_TOPIC)
         if not self.hass.data[DATA_MQTT].connected:
             return False
-        return availability_topic is None or self._available
+        return not self._avail_topics or self._available
 
 
 async def cleanup_device_registry(hass, device_id):

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -7,6 +7,7 @@ ABBREVIATIONS = {
     "aux_cmd_t": "aux_command_topic",
     "aux_stat_tpl": "aux_state_template",
     "aux_stat_t": "aux_state_topic",
+    "avty": "availability",
     "avty_t": "availability_topic",
     "away_mode_cmd_t": "away_mode_command_topic",
     "away_mode_stat_tpl": "away_mode_state_template",

--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/smappee",
   "dependencies": ["http"],
   "requirements": [
-    "pysmappee==0.1.4"
+    "pysmappee==0.1.5"
   ],
   "codeowners": [
     "@bsmappee"

--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -105,16 +105,14 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator):
         self.api = None
         self.servers = {}
         super().__init__(
-            self.hass,
-            _LOGGER,
-            name=DOMAIN,
-            update_method=self.async_update,
-            update_interval=timedelta(
+            self.hass, _LOGGER, name=DOMAIN, update_method=self.async_update,
+        )
+        if not self.config_entry.options.get(CONF_MANUAL):
+            self.update_interval = timedelta(
                 minutes=self.config_entry.options.get(
                     CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                 )
-            ),
-        )
+            )
 
     def update_servers(self):
         """Update list of test servers."""
@@ -189,12 +187,11 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator):
 
 async def options_updated_listener(hass, entry):
     """Handle options update."""
-    if not entry.options[CONF_MANUAL]:
-        hass.data[DOMAIN].update_interval = timedelta(
-            minutes=entry.options[CONF_SCAN_INTERVAL]
-        )
-        await hass.data[DOMAIN].async_request_refresh()
+    if entry.options[CONF_MANUAL]:
+        hass.data[DOMAIN].update_interval = None
         return
-    # set the update interval to a very long time
-    # if the user wants to disable auto update
-    hass.data[DOMAIN].update_interval = timedelta(days=7)
+
+    hass.data[DOMAIN].update_interval = timedelta(
+        minutes=entry.options[CONF_SCAN_INTERVAL]
+    )
+    await hass.data[DOMAIN].async_request_refresh()

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ubiquiti UniFi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": ["aiounifi==22"],
+  "requirements": ["aiounifi==23"],
   "codeowners": ["@Kane610"],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -200,7 +200,7 @@ def setup(hass, config):
 
         # If we can handle it as a HomeKit discovery, we do that here.
         if service_type == HOMEKIT_TYPE:
-            handle_homekit(hass, info)
+            discovery_was_forwarded = handle_homekit(hass, info)
             # Continue on here as homekit_controller
             # still needs to get updates on devices
             # so it can see when the 'c#' field is updated.
@@ -209,7 +209,8 @@ def setup(hass, config):
             # if the device is already paired in order to avoid
             # offering a second discovery for the same device
             if (
-                HOMEKIT_PROPERTIES in info
+                discovery_was_forwarded
+                and HOMEKIT_PROPERTIES in info
                 and HOMEKIT_PAIRED_STATUS_FLAG in info[HOMEKIT_PROPERTIES]
             ):
                 try:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 112
-PATCH_VERSION = "4"
+PATCH_VERSION = "5"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 0)

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -30,7 +30,7 @@ class DataUpdateCoordinator:
         logger: logging.Logger,
         *,
         name: str,
-        update_interval: timedelta,
+        update_interval: Optional[timedelta] = None,
         update_method: Optional[Callable[[], Awaitable]] = None,
         request_refresh_debouncer: Optional[Debouncer] = None,
     ):
@@ -91,6 +91,9 @@ class DataUpdateCoordinator:
     @callback
     def _schedule_refresh(self) -> None:
         """Schedule a refresh."""
+        if self.update_interval is None:
+            return
+
         if self._unsub_refresh:
             self._unsub_refresh()
             self._unsub_refresh = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -230,7 +230,7 @@ aiopylgtv==0.3.3
 aioswitcher==1.2.0
 
 # homeassistant.components.unifi
-aiounifi==22
+aiounifi==23
 
 # homeassistant.components.airly
 airly==0.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1610,7 +1610,7 @@ pysignalclirestapi==0.3.4
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.1.4
+pysmappee==0.1.5
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -348,7 +348,7 @@ bizkaibus==0.1.1
 blebox_uniapi==1.3.2
 
 # homeassistant.components.blink
-blinkpy==0.15.0
+blinkpy==0.15.1
 
 # homeassistant.components.blinksticklight
 blinkstick==1.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1282,7 +1282,7 @@ pydaikin==2.2.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==71
+pydeconz==72
 
 # homeassistant.components.delijn
 pydelijn==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -576,7 +576,7 @@ pycountry==19.8.18
 pydaikin==2.2.0
 
 # homeassistant.components.deconz
-pydeconz==71
+pydeconz==72
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -122,7 +122,7 @@ aiopylgtv==0.3.3
 aioswitcher==1.2.0
 
 # homeassistant.components.unifi
-aiounifi==22
+aiounifi==23
 
 # homeassistant.components.airly
 airly==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -715,7 +715,7 @@ pysignalclirestapi==0.3.4
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.1.4
+pysmappee==0.1.5
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -171,7 +171,7 @@ bellows==0.17.0
 blebox_uniapi==1.3.2
 
 # homeassistant.components.blink
-blinkpy==0.15.0
+blinkpy==0.15.1
 
 # homeassistant.components.bom
 bomradarloop==0.1.4

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -16,11 +16,14 @@ from .test_common import (
     help_test_availability_when_connection_lost,
     help_test_availability_without_topic,
     help_test_custom_availability_payload,
+    help_test_default_availability_list_payload,
+    help_test_default_availability_list_single,
     help_test_default_availability_payload,
     help_test_discovery_broken,
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_availability,
     help_test_entity_debug_info,
     help_test_entity_debug_info_max_messages,
     help_test_entity_debug_info_message,
@@ -250,9 +253,30 @@ async def test_default_availability_payload(hass, mqtt_mock):
     )
 
 
+async def test_default_availability_list_payload(hass, mqtt_mock):
+    """Test availability by default payload with defined topic."""
+    await help_test_default_availability_list_payload(
+        hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+async def test_default_availability_list_single(hass, mqtt_mock, caplog):
+    """Test availability list and availability_topic are mutually exclusive."""
+    await help_test_default_availability_list_single(
+        hass, mqtt_mock, caplog, sensor.DOMAIN, DEFAULT_CONFIG
+    )
+
+
 async def test_custom_availability_payload(hass, mqtt_mock):
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
+        hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+async def test_discovery_update_availability(hass, mqtt_mock):
+    """Test availability discovery update."""
+    await help_test_discovery_update_availability(
         hass, mqtt_mock, sensor.DOMAIN, DEFAULT_CONFIG
     )
 

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -15,9 +15,8 @@ from tests.common import async_fire_time_changed
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def crd(hass):
-    """Coordinator mock."""
+def get_crd(hass, update_interval):
+    """Make coordinator mocks."""
     calls = 0
 
     async def refresh():
@@ -30,9 +29,24 @@ def crd(hass):
         LOGGER,
         name="test",
         update_method=refresh,
-        update_interval=timedelta(seconds=10),
+        update_interval=update_interval,
     )
     return crd
+
+
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=10)
+
+
+@pytest.fixture
+def crd(hass):
+    """Coordinator mock with default update interval."""
+    return get_crd(hass, DEFAULT_UPDATE_INTERVAL)
+
+
+@pytest.fixture
+def crd_without_update_interval(hass):
+    """Coordinator mock that never automatically updates."""
+    return get_crd(hass, None)
 
 
 async def test_async_refresh(crd):
@@ -68,6 +82,20 @@ async def test_async_refresh(crd):
 
 async def test_request_refresh(crd):
     """Test request refresh for update coordinator."""
+    assert crd.data is None
+    await crd.async_request_refresh()
+    assert crd.data == 1
+    assert crd.last_update_success is True
+
+    # Second time we hit the debonuce
+    await crd.async_request_refresh()
+    assert crd.data == 1
+    assert crd.last_update_success is True
+
+
+async def test_request_refresh_no_auto_update(crd_without_update_interval):
+    """Test request refresh for update coordinator without automatic update."""
+    crd = crd_without_update_interval
     assert crd.data is None
     await crd.async_request_refresh()
     assert crd.data == 1
@@ -149,6 +177,37 @@ async def test_update_interval(hass, crd):
 
     # Test we stop updating after we lose last subscriber
     assert crd.data == 2
+
+
+async def test_update_interval_not_present(hass, crd_without_update_interval):
+    """Test update never happens with no update interval."""
+    crd = crd_without_update_interval
+    # Test we don't update without subscriber with no update interval
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+    assert crd.data is None
+
+    # Add subscriber
+    update_callback = Mock()
+    crd.async_add_listener(update_callback)
+
+    # Test twice we don't update with subscriber with no update interval
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+    assert crd.data is None
+
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+    assert crd.data is None
+
+    # Test removing listener
+    crd.async_remove_listener(update_callback)
+
+    async_fire_time_changed(hass, utcnow() + DEFAULT_UPDATE_INTERVAL)
+    await hass.async_block_till_done()
+
+    # Test we stop don't update after we lose last subscriber
+    assert crd.data is None
 
 
 async def test_refresh_recover(crd, caplog):


### PR DESCRIPTION
- Smappee dependency update ([@bsmappee] - [#37680]) ([smappee docs])
- Properly set update_interval during Speedtest setup ([@engrbm87] - [#37708]) ([speedtestdotnet docs])
- Support multiple MQTT availability topics ([@emontnemery] - [#37418]) ([mqtt docs])
- Tweak MQTT availability ([@emontnemery] - [#37719]) ([mqtt docs])
- Fix MQTT availability startup race ([@emontnemery] - [#37718]) ([mqtt docs])
- Fix homekit_controller discovery via zeroconf ([@bdraco] - [#37725]) ([zeroconf docs])
- Add support for the DataUpdateCoordinator to not automatically update ([@rohankapoorcom] - [#37734])
- Bump blinkpy version to fix connection errors ([@fronzbot] - [#37755]) ([blink docs])
- UniFi - Handle session expiration ([@Kane610] - [#37782]) ([unifi docs])
- deCONZ - don't let light "attr" events update group data ([@Kane610] - [#37797]) ([deconz docs])

[#37418]: https://github.com/home-assistant/core/pull/37418
[#37680]: https://github.com/home-assistant/core/pull/37680
[#37708]: https://github.com/home-assistant/core/pull/37708
[#37718]: https://github.com/home-assistant/core/pull/37718
[#37719]: https://github.com/home-assistant/core/pull/37719
[#37725]: https://github.com/home-assistant/core/pull/37725
[#37734]: https://github.com/home-assistant/core/pull/37734
[#37755]: https://github.com/home-assistant/core/pull/37755
[#37782]: https://github.com/home-assistant/core/pull/37782
[#37797]: https://github.com/home-assistant/core/pull/37797
[@Kane610]: https://github.com/Kane610
[@bdraco]: https://github.com/bdraco
[@bsmappee]: https://github.com/bsmappee
[@emontnemery]: https://github.com/emontnemery
[@engrbm87]: https://github.com/engrbm87
[@fronzbot]: https://github.com/fronzbot
[@rohankapoorcom]: https://github.com/rohankapoorcom
[blink docs]: https://www.home-assistant.io/integrations/blink/
[deconz docs]: https://www.home-assistant.io/integrations/deconz/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[smappee docs]: https://www.home-assistant.io/integrations/smappee/
[speedtestdotnet docs]: https://www.home-assistant.io/integrations/speedtestdotnet/
[unifi docs]: https://www.home-assistant.io/integrations/unifi/
[zeroconf docs]: https://www.home-assistant.io/integrations/zeroconf/