### PR TITLE
Switch async_track_state_change to the faster async_track_state_change_event part 4

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
@@ -127,8 +127,10 @@ class IntegrationSensor(RestoreEntity):
                 _LOGGER.warning("Could not restore last state: %s", err)
 
         @callback
-        def calc_integration(entity, old_state, new_state):
+        def calc_integration(event):
             """Handle the sensor state changes."""
+            old_state = event.data.get("old_state")
+            new_state = event.data.get("new_state")
             if (
                 old_state is None
                 or old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
@@ -174,7 +176,9 @@ class IntegrationSensor(RestoreEntity):
                 self._state += integral
                 self.async_write_ha_state()
 
-        async_track_state_change(self.hass, self._sensor_source_id, calc_integration)
+        async_track_state_change_event(
+            self.hass, [self._sensor_source_id], calc_integration
+        )
 
     @property
     def name(self):

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -17,8 +17,12 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv, event
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time,
+    async_track_state_change_event,
+)
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -120,7 +124,7 @@ class StatisticsSensor(Entity):
             """Add listener and get recorded state."""
             _LOGGER.debug("Startup for %s", self.entity_id)
 
-            event.async_track_state_change_event(
+            async_track_state_change_event(
                 self.hass, [self._entity_id], async_stats_sensor_state_listener
             )
 
@@ -296,7 +300,7 @@ class StatisticsSensor(Entity):
                 self.async_schedule_update_ha_state(True)
                 self._update_listener = None
 
-            self._update_listener = event.async_track_point_in_utc_time(
+            self._update_listener = async_track_point_in_utc_time(
                 self.hass, _scheduled_update, next_to_purge_timestamp
             )
 

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -101,8 +101,12 @@ class StatisticsSensor(Entity):
         """Register callbacks."""
 
         @callback
-        def async_stats_sensor_state_listener(entity, old_state, new_state):
+        def async_stats_sensor_state_listener(event):
             """Handle the sensor state changes."""
+            new_state = event.data.get("new_state")
+            if new_state is None:
+                return
+
             self._unit_of_measurement = new_state.attributes.get(
                 ATTR_UNIT_OF_MEASUREMENT
             )
@@ -116,8 +120,8 @@ class StatisticsSensor(Entity):
             """Add listener and get recorded state."""
             _LOGGER.debug("Startup for %s", self.entity_id)
 
-            event.async_track_state_change(
-                self.hass, self._entity_id, async_stats_sensor_state_listener
+            event.async_track_state_change_event(
+                self.hass, [self._entity_id], async_stats_sensor_state_listener
             )
 
             if "recorder" in self.hass.config.components:

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -184,7 +184,10 @@ class TestStatisticsSensor(unittest.TestCase):
 
     def test_max_age(self):
         """Test value deprecation."""
-        mock_data = {"return_time": datetime(2017, 8, 2, 12, 23, tzinfo=dt_util.UTC)}
+        now = dt_util.utcnow()
+        mock_data = {
+            "return_time": datetime(now.year + 1, 8, 2, 12, 23, tzinfo=dt_util.UTC)
+        }
 
         def mock_now():
             return mock_data["return_time"]
@@ -226,7 +229,10 @@ class TestStatisticsSensor(unittest.TestCase):
 
     def test_max_age_without_sensor_change(self):
         """Test value deprecation."""
-        mock_data = {"return_time": datetime(2017, 8, 2, 12, 23, tzinfo=dt_util.UTC)}
+        now = dt_util.utcnow()
+        mock_data = {
+            "return_time": datetime(now.year + 1, 8, 2, 12, 23, tzinfo=dt_util.UTC)
+        }
 
         def mock_now():
             return mock_data["return_time"]
@@ -279,8 +285,9 @@ class TestStatisticsSensor(unittest.TestCase):
 
     def test_change_rate(self):
         """Test min_age/max_age and change_rate."""
+        now = dt_util.utcnow()
         mock_data = {
-            "return_time": datetime(2017, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC)
+            "return_time": datetime(now.year + 1, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC)
         }
 
         def mock_now():
@@ -318,10 +325,10 @@ class TestStatisticsSensor(unittest.TestCase):
             state = self.hass.states.get("sensor.test")
 
         assert datetime(
-            2017, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC
+            now.year + 1, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC
         ) == state.attributes.get("min_age")
         assert datetime(
-            2017, 8, 2, 12, 23 + self.count - 1, 42, tzinfo=dt_util.UTC
+            now.year + 1, 8, 2, 12, 23 + self.count - 1, 42, tzinfo=dt_util.UTC
         ) == state.attributes.get("max_age")
         assert self.change_rate == state.attributes.get("change_rate")
 
@@ -364,8 +371,9 @@ class TestStatisticsSensor(unittest.TestCase):
 
     def test_initialize_from_database_with_maxage(self):
         """Test initializing the statistics from the database."""
+        now = dt_util.utcnow()
         mock_data = {
-            "return_time": datetime(2017, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC)
+            "return_time": datetime(now.year + 1, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC)
         }
 
         def mock_now():


### PR DESCRIPTION
I'm slowly switching these over so `async_track_state_change_event` gets used in new code instead of `async_track_state_change` when possible since code tends to get copied.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Calling async_track_state_change_event directly is faster than async_track_state_change (see #37251) since async_track_state_change is a wrapper around async_track_state_change_event now

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
