### PR TITLE
Revert "HA Cast: Prefer external URLs because internal can't have valid SSL"

### DIFF
--- a/homeassistant/components/cast/home_assistant_cast.py
+++ b/homeassistant/components/cast/home_assistant_cast.py
@@ -41,7 +41,7 @@ async def async_setup_ha_cast(
 
     async def handle_show_view(call: core.ServiceCall):
         """Handle a Show View service call."""
-        hass_url = get_url(hass, require_ssl=True, prefer_external=True)
+        hass_url = get_url(hass, require_ssl=True)
 
         controller = HomeAssistantController(
             # If you are developing Home Assistant Cast, uncomment and set to your dev app id.


### PR DESCRIPTION
Reverts home-assistant/core#37872

That PR breaks HA Cast for people with nat loopback issues.

In the original design of the internal/external URL, it was decided that if someone uses an internal URL with SSL as an override, the validity of it, becomes a user problem.

Furthermore the original PR states:

>  So we should prefer external url as an internal url with SSL will always fail.

This statement is incorrect and not true. There are many perfect cases of having an internal URL available with a valid SSL certificate.

So considering the above 2 reasonings, I want to revert this PR. Especially considering NAT loopback issues is a big common problem.

If there is anything to improve the situation at this point, it would be setting `prefer_cloud=True`, but that will make things slower.