### PR TITLE
Don't advertise switch devices as dimmable lights with emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -744,12 +744,11 @@ def entity_to_json(config, entity):
         retval["modelid"] = "HASS123"
         retval["state"].update({HUE_API_STATE_BRI: state[STATE_BRIGHTNESS]})
     else:
-        # Dimmable light (Zigbee Device ID: 0x0100)
-        # Supports groups, scenes, on/off and dimming
-        # Reports fixed brightness for compatibility with Alexa.
-        retval["type"] = "Dimmable light"
-        retval["modelid"] = "HASS123"
-        retval["state"].update({HUE_API_STATE_BRI: HUE_API_STATE_BRI_MAX})
+        # On/Off light (ZigBee Device ID: 0x0000)
+        # Supports groups, scenes and on/off control
+        retval["type"] = "On/Off light"
+        retval["productname"] = "On/Off light"
+        retval["modelid"] = "HASS321"
 
     return retval
 

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -252,7 +252,7 @@ async def test_light_without_brightness_supported(hass_hue, hue_client):
     )
 
     assert light_without_brightness_json["state"][HUE_API_STATE_ON] is True
-    assert light_without_brightness_json["type"] == "Dimmable light"
+    assert light_without_brightness_json["type"] == "On/Off light"
 
 
 async def test_light_without_brightness_can_be_turned_off(hass_hue, hue_client):


### PR DESCRIPTION
This issue has been corrected and then reverted multiple times.
It seems that the core issue was a casing one (On/off vs On/Off) ; for better
matching with a real Hue hub, also add the productname.

Tested to work with echo 2 and echo 5.

In order to prevent potential regressions, we add an extra config lights_all_dimmable which is a boolean.
If set to true, all lights/switches with no brightness feature will be advertised as dimmable lights.
The default is false.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
I've locally tested with both an Echo 5 and an Echo (2nd gen), and devices are now properly detected and existing ones are appearing as on/off switch only.
New devices are properly discovered as you would expect.
All existing devices should be updated properly after asking Alexa to discover devices.
so it should *not* break anything.

However, seeing that this a problem that has received multiple changes in the past, I can't guarantee that it will work for everyone.
See #30013, #31330 and #28317, so there's may be a need for those with the original problem to set lights_all_dimmable to true in their configuration.yaml

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
All on/off switches are currently being added as dimmable lights; this causes Alexa when asking to turn on or off a light on either the Alexa app or an Echo 5 to show a slider to change the brightness. If you attempt to modify the brightness you will get an error, and sometimes tAlexa will no longer take orders for that device.

This changes return to the attempted functionality provided by bug #28317. By using the correct casing and adding a missing property, there devices are always properly detected by Alexa.

That a switch appears as a non dimmable lights seems important enough that it is made the default. If for some unknown reasons it breaks things for some, they can add lights_all_dimmable = true to their config.
So we get the best of both world.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```
Going to: http://[IP_ADDRESS:80/api/pi/lights
should return "type": "On/Off light"
with the default config or with lights_all_dimmable set to false.

If set to true, it will show:
"type" : "Dimmable light"

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26860
- This PR is related to issue: #30013, #29899, #31413
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14039

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
