### PR TITLE
Add update available binary sensor to Tesla

### DIFF
--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -1,9 +1,8 @@
 """Support for Tesla binary sensor."""
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
-
-from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
+from homeassistant.components.binary_sensor import DEVICE_CLASSES, BinarySensorEntity
+from homeassistant.components.tesla import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +31,9 @@ class TeslaBinarySensor(TeslaDevice, BinarySensorEntity):
         """Initialise of a Tesla binary sensor."""
         super().__init__(tesla_device, controller, config_entry)
         self._state = None
-        self._sensor_type = tesla_device.sensor_type
+        self._sensor_type = None
+        if tesla_device.sensor_type in DEVICE_CLASSES:
+            self._sensor_type = tesla_device.sensor_type
 
     @property
     def device_class(self):

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -15,7 +15,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             TeslaBinarySensor(
                 device,
                 hass.data[TESLA_DOMAIN][config_entry.entry_id]["controller"],
-                "connectivity",
                 config_entry,
             )
             for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"][
@@ -29,21 +28,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class TeslaBinarySensor(TeslaDevice, BinarySensorEntity):
     """Implement an Tesla binary sensor for parking and charger."""
 
-    def __init__(self, tesla_device, controller, sensor_type, config_entry):
+    def __init__(self, tesla_device, controller, config_entry):
         """Initialise of a Tesla binary sensor."""
         super().__init__(tesla_device, controller, config_entry)
-        self._state = False
-        self._sensor_type = sensor_type
+        self._state = None
+        self._sensor_type = tesla_device.sensor_type
 
     @property
     def device_class(self):
         """Return the class of this binary sensor."""
         return self._sensor_type
-
-    @property
-    def name(self):
-        """Return the name of the binary sensor."""
-        return self._name
 
     @property
     def is_on(self):

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -2,7 +2,8 @@
 import logging
 
 from homeassistant.components.binary_sensor import DEVICE_CLASSES, BinarySensorEntity
-from homeassistant.components.tesla import DOMAIN as TESLA_DOMAIN, TeslaDevice
+
+from . import DOMAIN as TESLA_DOMAIN, TeslaDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -3,6 +3,6 @@
   "name": "Tesla",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
-  "requirements": ["teslajsonpy==0.10.0"],
+  "requirements": ["teslajsonpy==0.10.1"],
   "codeowners": ["@zabuldon", "@alandtse"]
 }

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -3,6 +3,6 @@
   "name": "Tesla",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
-  "requirements": ["teslajsonpy==0.9.3"],
+  "requirements": ["teslajsonpy==0.10.0"],
   "codeowners": ["@zabuldon", "@alandtse"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2092,7 +2092,7 @@ temperusb==1.5.3
 tesla-powerwall==0.2.11
 
 # homeassistant.components.tesla
-teslajsonpy==0.9.3
+teslajsonpy==0.10.0
 
 # homeassistant.components.thermoworks_smoke
 thermoworks_smoke==0.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2092,7 +2092,7 @@ temperusb==1.5.3
 tesla-powerwall==0.2.11
 
 # homeassistant.components.tesla
-teslajsonpy==0.10.0
+teslajsonpy==0.10.1
 
 # homeassistant.components.thermoworks_smoke
 thermoworks_smoke==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -918,7 +918,7 @@ tellduslive==0.10.11
 tesla-powerwall==0.2.11
 
 # homeassistant.components.tesla
-teslajsonpy==0.10.0
+teslajsonpy==0.10.1
 
 # homeassistant.components.toon
 toonapi==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -918,7 +918,7 @@ tellduslive==0.10.11
 tesla-powerwall==0.2.11
 
 # homeassistant.components.tesla
-teslajsonpy==0.9.3
+teslajsonpy==0.10.0
 
 # homeassistant.components.toon
 toonapi==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds an update available binary sensor to Tesla. Requires [teslajsonpy 0.10.0](https://github.com/zabuldon/teslajsonpy/releases/tag/v0.10.0)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14042

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
