### PR TITLE
Add support for multiple time triggers in automations

### DIFF
--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -13,20 +13,29 @@ from homeassistant.helpers.event import async_track_time_change
 _LOGGER = logging.getLogger(__name__)
 
 TRIGGER_SCHEMA = vol.Schema(
-    {vol.Required(CONF_PLATFORM): "time", vol.Required(CONF_AT): cv.time}
+    {
+        vol.Required(CONF_PLATFORM): "time",
+        vol.Required(CONF_AT): vol.All(cv.ensure_list, [cv.time]),
+    }
 )
 
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
-    at_time = config.get(CONF_AT)
-    hours, minutes, seconds = at_time.hour, at_time.minute, at_time.second
+    at_times = config[CONF_AT]
 
     @callback
     def time_automation_listener(now):
         """Listen for time changes and calls action."""
         hass.async_run_job(action, {"trigger": {"platform": "time", "now": now}})
 
-    return async_track_time_change(
-        hass, time_automation_listener, hour=hours, minute=minutes, second=seconds
-    )
+    return [
+        async_track_time_change(
+            hass,
+            time_automation_listener,
+            hour=at_time.hour,
+            minute=at_time.minute,
+            second=at_time.second,
+        )
+        for at_time in at_times
+    ]

--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -29,7 +29,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
         """Listen for time changes and calls action."""
         hass.async_run_job(action, {"trigger": {"platform": "time", "now": now}})
 
-    return [
+    removes = [
         async_track_time_change(
             hass,
             time_automation_listener,
@@ -39,3 +39,11 @@ async def async_attach_trigger(hass, config, action, automation_info):
         )
         for at_time in at_times
     ]
+
+    @callback
+    def remove_track_time_changes():
+        """Remove tracked time changes."""
+        for remove in removes:
+            remove()
+
+    return remove_track_time_changes

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -8,7 +8,7 @@ from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.async_mock import AsyncMock, patch
+from tests.async_mock import Mock, patch
 from tests.common import (
     assert_setup_component,
     async_fire_time_changed,
@@ -283,7 +283,7 @@ async def test_if_action_list_weekday(hass, calls):
 
 async def test_untrack_time_change(hass):
     """Test for removing tracked time changes."""
-    mock_track_time_change = AsyncMock()
+    mock_track_time_change = Mock()
     with patch(
         "homeassistant.components.automation.time.async_track_time_change",
         return_value=mock_track_time_change,

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -68,29 +68,45 @@ async def test_if_fires_using_at(hass, calls):
 
 async def test_if_fires_using_multiple_at(hass, calls):
     """Test for firing at."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {"platform": "time", "at": ["5:00:00", "6:00:00"]},
-                "action": {
-                    "service": "test.automation",
-                    "data_template": {
-                        "some": "{{ trigger.platform }} - {{ trigger.now.hour }}"
-                    },
-                },
-            }
-        },
+
+    now = dt_util.utcnow()
+
+    time_that_will_not_match_right_away = now.replace(
+        year=now.year + 1, hour=4, minute=59, second=0
     )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=5, minute=0, second=0))
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {"platform": "time", "at": ["5:00:00", "6:00:00"]},
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "{{ trigger.platform }} - {{ trigger.now.hour }}"
+                        },
+                    },
+                }
+            },
+        )
+
+    now = dt_util.utcnow()
+
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 1, hour=5, minute=0, second=0)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].data["some"] == "time - 5"
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=6, minute=0, second=0))
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 1, hour=6, minute=0, second=0)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 2

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -66,6 +66,37 @@ async def test_if_fires_using_at(hass, calls):
     assert calls[0].data["some"] == "time - 5"
 
 
+async def test_if_fires_using_multiple_at(hass, calls):
+    """Test for firing at."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "time", "at": ["5:00:00", "6:00:00"]},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "some": "{{ trigger.platform }} - {{ trigger.now.hour }}"
+                    },
+                },
+            }
+        },
+    )
+
+    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=5, minute=0, second=0))
+
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "time - 5"
+
+    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=6, minute=0, second=0))
+
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "time - 6"
+
+
 async def test_if_not_fires_using_wrong_at(hass, calls):
     """YAML translates time values to total seconds.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for having multiple time triggers in a single trigger.

I noticed that with the new `choose`, one would add more triggers to their automations. When you have automations that rely on time, adding multiple time triggers is rather expressive.

Before:

```yaml
automation:
  - alias: time trigger
    trigger:
      - platform: time
        at: "05:00:00"
      - platform: time
        at: "06:00:00"
      - platform: time
        at: "10:00:00"
    action:
      choose:
        ...
```

After:

```yaml
automation:
  - alias: time trigger
    trigger:
      - platform: time
        at:
          - "05:00:00"
          - "06:00:00"
          - "10:00:00"
    action:
      choose:
        ...
```

Or:

```yaml
automation:
  - alias: time trigger
    trigger:
      - platform: time
        at: ["05:00:00", 06:00:00", "10:00:00"]
    action:
      choose:
        ...
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14035

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
