### PR TITLE
Switch async_track_state_change to the faster async_track_state_change_event part 7

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -222,9 +222,9 @@ class Alert(ToggleEntity):
             return STATE_ON
         return STATE_IDLE
 
-    async def watched_entity_change(self, event):
+    async def watched_entity_change(self, ev):
         """Determine if the alert should start or stop."""
-        to_state = event.data.get("new_state")
+        to_state = ev.data.get("new_state")
         if to_state is None:
             return
         _LOGGER.debug("Watched entity (%s) has changed", event.data.get("entity_id"))

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -199,8 +199,8 @@ class Alert(ToggleEntity):
         self._send_done_message = False
         self.entity_id = f"{DOMAIN}.{entity_id}"
 
-        event.async_track_state_change(
-            hass, watched_entity_id, self.watched_entity_change
+        event.async_track_state_change_event(
+            hass, [watched_entity_id], self.watched_entity_change
         )
 
     @property
@@ -222,9 +222,12 @@ class Alert(ToggleEntity):
             return STATE_ON
         return STATE_IDLE
 
-    async def watched_entity_change(self, entity, from_state, to_state):
+    async def watched_entity_change(self, event):
         """Determine if the alert should start or stop."""
-        _LOGGER.debug("Watched entity (%s) has changed", entity)
+        to_state = event.data.get("new_state")
+        if to_state is None:
+            return
+        _LOGGER.debug("Watched entity (%s) has changed", event.data.get("entity_id"))
         if to_state.state == self._alert_state and not self._firing:
             await self.begin_alerting()
         if to_state.state != self._alert_state and self._firing:

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -227,7 +227,7 @@ class Alert(ToggleEntity):
         to_state = ev.data.get("new_state")
         if to_state is None:
             return
-        _LOGGER.debug("Watched entity (%s) has changed", event.data.get("entity_id"))
+        _LOGGER.debug("Watched entity (%s) has changed", ev.data.get("entity_id"))
         if to_state.state == self._alert_state and not self._firing:
             await self.begin_alerting()
         if to_state.state != self._alert_state and self._firing:

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -4,14 +4,14 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Dict, List, Optional
 
-from homeassistant.core import CALLBACK_TYPE, State, callback
+from homeassistant.core import CALLBACK_TYPE, Event, callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .core.const import (
@@ -245,7 +245,7 @@ class ZhaGroupEntity(BaseZhaEntity):
             signal_override=True,
         )
 
-        self._async_unsub_state_changed = async_track_state_change(
+        self._async_unsub_state_changed = async_track_state_change_event(
             self.hass, self._entity_ids, self.async_state_changed_listener
         )
 
@@ -258,9 +258,7 @@ class ZhaGroupEntity(BaseZhaEntity):
         await self.async_update()
 
     @callback
-    def async_state_changed_listener(
-        self, entity_id: str, old_state: State, new_state: State
-    ):
+    def async_state_changed_listener(self, event: Event):
         """Handle child updates."""
         self.async_schedule_update_ha_state(True)
 

--- a/pylintrc
+++ b/pylintrc
@@ -8,7 +8,7 @@ persistent=no
 extension-pkg-whitelist=ciso8601
 
 [BASIC]
-good-names=id,i,j,k,ex,Run,_,fp,T
+good-names=id,i,j,k,ex,Run,_,fp,T,ev
 
 [MESSAGES CONTROL]
 # Reasons disabled:


### PR DESCRIPTION
I'm slowly switching these over so `async_track_state_change_event` gets used in new code instead of `async_track_state_change` when possible since code tends to get copied.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Calling async_track_state_change_event directly is faster than async_track_state_change (see #37251) since async_track_state_change is a wrapper around async_track_state_change_event now



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
