### PR TITLE
Automatically recover when the sqlite3 database is malformed or corrupted

### DIFF
--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -1,3 +1,4 @@
 """Recorder constants."""
 
 DATA_INSTANCE = "recorder_instance"
+SQLITE_URL_PREFIX = "sqlite://"

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -1,8 +1,10 @@
 """Test util methods."""
+import os
+
 import pytest
 
 from homeassistant.components.recorder import util
-from homeassistant.components.recorder.const import DATA_INSTANCE
+from homeassistant.components.recorder.const import DATA_INSTANCE, SQLITE_URL_PREFIX
 
 from tests.async_mock import MagicMock, patch
 from tests.common import get_test_home_assistant, init_recorder_component
@@ -60,3 +62,47 @@ def test_recorder_bad_execute(hass_recorder):
         util.execute((mck1,), to_native=True)
 
     assert e_mock.call_count == 2
+
+
+async def test_validate_or_move_away_sqlite_database(hass, tmpdir, caplog):
+    """Ensure a malformed sqlite database is moved away."""
+
+    test_dir = tmpdir.mkdir("test_validate_or_move_away_sqlite_database")
+    test_db_file = f"{test_dir}/broken.db"
+    dburl = f"{SQLITE_URL_PREFIX}{test_db_file}"
+
+    assert (
+        await hass.async_add_executor_job(util.validate_sqlite_database, test_db_file)
+        is True
+    )
+    assert os.path.exists(test_db_file) is True
+    assert (
+        await hass.async_add_executor_job(
+            util.validate_or_move_away_sqlite_database, dburl
+        )
+        is True
+    )
+
+    await hass.async_add_executor_job(_corrupt_db_file, test_db_file)
+
+    assert (
+        await hass.async_add_executor_job(
+            util.validate_or_move_away_sqlite_database, dburl
+        )
+        is False
+    )
+    assert "corrupt or malformed" in caplog.text
+
+    assert (
+        await hass.async_add_executor_job(
+            util.validate_or_move_away_sqlite_database, dburl
+        )
+        is True
+    )
+
+
+def _corrupt_db_file(test_db_file):
+    """Corrupt an sqlite3 database file."""
+    f = open(test_db_file, "a")
+    f.write("I am a corrupt db")
+    f.close()

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -64,41 +64,25 @@ def test_recorder_bad_execute(hass_recorder):
     assert e_mock.call_count == 2
 
 
-async def test_validate_or_move_away_sqlite_database(hass, tmpdir, caplog):
+def test_validate_or_move_away_sqlite_database(hass, tmpdir, caplog):
     """Ensure a malformed sqlite database is moved away."""
 
     test_dir = tmpdir.mkdir("test_validate_or_move_away_sqlite_database")
     test_db_file = f"{test_dir}/broken.db"
     dburl = f"{SQLITE_URL_PREFIX}{test_db_file}"
 
-    assert (
-        await hass.async_add_executor_job(util.validate_sqlite_database, test_db_file)
-        is True
-    )
+    util.validate_sqlite_database(test_db_file) is True
+
     assert os.path.exists(test_db_file) is True
-    assert (
-        await hass.async_add_executor_job(
-            util.validate_or_move_away_sqlite_database, dburl
-        )
-        is True
-    )
+    assert util.validate_or_move_away_sqlite_database(dburl) is True
 
-    await hass.async_add_executor_job(_corrupt_db_file, test_db_file)
+    _corrupt_db_file(test_db_file)
 
-    assert (
-        await hass.async_add_executor_job(
-            util.validate_or_move_away_sqlite_database, dburl
-        )
-        is False
-    )
+    assert util.validate_or_move_away_sqlite_database(dburl) is False
+
     assert "corrupt or malformed" in caplog.text
 
-    assert (
-        await hass.async_add_executor_job(
-            util.validate_or_move_away_sqlite_database, dburl
-        )
-        is True
-    )
+    assert util.validate_or_move_away_sqlite_database(dburl) is True
 
 
 def _corrupt_db_file(test_db_file):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Automatically recover when the sqlite3 database is malformed or corrupted.

Validate sqlite database on startup and move away if corruption is detected.

If corruption is detected, the database is renamed to `home-assistant_v2.db.corrupt.{ISOTIME}` and startup proceeds with a fresh database.

```
2020-07-17 23:45:05 ERROR (Recorder) [homeassistant.components.recorder.util] The database at /config/home-assistant_v2.db is corrupt or malformed.
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/recorder/util.py", line 125, in validate_sqlite_database
    conn.cursor().execute("PRAGMA QUICK_CHECK")
sqlite3.DatabaseError: database disk image is malformed
2020-07-17 23:45:05 ERROR (Recorder) [homeassistant.components.recorder.util] The system will rename the corrupt database file /config/home-assistant_v2.db to /config/home-assistant_v2.db.corrupt.2020-07-17T23:45:05.678820+00:00 in order to allow startup to proceed
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
