### PR TITLE
Create option flow for Rfxtrx integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -710,6 +710,11 @@ omit =
     homeassistant/components/rest/binary_sensor.py
     homeassistant/components/rest/notify.py
     homeassistant/components/rest/switch.py
+    homeassistant/components/rfxtrx/binary_sensor.py
+    homeassistant/components/rfxtrx/cover.py
+    homeassistant/components/rfxtrx/light.py
+    homeassistant/components/rfxtrx/sensor.py
+    homeassistant/components/rfxtrx/switch.py
     homeassistant/components/ring/camera.py
     homeassistant/components/ripple/sensor.py
     homeassistant/components/rocketchat/notify.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -710,11 +710,6 @@ omit =
     homeassistant/components/rest/binary_sensor.py
     homeassistant/components/rest/notify.py
     homeassistant/components/rest/switch.py
-    homeassistant/components/rfxtrx/binary_sensor.py
-    homeassistant/components/rfxtrx/cover.py
-    homeassistant/components/rfxtrx/light.py
-    homeassistant/components/rfxtrx/sensor.py
-    homeassistant/components/rfxtrx/switch.py
     homeassistant/components/ring/camera.py
     homeassistant/components/ripple/sensor.py
     homeassistant/components/rocketchat/notify.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -343,7 +343,7 @@ homeassistant/components/rainforest_eagle/* @gtdiehl @jcalbert
 homeassistant/components/rainmachine/* @bachya
 homeassistant/components/random/* @fabaff
 homeassistant/components/repetier/* @MTrab
-homeassistant/components/rfxtrx/* @danielhiversen @elupus
+homeassistant/components/rfxtrx/* @danielhiversen @elupus @RobBie1221
 homeassistant/components/ring/* @balloob
 homeassistant/components/rmvtransport/* @cgtobi
 homeassistant/components/roku/* @ctalkington

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -418,6 +418,7 @@ class RfxtrxEntity(RestoreEntity):
         self._event = event
         self._device_id = device_id
         self._unique_id = "_".join(x for x in self._device_id)
+        # hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _start_rfxtrx)
 
     async def async_added_to_hass(self):
         """Restore RFXtrx device state (ON/OFF)."""
@@ -427,6 +428,12 @@ class RfxtrxEntity(RestoreEntity):
         self.async_on_remove(
             self.hass.helpers.dispatcher.async_dispatcher_connect(
                 SIGNAL_EVENT, self._handle_event
+            )
+        )
+
+        self.async_on_remove(
+            self.hass.helpers.dispatcher.async_dispatcher_connect(
+                f"{DOMAIN}_{self._device_id}", self.async_remove
             )
         )
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_DEBUG,
     CONF_FIRE_EVENT,
     CONF_OFF_DELAY,
+    CONF_REMOVE_DEVICE,
     CONF_SIGNAL_REPETITIONS,
     DEVICE_PACKET_TYPE_LIGHTING4,
     EVENT_RFXTRX_EVENT,
@@ -432,7 +433,7 @@ class RfxtrxEntity(RestoreEntity):
 
         self.async_on_remove(
             self.hass.helpers.dispatcher.async_dispatcher_connect(
-                f"{DOMAIN}_{self._device_id}", self.async_remove
+                f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{self._device_id}", self.async_remove
             )
         )
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -30,6 +30,12 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     ATTR_EVENT,
+    CONF_AUTOMATIC_ADD,
+    CONF_DATA_BITS,
+    CONF_DEBUG,
+    CONF_FIRE_EVENT,
+    CONF_OFF_DELAY,
+    CONF_SIGNAL_REPETITIONS,
     DEVICE_PACKET_TYPE_LIGHTING4,
     EVENT_RFXTRX_EVENT,
     SERVICE_SEND,
@@ -39,12 +45,6 @@ DOMAIN = "rfxtrx"
 
 DEFAULT_SIGNAL_REPETITIONS = 1
 
-CONF_FIRE_EVENT = "fire_event"
-CONF_DATA_BITS = "data_bits"
-CONF_AUTOMATIC_ADD = "automatic_add"
-CONF_SIGNAL_REPETITIONS = "signal_repetitions"
-CONF_DEBUG = "debug"
-CONF_OFF_DELAY = "off_delay"
 SIGNAL_EVENT = f"{DOMAIN}_event"
 
 DATA_TYPES = OrderedDict(

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -418,7 +418,6 @@ class RfxtrxEntity(RestoreEntity):
         self._event = event
         self._device_id = device_id
         self._unique_id = "_".join(x for x in self._device_id)
-        # hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _start_rfxtrx)
 
     async def async_added_to_hass(self):
         """Restore RFXtrx device state (ON/OFF)."""

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -61,6 +61,18 @@ DEVICE_TYPE_DEVICE_CLASS = {
 }
 
 
+def supported(event):
+    """Return whether an event supports binary_sensor."""
+    if isinstance(event, rfxtrxmod.ControlEvent):
+        return True
+    if isinstance(event, rfxtrxmod.SensorEvent):
+        return event.values.get("Sensor Status") in [
+            *SENSOR_STATUS_ON,
+            *SENSOR_STATUS_OFF,
+        ]
+    return False
+
+
 async def async_setup_entry(
     hass, config_entry, async_add_entities,
 ):
@@ -71,16 +83,6 @@ async def async_setup_entry(
     pt2262_devices = []
 
     discovery_info = config_entry.data
-
-    def supported(event):
-        if isinstance(event, rfxtrxmod.ControlEvent):
-            return True
-        if isinstance(event, rfxtrxmod.SensorEvent):
-            return event.values.get("Sensor Status") in [
-                *SENSOR_STATUS_ON,
-                *SENSOR_STATUS_OFF,
-            ]
-        return False
 
     for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -238,11 +238,11 @@ class OptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_COMMAND_ON,
                         default=hex(device_data.get(CONF_COMMAND_ON, 0)),
-                    ): vol.All(str, lambda value: int(value, 16)),
+                    ): str,
                     vol.Optional(
                         CONF_COMMAND_OFF,
                         default=hex(device_data.get(CONF_COMMAND_OFF, 0)),
-                    ): vol.All(str, lambda value: int(value, 16)),
+                    ): str,
                 }
             )
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -1,11 +1,134 @@
 """Config flow for RFXCOM RFXtrx integration."""
 import logging
 
+import voluptuous as vol
+
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
 
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class OptionsFlow(config_entries.OptionsFlow):
+    """Handle Vizio options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize vizio options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        return await self.async_step_prompt_options()
+
+    async def async_step_prompt_options(self, user_input=None):
+        """Prompt for options."""
+        if user_input is not None:
+            if user_input["selected_option"] == "Set global options":
+                return await self.async_step_global_options()
+            if user_input["selected_option"] == "Add device from discovery":
+                return await self.async_step_discovered_devices()
+            if user_input["selected_option"] == "Add device by id":
+                return await self.async_step_device_by_id()
+            if user_input["selected_option"] == "Configure device options":
+                return await self.async_step_select_device_conf()
+
+        options = [
+            "Set global options",
+            "Add device from discovery",
+            "Add device by id",
+            "Configure device options",
+            "Update device id",
+        ]
+
+        options_scheme = {
+            vol.Required("selected_option"): vol.In(options),
+        }
+
+        return self.async_show_form(
+            step_id="prompt_options", data_schema=vol.Schema(options_scheme)
+        )
+
+    async def async_step_global_options(self, user_input=None):
+        """Manage global options."""
+        if user_input is not None:
+            return None
+
+        data_scheme = {
+            vol.Optional("debug"): bool,
+        }
+
+        return self.async_show_form(
+            step_id="global_options", data_schema=vol.Schema(data_scheme)
+        )
+
+    async def async_step_discovered_devices(self, user_input=None):
+        """Show discovered devices options."""
+        if user_input is not None:
+            return await self.async_step_set_device_options()
+
+        dummy_device_list = ["test1", "test2", "test3"]
+        device_class = ["light", "power", "window"]
+
+        data_scheme = {
+            vol.Optional("discovered_devices"): vol.In(dummy_device_list),
+            vol.Optional("device_class"): vol.In(device_class),
+        }
+
+        return self.async_show_form(
+            step_id="discovered_devices", data_schema=vol.Schema(data_scheme)
+        )
+
+    async def async_step_set_device_options(self, user_input=None):
+        """Manage device options."""
+        if user_input is not None:
+            return None
+
+        data_scheme = {
+            vol.Optional("fire_event"): bool,
+            vol.Optional("off_delay"): int,
+            vol.Optional("data_bit"): int,
+            vol.Optional("command_on"): int,
+            vol.Optional("command_off"): int,
+            vol.Optional("signal_repetitions"): int,
+        }
+
+        return self.async_show_form(
+            step_id="set_device_options", data_schema=vol.Schema(data_scheme)
+        )
+
+    async def async_step_device_by_id(self, user_input=None):
+        """Prompt for device id."""
+        if user_input is not None:
+            return await self.async_step_set_device_options()
+
+        device_class = ["light", "power", "window"]
+
+        data_scheme = {
+            vol.Required("device_id"): int,
+            vol.Optional("device_class"): vol.In(device_class),
+        }
+
+        return self.async_show_form(
+            step_id="device_by_id", data_schema=vol.Schema(data_scheme)
+        )
+
+    async def async_step_select_device_conf(self, user_input=None):
+        """Select device from list."""
+        if user_input is not None:
+            return await self.async_step_set_device_options()
+
+        dummy_device_list = ["test1", "test2", "test3"]
+
+        data_scheme = {
+            vol.Optional("configured_devices"): vol.In(dummy_device_list),
+        }
+
+        return self.async_show_form(
+            step_id="select_device_conf", data_schema=vol.Schema(data_scheme)
+        )
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -21,3 +144,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.hass.config_entries.async_update_entry(entry, data=import_config)
             return self.async_abort(reason="already_configured")
         return self.async_create_entry(title="RFXTRX", data=import_config)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Get the options flow for this handler."""
+        return OptionsFlow(config_entry)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -65,15 +65,16 @@ class OptionsFlow(config_entries.OptionsFlow):
             }
             if CONF_DEVICE in user_input:
                 event_code = None
+                device_id = None
                 for entry in self._device_entries:
                     if entry.id == user_input[CONF_DEVICE]:
                         device_id = next(iter(entry.identifiers))[1:]
-                        for packet_id, entity_info in self._config_entry.data[
-                            CONF_DEVICES
-                        ].items():
-                            if entity_info.get(CONF_DEVICE_ID) == device_id:
-                                event_code = packet_id
-                                break
+                        break
+                for packet_id, entity_info in self._config_entry.data[
+                    CONF_DEVICES
+                ].items():
+                    if entity_info.get(CONF_DEVICE_ID) == device_id:
+                        event_code = packet_id
                         break
                 if not event_code:
                     errors = {"base": "unknown_event_code"}

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -74,6 +74,9 @@ class OptionsFlow(config_entries.OptionsFlow):
                     self._selected_device = self._config_entry.data[CONF_DEVICES][
                         event_code
                     ]
+                    self._selected_device_object = get_rfx_object(
+                        self._selected_device_event_code
+                    )
                     return await self.async_step_set_device_options()
             if CONF_REMOVE_DEVICE in user_input:
                 device_data = self._get_device_data(user_input[CONF_REMOVE_DEVICE])
@@ -96,6 +99,9 @@ class OptionsFlow(config_entries.OptionsFlow):
             if CONF_DEVICE_ID in user_input:
                 self._selected_device_event_code = user_input[CONF_DEVICE_ID]
                 self._selected_device = {}
+                self._selected_device_object = get_rfx_object(
+                    self._selected_device_event_code
+                )
                 return await self.async_step_set_device_options()
 
             if not errors:
@@ -180,11 +186,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                 return self.async_create_entry(title="", data={})
 
         device_data = self._selected_device
-
-        if self._selected_device_object is None:
-            self._selected_device_object = get_rfx_object(
-                self._selected_device_event_code
-            )
 
         data_scheme = {
             vol.Optional(

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -99,10 +99,14 @@ class OptionsFlow(config_entries.OptionsFlow):
             if CONF_DEVICE_ID in user_input:
                 self._selected_device_event_code = user_input[CONF_DEVICE_ID]
                 self._selected_device = {}
-                self._selected_device_object = get_rfx_object(
+                selected_device_object = get_rfx_object(
                     self._selected_device_event_code
                 )
-                return await self.async_step_set_device_options()
+                if selected_device_object is None:
+                    errors = {"base": "invalid_event_code"}
+                else:
+                    self._selected_device_object = selected_device_object
+                    return await self.async_step_set_device_options()
 
             if not errors:
                 self.update_config_data(global_options=self._global_options)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -37,6 +37,7 @@ from .switch import supported as switch_supported
 _LOGGER = logging.getLogger(__name__)
 
 CONF_OFF_DELAY_ENABLED = CONF_OFF_DELAY + "_enabled"
+CONF_EVENT_CODE = "event_code"
 
 
 class OptionsFlow(config_entries.OptionsFlow):
@@ -66,10 +67,10 @@ class OptionsFlow(config_entries.OptionsFlow):
             }
             if CONF_DEVICE in user_input:
                 device_data = self._get_device_data(user_input[CONF_DEVICE])
-                if not device_data.get("event_code"):
+                if not device_data.get(CONF_EVENT_CODE):
                     errors = {"base": "unknown_event_code"}
                 else:
-                    event_code = device_data["event_code"]
+                    event_code = device_data[CONF_EVENT_CODE]
                     self._selected_device_event_code = event_code
                     self._selected_device = self._config_entry.data[CONF_DEVICES][
                         event_code
@@ -80,11 +81,11 @@ class OptionsFlow(config_entries.OptionsFlow):
                     return await self.async_step_set_device_options()
             if CONF_REMOVE_DEVICE in user_input:
                 device_data = self._get_device_data(user_input[CONF_REMOVE_DEVICE])
-                if not device_data.get("event_code"):
+                if not device_data.get(CONF_EVENT_CODE):
                     errors = {"base": "unknown_event_code"}
                 else:
-                    event_code = device_data["event_code"]
-                    device_id = device_data["device_id"]
+                    event_code = device_data[CONF_EVENT_CODE]
+                    device_id = device_data[CONF_DEVICE_ID]
                     self.hass.helpers.dispatcher.async_dispatcher_send(
                         f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{device_id}"
                     )
@@ -96,8 +97,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                     )
 
                     return self.async_create_entry(title="", data={})
-            if CONF_DEVICE_ID in user_input:
-                self._selected_device_event_code = user_input[CONF_DEVICE_ID]
+            if CONF_EVENT_CODE in user_input:
+                self._selected_device_event_code = user_input[CONF_EVENT_CODE]
                 self._selected_device = {}
                 selected_device_object = get_rfx_object(
                     self._selected_device_event_code
@@ -129,7 +130,7 @@ class OptionsFlow(config_entries.OptionsFlow):
             vol.Optional(
                 CONF_AUTOMATIC_ADD, default=self._config_entry.data[CONF_AUTOMATIC_ADD],
             ): bool,
-            vol.Optional(CONF_DEVICE_ID): str,
+            vol.Optional(CONF_EVENT_CODE): str,
             vol.Optional(CONF_DEVICE): vol.In(devices),
             vol.Optional(CONF_REMOVE_DEVICE): vol.In(devices),
         }
@@ -264,7 +265,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                 event_code = packet_id
                 break
 
-        data = {"event_code": event_code, "device_id": device_id}
+        data = {CONF_EVENT_CODE: event_code, CONF_DEVICE_ID: device_id}
 
         return data
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -67,18 +67,15 @@ class OptionsFlow(config_entries.OptionsFlow):
             }
             if CONF_DEVICE in user_input:
                 device_data = self._get_device_data(user_input[CONF_DEVICE])
-                if not device_data.get(CONF_EVENT_CODE):
-                    errors = {"base": "unknown_event_code"}
-                else:
-                    event_code = device_data[CONF_EVENT_CODE]
-                    self._selected_device_event_code = event_code
-                    self._selected_device = self._config_entry.data[CONF_DEVICES][
-                        event_code
-                    ]
-                    self._selected_device_object = get_rfx_object(
-                        self._selected_device_event_code
-                    )
-                    return await self.async_step_set_device_options()
+                event_code = device_data[CONF_EVENT_CODE]
+                self._selected_device_event_code = event_code
+                self._selected_device = self._config_entry.data[CONF_DEVICES][
+                    event_code
+                ]
+                self._selected_device_object = get_rfx_object(
+                    self._selected_device_event_code
+                )
+                return await self.async_step_set_device_options()
             if CONF_REMOVE_DEVICE in user_input:
                 device_data = self._get_device_data(user_input[CONF_REMOVE_DEVICE])
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -5,15 +5,24 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_COMMAND_OFF, CONF_COMMAND_ON
 from homeassistant.core import callback
 
 from . import DOMAIN
+from .const import (
+    CONF_AUTOMATIC_ADD,
+    CONF_DATA_BITS,
+    CONF_DEBUG,
+    CONF_FIRE_EVENT,
+    CONF_OFF_DELAY,
+    CONF_SIGNAL_REPETITIONS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class OptionsFlow(config_entries.OptionsFlow):
-    """Handle Vizio options."""
+    """Handle Rfxtrx options."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize vizio options flow."""
@@ -26,77 +35,21 @@ class OptionsFlow(config_entries.OptionsFlow):
     async def async_step_prompt_options(self, user_input=None):
         """Prompt for options."""
         if user_input is not None:
-            if user_input["selected_option"] == "Set global options":
-                return await self.async_step_global_options()
-            if user_input["selected_option"] == "Add device from discovery":
-                return await self.async_step_discovered_devices()
             if user_input["selected_option"] == "Add device by id":
                 return await self.async_step_device_by_id()
             if user_input["selected_option"] == "Configure device options":
                 return await self.async_step_select_device_conf()
 
-        options = [
-            "Set global options",
-            "Add device from discovery",
-            "Add device by id",
-            "Configure device options",
-            "Update device id",
-        ]
+        options = ["Add device by id", "Configure device options"]
 
         options_scheme = {
-            vol.Required("selected_option"): vol.In(options),
+            vol.Optional(CONF_DEBUG): bool,
+            vol.Optional(CONF_AUTOMATIC_ADD): bool,
+            vol.Optional("selected_option"): vol.In(options),
         }
 
         return self.async_show_form(
             step_id="prompt_options", data_schema=vol.Schema(options_scheme)
-        )
-
-    async def async_step_global_options(self, user_input=None):
-        """Manage global options."""
-        if user_input is not None:
-            return None
-
-        data_scheme = {
-            vol.Optional("debug"): bool,
-        }
-
-        return self.async_show_form(
-            step_id="global_options", data_schema=vol.Schema(data_scheme)
-        )
-
-    async def async_step_discovered_devices(self, user_input=None):
-        """Show discovered devices options."""
-        if user_input is not None:
-            return await self.async_step_set_device_options()
-
-        dummy_device_list = ["test1", "test2", "test3"]
-        device_class = ["light", "power", "window"]
-
-        data_scheme = {
-            vol.Optional("discovered_devices"): vol.In(dummy_device_list),
-            vol.Optional("device_class"): vol.In(device_class),
-        }
-
-        return self.async_show_form(
-            step_id="discovered_devices", data_schema=vol.Schema(data_scheme)
-        )
-
-    async def async_step_set_device_options(self, user_input=None):
-        """Manage device options."""
-        if user_input is not None:
-            return None
-
-        data_scheme = {
-            vol.Optional("fire_event"): bool,
-            vol.Optional("off_delay"): int,
-            vol.Optional("data_bit"): int,
-            vol.Optional("command_on"): int,
-            vol.Optional("command_off"): int,
-            vol.Optional("signal_repetitions"): int,
-        }
-
-        return self.async_show_form(
-            step_id="set_device_options", data_schema=vol.Schema(data_scheme)
         )
 
     async def async_step_device_by_id(self, user_input=None):
@@ -104,11 +57,8 @@ class OptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             return await self.async_step_set_device_options()
 
-        device_class = ["light", "power", "window"]
-
         data_scheme = {
             vol.Required("device_id"): int,
-            vol.Optional("device_class"): vol.In(device_class),
         }
 
         return self.async_show_form(
@@ -128,6 +78,27 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="select_device_conf", data_schema=vol.Schema(data_scheme)
+        )
+
+    async def async_step_set_device_options(self, user_input=None):
+        """Manage device options."""
+        if user_input is not None:
+            return None
+
+        device_class = ["light", "power", "window"]
+
+        data_scheme = {
+            vol.Optional("device_class"): vol.In(device_class),
+            vol.Optional(CONF_FIRE_EVENT): bool,
+            vol.Optional(CONF_OFF_DELAY): int,
+            vol.Optional(CONF_DATA_BITS): int,
+            vol.Optional(CONF_COMMAND_ON): int,
+            vol.Optional(CONF_COMMAND_OFF): int,
+            vol.Optional(CONF_SIGNAL_REPETITIONS): int,
+        }
+
+        return self.async_show_form(
+            step_id="set_device_options", data_schema=vol.Schema(data_scheme)
         )
 
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -141,7 +141,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                     if user_input.get(CONF_COMMAND_OFF)
                     else None
                 )
-            except NameError:
+            except (NameError, ValueError):
                 errors = {"base": "invalid_input_2262"}
 
             if not errors:
@@ -205,7 +205,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                 {
                     vol.Optional(
                         CONF_SIGNAL_REPETITIONS,
-                        default=device_data.get(CONF_SIGNAL_REPETITIONS),
+                        default=device_data.get(CONF_SIGNAL_REPETITIONS, 1),
                     ): int,
                 }
             )

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -7,6 +7,8 @@ CONF_SIGNAL_REPETITIONS = "signal_repetitions"
 CONF_DEBUG = "debug"
 CONF_OFF_DELAY = "off_delay"
 
+CONF_REMOVE_DEVICE = "remove_device"
+
 COMMAND_ON_LIST = [
     "On",
     "Up",

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -1,5 +1,11 @@
 """Constants for RFXtrx integration."""
 
+CONF_FIRE_EVENT = "fire_event"
+CONF_DATA_BITS = "data_bits"
+CONF_AUTOMATIC_ADD = "automatic_add"
+CONF_SIGNAL_REPETITIONS = "signal_repetitions"
+CONF_DEBUG = "debug"
+CONF_OFF_DELAY = "off_delay"
 
 COMMAND_ON_LIST = [
     "On",

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -20,15 +20,17 @@ from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 _LOGGER = logging.getLogger(__name__)
 
 
+def supported(event):
+    """Return whether an event supports cover."""
+    return event.device.known_to_be_rollershutter
+
+
 async def async_setup_entry(
     hass, config_entry, async_add_entities,
 ):
     """Set up config entry."""
     discovery_info = config_entry.data
     device_ids = set()
-
-    def supported(event):
-        return event.device.known_to_be_rollershutter
 
     entities = []
     for packet_id, entity_info in discovery_info[CONF_DEVICES].items():

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -28,18 +28,20 @@ _LOGGER = logging.getLogger(__name__)
 SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 
 
+def supported(event):
+    """Return whether an event supports light."""
+    return (
+        isinstance(event.device, rfxtrxmod.LightingDevice)
+        and event.device.known_to_be_dimmable
+    )
+
+
 async def async_setup_entry(
     hass, config_entry, async_add_entities,
 ):
     """Set up config entry."""
     discovery_info = config_entry.data
     device_ids = set()
-
-    def supported(event):
-        return (
-            isinstance(event.device, rfxtrxmod.LightingDevice)
-            and event.device.known_to_be_dimmable
-        )
 
     # Add switch from config file
     entities = []

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -3,6 +3,6 @@
   "name": "RFXCOM RFXtrx",
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "requirements": ["pyRFXtrx==0.25"],
-  "codeowners": ["@danielhiversen", "@elupus"],
+  "codeowners": ["@danielhiversen", "@elupus", "@RobBie1221"],
   "config_flow": false
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -27,7 +27,9 @@
     },
     "error": {
       "invalid_event_code": "Invalid event code",
-      "invalid_input_2262": "Invalid input for command on/off",
+      "invalid_input_2262_on": "Invalid input for command on",
+      "invalid_input_2262_off": "Invalid input for command off",
+      "invalid_input_off_delay": "Invalid input for off delay",
       "unknown": "Unexpected error"
     }
   }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -27,7 +27,6 @@
     },
     "error": {
       "invalid_event_code": "Invalid event code",
-      "unknown_event_code": "Unable to find event code",
       "invalid_input_2262": "Invalid input for command on/off",
       "unknown": "Unexpected error"
     }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -1,26 +1,35 @@
 {
   "title": "Rfxtrx",
-  "config": {
-    "flow_title": "Rfxtrx",
-    "step": {
-      "init": {
-        "data": {}
-      }
-    },
-    "error": {
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    }
-  },
   "options": {
     "step": {
       "prompt_options": {
         "data": {
-          "selected_option": "Select configuration option"
-        }
+          "debug": "Enable debugging",
+          "automatic_add": "Enable automatic add",
+          "event_code": "Enter event code to add",
+          "device": "Select device to configure",
+          "remove_device": "Select device to delete"
+        },
+        "title": "Rfxtrx Options"
+      },
+      "set_device_options": {
+        "data": {
+          "fire_event": "Enable device event",
+          "off_delay": "Off delay",
+          "off_delay_enabled": "Enable off delay",
+          "data_bit": "Number of data bits",
+          "command_on": "Data bits value for command on",
+          "command_off": "Data bits value for command off",
+          "signal_repetitions": "Number of signal repetitions"
+        },
+        "title": "Configure device options"
       }
+    },
+    "error": {
+      "invalid_event_code": "Invalid event code",
+      "unknown_event_code": "Unable to find event code",
+      "invalid_input_2262": "Invalid input for command on/off",
+      "unknown": "Unexpected error"
     }
   }
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -1,9 +1,26 @@
 {
-    "config": {
-        "step": {},
-        "error": {},
-        "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-        }
+  "title": "Rfxtrx",
+  "config": {
+    "flow_title": "Rfxtrx",
+    "step": {
+      "init": {
+        "data": {}
+      }
+    },
+    "error": {
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
+  },
+  "options": {
+    "step": {
+      "prompt_options": {
+        "data": {
+          "selected_option": "Select configuration option"
+        }
+      }
+    }
+  }
 }

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -25,20 +25,22 @@ DATA_SWITCH = f"{DOMAIN}_switch"
 _LOGGER = logging.getLogger(__name__)
 
 
+def supported(event):
+    """Return whether an event supports switch."""
+    return (
+        isinstance(event.device, rfxtrxmod.LightingDevice)
+        and not event.device.known_to_be_dimmable
+        and not event.device.known_to_be_rollershutter
+        or isinstance(event.device, rfxtrxmod.RfyDevice)
+    )
+
+
 async def async_setup_entry(
     hass, config_entry, async_add_entities,
 ):
     """Set up config entry."""
     discovery_info = config_entry.data
     device_ids = set()
-
-    def supported(event):
-        return (
-            isinstance(event.device, rfxtrxmod.LightingDevice)
-            and not event.device.known_to_be_dimmable
-            and not event.device.known_to_be_rollershutter
-            or isinstance(event.device, rfxtrxmod.RfyDevice)
-        )
 
     # Add switch from config file
     entities = []

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -26,7 +26,6 @@
         },
         "error": {
             "invalid_event_code": "Invalid event code",
-            "unknown_event_code": "Unable to find event code",
             "invalid_input_2262": "Invalid input for command on/off",
             "unknown": "Unexpected error"
         }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -5,7 +5,7 @@
                 "data": {
                   "debug": "Enable debugging",
                   "automatic_add": "Enable automatic add",
-                  "device_id": "Select device id to add",
+                  "device_id": "Enter device id to add",
                   "device": "Select device to configure",
                   "remove_device": "Select device to delete"
                 },

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -14,6 +14,7 @@
                 "data": {
                   "fire_event": "Enable device event",
                   "off_delay": "Off delay",
+                  "off_delay_enabled": "Enable off delay",
                   "data_bit": "Number of data bits",
                   "command_on": "Data bits value for command on",
                   "command_off": "Data bits value for command off",

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -25,6 +25,7 @@
             }
         },
         "error": {
+            "invalid_event_code": "Invalid event code",
             "unknown_event_code": "Unable to find event code",
             "invalid_input_2262": "Invalid input for command on/off",
             "unknown": "Unexpected error"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -26,7 +26,9 @@
         },
         "error": {
             "invalid_event_code": "Invalid event code",
-            "invalid_input_2262": "Invalid input for command on/off",
+            "invalid_input_2262_on": "Invalid input for command on",
+            "invalid_input_2262_off": "Invalid input for command off",
+            "invalid_input_off_delay": "Invalid input for off delay",
             "unknown": "Unexpected error"
         }
     },

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -6,7 +6,8 @@
                   "debug": "Enable debugging",
                   "automatic_add": "Enable automatic add",
                   "device_id": "Select device id to add",
-                  "device": "Select device to configure"
+                  "device": "Select device to configure",
+                  "remove_device": "Select device to delete"
                 },
                 "title": "Rfxtrx Options"
             },
@@ -22,6 +23,11 @@
                 },
                 "title": "Configure device options"
             }
+        },
+        "error": {
+            "unknown_event_code": "Unable to find event code",
+            "invalid_input_2262": "Invalid input for command on/off",
+            "unknown": "Unexpected error"
         }
     },
     "title": "Rfxtrx"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -3,15 +3,11 @@
         "step": {
             "prompt_options": {
                 "data": {
+                  "debug": "Enable debugging",
+                  "automatic_add": "Enable automatic add",
                   "selected_option": "Select configuration option"
                 },
                 "title": "Rfxtrx Options"
-            },
-            "global_options": {
-                "data": {
-                  "debug": "Enable debugging"
-                },
-                "title": "Global Rfxtrx Options"
             },
             "discovered_devices": {
                 "data": {
@@ -46,5 +42,5 @@
             }
         }
     },
-    "title": "Demo"
+    "title": "Rfxtrx"
 }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -5,16 +5,10 @@
                 "data": {
                   "debug": "Enable debugging",
                   "automatic_add": "Enable automatic add",
-                  "selected_option": "Select configuration option"
+                  "device_id": "Select device id to add",
+                  "device": "Select device to configure"
                 },
                 "title": "Rfxtrx Options"
-            },
-            "discovered_devices": {
-                "data": {
-                  "discovered_devices": "Select device",
-                  "device_class": "Select device class"
-                },
-                "title": "Discovered devices"
             },
             "set_device_options": {
                 "data": {
@@ -26,19 +20,6 @@
                   "signal_repetitions": "Number of signal repetitions"
                 },
                 "title": "Configure device options"
-            },
-            "device_by_id": {
-                "data": {
-                    "device_id": "Device id",
-                    "device_class": "Select device class"
-                },
-                "title": "Enter device id"
-            },
-            "select_device_conf": {
-                "data": {
-                    "configured_devices": "Select configured device"
-                },
-                "title": "Enter device id"
             }
         }
     },

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,9 +1,50 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-        },
-        "error": {},
-        "step": {}
-    }
+    "options": {
+        "step": {
+            "prompt_options": {
+                "data": {
+                  "selected_option": "Select configuration option"
+                },
+                "title": "Rfxtrx Options"
+            },
+            "global_options": {
+                "data": {
+                  "debug": "Enable debugging"
+                },
+                "title": "Global Rfxtrx Options"
+            },
+            "discovered_devices": {
+                "data": {
+                  "discovered_devices": "Select device",
+                  "device_class": "Select device class"
+                },
+                "title": "Discovered devices"
+            },
+            "set_device_options": {
+                "data": {
+                  "fire_event": "Enable device event",
+                  "off_delay": "Off delay",
+                  "data_bit": "Number of data bits",
+                  "command_on": "Data bits value for command on",
+                  "command_off": "Data bits value for command off",
+                  "signal_repetitions": "Number of signal repetitions"
+                },
+                "title": "Configure device options"
+            },
+            "device_by_id": {
+                "data": {
+                    "device_id": "Device id",
+                    "device_class": "Select device class"
+                },
+                "title": "Enter device id"
+            },
+            "select_device_conf": {
+                "data": {
+                    "configured_devices": "Select configured device"
+                },
+                "title": "Enter device id"
+            }
+        }
+    },
+    "title": "Demo"
 }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -5,7 +5,7 @@
                 "data": {
                   "debug": "Enable debugging",
                   "automatic_add": "Enable automatic add",
-                  "device_id": "Enter device id to add",
+                  "event_code": "Enter event code to add",
                   "device": "Select device to configure",
                   "remove_device": "Select device to delete"
                 },

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -44,4 +44,3 @@ async def test_import_update(hass):
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data["debug"]

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -108,6 +108,18 @@ async def test_options_add_device(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
 
+    # Try with invalid event code
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"debug": True, "automatic_add": True, "event_code": "1234"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+    assert result["errors"]
+    assert result["errors"]["event_code"] == "invalid_event_code"
+
+    # Try with valid event code
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
@@ -179,12 +191,7 @@ async def test_options_add_remove_device(hass):
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={
-            "fire_event": True,
-            "signal_repetitions": 5,
-            "off_delay_enabled": True,
-            "off_delay": 4,
-        },
+        user_input={"fire_event": True, "signal_repetitions": 5, "off_delay": "4"},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -277,6 +284,25 @@ async def test_options_add_and_configure_device(hass):
             "fire_event": False,
             "signal_repetitions": 5,
             "data_bits": 4,
+            "off_delay": "abcdef",
+            "command_on": "xyz",
+            "command_off": "xyz",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+    assert result["errors"]
+    assert result["errors"]["off_delay"] == "invalid_input_off_delay"
+    assert result["errors"]["command_on"] == "invalid_input_2262_on"
+    assert result["errors"]["command_off"] == "invalid_input_2262_off"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "fire_event": False,
+            "signal_repetitions": 5,
+            "data_bits": 4,
             "command_on": "0xE",
             "command_off": "0x7",
         },
@@ -329,8 +355,7 @@ async def test_options_add_and_configure_device(hass):
             "data_bits": 4,
             "command_on": "0xE",
             "command_off": "0x7",
-            "off_delay_enabled": True,
-            "off_delay": 9,
+            "off_delay": "9",
         },
     )
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -113,7 +113,7 @@ async def test_options_add_device(hass):
         user_input={
             "debug": True,
             "automatic_add": True,
-            "device_id": "0b1100cd0213c7f230010f71",
+            "event_code": "0b1100cd0213c7f230010f71",
         },
     )
 
@@ -170,7 +170,7 @@ async def test_options_add_remove_device(hass):
         user_input={
             "debug": True,
             "automatic_add": True,
-            "device_id": "0b1100cd0213c7f230010f71",
+            "event_code": "0b1100cd0213c7f230010f71",
         },
     )
 
@@ -264,7 +264,7 @@ async def test_options_add_and_configure_device(hass):
         user_input={
             "debug": True,
             "automatic_add": True,
-            "device_id": "0913000022670e013970",
+            "event_code": "0913000022670e013970",
         },
     )
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -305,6 +305,7 @@ async def test_options_add_and_configure_device(hass):
             "data_bits": 4,
             "command_on": "0xE",
             "command_off": "0x7",
+            "off_delay": "9",
         },
     )
 
@@ -318,7 +319,7 @@ async def test_options_add_and_configure_device(hass):
     assert entry.data["devices"]["0913000022670e013970"]
     assert not entry.data["devices"]["0913000022670e013970"]["fire_event"]
     assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
-    assert "delay_off" not in entry.data["devices"]["0913000022670e013970"]
+    assert entry.data["devices"]["0913000022670e013970"]["off_delay"] == 9
 
     state = hass.states.get("binary_sensor.pt2262_22670e")
     assert state
@@ -355,7 +356,6 @@ async def test_options_add_and_configure_device(hass):
             "data_bits": 4,
             "command_on": "0xE",
             "command_off": "0x7",
-            "off_delay": "9",
         },
     )
 
@@ -366,4 +366,4 @@ async def test_options_add_and_configure_device(hass):
     assert entry.data["devices"]["0913000022670e013970"]
     assert entry.data["devices"]["0913000022670e013970"]["fire_event"]
     assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
-    assert entry.data["devices"]["0913000022670e013970"]["off_delay"] == 9
+    assert "delay_off" not in entry.data["devices"]["0913000022670e013970"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- yaml support is limited to one-time import
- Options must be set through the UI once import is done (global options/add device/remove device/change device options)
- For newly added or detected devices, device_class cannot be set. Instead, it should be set by customizing entities:
https://www.home-assistant.io/docs/configuration/customizing-devices/

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement an option flow for Rfxtrx integration to:
- Change global options
- Change device options
- Add new devices by id

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14158

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
