### PR TITLE
Switch async_track_state_change to the faster async_track_state_change_event part 6

### DIFF
--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -132,8 +132,11 @@ class MinMaxSensor(Entity):
         self.states = {}
 
         @callback
-        def async_min_max_sensor_state_listener(entity, old_state, new_state):
+        def async_min_max_sensor_state_listener(event):
             """Handle the sensor state changes."""
+            new_state = event.data.get("new_state")
+            entity = event.data.get("entity_id")
+
             if new_state.state is None or new_state.state in [
                 STATE_UNKNOWN,
                 STATE_UNAVAILABLE,
@@ -166,7 +169,9 @@ class MinMaxSensor(Entity):
 
             hass.async_add_job(self.async_update_ha_state, True)
 
-        async_track_state_change(hass, entity_ids, async_min_max_sensor_state_listener)
+        async_track_state_change_event(
+            hass, entity_ids, async_min_max_sensor_state_listener
+        )
 
     @property
     def name(self):

--- a/homeassistant/components/mold_indicator/sensor.py
+++ b/homeassistant/components/mold_indicator/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -106,8 +106,11 @@ class MoldIndicator(Entity):
         """Register callbacks."""
 
         @callback
-        def mold_indicator_sensors_state_listener(entity, old_state, new_state):
+        def mold_indicator_sensors_state_listener(event):
             """Handle for state changes for dependent sensors."""
+            new_state = event.data.get("new_state")
+            old_state = event.data.get("old_state")
+            entity = event.data.get("entity_id")
             _LOGGER.debug(
                 "Sensor state change for %s that had old state %s and new state %s",
                 entity,
@@ -123,8 +126,8 @@ class MoldIndicator(Entity):
             """Add listeners and get 1st state."""
             _LOGGER.debug("Startup for %s", self.entity_id)
 
-            async_track_state_change(
-                self.hass, self._entities, mold_indicator_sensors_state_listener
+            async_track_state_change_event(
+                self.hass, list(self._entities), mold_indicator_sensors_state_listener
             )
 
             # Read initial state

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -54,7 +54,6 @@ async def test_valid_data(hass):
     for reading, value in GOOD_DATA.items():
         sensor.state_changed(
             GOOD_CONFIG["sensors"][reading],
-            None,
             State(GOOD_CONFIG["sensors"][reading], value),
         )
     assert sensor.state == "ok"
@@ -72,9 +71,7 @@ async def test_low_battery(hass):
     sensor.hass = hass
     assert sensor.state_attributes["problem"] == "none"
     sensor.state_changed(
-        "sensor.mqtt_plant_battery",
-        State("sensor.mqtt_plant_battery", 45),
-        State("sensor.mqtt_plant_battery", 10),
+        "sensor.mqtt_plant_battery", State("sensor.mqtt_plant_battery", 10),
     )
     assert sensor.state == "problem"
     assert sensor.state_attributes["problem"] == "battery low"


### PR DESCRIPTION
I'm slowly switching these over so `async_track_state_change_event` gets used in new code instead of `async_track_state_change` when possible since code tends to get copied.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Calling async_track_state_change_event directly is faster than async_track_state_change (see #37251) since async_track_state_change is a wrapper around async_track_state_change_event now



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
