### PR TITLE
Provide workaround for missing/disabled/broken IPv6

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -9,6 +9,7 @@ from zeroconf import (
     DNSPointer,
     DNSRecord,
     InterfaceChoice,
+    IPVersion,
     NonUniqueNameException,
     ServiceBrowser,
     ServiceInfo,
@@ -42,7 +43,9 @@ ZEROCONF_TYPE = "_home-assistant._tcp.local."
 HOMEKIT_TYPE = "_hap._tcp.local."
 
 CONF_DEFAULT_INTERFACE = "default_interface"
+CONF_IPV6 = "ipv6"
 DEFAULT_DEFAULT_INTERFACE = False
+DEFAULT_IPV6 = True
 
 HOMEKIT_PROPERTIES = "properties"
 HOMEKIT_PAIRED_STATUS_FLAG = "sf"
@@ -54,7 +57,8 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional(
                     CONF_DEFAULT_INTERFACE, default=DEFAULT_DEFAULT_INTERFACE
-                ): cv.boolean
+                ): cv.boolean,
+                vol.Optional(CONF_IPV6, default=DEFAULT_IPV6): cv.boolean,
             }
         )
     },
@@ -68,11 +72,17 @@ async def async_get_instance(hass):
     return await hass.async_add_executor_job(_get_instance, hass)
 
 
-def _get_instance(hass, default_interface=False):
+def _get_instance(hass, default_interface=False, ipv6=True):
     """Create an instance."""
     logging.getLogger("zeroconf").setLevel(logging.NOTSET)
-    args = [InterfaceChoice.Default] if default_interface else []
-    zeroconf = HaZeroconf(*args)
+
+    zc_args = {}
+    if default_interface:
+        zc_args["interfaces"] = InterfaceChoice.Default
+    if not ipv6:
+        zc_args["ip_version"] = IPVersion.V4Only
+
+    zeroconf = HaZeroconf(**zc_args)
 
     def stop_zeroconf(_):
         """Stop Zeroconf."""
@@ -115,8 +125,11 @@ class HaZeroconf(Zeroconf):
 
 def setup(hass, config):
     """Set up Zeroconf and make Home Assistant discoverable."""
+    zc_config = config.get(DOMAIN, {})
     zeroconf = hass.data[DOMAIN] = _get_instance(
-        hass, config.get(DOMAIN, {}).get(CONF_DEFAULT_INTERFACE)
+        hass,
+        default_interface=zc_config[CONF_DEFAULT_INTERFACE],
+        ipv6=zc_config[CONF_IPV6],
     )
 
     # Get instance UUID

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -128,8 +128,10 @@ def setup(hass, config):
     zc_config = config.get(DOMAIN, {})
     zeroconf = hass.data[DOMAIN] = _get_instance(
         hass,
-        default_interface=zc_config[CONF_DEFAULT_INTERFACE],
-        ipv6=zc_config[CONF_IPV6],
+        default_interface=zc_config.get(
+            CONF_DEFAULT_INTERFACE, DEFAULT_DEFAULT_INTERFACE
+        ),
+        ipv6=zc_config.get(CONF_IPV6, DEFAULT_IPV6),
     )
 
     # Get instance UUID

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,9 +1,9 @@
 """Test Zeroconf component setup process."""
 import pytest
-from zeroconf import InterfaceChoice, ServiceInfo, ServiceStateChange
+from zeroconf import InterfaceChoice, IPVersion, ServiceInfo, ServiceStateChange
 
 from homeassistant.components import zeroconf
-from homeassistant.components.zeroconf import CONF_DEFAULT_INTERFACE
+from homeassistant.components.zeroconf import CONF_DEFAULT_INTERFACE, CONF_IPV6
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.setup import async_setup_component
@@ -110,6 +110,43 @@ async def test_setup_without_default_interface(hass, mock_zeroconf):
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_DEFAULT_INTERFACE: False}}
         )
+
+    assert mock_zeroconf.called_with()
+
+
+async def test_setup_without_ipv6(hass, mock_zeroconf):
+    """Test without ipv6."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(
+            hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_IPV6: False}}
+        )
+
+    assert mock_zeroconf.called_with(ip_version=IPVersion.V4Only)
+
+
+async def test_setup_with_ipv6(hass, mock_zeroconf):
+    """Test without ipv6."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(
+            hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_IPV6: True}}
+        )
+
+    assert mock_zeroconf.called_with()
+
+
+async def test_setup_with_ipv6_default(hass, mock_zeroconf):
+    """Test without ipv6 as default."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert mock_zeroconf.called_with()
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many users are stuck with broken routers provided by their ISP that disable or break IPv6.  This can cause problems for zeroconf so we need a way to disable it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35031 and fixes #37791
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14007

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
