### PR TITLE
Add Xiaomi Aqara wireless and light switches (2020 model)

### DIFF
--- a/homeassistant/components/xiaomi_aqara/binary_sensor.py
+++ b/homeassistant/components/xiaomi_aqara/binary_sensor.py
@@ -57,6 +57,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             "sensor_86sw1",
             "sensor_86sw1.aq1",
             "remote.b186acn01",
+            "remote.b186acn02",
         ]:
             if "proto" not in entity or int(entity["proto"][0:1]) == 1:
                 data_key = "channel_0"
@@ -72,6 +73,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             "sensor_86sw2",
             "sensor_86sw2.aq1",
             "remote.b286acn01",
+            "remote.b286acn02",
         ]:
             if "proto" not in entity or int(entity["proto"][0:1]) == 1:
                 data_key_left = "channel_0"

--- a/homeassistant/components/xiaomi_aqara/manifest.json
+++ b/homeassistant/components/xiaomi_aqara/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Gateway (Aqara)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_aqara",
-  "requirements": ["PyXiaomiGateway==0.12.4"],
+  "requirements": ["PyXiaomiGateway==0.13.2"],
   "after_dependencies": ["discovery"],
   "codeowners": ["@danielhiversen", "@syssi"],
   "zeroconf": ["_miio._udp.local."]

--- a/homeassistant/components/xiaomi_aqara/switch.py
+++ b/homeassistant/components/xiaomi_aqara/switch.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     device, "Plug", data_key, True, gateway, config_entry
                 )
             )
-        elif model in ["ctrl_neutral1", "ctrl_neutral1.aq1"]:
+        elif model in ["ctrl_neutral1", "ctrl_neutral1.aq1", "switch_b1lacn02"]:
             entities.append(
                 XiaomiGenericSwitch(
                     device, "Wall Switch", "channel_0", False, gateway, config_entry
@@ -49,7 +49,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     device, "Wall Switch LN", "channel_0", False, gateway, config_entry
                 )
             )
-        elif model in ["ctrl_neutral2", "ctrl_neutral2.aq1"]:
+        elif model in ["ctrl_neutral2", "ctrl_neutral2.aq1", "switch_b2lacn02"]:
             entities.append(
                 XiaomiGenericSwitch(
                     device,
@@ -70,7 +70,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     config_entry,
                 )
             )
-        elif model in ["ctrl_ln2", "ctrl_ln2.aq1"]:
+        elif model in ["ctrl_ln2", "ctrl_ln2.aq1", "switch_b2nacn02"]:
             entities.append(
                 XiaomiGenericSwitch(
                     device,

--- a/homeassistant/components/xiaomi_aqara/switch.py
+++ b/homeassistant/components/xiaomi_aqara/switch.py
@@ -43,7 +43,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     device, "Wall Switch", "channel_0", False, gateway, config_entry
                 )
             )
-        elif model in ["ctrl_ln1", "ctrl_ln1.aq1"]:
+        elif model in ["ctrl_ln1", "ctrl_ln1.aq1", "switch_b1nacn02"]:
             entities.append(
                 XiaomiGenericSwitch(
                     device, "Wall Switch LN", "channel_0", False, gateway, config_entry

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -71,7 +71,7 @@ PyTurboJPEG==1.4.0
 PyViCare==0.2.0
 
 # homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.12.4
+PyXiaomiGateway==0.13.2
 
 # homeassistant.components.bmp280
 # homeassistant.components.mcp23017

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -31,7 +31,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.4.0
 
 # homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.12.4
+PyXiaomiGateway==0.13.2
 
 # homeassistant.components.remember_the_milk
 RtmAPI==0.7.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable the xiaomi_aqara integration to add the following new models of wireless and light switches as devices to Home Assistant:
- Aqara D1 1 Gang No Neutral Wall Switch (QBKG21LM) (lumi.switch.b1lacn02)
- Aqara D1 2 Gang No Neutral Wall Switch (QBKG22LM) (lumi.switch.b2lacn02)
- Aqara D1 2 Gang Wall Switch (QBKG24LM) (lumi.switch.b2nacn02)
- Aqara D1 Wireless Remote Switch (Single Rocker) (WXKG06LM) (lumi.remote.b186acn02)
- Aqara D1 Wireless Remote Switch (Double Rocker) (WXKG07LM) (lumi.remote.b286acn02)

The same entries of devices need to be added to the list of devices in [PyXiaomiGateway](https://github.com/Danielhiversen/PyXiaomiGateway) that `xiaomi_aqara` depends on as well. See [this](Danielhiversen/PyXiaomiGateway#174) 

Release notes `PyXiaomiGateway`:
- <https://github.com/Danielhiversen/PyXiaomiGateway/releases/tag/0.13.0>
- <https://github.com/Danielhiversen/PyXiaomiGateway/releases/tag/0.13.1>
- <https://github.com/Danielhiversen/PyXiaomiGateway/releases/tag/0.13.2>

Changelog: <https://github.com/Danielhiversen/PyXiaomiGateway/compare/0.12.4...0.13.2>



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
