### PR TITLE
Fix notify.slack service calls using data_template

### DIFF
--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -224,7 +224,10 @@ class SlackNotificationService(BaseNotificationService):
 
     async def async_send_message(self, message, **kwargs):
         """Send a message to Slack."""
-        data = kwargs.get(ATTR_DATA, {})
+        data = kwargs.get(ATTR_DATA)
+
+        if data is None:
+            data = {}
 
         try:
             DATA_SCHEMA(data)


### PR DESCRIPTION
## Proposed change

This change restores support for this form of using the Slack notification integration:

```yaml
- service: notify.slack
  data_template:
    message: '{{ template }} string'
```

This form appears to have worked before https://github.com/home-assistant/core/pull/37161. After that PR, it throws the following error:

```
ERROR (MainThread) [homeassistant.components.script.deploy] deploy: Error executing script. Unexpected error for call_service at pos 1: argument of type 'NoneType' is not iterable
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 181, in _async_step
    await getattr(
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 370, in _async_call_service_step
    await service_task
  File "/usr/src/homeassistant/homeassistant/core.py", line 1250, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1285, in _execute_service
    await handler.func(service_call)
  File "/usr/src/homeassistant/homeassistant/components/notify/__init__.py", line 119, in async_notify_message
    await notify_service.async_send_message(**kwargs)
  File "/usr/src/homeassistant/homeassistant/components/slack/notify.py", line 241, in async_send_message
    if ATTR_FILE not in data:
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
- service: notify.slack
  data_template:
    message: '{{ template }} string'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: https://github.com/home-assistant/core/pull/37161

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
