### PR TITLE
Change ZHA power unit from kW to W

### DIFF
--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -118,10 +118,6 @@ class Metering(ZigbeeChannel):
         self._multiplier = results.get("multiplier", self._multiplier)
         self._unit_enum = results.get("unit_of_measure", 0x7F)  # default to unknown
 
-        if self.unit_of_measurement == POWER_WATT:
-            # Zigbee spec power unit is kW, but we show the value in W
-            self._multiplier = self._multiplier * 1000
-
         fmting = results.get(
             "demand_formatting", 0xF9
         )  # 1 digit to the right, 15 digits to the left
@@ -139,6 +135,12 @@ class Metering(ZigbeeChannel):
 
     def formatter_function(self, value):
         """Return formatted value for display."""
+        if self.unit_of_measurement == POWER_WATT:
+            # Zigbee spec power unit is kW, but we show the value in W
+            value_watt = value * 1000
+            if value_watt < 100:
+                return round(value_watt, 1)
+            return round(value_watt)
         return self._format_spec.format(value).lstrip()
 
 

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -118,7 +118,7 @@ class Metering(ZigbeeChannel):
         self._multiplier = results.get("multiplier", self._multiplier)
         self._unit_enum = results.get("unit_of_measure", 0x7F)  # default to unknown
 
-        if self.unit_of_measurement == "W":
+        if self.unit_of_measurement == POWER_WATT:
             # Zigbee spec power unit is kW, but we show the value in W
             self._multiplier = self._multiplier * 1000
 

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -3,7 +3,7 @@ import logging
 
 import zigpy.zcl.clusters.smartenergy as smartenergy
 
-from homeassistant.const import LENGTH_FEET, TIME_HOURS, TIME_SECONDS
+from homeassistant.const import LENGTH_FEET, POWER_WATT, TIME_HOURS, TIME_SECONDS
 from homeassistant.core import callback
 
 from .. import registries, typing as zha_typing
@@ -60,7 +60,7 @@ class Metering(ZigbeeChannel):
     REPORT_CONFIG = [{"attr": "instantaneous_demand", "config": REPORT_CONFIG_DEFAULT}]
 
     unit_of_measure_map = {
-        0x00: "kW",
+        0x00: POWER_WATT,
         0x01: f"m³/{TIME_HOURS}",
         0x02: f"{LENGTH_FEET}³/{TIME_HOURS}",
         0x03: f"ccf/{TIME_HOURS}",
@@ -117,6 +117,10 @@ class Metering(ZigbeeChannel):
         self._divisor = results.get("divisor", self._divisor)
         self._multiplier = results.get("multiplier", self._multiplier)
         self._unit_enum = results.get("unit_of_measure", 0x7F)  # default to unknown
+
+        if self.unit_of_measurement == "W":
+            # Zigbee spec power unit is kW, but we show the value in W
+            self._multiplier = self._multiplier * 1000
 
         fmting = results.get(
             "demand_formatting", 0xF9


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously ZHA was displaying power as kilowatt (kW) for some devices (the ones with the SmartEnergy cluster), but since watts are more common as household power unit, ZHA will start using W for those instead. If you have any calculations or accumulation based on power sensors, they may need to be updated.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It makes more sense to show power as W, since usually most devices consume less than 1kW, and almost never over 3.5kW.
This also makes the SmartEnergy cluster use the same unit as the ElectricalMeasurement cluster.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
