### PR TITLE
Switch async_track_state_change to the faster async_track_state_change_event part 5

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -44,7 +44,7 @@ from homeassistant.helpers import (
     service,
 )
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
@@ -440,14 +440,14 @@ class Person(RestoreEntity):
         if trackers:
             _LOGGER.debug("Subscribe to device trackers for %s", self.entity_id)
 
-            self._unsub_track_device = async_track_state_change(
+            self._unsub_track_device = async_track_state_change_event(
                 self.hass, trackers, self._async_handle_tracker_update
             )
 
         self._update_state()
 
     @callback
-    def _async_handle_tracker_update(self, entity, old_state, new_state):
+    def _async_handle_tracker_update(self, event):
         """Handle the device tracker state changes."""
         self._update_state()
 

--- a/homeassistant/components/threshold/binary_sensor.py
+++ b/homeassistant/components/threshold/binary_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,8 +93,12 @@ class ThresholdSensor(BinarySensorEntity):
         self.sensor_value = None
 
         @callback
-        def async_threshold_sensor_state_listener(entity, old_state, new_state):
+        def async_threshold_sensor_state_listener(event):
             """Handle sensor state changes."""
+            new_state = event.data.get("new_state")
+            if new_state is None:
+                return
+
             try:
                 self.sensor_value = (
                     None if new_state.state == STATE_UNKNOWN else float(new_state.state)
@@ -105,7 +109,9 @@ class ThresholdSensor(BinarySensorEntity):
 
             hass.async_add_job(self.async_update_ha_state, True)
 
-        async_track_state_change(hass, entity_id, async_threshold_sensor_state_listener)
+        async_track_state_change_event(
+            hass, [entity_id], async_threshold_sensor_state_listener
+        )
 
     @property
     def name(self):

--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import utcnow
 
 _LOGGER = logging.getLogger(__name__)
@@ -162,8 +162,11 @@ class SensorTrend(BinarySensorEntity):
         """Complete device setup after being added to hass."""
 
         @callback
-        def trend_sensor_state_listener(entity, old_state, new_state):
+        def trend_sensor_state_listener(event):
             """Handle state changes on the observed device."""
+            new_state = event.data.get("new_state")
+            if new_state is None:
+                return
             try:
                 if self._attribute:
                     state = new_state.attributes.get(self._attribute)
@@ -176,8 +179,8 @@ class SensorTrend(BinarySensorEntity):
             except (ValueError, TypeError) as ex:
                 _LOGGER.error(ex)
 
-        async_track_state_change(
-            self.hass, self._entity_id, trend_sensor_state_listener
+        async_track_state_change_event(
+            self.hass, [self._entity_id], trend_sensor_state_listener
         )
 
     async def async_update(self):

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import (
-    async_track_state_change,
+    async_track_state_change_event,
     async_track_time_change,
 )
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -131,8 +131,10 @@ class UtilityMeterSensor(RestoreEntity):
         self._tariff_entity = tariff_entity
 
     @callback
-    def async_reading(self, entity, old_state, new_state):
+    def async_reading(self, event):
         """Handle the sensor state changes."""
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
         if (
             old_state is None
             or new_state is None
@@ -166,11 +168,14 @@ class UtilityMeterSensor(RestoreEntity):
         self.async_write_ha_state()
 
     @callback
-    def async_tariff_change(self, entity, old_state, new_state):
+    def async_tariff_change(self, event):
         """Handle tariff changes."""
+        new_state = event.data.get("new_state")
+        if new_state is None:
+            return
         if self._tariff == new_state.state:
-            self._collecting = async_track_state_change(
-                self.hass, self._sensor_source_id, self.async_reading
+            self._collecting = async_track_state_change_event(
+                self.hass, [self._sensor_source_id], self.async_reading
             )
         else:
             if self._collecting:
@@ -263,8 +268,8 @@ class UtilityMeterSensor(RestoreEntity):
             """Wait for source to be ready, then start meter."""
             if self._tariff_entity is not None:
                 _LOGGER.debug("Track %s", self._tariff_entity)
-                async_track_state_change(
-                    self.hass, self._tariff_entity, self.async_tariff_change
+                async_track_state_change_event(
+                    self.hass, [self._tariff_entity], self.async_tariff_change
                 )
 
                 tariff_entity_state = self.hass.states.get(self._tariff_entity)
@@ -272,8 +277,8 @@ class UtilityMeterSensor(RestoreEntity):
                     return
 
             _LOGGER.debug("tracking source: %s", self._sensor_source_id)
-            self._collecting = async_track_state_change(
-                self.hass, self._sensor_source_id, self.async_reading
+            self._collecting = async_track_state_change_event(
+                self.hass, [self._sensor_source_id], self.async_reading
             )
 
         self.hass.bus.async_listen_once(


### PR DESCRIPTION
I'm slowly switching these over so `async_track_state_change_event` gets used in new code instead of `async_track_state_change` when possible since code tends to get copied.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Calling async_track_state_change_event directly is faster than async_track_state_change (see #37251) since async_track_state_change is a wrapper around async_track_state_change_event now


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
