### PR TITLE
Frontend: deprecate `extra_html_url`

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -84,25 +84,29 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
+        DOMAIN: vol.All(
             cv.deprecated(CONF_EXTRA_HTML_URL, invalidation_version="0.115"),
             cv.deprecated(CONF_EXTRA_HTML_URL_ES5, invalidation_version="0.115"),
-            {
-                vol.Optional(CONF_FRONTEND_REPO): cv.isdir,
-                vol.Optional(CONF_THEMES): vol.Schema(
-                    {cv.string: {cv.string: cv.string}}
-                ),
-                vol.Optional(CONF_EXTRA_HTML_URL): vol.All(cv.ensure_list, [cv.string]),
-                vol.Optional(CONF_EXTRA_MODULE_URL): vol.All(
-                    cv.ensure_list, [cv.string]
-                ),
-                vol.Optional(CONF_EXTRA_JS_URL_ES5): vol.All(
-                    cv.ensure_list, [cv.string]
-                ),
-                # We no longer use these options.
-                vol.Optional(CONF_EXTRA_HTML_URL_ES5): cv.match_all,
-                vol.Optional(CONF_JS_VERSION): cv.match_all,
-            },
+            vol.Schema(
+                {
+                    vol.Optional(CONF_FRONTEND_REPO): cv.isdir,
+                    vol.Optional(CONF_THEMES): vol.Schema(
+                        {cv.string: {cv.string: cv.string}}
+                    ),
+                    vol.Optional(CONF_EXTRA_HTML_URL): vol.All(
+                        cv.ensure_list, [cv.string]
+                    ),
+                    vol.Optional(CONF_EXTRA_MODULE_URL): vol.All(
+                        cv.ensure_list, [cv.string]
+                    ),
+                    vol.Optional(CONF_EXTRA_JS_URL_ES5): vol.All(
+                        cv.ensure_list, [cv.string]
+                    ),
+                    # We no longer use these options.
+                    vol.Optional(CONF_EXTRA_HTML_URL_ES5): cv.match_all,
+                    vol.Optional(CONF_JS_VERSION): cv.match_all,
+                },
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -85,6 +85,8 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
+            cv.deprecated(CONF_EXTRA_HTML_URL, invalidation_version="0.115"),
+            cv.deprecated(CONF_EXTRA_HTML_URL_ES5, invalidation_version="0.115"),
             {
                 vol.Optional(CONF_FRONTEND_REPO): cv.isdir,
                 vol.Optional(CONF_THEMES): vol.Schema(
@@ -100,7 +102,7 @@ CONFIG_SCHEMA = vol.Schema(
                 # We no longer use these options.
                 vol.Optional(CONF_EXTRA_HTML_URL_ES5): cv.match_all,
                 vol.Optional(CONF_JS_VERSION): cv.match_all,
-            }
+            },
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -47,6 +47,7 @@ def url_validator(value):
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
+            cv.deprecated(CONF_WEBCOMPONENT_PATH, invalidation_version="0.115"),
             cv.ensure_list,
             [
                 vol.All(

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -47,39 +47,35 @@ def url_validator(value):
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
-            cv.deprecated(CONF_WEBCOMPONENT_PATH, invalidation_version="0.115"),
-            vol.Schema(
-                cv.ensure_list,
-                [
-                    vol.All(
-                        vol.Schema(
-                            {
-                                vol.Required(CONF_COMPONENT_NAME): cv.string,
-                                vol.Optional(CONF_SIDEBAR_TITLE): cv.string,
-                                vol.Optional(
-                                    CONF_SIDEBAR_ICON, default=DEFAULT_ICON
-                                ): cv.icon,
-                                vol.Optional(CONF_URL_PATH): cv.string,
-                                vol.Optional(CONF_CONFIG): dict,
-                                vol.Optional(CONF_WEBCOMPONENT_PATH,): cv.string,
-                                vol.Optional(CONF_JS_URL,): cv.string,
-                                vol.Optional(CONF_MODULE_URL,): cv.string,
-                                vol.Optional(
-                                    CONF_EMBED_IFRAME, default=DEFAULT_EMBED_IFRAME
-                                ): cv.boolean,
-                                vol.Optional(
-                                    CONF_TRUST_EXTERNAL_SCRIPT,
-                                    default=DEFAULT_TRUST_EXTERNAL,
-                                ): cv.boolean,
-                                vol.Optional(
-                                    CONF_REQUIRE_ADMIN, default=False
-                                ): cv.boolean,
-                            }
-                        ),
-                        url_validator,
-                    )
-                ],
-            ),
+            cv.ensure_list,
+            [
+                vol.All(
+                    cv.deprecated(CONF_WEBCOMPONENT_PATH, invalidation_version="0.115"),
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_COMPONENT_NAME): cv.string,
+                            vol.Optional(CONF_SIDEBAR_TITLE): cv.string,
+                            vol.Optional(
+                                CONF_SIDEBAR_ICON, default=DEFAULT_ICON
+                            ): cv.icon,
+                            vol.Optional(CONF_URL_PATH): cv.string,
+                            vol.Optional(CONF_CONFIG): dict,
+                            vol.Optional(CONF_WEBCOMPONENT_PATH,): cv.string,
+                            vol.Optional(CONF_JS_URL,): cv.string,
+                            vol.Optional(CONF_MODULE_URL,): cv.string,
+                            vol.Optional(
+                                CONF_EMBED_IFRAME, default=DEFAULT_EMBED_IFRAME
+                            ): cv.boolean,
+                            vol.Optional(
+                                CONF_TRUST_EXTERNAL_SCRIPT,
+                                default=DEFAULT_TRUST_EXTERNAL,
+                            ): cv.boolean,
+                            vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
+                        }
+                    ),
+                    url_validator,
+                )
+            ],
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -48,34 +48,38 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
             cv.deprecated(CONF_WEBCOMPONENT_PATH, invalidation_version="0.115"),
-            cv.ensure_list,
-            [
-                vol.All(
-                    vol.Schema(
-                        {
-                            vol.Required(CONF_COMPONENT_NAME): cv.string,
-                            vol.Optional(CONF_SIDEBAR_TITLE): cv.string,
-                            vol.Optional(
-                                CONF_SIDEBAR_ICON, default=DEFAULT_ICON
-                            ): cv.icon,
-                            vol.Optional(CONF_URL_PATH): cv.string,
-                            vol.Optional(CONF_CONFIG): dict,
-                            vol.Optional(CONF_WEBCOMPONENT_PATH,): cv.string,
-                            vol.Optional(CONF_JS_URL,): cv.string,
-                            vol.Optional(CONF_MODULE_URL,): cv.string,
-                            vol.Optional(
-                                CONF_EMBED_IFRAME, default=DEFAULT_EMBED_IFRAME
-                            ): cv.boolean,
-                            vol.Optional(
-                                CONF_TRUST_EXTERNAL_SCRIPT,
-                                default=DEFAULT_TRUST_EXTERNAL,
-                            ): cv.boolean,
-                            vol.Optional(CONF_REQUIRE_ADMIN, default=False): cv.boolean,
-                        }
-                    ),
-                    url_validator,
-                )
-            ],
+            vol.Schema(
+                cv.ensure_list,
+                [
+                    vol.All(
+                        vol.Schema(
+                            {
+                                vol.Required(CONF_COMPONENT_NAME): cv.string,
+                                vol.Optional(CONF_SIDEBAR_TITLE): cv.string,
+                                vol.Optional(
+                                    CONF_SIDEBAR_ICON, default=DEFAULT_ICON
+                                ): cv.icon,
+                                vol.Optional(CONF_URL_PATH): cv.string,
+                                vol.Optional(CONF_CONFIG): dict,
+                                vol.Optional(CONF_WEBCOMPONENT_PATH,): cv.string,
+                                vol.Optional(CONF_JS_URL,): cv.string,
+                                vol.Optional(CONF_MODULE_URL,): cv.string,
+                                vol.Optional(
+                                    CONF_EMBED_IFRAME, default=DEFAULT_EMBED_IFRAME
+                                ): cv.boolean,
+                                vol.Optional(
+                                    CONF_TRUST_EXTERNAL_SCRIPT,
+                                    default=DEFAULT_TRUST_EXTERNAL,
+                                ): cv.boolean,
+                                vol.Optional(
+                                    CONF_REQUIRE_ADMIN, default=False
+                                ): cv.boolean,
+                            }
+                        ),
+                        url_validator,
+                    )
+                ],
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,


### PR DESCRIPTION
## Breaking change
We used to allow the user to specify HTML files via `extra_html_url` that we would import into the page. When it became clear that HTML imports were not going to make it, we replaced that with `extra_module_url` and `extra_js_url_es5` (#24675 by @thomasloven, June 21, 2019).

HTML imports are no longer supported by any browser, and we have to polyfill it to make it work, this is expensive.

`extra_html_url` is now deprecated and support will be removed in 0.115. You can switch to the new `extra_module_url` or `extra_js_url_es5` by changing your imported file to JavaScript.

## Proposed change
https://github.com/home-assistant/frontend/issues/6028

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13997

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
