### PR TITLE
Allow to set default dark theme

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -78,6 +78,7 @@ DATA_THEMES = "frontend_themes"
 DATA_DEFAULT_THEME = "frontend_default_theme"
 DATA_DEFAULT_DARK_THEME = "frontend_default_dark_theme"
 DEFAULT_THEME = "default"
+VALUE_NO_THEME = "none"
 
 PRIMARY_COLOR = "primary-color"
 
@@ -367,6 +368,9 @@ def _async_setup_themes(hass, themes):
         if name == DEFAULT_THEME or name in hass.data[DATA_THEMES]:
             _LOGGER.info("Theme %s set as default dark", name)
             hass.data[DATA_DEFAULT_DARK_THEME] = name
+            update_theme_and_fire_event()
+        elif name == VALUE_NO_THEME:
+            hass.data[DATA_DEFAULT_DARK_THEME] = None
             update_theme_and_fire_event()
         else:
             _LOGGER.warning("Theme %s is not defined", name)

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -117,6 +117,7 @@ async def test_themes_api(hass, hass_ws_client):
     msg = await client.receive_json()
 
     assert msg["result"]["default_theme"] == "default"
+    assert msg["result"]["default_dark_theme"] is None
     assert msg["result"]["themes"] == {"happy": {"primary-color": "red"}}
 
     # safe mode
@@ -168,6 +169,55 @@ async def test_themes_set_theme_wrong_name(hass, hass_ws_client):
     msg = await client.receive_json()
 
     assert msg["result"]["default_theme"] == "default"
+
+
+async def test_themes_set_dark_theme(hass, hass_ws_client):
+    """Test frontend.set_dark_theme service."""
+    assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
+    client = await hass_ws_client(hass)
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "happy"}, blocking=True
+    )
+
+    await client.send_json({"id": 5, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] == "happy"
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "default"}, blocking=True
+    )
+
+    await client.send_json({"id": 6, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] == "default"
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "none"}, blocking=True
+    )
+
+    await client.send_json({"id": 7, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] is None
+
+
+async def test_themes_set_dark_theme_wrong_name(hass, hass_ws_client):
+    """Test frontend.set_dark_theme service called with wrong name."""
+    assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
+    client = await hass_ws_client(hass)
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "wrong"}, blocking=True
+    )
+
+    await client.send_json({"id": 5, "type": "frontend/get_themes"})
+
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] is None
 
 
 async def test_themes_reload_themes(hass, hass_ws_client):


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a service to set a default dark mode theme, that will be used when the browser/device is in dark mode.

Not sure if this should be an extra service call or should be combined in the existing set theme service.

<https://github.com/home-assistant/frontend/pull/6430>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
