### PR TITLE
Ensure a state change tracker setup from inside a state change listener does not fire immediately

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -163,7 +163,7 @@ def async_track_state_change_event(
             if entity_id not in entity_callbacks:
                 return
 
-            for action in entity_callbacks[entity_id][:]:
+            for action in list(entity_callbacks[entity_id]):
                 try:
                     hass.async_run_job(action, event)
                 except Exception:  # pylint: disable=broad-except

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -163,7 +163,7 @@ def async_track_state_change_event(
             if entity_id not in entity_callbacks:
                 return
 
-            for action in list(entity_callbacks[entity_id]):
+            for action in entity_callbacks[entity_id][:]:
                 try:
                     hass.async_run_job(action, event)
                 except Exception:  # pylint: disable=broad-except

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1011,3 +1011,104 @@ async def test_async_call_later(hass):
     assert p_action is action
     assert p_point == now + timedelta(seconds=3)
     assert remove is mock()
+
+
+async def test_track_state_change_event_chain_multple_entity(hass):
+    """Test that adding a new state tracker inside a tracker does not fire right away."""
+    tracker_called = []
+    chained_tracker_called = []
+
+    chained_tracker_unsub = []
+    tracker_unsub = []
+
+    @ha.callback
+    def chained_single_run_callback(event):
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        chained_tracker_called.append((old_state, new_state))
+
+    @ha.callback
+    def single_run_callback(event):
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        tracker_called.append((old_state, new_state))
+
+        chained_tracker_unsub.append(
+            async_track_state_change_event(
+                hass, ["light.bowl", "light.top"], chained_single_run_callback
+            )
+        )
+
+    tracker_unsub.append(
+        async_track_state_change_event(
+            hass, ["light.bowl", "light.top"], single_run_callback
+        )
+    )
+
+    hass.states.async_set("light.bowl", "on")
+    hass.states.async_set("light.top", "on")
+    await hass.async_block_till_done()
+
+    assert len(tracker_called) == 2
+    assert len(chained_tracker_called) == 1
+    assert len(tracker_unsub) == 1
+    assert len(chained_tracker_unsub) == 2
+
+    hass.states.async_set("light.bowl", "off")
+    await hass.async_block_till_done()
+
+    assert len(tracker_called) == 3
+    assert len(chained_tracker_called) == 3
+    assert len(tracker_unsub) == 1
+    assert len(chained_tracker_unsub) == 3
+
+
+async def test_track_state_change_event_chain_single_entity(hass):
+    """Test that adding a new state tracker inside a tracker does not fire right away."""
+    tracker_called = []
+    chained_tracker_called = []
+
+    chained_tracker_unsub = []
+    tracker_unsub = []
+
+    @ha.callback
+    def chained_single_run_callback(event):
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        chained_tracker_called.append((old_state, new_state))
+
+    @ha.callback
+    def single_run_callback(event):
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        tracker_called.append((old_state, new_state))
+
+        chained_tracker_unsub.append(
+            async_track_state_change_event(
+                hass, "light.bowl", chained_single_run_callback
+            )
+        )
+
+    tracker_unsub.append(
+        async_track_state_change_event(hass, "light.bowl", single_run_callback)
+    )
+
+    hass.states.async_set("light.bowl", "on")
+    await hass.async_block_till_done()
+
+    assert len(tracker_called) == 1
+    assert len(chained_tracker_called) == 0
+    assert len(tracker_unsub) == 1
+    assert len(chained_tracker_unsub) == 1
+
+    hass.states.async_set("light.bowl", "off")
+    await hass.async_block_till_done()
+
+    assert len(tracker_called) == 2
+    assert len(chained_tracker_called) == 1
+    assert len(tracker_unsub) == 1
+    assert len(chained_tracker_unsub) == 2


### PR DESCRIPTION
I still haven't been able to replicate #37905 or #37902 after trying various ways to get it to break.  I was able to write a test showing the behavior is wrong at least in this case.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since we were adding the callback to the list of callbacks for the entity
while we were iterating the list when async_track_state_change* was
called from a listener, it would fire immediately.

Allow a single entity_id to be passed to async_track_state_change_event as
I suspect we have a bug where its not an Iterable which results in
a subscription to every character in the entity_id instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
