### PR TITLE
Fix Sonos speaker lookup for Plex

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -215,7 +215,7 @@ def play_on_sonos(hass, service_call):
 
     sonos = hass.components.sonos
     try:
-        sonos_id = sonos.get_coordinator_id(entity_id)
+        sonos_name = sonos.get_coordinator_name(entity_id)
     except HomeAssistantError as err:
         _LOGGER.error("Cannot get Sonos device: %s", err)
         return
@@ -239,10 +239,10 @@ def play_on_sonos(hass, service_call):
     else:
         plex_server = next(iter(plex_servers))
 
-    sonos_speaker = plex_server.account.sonos_speaker_by_id(sonos_id)
+    sonos_speaker = plex_server.account.sonos_speaker(sonos_name)
     if sonos_speaker is None:
         _LOGGER.error(
-            "Sonos speaker '%s' could not be found on this Plex account", sonos_id
+            "Sonos speaker '%s' could not be found on this Plex account", sonos_name
         )
         return
 

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -58,8 +58,10 @@ async def async_setup_entry(hass, entry):
 
 
 @bind_hass
-def get_coordinator_id(hass, entity_id):
-    """Obtain the unique_id of a device's coordinator.
+def get_coordinator_name(hass, entity_id):
+    """Obtain the room/name of a device's coordinator.
+
+    Used by the Plex integration.
 
     This function is safe to run inside the event loop.
     """
@@ -71,5 +73,5 @@ def get_coordinator_id(hass, entity_id):
     )
 
     if device.is_coordinator:
-        return device.unique_id
-    return device.coordinator.unique_id
+        return device.name
+    return device.coordinator.name

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -78,9 +78,9 @@ class MockPlexAccount:
         """Mock the PlexAccount resources listing method."""
         return self._resources
 
-    def sonos_speaker_by_id(self, machine_identifier):
+    def sonos_speaker(self, speaker_name):
         """Mock the PlexAccount Sonos lookup method."""
-        return MockPlexSonosClient(machine_identifier)
+        return MockPlexSonosClient(speaker_name)
 
 
 class MockPlexSystemAccount:
@@ -378,9 +378,9 @@ class MockPlexMediaTrack(MockPlexMediaItem):
 class MockPlexSonosClient:
     """Mock a PlexSonosClient instance."""
 
-    def __init__(self, machine_identifier):
+    def __init__(self, name):
         """Initialize the object."""
-        self.machineIdentifier = machine_identifier
+        self.name = name
 
     def playMedia(self, item):
         """Mock the playMedia method."""

--- a/tests/components/plex/test_playback.py
+++ b/tests/components/plex/test_playback.py
@@ -39,7 +39,7 @@ async def test_sonos_playback(hass):
 
     # Test Sonos integration lookup failure
     with patch.object(
-        hass.components.sonos, "get_coordinator_id", side_effect=HomeAssistantError
+        hass.components.sonos, "get_coordinator_name", side_effect=HomeAssistantError
     ):
         assert await hass.services.async_call(
             DOMAIN,
@@ -55,7 +55,7 @@ async def test_sonos_playback(hass):
     # Test success with dict
     with patch.object(
         hass.components.sonos,
-        "get_coordinator_id",
+        "get_coordinator_name",
         return_value="media_player.sonos_kitchen",
     ), patch("plexapi.playqueue.PlayQueue.create"):
         assert await hass.services.async_call(
@@ -72,7 +72,7 @@ async def test_sonos_playback(hass):
     # Test success with plex_key
     with patch.object(
         hass.components.sonos,
-        "get_coordinator_id",
+        "get_coordinator_name",
         return_value="media_player.sonos_kitchen",
     ), patch("plexapi.playqueue.PlayQueue.create"):
         assert await hass.services.async_call(
@@ -89,7 +89,7 @@ async def test_sonos_playback(hass):
     # Test invalid Plex server requested
     with patch.object(
         hass.components.sonos,
-        "get_coordinator_id",
+        "get_coordinator_name",
         return_value="media_player.sonos_kitchen",
     ):
         assert await hass.services.async_call(
@@ -105,10 +105,10 @@ async def test_sonos_playback(hass):
 
     # Test no speakers available
     with patch.object(
-        loaded_server.account, "sonos_speaker_by_id", return_value=None
+        loaded_server.account, "sonos_speaker", return_value=None
     ), patch.object(
         hass.components.sonos,
-        "get_coordinator_id",
+        "get_coordinator_name",
         return_value="media_player.sonos_kitchen",
     ):
         assert await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I recently found that the identifiers of Sonos speakers returned by the Plex API are not speaker IDs but actually Sonos group IDs. Although these group IDs usually match the individual speaker hardware IDs (based on MAC), they cannot be used that way reliably. In some scenarios of grouping/ungrouping sequences, the hardware ID from one speaker may be used as the group ID for an unrelated speaker or multiple speakers can have similar group IDs.

Example:
```
('RINCON_14785236987401400:3958327572', 'Front Room')
('RINCON_12345678949401400:1714627337', 'Basement')     <-- Similar
('RINCON_12345678949401400:1714627340', 'Kitchen + 1')  <--  base IDs
('RINCON_95123574862001400:1932839905', 'Bedroom')
```

As of now the only reliable way to address a specific speaker is to use the room/speaker name.

Without this fix, the `plex.play_on_sonos` service can sometimes fail to work or can play music on an unexpected speaker. 😮 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
