### PR TITLE
Stop running scripts at shutdown

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -74,6 +74,8 @@ ATTR_CUR = "current"
 ATTR_MAX = "max"
 ATTR_MODE = "mode"
 
+DATA_SCRIPTS = "helpers.script"
+
 _LOGGER = logging.getLogger(__name__)
 
 _LOG_EXCEPTION = logging.ERROR + 1
@@ -553,7 +555,7 @@ class _QueuedScriptRun(_ScriptRun):
 async def _async_stop_scripts_after_shutdown(hass, point_in_time):
     """Stop running Script objects started after shutdown."""
     running_scripts = [
-        script for script in hass.data["Scripts"] if script["instance"].is_running
+        script for script in hass.data[DATA_SCRIPTS] if script["instance"].is_running
     ]
     if running_scripts:
         names = ", ".join([script["instance"].name for script in running_scripts])
@@ -574,7 +576,7 @@ async def _async_stop_scripts_at_shutdown(hass, event):
 
     running_scripts = [
         script
-        for script in hass.data["Scripts"]
+        for script in hass.data[DATA_SCRIPTS]
         if script["instance"].is_running and script["started_before_shutdown"]
     ]
     if running_scripts:
@@ -601,9 +603,9 @@ class Script:
         top_level: bool = True,
     ) -> None:
         """Initialize the script."""
-        all_scripts = hass.data.get("Scripts")
+        all_scripts = hass.data.get(DATA_SCRIPTS)
         if not all_scripts:
-            all_scripts = hass.data["Scripts"] = []
+            all_scripts = hass.data[DATA_SCRIPTS] = []
             hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_STOP, partial(_async_stop_scripts_at_shutdown, hass)
             )

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     CONF_UNTIL,
     CONF_WAIT_TEMPLATE,
     CONF_WHILE,
+    EVENT_HOMEASSISTANT_STOP,
     SERVICE_TURN_ON,
 )
 from homeassistant.core import SERVICE_CALL_LIMIT, Context, HomeAssistant, callback
@@ -43,7 +44,7 @@ from homeassistant.helpers import (
     config_validation as cv,
     template as template,
 )
-from homeassistant.helpers.event import async_track_template
+from homeassistant.helpers.event import async_call_later, async_track_template
 from homeassistant.helpers.service import (
     CONF_SERVICE_DATA,
     async_prepare_call_from_config,
@@ -73,8 +74,12 @@ ATTR_CUR = "current"
 ATTR_MAX = "max"
 ATTR_MODE = "mode"
 
+_LOGGER = logging.getLogger(__name__)
+
 _LOG_EXCEPTION = logging.ERROR + 1
 _TIMEOUT_MSG = "Timeout reached, abort script."
+
+_SHUTDOWN_MAX_WAIT = 60
 
 
 def make_script_schema(schema, default_script_mode, extra=vol.PREVENT_EXTRA):
@@ -545,6 +550,45 @@ class _QueuedScriptRun(_ScriptRun):
         super()._finish()
 
 
+_HASS = None
+
+
+async def _async_stop_scripts_after_shutdown(point_in_time):
+    """Stop running Script objects started after shutdown."""
+    running_scripts = [
+        script for script in _HASS.data["Scripts"] if script["instance"].is_running
+    ]
+    if running_scripts:
+        names = ", ".join([script["instance"].name for script in running_scripts])
+        _LOGGER.warning("Stopping scripts running too long after shutdown: %s", names)
+        await asyncio.gather(
+            *[
+                script["instance"].async_stop(update_state=False)
+                for script in running_scripts
+            ]
+        )
+
+
+async def _async_stop_scripts_at_shutdown(event):
+    """Stop running Script objects started before shutdown."""
+    async_call_later(_HASS, _SHUTDOWN_MAX_WAIT, _async_stop_scripts_after_shutdown)
+
+    running_scripts = [
+        script
+        for script in _HASS.data["Scripts"]
+        if script["instance"].is_running and script["started_before_shutdown"]
+    ]
+    if running_scripts:
+        names = ", ".join([script["instance"].name for script in running_scripts])
+        _LOGGER.debug("Stopping scripts running at shutdown: %s", names)
+        await asyncio.gather(
+            *[
+                script["instance"].async_stop(update_state=False)
+                for script in running_scripts
+            ]
+        )
+
+
 class Script:
     """Representation of a script."""
 
@@ -558,8 +602,23 @@ class Script:
         max_runs: int = DEFAULT_MAX,
         logger: Optional[logging.Logger] = None,
         log_exceptions: bool = True,
+        top_level: bool = True,
     ) -> None:
         """Initialize the script."""
+        global _HASS
+
+        all_scripts = hass.data.get("Scripts")
+        if not all_scripts:
+            _HASS = hass
+            all_scripts = hass.data["Scripts"] = []
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP, _async_stop_scripts_at_shutdown
+            )
+        if top_level:
+            all_scripts.append(
+                {"instance": self, "started_before_shutdown": not hass.is_stopping}
+            )
+
         self._hass = hass
         self.sequence = sequence
         template.attach(hass, self.sequence)
@@ -732,6 +791,7 @@ class Script:
             f"{self.name}: {step_name}",
             script_mode=SCRIPT_MODE_PARALLEL,
             logger=self._logger,
+            top_level=False,
         )
         sub_script.change_listener = partial(self._chain_change_listener, sub_script)
         return sub_script
@@ -758,6 +818,7 @@ class Script:
                 f"{self.name}: {step_name}: choice {idx}",
                 script_mode=SCRIPT_MODE_PARALLEL,
                 logger=self._logger,
+                top_level=False,
             )
             sub_script.change_listener = partial(
                 self._chain_change_listener, sub_script
@@ -771,6 +832,7 @@ class Script:
                 f"{self.name}: {step_name}: default",
                 script_mode=SCRIPT_MODE_PARALLEL,
                 logger=self._logger,
+                top_level=False,
             )
             default_script.change_listener = partial(
                 self._chain_change_listener, default_script


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the rewrite of the script infrastructure scripts or automation actions, or anything that uses the "script helper", that is running at shutdown can prevent Home Assistant from completing the shutdown process. This change effectively restores the previous behavior that these "action sequences" are stopped at shutdown. It also handles automations triggered at shutdown (or anything else, for that matter, that uses the script helper and runs after shutdown) by giving them up to 60 seconds to complete, and stopping them if they haven't stopped themselves in that period.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
