### PR TITLE
Fixing some of the color correction math

### DIFF
--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -30,8 +30,8 @@ COLOR_CHANNEL_COLD_WHITE = 0x02
 COLOR_CHANNEL_RED = 0x04
 COLOR_CHANNEL_GREEN = 0x08
 COLOR_CHANNEL_BLUE = 0x10
-TEMP_COLOR_MAX = 500  # mireds (inverted)
-TEMP_COLOR_MIN = 154
+TEMP_COLOR_MAX = 370   #mired equivalend of 2700K
+TEMP_COLOR_MIN = 154   #mired equivalent of 6500K
 TEMP_COLOR_DIFF = TEMP_COLOR_MAX - TEMP_COLOR_MIN
 
 
@@ -194,9 +194,11 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
 
         elif color_temp is not None:
             cold = round((TEMP_COLOR_MAX - round(color_temp)) / TEMP_COLOR_DIFF * 255)
+            if cold < 0:
+                cold = 0
+            if cold > 255:
+                cold = 255
             warm = 255 - cold
-            if warm < 0:
-                warm = 0
             rgbw = f"#000000{warm:02x}{cold:02x}"
 
         if rgbw and self.values.color:

--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -30,8 +30,8 @@ COLOR_CHANNEL_COLD_WHITE = 0x02
 COLOR_CHANNEL_RED = 0x04
 COLOR_CHANNEL_GREEN = 0x08
 COLOR_CHANNEL_BLUE = 0x10
-TEMP_COLOR_MAX = 370   #mired equivalend of 2700K
-TEMP_COLOR_MIN = 154   #mired equivalent of 6500K
+TEMP_COLOR_MAX = 370   # mired equivalend of 2700K
+TEMP_COLOR_MIN = 154   # mired equivalent of 6500K
 TEMP_COLOR_DIFF = TEMP_COLOR_MAX - TEMP_COLOR_MIN
 
 
@@ -193,11 +193,7 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
                 rgbw = f"#00000000{white:02x}"
 
         elif color_temp is not None:
-            cold = round((TEMP_COLOR_MAX - round(color_temp)) / TEMP_COLOR_DIFF * 255)
-            if cold < 0:
-                cold = 0
-            if cold > 255:
-                cold = 255
+            cold = max(0, min( 255, round((TEMP_COLOR_MAX - round(color_temp)) / TEMP_COLOR_DIFF * 255))
             warm = 255 - cold
             rgbw = f"#000000{warm:02x}{cold:02x}"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Lower mireds for max (cool) color temp 500 -> 370  (changes lower color temp from 2000K to 2700K, which is more in line with most common CCT bulbs)
I'd love to add a variable to adjust the max/min per bulb (in case that bulb supports amber/UV to give fuller range), but that is out of my depth.

Also added limit math to the color temp calculation to prevent overflow/underflow (if you provide 1000K or 9000K color temp values, it just gives you the min/max, not random numbers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  This continues @firstof9 's work (PR#37636) on the ozw integration and rgb lights 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
