### PR TITLE
Add support for generic device (switch) to bond integration

### DIFF
--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import device_registry as dr
 from .const import DOMAIN
 from .utils import BondHub
 
-PLATFORMS = ["cover", "fan", "light"]
+PLATFORMS = ["cover", "fan", "light", "switch"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/homeassistant/components/bond/switch.py
+++ b/homeassistant/components/bond/switch.py
@@ -1,0 +1,60 @@
+"""Support for Bond generic devices."""
+from typing import Any, Callable, List, Optional
+
+from bond import DeviceTypes
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
+
+from ..switch import SwitchEntity
+from .const import DOMAIN
+from .entity import BondEntity
+from .utils import BondDevice, BondHub
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[List[Entity], bool], None],
+) -> None:
+    """Set up Bond generic devices."""
+    hub: BondHub = hass.data[DOMAIN][entry.entry_id]
+
+    devices = await hass.async_add_executor_job(hub.get_bond_devices)
+
+    switches = [
+        BondSwitch(hub, device)
+        for device in devices
+        if device.type == DeviceTypes.GENERIC_DEVICE
+    ]
+
+    async_add_entities(switches, True)
+
+
+class BondSwitch(BondEntity, SwitchEntity):
+    """Representation of a Bond generic device."""
+
+    def __init__(self, hub: BondHub, device: BondDevice):
+        """Create HA entity representing Bond generic device (switch)."""
+        super().__init__(hub, device)
+
+        self._power: Optional[bool] = None
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if power is on."""
+        return self._power == 1
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        self._hub.bond.turnOn(self._device.device_id)
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        self._hub.bond.turnOff(self._device.device_id)
+
+    def update(self):
+        """Fetch assumed state of the device from the hub using API."""
+        state: dict = self._hub.bond.getDeviceState(self._device.device_id)
+        self._power = state.get("power")

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -31,7 +31,9 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
         "homeassistant.components.bond.fan.async_setup_entry"
     ) as mock_fan_async_setup_entry, patch(
         "homeassistant.components.bond.light.async_setup_entry"
-    ) as mock_light_async_setup_entry:
+    ) as mock_light_async_setup_entry, patch(
+        "homeassistant.components.bond.switch.async_setup_entry"
+    ) as mock_switch_async_setup_entry:
         result = await setup_bond_entity(
             hass,
             config_entry,
@@ -61,6 +63,7 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
     assert len(mock_cover_async_setup_entry.mock_calls) == 1
     assert len(mock_fan_async_setup_entry.mock_calls) == 1
     assert len(mock_light_async_setup_entry.mock_calls) == 1
+    assert len(mock_switch_async_setup_entry.mock_calls) == 1
 
 
 async def test_unload_config_entry(hass: HomeAssistant):

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -1,0 +1,87 @@
+"""Tests for the Bond switch device."""
+from datetime import timedelta
+import logging
+
+from bond import DeviceTypes
+
+from homeassistant import core
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.util import utcnow
+
+from .common import setup_platform
+
+from tests.async_mock import patch
+from tests.common import async_fire_time_changed
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def generic_device(name: str):
+    """Create a generic device with given name."""
+    return {"name": name, "type": DeviceTypes.GENERIC_DEVICE}
+
+
+async def test_entity_registry(hass: core.HomeAssistant):
+    """Tests that the devices are registered in the entity registry."""
+    await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
+
+    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    assert [key for key in registry.entities] == ["switch.name_1"]
+
+
+async def test_turn_on_switch(hass: core.HomeAssistant):
+    """Tests that turn on command delegates to API."""
+    await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
+
+    with patch("homeassistant.components.bond.Bond.turnOn") as mock_turn_on:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.name_1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_turn_on.assert_called_once()
+
+
+async def test_turn_off_switch(hass: core.HomeAssistant):
+    """Tests that turn off command delegates to API."""
+    await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
+
+    with patch("homeassistant.components.bond.Bond.turnOff") as mock_turn_off:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.name_1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_turn_off.assert_called_once()
+
+
+async def test_update_reports_switch_is_on(hass: core.HomeAssistant):
+    """Tests that update command sets correct state when Bond API reports the device is on."""
+    await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
+
+    with patch(
+        "homeassistant.components.bond.Bond.getDeviceState", return_value={"power": 1}
+    ):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+        await hass.async_block_till_done()
+
+    assert hass.states.get("switch.name_1").state == "on"
+
+
+async def test_update_reports_switch_is_off(hass: core.HomeAssistant):
+    """Tests that update command sets correct state when Bond API reports the device is off."""
+    await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
+
+    with patch(
+        "homeassistant.components.bond.Bond.getDeviceState", return_value={"power": 0}
+    ):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+        await hass.async_block_till_done()
+
+    assert hass.states.get("switch.name_1").state == "off"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add additional domain (switch) to bond integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
