### PR TITLE
Index the device registry

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1,7 +1,7 @@
 """Provide a way to connect entities belonging to one device."""
 from collections import OrderedDict
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 import uuid
 
 import attr
@@ -31,6 +31,11 @@ CLEANUP_DELAY = 10
 CONNECTION_NETWORK_MAC = "mac"
 CONNECTION_UPNP = "upnp"
 CONNECTION_ZIGBEE = "zigbee"
+
+IDX_CONNECTIONS = "connections"
+IDX_IDENTIFIERS = "identifiers"
+REGISTERED_DEVICE = "registered"
+DELETED_DEVICE = "deleted"
 
 
 @attr.s(slots=True, frozen=True)
@@ -98,11 +103,13 @@ class DeviceRegistry:
 
     devices: Dict[str, DeviceEntry]
     deleted_devices: Dict[str, DeletedDeviceEntry]
+    _devices_index: Dict[str, Dict[str, Dict[str, str]]]
 
     def __init__(self, hass: HomeAssistantType) -> None:
         """Initialize the device registry."""
         self.hass = hass
         self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self._clear_index()
 
     @callback
     def async_get(self, device_id: str) -> Optional[DeviceEntry]:
@@ -114,24 +121,103 @@ class DeviceRegistry:
         self, identifiers: set, connections: set
     ) -> Optional[DeviceEntry]:
         """Check if device is registered."""
-        for device in self.devices.values():
-            if any(iden in device.identifiers for iden in identifiers) or any(
-                conn in device.connections for conn in connections
-            ):
-                return device
-        return None
+        device_id = self._async_get_device_id_from_index(
+            REGISTERED_DEVICE, identifiers, connections
+        )
+        if device_id is None:
+            return None
+        return self.devices[device_id]
 
-    @callback
     def _async_get_deleted_device(
         self, identifiers: set, connections: set
     ) -> Optional[DeletedDeviceEntry]:
+        """Check if device is deleted."""
+        device_id = self._async_get_device_id_from_index(
+            DELETED_DEVICE, identifiers, connections
+        )
+        if device_id is None:
+            return None
+        return self.deleted_devices[device_id]
+
+    def _async_get_device_id_from_index(
+        self, index: str, identifiers: set, connections: set
+    ) -> Optional[str]:
         """Check if device has previously been registered."""
-        for device in self.deleted_devices.values():
-            if any(iden in device.identifiers for iden in identifiers) or any(
-                conn in device.connections for conn in connections
-            ):
-                return device
+        _devices_index = self._devices_index[index]
+        for identifier in identifiers:
+            if identifier in _devices_index[IDX_IDENTIFIERS]:
+                return _devices_index[IDX_IDENTIFIERS][identifier]
+        if not connections:
+            return None
+        for connection in _normalize_connections(connections):
+            if connection in _devices_index[IDX_CONNECTIONS]:
+                return _devices_index[IDX_CONNECTIONS][connection]
         return None
+
+    def _add_device(self, device: Union[DeviceEntry, DeletedDeviceEntry]) -> None:
+        """Add a device and index it."""
+        if isinstance(device, DeletedDeviceEntry):
+            device_index = self._devices_index[DELETED_DEVICE]
+            self.deleted_devices[device.id] = device
+        else:
+            device_index = self._devices_index[REGISTERED_DEVICE]
+            self.devices[device.id] = device
+
+        self._add_device_to_index(device_index, device)
+
+    def _add_device_to_index(
+        self, device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+    ) -> None:
+        """Add a device to the index."""
+        for identifier in device.identifiers:
+            device_index[IDX_IDENTIFIERS][identifier] = device.id
+        for connection in device.connections:
+            device_index[IDX_CONNECTIONS][connection] = device.id
+
+    def _remove_device(self, device: Union[DeviceEntry, DeletedDeviceEntry]) -> None:
+        """Remove a device and remove it from the index."""
+        if isinstance(device, DeletedDeviceEntry):
+            device_index = self._devices_index[DELETED_DEVICE]
+            self.deleted_devices.pop(device.id)
+        else:
+            device_index = self._devices_index[REGISTERED_DEVICE]
+            self.devices.pop(device.id)
+
+        self._remove_device_from_index(device_index, device)
+
+    def _remove_device_from_index(
+        self, device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+    ) -> None:
+        """Remove a device from the index."""
+        for identifier in device.identifiers:
+            if identifier in device_index[IDX_IDENTIFIERS]:
+                del device_index[IDX_IDENTIFIERS][identifier]
+        for connection in device.connections:
+            if connection in device_index[IDX_CONNECTIONS]:
+                del device_index[IDX_CONNECTIONS][connection]
+
+    def _update_device(self, old_device: DeviceEntry, new_device: DeviceEntry) -> None:
+        """Update a device and the index."""
+        self.devices[new_device.id] = new_device
+
+        device_index = self._devices_index[REGISTERED_DEVICE]
+        self._remove_device_from_index(device_index, old_device)
+        self._add_device_to_index(device_index, new_device)
+
+    def _clear_index(self):
+        """Clear the index."""
+        self._devices_index = {
+            REGISTERED_DEVICE: {IDX_IDENTIFIERS: {}, IDX_CONNECTIONS: {}},
+            DELETED_DEVICE: {IDX_IDENTIFIERS: {}, IDX_CONNECTIONS: {}},
+        }
+
+    def _rebuild_index(self):
+        """Create the index after loading devices."""
+        self._clear_index()
+        for device in self.devices.values():
+            self._add_device_to_index(self._devices_index[REGISTERED_DEVICE], device)
+        for device in self.deleted_devices.values():
+            self._add_device_to_index(self._devices_index[DELETED_DEVICE], device)
 
     @callback
     def async_get_or_create(
@@ -156,11 +242,8 @@ class DeviceRegistry:
 
         if connections is None:
             connections = set()
-
-        connections = {
-            (key, format_mac(value)) if key == CONNECTION_NETWORK_MAC else (key, value)
-            for key, value in connections
-        }
+        else:
+            connections = _normalize_connections(connections)
 
         device = self.async_get_device(identifiers, connections)
 
@@ -169,9 +252,9 @@ class DeviceRegistry:
             if deleted_device is None:
                 device = DeviceEntry(is_new=True)
             else:
-                self.deleted_devices.pop(deleted_device.id)
+                self._remove_device(deleted_device)
                 device = deleted_device.to_device_entry()
-            self.devices[device.id] = device
+            self._add_device(device)
 
         if via_device is not None:
             via = self.async_get_device({via_device}, set())
@@ -301,7 +384,8 @@ class DeviceRegistry:
         if not changes:
             return old
 
-        new = self.devices[device_id] = attr.evolve(old, **changes)
+        new = attr.evolve(old, **changes)
+        self._update_device(old, new)
         self.async_schedule_save()
 
         self.hass.bus.async_fire(
@@ -317,12 +401,15 @@ class DeviceRegistry:
     @callback
     def async_remove_device(self, device_id: str) -> None:
         """Remove a device from the device registry."""
-        device = self.devices.pop(device_id)
-        self.deleted_devices[device_id] = DeletedDeviceEntry(
-            config_entries=device.config_entries,
-            connections=device.connections,
-            identifiers=device.identifiers,
-            id=device.id,
+        device = self.devices[device_id]
+        self._remove_device(device)
+        self._add_device(
+            DeletedDeviceEntry(
+                config_entries=device.config_entries,
+                connections=device.connections,
+                identifiers=device.identifiers,
+                id=device.id,
+            )
         )
         self.hass.bus.async_fire(
             EVENT_DEVICE_REGISTRY_UPDATED, {"action": "remove", "device_id": device_id}
@@ -371,6 +458,7 @@ class DeviceRegistry:
 
         self.devices = devices
         self.deleted_devices = deleted_devices
+        self._rebuild_index()
 
     @callback
     def async_schedule_save(self) -> None:
@@ -422,9 +510,11 @@ class DeviceRegistry:
                 continue
             if config_entries == {config_entry_id}:
                 # Permanently remove the device from the device registry.
-                del self.deleted_devices[deleted_device.id]
+                self._remove_device(deleted_device)
             else:
                 config_entries = config_entries - {config_entry_id}
+                # No need to reindex here since we currently
+                # do not have a lookup by config entry
                 self.deleted_devices[deleted_device.id] = attr.evolve(
                     deleted_device, config_entries=config_entries
                 )
@@ -536,3 +626,11 @@ def async_setup_cleanup(hass: HomeAssistantType, dev_reg: DeviceRegistry) -> Non
         await debounced_cleanup.async_call()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, startup_clean)
+
+
+def _normalize_connections(connections: set) -> set:
+    """Normalize connections to ensure we can match mac addresses."""
+    return {
+        (key, format_mac(value)) if key == CONNECTION_NETWORK_MAC else (key, value)
+        for key, value in connections
+    }

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -143,46 +143,46 @@ class DeviceRegistry:
         self, index: str, identifiers: set, connections: set
     ) -> Optional[str]:
         """Check if device has previously been registered."""
-        _devices_index = self._devices_index[index]
+        devices_index = self._devices_index[index]
         for identifier in identifiers:
-            if identifier in _devices_index[IDX_IDENTIFIERS]:
-                return _devices_index[IDX_IDENTIFIERS][identifier]
+            if identifier in devices_index[IDX_IDENTIFIERS]:
+                return devices_index[IDX_IDENTIFIERS][identifier]
         if not connections:
             return None
         for connection in _normalize_connections(connections):
-            if connection in _devices_index[IDX_CONNECTIONS]:
-                return _devices_index[IDX_CONNECTIONS][connection]
+            if connection in devices_index[IDX_CONNECTIONS]:
+                return devices_index[IDX_CONNECTIONS][connection]
         return None
 
     def _add_device(self, device: Union[DeviceEntry, DeletedDeviceEntry]) -> None:
         """Add a device and index it."""
         if isinstance(device, DeletedDeviceEntry):
-            device_index = self._devices_index[DELETED_DEVICE]
+            devices_index = self._devices_index[DELETED_DEVICE]
             self.deleted_devices[device.id] = device
         else:
-            device_index = self._devices_index[REGISTERED_DEVICE]
+            devices_index = self._devices_index[REGISTERED_DEVICE]
             self.devices[device.id] = device
 
-        _add_device_to_index(device_index, device)
+        _add_device_to_index(devices_index, device)
 
     def _remove_device(self, device: Union[DeviceEntry, DeletedDeviceEntry]) -> None:
         """Remove a device and remove it from the index."""
         if isinstance(device, DeletedDeviceEntry):
-            device_index = self._devices_index[DELETED_DEVICE]
+            devices_index = self._devices_index[DELETED_DEVICE]
             self.deleted_devices.pop(device.id)
         else:
-            device_index = self._devices_index[REGISTERED_DEVICE]
+            devices_index = self._devices_index[REGISTERED_DEVICE]
             self.devices.pop(device.id)
 
-        _remove_device_from_index(device_index, device)
+        _remove_device_from_index(devices_index, device)
 
     def _update_device(self, old_device: DeviceEntry, new_device: DeviceEntry) -> None:
         """Update a device and the index."""
         self.devices[new_device.id] = new_device
 
-        device_index = self._devices_index[REGISTERED_DEVICE]
-        _remove_device_from_index(device_index, old_device)
-        _add_device_to_index(device_index, new_device)
+        devices_index = self._devices_index[REGISTERED_DEVICE]
+        _remove_device_from_index(devices_index, old_device)
+        _add_device_to_index(devices_index, new_device)
 
     def _clear_index(self):
         """Clear the index."""
@@ -617,22 +617,22 @@ def _normalize_connections(connections: set) -> set:
 
 
 def _add_device_to_index(
-    device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+    devices_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
 ) -> None:
     """Add a device to the index."""
     for identifier in device.identifiers:
-        device_index[IDX_IDENTIFIERS][identifier] = device.id
+        devices_index[IDX_IDENTIFIERS][identifier] = device.id
     for connection in device.connections:
-        device_index[IDX_CONNECTIONS][connection] = device.id
+        devices_index[IDX_CONNECTIONS][connection] = device.id
 
 
 def _remove_device_from_index(
-    device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+    devices_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
 ) -> None:
     """Remove a device from the index."""
     for identifier in device.identifiers:
-        if identifier in device_index[IDX_IDENTIFIERS]:
-            del device_index[IDX_IDENTIFIERS][identifier]
+        if identifier in devices_index[IDX_IDENTIFIERS]:
+            del devices_index[IDX_IDENTIFIERS][identifier]
     for connection in device.connections:
-        if connection in device_index[IDX_CONNECTIONS]:
-            del device_index[IDX_CONNECTIONS][connection]
+        if connection in devices_index[IDX_CONNECTIONS]:
+            del devices_index[IDX_CONNECTIONS][connection]

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -163,16 +163,7 @@ class DeviceRegistry:
             device_index = self._devices_index[REGISTERED_DEVICE]
             self.devices[device.id] = device
 
-        self._add_device_to_index(device_index, device)
-
-    def _add_device_to_index(
-        self, device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
-    ) -> None:
-        """Add a device to the index."""
-        for identifier in device.identifiers:
-            device_index[IDX_IDENTIFIERS][identifier] = device.id
-        for connection in device.connections:
-            device_index[IDX_CONNECTIONS][connection] = device.id
+        _add_device_to_index(device_index, device)
 
     def _remove_device(self, device: Union[DeviceEntry, DeletedDeviceEntry]) -> None:
         """Remove a device and remove it from the index."""
@@ -183,26 +174,15 @@ class DeviceRegistry:
             device_index = self._devices_index[REGISTERED_DEVICE]
             self.devices.pop(device.id)
 
-        self._remove_device_from_index(device_index, device)
-
-    def _remove_device_from_index(
-        self, device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
-    ) -> None:
-        """Remove a device from the index."""
-        for identifier in device.identifiers:
-            if identifier in device_index[IDX_IDENTIFIERS]:
-                del device_index[IDX_IDENTIFIERS][identifier]
-        for connection in device.connections:
-            if connection in device_index[IDX_CONNECTIONS]:
-                del device_index[IDX_CONNECTIONS][connection]
+        _remove_device_from_index(device_index, device)
 
     def _update_device(self, old_device: DeviceEntry, new_device: DeviceEntry) -> None:
         """Update a device and the index."""
         self.devices[new_device.id] = new_device
 
         device_index = self._devices_index[REGISTERED_DEVICE]
-        self._remove_device_from_index(device_index, old_device)
-        self._add_device_to_index(device_index, new_device)
+        _remove_device_from_index(device_index, old_device)
+        _add_device_to_index(device_index, new_device)
 
     def _clear_index(self):
         """Clear the index."""
@@ -215,9 +195,9 @@ class DeviceRegistry:
         """Create the index after loading devices."""
         self._clear_index()
         for device in self.devices.values():
-            self._add_device_to_index(self._devices_index[REGISTERED_DEVICE], device)
+            _add_device_to_index(self._devices_index[REGISTERED_DEVICE], device)
         for device in self.deleted_devices.values():
-            self._add_device_to_index(self._devices_index[DELETED_DEVICE], device)
+            _add_device_to_index(self._devices_index[DELETED_DEVICE], device)
 
     @callback
     def async_get_or_create(
@@ -634,3 +614,25 @@ def _normalize_connections(connections: set) -> set:
         (key, format_mac(value)) if key == CONNECTION_NETWORK_MAC else (key, value)
         for key, value in connections
     }
+
+
+def _add_device_to_index(
+    device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+) -> None:
+    """Add a device to the index."""
+    for identifier in device.identifiers:
+        device_index[IDX_IDENTIFIERS][identifier] = device.id
+    for connection in device.connections:
+        device_index[IDX_CONNECTIONS][connection] = device.id
+
+
+def _remove_device_from_index(
+    device_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+) -> None:
+    """Remove a device from the index."""
+    for identifier in device.identifiers:
+        if identifier in device_index[IDX_IDENTIFIERS]:
+            del device_index[IDX_IDENTIFIERS][identifier]
+    for connection in device.connections:
+        if connection in device_index[IDX_CONNECTIONS]:
+            del device_index[IDX_CONNECTIONS][connection]

--- a/tests/common.py
+++ b/tests/common.py
@@ -370,6 +370,7 @@ def mock_device_registry(hass, mock_entries=None, mock_deleted_entries=None):
     registry = device_registry.DeviceRegistry(hass)
     registry.devices = mock_entries or OrderedDict()
     registry.deleted_devices = mock_deleted_entries or OrderedDict()
+    registry._rebuild_index()
 
     hass.data[device_registry.DATA_REGISTRY] = registry
     return registry

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -562,6 +562,21 @@ async def test_update(registry):
     assert updated_entry.identifiers == new_identifiers
     assert updated_entry.via_device_id == "98765B"
 
+    assert registry.async_get_device({("hue", "456")}, {}) is None
+    assert registry.async_get_device({("bla", "123")}, {}) is None
+
+    assert registry.async_get_device({("hue", "654")}, {}) == updated_entry
+    assert registry.async_get_device({("bla", "321")}, {}) == updated_entry
+
+    assert (
+        registry.async_get_device(
+            {}, {(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")}
+        )
+        == updated_entry
+    )
+
+    assert registry.async_get(updated_entry.id) is not None
+
 
 async def test_update_remove_config_entries(hass, registry, update_events):
     """Make sure we do not get duplicate entries."""


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As the device registry grows, and more integrations are making use of it, the
linear searches for `connections` and `identifiers` need faster lookups.

Currently at 262 devices in the registry they represent 38% of the time to
add a new entity.  After the change, the time spent in `async_get_or_create`
no longer registers in the profile.

This change creates an index so we can quickly lookup connections
and identifiers.

Fixed lookup by mac address as we didn't normalize the mac address
when doing the lookup (added a test to verify)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
