### PR TITLE
Initial version of pyscript - adds rich python scripting to HA

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -324,6 +324,7 @@ homeassistant/components/ptvsd/* @swamp-ig
 homeassistant/components/push/* @dgomes
 homeassistant/components/pvoutput/* @fabaff
 homeassistant/components/pvpc_hourly_pricing/* @azogue
+homeassistant/components/pyscript/* @craigbarratt
 homeassistant/components/qld_bushfire/* @exxamalte
 homeassistant/components/qnap/* @colinodell
 homeassistant/components/quantum_gateway/* @cisasteelersfan

--- a/homeassistant/components/pyscript/__init__.py
+++ b/homeassistant/components/pyscript/__init__.py
@@ -1,0 +1,293 @@
+"""Component to allow running Python scripts."""
+
+from collections import OrderedDict
+import glob
+import io
+import logging
+import os
+
+import voluptuous as vol
+import yaml
+
+from homeassistant.components.pyscript.eval import AstEval, EvalFunc
+from homeassistant.components.pyscript.event import Event
+from homeassistant.components.pyscript.handler import Handler
+from homeassistant.components.pyscript.state import State
+from homeassistant.components.pyscript.trigger import TrigInfo, TrigTime
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
+    EVENT_HOMEASSISTANT_STOP,
+    EVENT_STATE_CHANGED,
+    SERVICE_RELOAD,
+)
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.service import async_set_service_schema
+from homeassistant.loader import bind_hass
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "pyscript"
+
+FOLDER = "pyscript"
+
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema(dict)}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Initialize the pyscript component."""
+
+    handler_func = Handler(hass)
+    event_func = Event(hass)
+    trig_time_func = TrigTime(hass, handler_func)
+    state_func = State(hass, handler_func)
+    state_func.register_functions()
+
+    path = hass.config.path(FOLDER)
+
+    if not os.path.isdir(path):
+        _LOGGER.error("Folder %s not found in configuration folder", FOLDER)
+        return False
+
+    triggers, services = await compile_scripts(  # pylint: disable=unused-variable
+        hass,
+        event_func=event_func,
+        state_func=state_func,
+        handler_func=handler_func,
+        trig_time_func=trig_time_func,
+    )
+
+    _LOGGER.debug("adding reload handler")
+
+    async def reload_scripts_handler(call):
+        """Handle reload service calls."""
+        nonlocal triggers, services
+
+        _LOGGER.debug(
+            "stopping triggers and services, reloading scripts, and restarting"
+        )
+        for trig in triggers.values():
+            await trig.stop()
+        for name in services:
+            hass.services.async_remove(DOMAIN, name)
+        triggers, services = await compile_scripts(
+            hass,
+            event_func=event_func,
+            state_func=state_func,
+            handler_func=handler_func,
+            trig_time_func=trig_time_func,
+        )
+        for trig in triggers.values():
+            trig.start()
+
+    hass.services.async_register(DOMAIN, SERVICE_RELOAD, reload_scripts_handler)
+
+    async def state_changed(event):
+        var_name = event.data["entity_id"]
+        # attr = event.data["new_state"].attributes
+        new_val = event.data["new_state"].state
+        old_val = event.data["old_state"].state if event.data["old_state"] else None
+        new_vars = {var_name: new_val, f"{var_name}.old": old_val}
+        func_args = {
+            "trigger_type": "state",
+            "var_name": var_name,
+            "value": new_val,
+            "old_value": old_val,
+        }
+        await state_func.update(new_vars, func_args)
+
+    async def start_triggers(event):
+        _LOGGER.debug("adding state changed listener")
+        hass.bus.async_listen(EVENT_STATE_CHANGED, state_changed)
+        _LOGGER.debug("starting triggers")
+        for trig in triggers.values():
+            trig.start()
+
+    async def stop_triggers(event):
+        _LOGGER.debug("stopping triggers")
+        for trig in triggers.values():
+            await trig.stop()
+
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STARTED, start_triggers)
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, stop_triggers)
+
+    return True
+
+
+@bind_hass
+async def compile_scripts(
+    hass, event_func=None, state_func=None, handler_func=None, trig_time_func=None
+):
+    """Compile all python scripts in FOLDER."""
+
+    path = hass.config.path(FOLDER)
+
+    _LOGGER.debug("compile_scripts: path = %s", path)
+
+    def pyscript_service_factory(name, func, sym_table):
+        async def pyscript_service_handler(call):
+            """Handle python script service calls."""
+            # ignore call.service
+            _LOGGER.debug("service call to %s", name)
+            #
+            # use a new AstEval context so it can run fully independently
+            # of other instances (except for global_sym_table which is common)
+            #
+            ast_ctx = AstEval(
+                name,
+                global_sym_table=sym_table,
+                state_func=state_func,
+                event_func=event_func,
+                handler_func=handler_func,
+            )
+            handler_func.install_ast_funcs(ast_ctx)
+            func_args = {
+                "trigger_type": "service",
+            }
+            func_args = func_args.update(call.data)
+            handler_func.create_task(func.call(ast_ctx, [], call.data))
+
+        return pyscript_service_handler
+
+    triggers = {}
+    services = set()
+    for file in glob.iglob(os.path.join(path, "*.py")):
+        name = os.path.splitext(os.path.basename(file))[0]
+        _LOGGER.debug("parsing %s", file)
+        with open(file) as file_desc:
+            source = file_desc.read()
+
+        global_sym_table = {}
+        ast_ctx = AstEval(
+            name,
+            global_sym_table=global_sym_table,
+            state_func=state_func,
+            event_func=event_func,
+            handler_func=handler_func,
+        )
+        handler_func.install_ast_funcs(ast_ctx)
+        if not ast_ctx.parse(source, filename=file):
+            continue
+        await ast_ctx.eval()
+
+        for name, func in global_sym_table.items():
+            _LOGGER.debug("global_sym_table got %s, %s", name, func)
+            if not isinstance(func, EvalFunc):
+                continue
+            if name == SERVICE_RELOAD:
+                _LOGGER.error(
+                    "function '%s' in %s conflicts with %s service; ignoring (please rename)",
+                    name,
+                    file,
+                    SERVICE_RELOAD,
+                )
+                continue
+            desc = func.get_doc_string()
+            if desc is None or desc == "":
+                desc = f"pyscript function {name}()"
+            desc = desc.lstrip(" \n\r")
+            if desc.startswith("yaml"):
+                try:
+                    desc = desc[4:].lstrip(" \n\r")
+                    file_desc = io.StringIO(desc)
+                    service_desc = (
+                        yaml.load(file_desc, Loader=yaml.BaseLoader) or OrderedDict()
+                    )
+                    file_desc.close()
+                except Exception as exc:
+                    _LOGGER.error(
+                        "Unable to decode yaml doc_string for %s(): %s", name, str(exc)
+                    )
+                    raise HomeAssistantError(exc)
+            else:
+                fields = OrderedDict()
+                for arg in func.get_positional_args():
+                    fields[arg] = OrderedDict(description=f"argument {arg}")
+                service_desc = {"description": desc, "fields": fields}
+
+            trig_args = {}
+            trig_decorators = {
+                "time_trigger",
+                "state_trigger",
+                "event_trigger",
+                "state_active",
+                "time_active",
+            }
+            for dec in func.get_decorators():
+                dec_name, dec_args = dec[0], dec[1]
+                if dec_name in trig_decorators:
+                    if dec_name not in trig_args:
+                        trig_args[dec_name] = []
+                    if dec_args is not None:
+                        trig_args[dec_name] += dec_args
+                elif dec_name == "service":
+                    if dec_args is not None:
+                        _LOGGER.error(
+                            "%s defined in %s: decorator @service takes no arguments; ignored",
+                            name,
+                            file,
+                        )
+                        continue
+                    _LOGGER.debug(
+                        "registering %s/%s (desc = %s)", DOMAIN, name, service_desc
+                    )
+                    hass.services.async_register(
+                        DOMAIN,
+                        name,
+                        pyscript_service_factory(name, func, global_sym_table),
+                    )
+                    async_set_service_schema(hass, DOMAIN, name, service_desc)
+                    services.add(name)
+                else:
+                    _LOGGER.warning(
+                        "%s defined in %s has unknown decorator @%s",
+                        name,
+                        file,
+                        dec_name,
+                    )
+            for dec_name in trig_decorators:
+                if dec_name in trig_args and len(trig_args[dec_name]) == 0:
+                    trig_args[dec_name] = None
+
+            arg_check = {
+                "state_trigger": {1},
+                "state_active": {1},
+                "event_trigger": {1, 2},
+            }
+            for dec_name, arg_cnt in arg_check.items():
+                if dec_name not in trig_args or trig_args[dec_name] is None:
+                    continue
+                if len(trig_args[dec_name]) not in arg_cnt:
+                    _LOGGER.error(
+                        "%s defined in %s decorator @%s got %d argument%s, expected %s; ignored",
+                        name,
+                        file,
+                        dec_name,
+                        len(trig_args[dec_name]),
+                        "s" if len(trig_args[dec_name]) > 1 else "",
+                        " or ".join(sorted(arg_cnt)),
+                    )
+                    del trig_args[dec_name]
+                if arg_cnt == 1:
+                    trig_args[dec_name] = trig_args[dec_name][0]
+
+            if len(trig_args) > 0:
+                trig_args["action"] = func
+                trig_args["action_ast_ctx"] = AstEval(
+                    name,
+                    global_sym_table=global_sym_table,
+                    state_func=state_func,
+                    event_func=event_func,
+                    handler_func=handler_func,
+                )
+                handler_func.install_ast_funcs(trig_args["action_ast_ctx"])
+                trig_args["global_sym_table"] = global_sym_table
+                triggers[name] = TrigInfo(
+                    name,
+                    trig_args,
+                    event_func=event_func,
+                    state_func=state_func,
+                    handler_func=handler_func,
+                    trig_time=trig_time_func,
+                )
+
+    return triggers, services

--- a/homeassistant/components/pyscript/__init__.py
+++ b/homeassistant/components/pyscript/__init__.py
@@ -274,7 +274,7 @@ async def compile_scripts(
                         dec_name,
                         len(trig_args[dec_name]),
                         "s" if len(trig_args[dec_name]) > 1 else "",
-                        " or ".join(sorted(arg_cnt)),
+                        " or ".join([str(cnt) for cnt in sorted(arg_cnt)]),
                     )
                     del trig_args[dec_name]
                 if arg_cnt == 1:

--- a/homeassistant/components/pyscript/eval.py
+++ b/homeassistant/components/pyscript/eval.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 # Built-in functions available.  Certain functions are excluded
 # to avoid potential security issues.
 #
-builtinFuncs = {
+BUILTIN_FUNCS = {
     "abs": abs,
     "all": all,
     "any": any,
@@ -64,7 +64,7 @@ builtinFuncs = {
 }
 
 
-allowedImports = {
+ALLOWED_IMPORTS = {
     "cmath",
     "datetime",
     "decimal",
@@ -310,7 +310,7 @@ class AstEval:
     async def ast_import(self, arg):
         """Execute import."""
         for imp in arg.names:
-            if imp.name not in allowedImports:
+            if imp.name not in ALLOWED_IMPORTS:
                 raise ModuleNotFoundError(f"import of {imp.name} not allowed")
             if imp.name not in sys.modules:
                 mod = importlib.import_module(imp.name)
@@ -320,7 +320,7 @@ class AstEval:
 
     async def ast_importfrom(self, arg):
         """Execute from X import Y."""
-        if arg.module not in allowedImports:
+        if arg.module not in ALLOWED_IMPORTS:
             raise ModuleNotFoundError(f"import from {arg.module} not allowed")
         if arg.module not in sys.modules:
             mod = importlib.import_module(arg.module)
@@ -583,8 +583,8 @@ class AstEval:
                 return self.local_sym_table[arg.id]
             if arg.id in self.global_sym_table:
                 return self.global_sym_table[arg.id]
-            if arg.id in builtinFuncs:
-                return builtinFuncs[arg.id]
+            if arg.id in BUILTIN_FUNCS:
+                return BUILTIN_FUNCS[arg.id]
             if self.handler.get(arg.id):
                 return self.handler.get(arg.id)
             if self.state.exist(arg.id):

--- a/homeassistant/components/pyscript/eval.py
+++ b/homeassistant/components/pyscript/eval.py
@@ -1,0 +1,970 @@
+"""Python interpreter for pyscript."""
+
+import ast
+import asyncio
+import importlib
+import logging
+import sys
+import traceback
+
+_LOGGER = logging.getLogger(__name__)
+
+#
+# Built-in functions available.  Certain functions are excluded
+# to avoid potential security issues.
+#
+builtinFuncs = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "ascii": ascii,
+    "bin": bin,
+    "bool": bool,
+    "bytearray": bytearray,
+    "bytearray.fromhex": bytearray.fromhex,
+    "bytes": bytes,
+    "bytes.fromhex": bytes.fromhex,
+    "callable": callable,
+    "chr": chr,
+    "complex": complex,
+    "dict": dict,
+    "divmod": divmod,
+    "enumerate": enumerate,
+    "filter": filter,
+    "float": float,
+    "format": format,
+    "frozenset": frozenset,
+    "hash": hash,
+    "hex": hex,
+    "int": int,
+    "isinstance": isinstance,
+    "issubclass": issubclass,
+    "iter": iter,
+    "len": len,
+    "list": list,
+    "map": map,
+    "max": max,
+    "min": min,
+    "next": next,
+    "oct": oct,
+    "ord": ord,
+    "pow": pow,
+    "range": range,
+    "repr": repr,
+    "reversed": reversed,
+    "round": round,
+    "set": set,
+    "slice": slice,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "type": type,
+    "zip": zip,
+}
+
+
+allowedImports = {
+    "cmath",
+    "datetime",
+    "decimal",
+    "fractions",
+    "homeassistant.const",
+    "math",
+    "number",
+    "random",
+    "re",
+    "statistics",
+    "string",
+    "time",
+}
+
+
+#
+# Objects returned by return, break and continue statements that change execution flow
+#
+class EvalStopFlow:
+    """Denotes a statement or action that stops execution flow, eg: return, break etc."""
+
+
+class EvalReturn(EvalStopFlow):
+    """Return statement."""
+
+    def __init__(self, value):
+        """Initialize return statement value."""
+        self.value = value
+
+
+class EvalBreak(EvalStopFlow):
+    """Break statement."""
+
+
+class EvalContinue(EvalStopFlow):
+    """Continue statement."""
+
+
+class EvalName:
+    """Identifier that hasn't yet been resolved."""
+
+    def __init__(self, name):
+        """Initialize identifier to name."""
+        self.name = name
+
+
+class EvalFunc:
+    """Class for a callable pyscript function."""
+
+    def __init__(self, func_def):
+        """Initialize a function calling context."""
+        self.func_def = func_def
+        self.name = func_def.name
+        self.defaults = []
+        self.kw_defaults = []
+        self.decorators = []
+        self.global_names = set()
+        self.nonlocal_names = set()
+        self.doc_string = ast.get_docstring(func_def)
+        self.num_posn_arg = len(self.func_def.args.args) - len(self.defaults)
+
+    def get_name(self):
+        """Return the function name."""
+        return self.name
+
+    async def eval_defaults(self, ast_ctx):
+        """Evaluate the default function arguments."""
+        self.defaults = []
+        for val in self.func_def.args.defaults:
+            self.defaults.append(await ast_ctx.aeval(val))
+        self.num_posn_arg = len(self.func_def.args.args) - len(self.defaults)
+        self.kw_defaults = []
+        for val in self.func_def.args.kw_defaults:
+            self.kw_defaults.append(
+                {"ok": bool(val), "val": None if not val else await ast_ctx.aeval(val)}
+            )
+
+    async def eval_decorators(self, ast_ctx):
+        """Evaluate the function decorators arguments."""
+        self.decorators = []
+        for dec in self.func_def.decorator_list:
+            if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Name):
+                args = []
+                for arg in dec.args:
+                    args.append(await ast_ctx.aeval(arg))
+                self.decorators.append([dec.func.id, args])
+            elif isinstance(dec, ast.Name):
+                self.decorators.append([dec.id, None])
+            else:
+                _LOGGER.error(
+                    "function %s has unexpected decorator type %s", self.name, dec
+                )
+
+    def get_decorators(self):
+        """Return the function decorators."""
+        return self.decorators
+
+    def get_doc_string(self):
+        """Return the function doc_string."""
+        return self.doc_string
+
+    def get_positional_args(self):
+        """Return the function positional arguments."""
+        args = []
+        for arg in self.func_def.args.args:
+            args.append(arg.arg)
+        return args
+
+    async def call(self, ast_ctx, args=None, kwargs=None):
+        """Call the function with the given context and arguments."""
+        sym_table = {}
+        if args is None:
+            args = []
+        kwargs = kwargs.copy() if kwargs else {}
+        for i in range(len(self.func_def.args.args)):
+            var_name = self.func_def.args.args[i].arg
+            val = None
+            if i < len(args):
+                val = args[i]
+                if var_name in kwargs:
+                    raise TypeError(
+                        "{self.name}() got multiple values for argument '{var_name}'"
+                    )
+            elif var_name in kwargs:
+                val = kwargs[var_name]
+                del kwargs[var_name]
+            elif self.num_posn_arg <= i < len(self.defaults) + self.num_posn_arg:
+                val = self.defaults[i - self.num_posn_arg]
+            else:
+                raise TypeError(
+                    f"{self.name}() missing {self.num_posn_arg - i} required positional arguments"
+                )
+            sym_table[var_name] = val
+        for i in range(len(self.func_def.args.kwonlyargs)):
+            var_name = self.func_def.args.kwonlyargs[i].arg
+            if var_name in kwargs:
+                val = kwargs[var_name]
+                del kwargs[var_name]
+            elif i < len(self.kw_defaults) and self.kw_defaults[i]["ok"]:
+                val = self.kw_defaults[i]["val"]
+            else:
+                raise TypeError(
+                    f"{self.name}() missing required keyword-only arguments"
+                )
+            sym_table[var_name] = val
+        if self.func_def.args.kwarg:
+            sym_table[self.func_def.args.kwarg.arg] = kwargs
+        if self.func_def.args.vararg:
+            if len(args) > len(self.func_def.args.args):
+                sym_table[self.func_def.args.vararg.arg] = tuple(
+                    args[len(self.func_def.args.args) :]
+                )
+            else:
+                sym_table[self.func_def.args.vararg.arg] = ()
+        elif len(args) > len(self.func_def.args.args):
+            raise TypeError(f"{self.name}() called with too many positional arguments")
+        ast_ctx.sym_table_stack.append(ast_ctx.sym_table)
+        ast_ctx.sym_table = sym_table
+        prev_func = ast_ctx.curr_func
+        ast_ctx.curr_func = self
+        for arg1 in self.func_def.body:
+            val = await ast_ctx.aeval(arg1)
+            if isinstance(val, EvalReturn):
+                val = val.value
+                break
+            # return None at end if there isn't a return
+            val = None
+        ast_ctx.sym_table = ast_ctx.sym_table_stack.pop()
+        ast_ctx.curr_func = prev_func
+        return val
+
+
+class AstEval:
+    """Python interpreter AST object evaluator."""
+
+    def __init__(
+        self,
+        name,
+        global_sym_table=None,
+        state_func=None,
+        event_func=None,
+        handler_func=None,
+    ):
+        """Initialize a interpreter execution context."""
+        self.name = name
+        self.str = None
+        self.ast = None
+        self.global_sym_table = global_sym_table if global_sym_table is not None else {}
+        self.sym_table_stack = []
+        self.sym_table = self.global_sym_table
+        self.local_sym_table = {}
+        self.curr_func = None
+        self.filename = ""
+        self.exception = None
+        self.exception_long = None
+        self.state = state_func
+        self.handler = handler_func
+        self.event = event_func
+
+    async def ast_not_implemented(self, arg, *args):
+        """Raise NotImplementedError exception for unimplemented AST types."""
+        name = "ast_" + arg.__class__.__name__.lower()
+        raise NotImplementedError(f"{self.name}: not implemented ast " + name)
+
+    async def aeval(self, arg, undefined_check=True):
+        """Vector to specific function based on ast class type."""
+        name = "ast_" + arg.__class__.__name__.lower()
+        try:
+            func = getattr(self, name, self.ast_not_implemented)
+            if asyncio.iscoroutinefunction(func):
+                val = await func(arg)
+            else:
+                val = func(arg)
+            if undefined_check and isinstance(val, EvalName):
+                raise NameError(f"name '{val.name}' is not defined")
+            return val
+        except asyncio.CancelledError:  # pylint: disable=try-except-raise
+            raise
+        except Exception as err:  # pylint: disable=broad-except
+            func_name = self.curr_func.get_name() + "(), " if self.curr_func else ""
+            self.exception = f"Exception in {func_name}{self.filename} line {arg.lineno} column {arg.col_offset}: {err}"
+            self.exception_long = f"Exception in {func_name}{self.filename} line {arg.lineno} column {arg.col_offset}: {traceback.format_exc(0)}"
+            _LOGGER.error(
+                "Exception in %s%s line %s column %s: %s",
+                func_name,
+                self.filename,
+                arg.lineno,
+                arg.col_offset,
+                err,
+            )
+        return None
+
+    # Statements return NONE, EvalBreak, EvalContinue, EvalReturn
+    async def ast_module(self, arg):
+        """Execute ast_module - a list of statements."""
+        val = None
+        for arg1 in arg.body:
+            val = await self.aeval(arg1)
+            if isinstance(val, EvalStopFlow):
+                return val
+        return val
+
+    async def ast_import(self, arg):
+        """Execute import."""
+        for imp in arg.names:
+            if imp.name not in allowedImports:
+                raise ModuleNotFoundError(f"import of {imp.name} not allowed")
+            if imp.name not in sys.modules:
+                mod = importlib.import_module(imp.name)
+            else:
+                mod = sys.modules[imp.name]
+            self.sym_table[imp.name if imp.asname is None else imp.asname] = mod
+
+    async def ast_importfrom(self, arg):
+        """Execute from X import Y."""
+        if arg.module not in allowedImports:
+            raise ModuleNotFoundError(f"import from {arg.module} not allowed")
+        if arg.module not in sys.modules:
+            mod = importlib.import_module(arg.module)
+        else:
+            mod = sys.modules[arg.module]
+        for imp in arg.names:
+            self.sym_table[imp.name if imp.asname is None else imp.asname] = getattr(
+                mod, imp.name
+            )
+
+    async def ast_if(self, arg):
+        """Execute if statement."""
+        val = None
+        if await self.aeval(arg.test):
+            for arg1 in arg.body:
+                val = await self.aeval(arg1)
+                if isinstance(val, EvalStopFlow):
+                    return val
+        else:
+            for arg1 in arg.orelse:
+                val = await self.aeval(arg1)
+                if isinstance(val, EvalStopFlow):
+                    return val
+        return val
+
+    async def ast_for(self, arg):
+        """Execute for statement."""
+        loop_var = await self.aeval(arg.target)
+        loop_iter = await self.aeval(arg.iter)
+        for i in loop_iter:
+            self.sym_table[loop_var] = i
+            for arg1 in arg.body:
+                val = await self.aeval(arg1)
+                if isinstance(val, EvalStopFlow):
+                    break
+            if isinstance(val, EvalBreak):
+                break
+            if isinstance(val, EvalContinue):
+                continue
+            if isinstance(val, EvalReturn):
+                return val
+        if not isinstance(val, EvalBreak):
+            for arg1 in arg.orelse:
+                val = await self.aeval(arg1)
+                if isinstance(val, EvalReturn):
+                    return val
+        return None
+
+    async def ast_while(self, arg):
+        """Execute while statement."""
+        while 1:
+            val = await self.aeval(arg.test)
+            if not val:
+                break
+            for arg1 in arg.body:
+                val = await self.aeval(arg1)
+                if isinstance(val, EvalStopFlow):
+                    break
+            if isinstance(val, EvalBreak):
+                break
+            if isinstance(val, EvalContinue):
+                continue
+            if isinstance(val, EvalReturn):
+                return val
+        if not isinstance(val, EvalBreak):
+            for arg1 in arg.orelse:
+                val = await self.aeval(arg1)
+                if isinstance(val, EvalReturn):
+                    return val
+        return None
+
+    async def ast_pass(self, arg):
+        """Execute pass statement."""
+
+    async def ast_expr(self, arg):
+        """Execute expression statement."""
+        return await self.aeval(arg.value)
+
+    async def ast_break(self, arg):
+        """Execute break statement - return special class."""
+        return EvalBreak()
+
+    async def ast_continue(self, arg):
+        """Execute continue statement - return special class."""
+        return EvalContinue()
+
+    async def ast_return(self, arg):
+        """Execute return statement - return special class."""
+        val = await self.aeval(arg.value)
+        return EvalReturn(val)
+
+    async def ast_global(self, arg):
+        """Execute global statement."""
+        if self.curr_func:
+            for var_name in arg.names:
+                self.curr_func.global_names.add(var_name)
+
+    async def ast_nonlocal(self, arg):
+        """Execute nonlocal statement."""
+        if self.curr_func:
+            for var_name in arg.names:
+                self.curr_func.nonlocal_names.add(var_name)
+
+    async def ast_assign(self, arg):
+        """Execute assignment statement."""
+        val = await self.aeval(arg.value)
+        for lhs in arg.targets:  # pylint: disable=too-many-nested-blocks
+            if isinstance(lhs, ast.Subscript):
+                var = await self.aeval(lhs.value)
+                if isinstance(lhs.slice, ast.Index):
+                    ind = await self.aeval(lhs.slice.value)
+                    var[ind] = val
+                elif isinstance(lhs.slice, ast.Slice):
+                    lower = (
+                        await self.aeval(lhs.slice.lower) if lhs.slice.lower else None
+                    )
+                    upper = (
+                        await self.aeval(lhs.slice.upper) if lhs.slice.upper else None
+                    )
+                    step = await self.aeval(lhs.slice.step) if lhs.slice.step else None
+                    if not lower and not upper and not step:
+                        return val
+                    if not lower and not upper and step:
+                        var[::step] = val
+                    elif not lower and upper and not step:
+                        var[:upper] = val
+                    elif not lower and upper and step:
+                        var[:upper:step] = val
+                    elif lower and not upper and not step:
+                        var[lower] = val
+                    elif lower and not upper and step:
+                        var[lower::step] = val
+                    elif lower and upper and not step:
+                        var[lower:upper] = val
+                    else:
+                        var[lower:upper:step] = val
+            else:
+                var_name = await self.aeval(lhs)
+                if var_name.find(".") >= 0:
+                    self.state.set(var_name, val)
+                else:
+                    if self.curr_func and var_name in self.curr_func.global_names:
+                        self.global_sym_table[var_name] = val
+                    elif self.curr_func and var_name in self.curr_func.nonlocal_names:
+                        for sym_table in reversed(self.sym_table_stack):
+                            if var_name in sym_table:
+                                sym_table[var_name] = val
+                                break
+                        else:
+                            raise TypeError(
+                                "can't find nonlocal '{var_name}' for assignment"
+                            )
+                    else:
+                        self.sym_table[var_name] = val
+
+    async def ast_augassign(self, arg):
+        """Execute augmented assignment statement (lhs <BinOp>= value)."""
+        var_name = await self.aeval(arg.target)
+        val = await self.aeval(
+            ast.BinOp(
+                left=ast.Name(id=var_name, ctx=ast.Load()), op=arg.op, right=arg.value
+            )
+        )
+        if self.curr_func and var_name in self.curr_func.global_names:
+            self.global_sym_table[var_name] = val
+        elif self.curr_func and var_name in self.curr_func.nonlocal_names:
+            for sym_table in reversed(self.sym_table_stack):
+                if var_name in sym_table:
+                    sym_table[var_name] = val
+                    break
+            else:
+                raise TypeError("can't find nonlocal '{var_name}' for assignment")
+        else:
+            self.sym_table[var_name] = val
+
+    async def ast_delete(self, arg):
+        """Execute del statement."""
+        for arg1 in arg.targets:
+            if isinstance(arg1, ast.Subscript):
+                var = await self.aeval(arg1.value)
+                if isinstance(arg1.slice, ast.Index):
+                    ind = await self.aeval(arg1.slice.value)
+                    for elt in ind if isinstance(ind, list) else [ind]:
+                        del var[elt]
+                else:
+                    raise NotImplementedError(
+                        f"{self.name}: not implemented slice type {arg1.slice} in del"
+                    )
+            elif isinstance(arg1, ast.Name):
+                if self.curr_func and arg1.id in self.curr_func.global_names:
+                    if arg1.id in self.global_sym_table:
+                        del self.global_sym_table[arg1.id]
+                elif self.curr_func and arg1.id in self.curr_func.nonlocal_names:
+                    for sym_table in reversed(self.sym_table_stack):
+                        if arg1.id in sym_table:
+                            del sym_table[arg1.id]
+                            break
+                elif arg1.id in self.sym_table:
+                    del self.sym_table[arg1.id]
+                else:
+                    raise NameError(f"name '{arg1.id}' is not defined in del")
+            else:
+                raise NotImplementedError(f"unknown target type {arg1} in del")
+
+    def ast_attribute2_name(self, arg):  # pylint: disable=no-self-use
+        """Combine dotted attributes to allow variable names to have dots."""
+        # collapse dotted names, eg:
+        #   Attribute(value=Attribute(value=Name(id='i', ctx=Load()), attr='j', ctx=Load()), attr='k', ctx=Store())
+        name = arg.attr
+        val = arg.value
+        while isinstance(val, ast.Attribute):
+            name = val.attr + "." + name
+            val = val.value
+        if isinstance(val, ast.Name):
+            name = val.id + "." + name
+        else:
+            return None
+        return name
+
+    async def ast_attribute(self, arg):
+        """Assemble or apply attributes."""
+        full_name = self.ast_attribute2_name(arg)
+        if full_name is not None:
+            val = await self.ast_name(ast.Name(id=full_name, ctx=arg.ctx))
+        else:
+            val = await self.aeval(arg.value, undefined_check=False)
+            if isinstance(val, EvalName):
+                return await self.ast_name(
+                    ast.Name(id=f"{val.name}.{arg.attr}", ctx=arg.ctx)
+                )
+            return getattr(val, arg.attr, None)
+        if isinstance(val, EvalName):
+            parts = full_name.rsplit(".", 1)
+            if len(parts) == 2:
+                val = await self.ast_name(ast.Name(id=parts[0], ctx=arg.ctx))
+                val = getattr(val, parts[1])
+        return val
+
+    async def ast_name(self, arg):
+        """Look up value of identifier on load, or returns name on set."""
+        if isinstance(arg.ctx, ast.Load):
+            #
+            # check other scopes if required by global or nonlocal declarations
+            #
+            if self.curr_func and arg.id in self.curr_func.global_names:
+                if arg.id in self.global_sym_table:
+                    return self.global_sym_table[arg.id]
+                raise NameError(f"global name '{arg.id}' is not defined")
+            if self.curr_func and arg.id in self.curr_func.nonlocal_names:
+                for sym_table in reversed(self.sym_table_stack):
+                    if arg.id in sym_table:
+                        return sym_table[arg.id]
+                raise NameError(f"nonlocal name '{arg.id}' is not defined")
+            #
+            # now check in our current symbol table, and then some other places
+            #
+            if arg.id in self.sym_table:
+                return self.sym_table[arg.id]
+            if arg.id in self.local_sym_table:
+                return self.local_sym_table[arg.id]
+            if arg.id in self.global_sym_table:
+                return self.global_sym_table[arg.id]
+            if arg.id in builtinFuncs:
+                return builtinFuncs[arg.id]
+            if self.handler.get(arg.id):
+                return self.handler.get(arg.id)
+            if self.state.exist(arg.id):
+                return self.state.get(arg.id)
+            #
+            # Couldn't find it, so return just the name wrapped in EvalName to
+            # distinguish from a string variable value.  This is to support
+            # names with ".", which are joined by ast_attribute
+            #
+            return EvalName(arg.id)
+        return arg.id
+
+    async def ast_binop(self, arg):
+        """Evaluate binary operators by calling function based on class."""
+        name = "ast_binop_" + arg.op.__class__.__name__.lower()
+        return await getattr(self, name, self.ast_not_implemented)(arg.left, arg.right)
+
+    async def ast_binop_add(self, arg0, arg1):
+        """Evaluate binary operator: +."""
+        return (await self.aeval(arg0)) + (await self.aeval(arg1))
+
+    async def ast_binop_sub(self, arg0, arg1):
+        """Evaluate binary operator: -."""
+        return (await self.aeval(arg0)) - (await self.aeval(arg1))
+
+    async def ast_binop_mult(self, arg0, arg1):
+        """Evaluate binary operator: *."""
+        return (await self.aeval(arg0)) * (await self.aeval(arg1))
+
+    async def ast_binop_div(self, arg0, arg1):
+        """Evaluate binary operator: /."""
+        return (await self.aeval(arg0)) / (await self.aeval(arg1))
+
+    async def ast_binop_mod(self, arg0, arg1):
+        """Evaluate binary operator: %."""
+        return (await self.aeval(arg0)) % (await self.aeval(arg1))
+
+    async def ast_binop_pow(self, arg0, arg1):
+        """Evaluate binary operator: **."""
+        return (await self.aeval(arg0)) ** (await self.aeval(arg1))
+
+    async def ast_binop_lshift(self, arg0, arg1):
+        """Evaluate binary operator: <<."""
+        return (await self.aeval(arg0)) << (await self.aeval(arg1))
+
+    async def ast_binop_rshift(self, arg0, arg1):
+        """Evaluate binary operator: >>."""
+        return (await self.aeval(arg0)) >> (await self.aeval(arg1))
+
+    async def ast_binop_bitor(self, arg0, arg1):
+        """Evaluate binary operator: |."""
+        return (await self.aeval(arg0)) | (await self.aeval(arg1))
+
+    async def ast_binop_bitxor(self, arg0, arg1):
+        """Evaluate binary operator: ^."""
+        return (await self.aeval(arg0)) ^ (await self.aeval(arg1))
+
+    async def ast_binop_bitand(self, arg0, arg1):
+        """Evaluate binary operator: &."""
+        return (await self.aeval(arg0)) & (await self.aeval(arg1))
+
+    async def ast_binop_floordiv(self, arg0, arg1):
+        """Evaluate binary operator: //."""
+        return (await self.aeval(arg0)) // (await self.aeval(arg1))
+
+    async def ast_unaryop(self, arg):
+        """Evaluate unary operators by calling function based on class."""
+        name = "ast_unaryop_" + arg.op.__class__.__name__.lower()
+        return await getattr(self, name, self.ast_not_implemented)(arg.operand)
+
+    async def ast_unaryop_not(self, arg0):
+        """Evaluate unary operator: not."""
+        return not (await self.aeval(arg0))
+
+    async def ast_unaryop_invert(self, arg0):
+        """Evaluate unary operator: ~."""
+        return ~(await self.aeval(arg0))
+
+    async def ast_unaryop_uadd(self, arg0):
+        """Evaluate unary operator: +."""
+        return await self.aeval(arg0)
+
+    async def ast_unaryop_usub(self, arg0):
+        """Evaluate unary operator: -."""
+        return -(await self.aeval(arg0))
+
+    async def ast_compare(self, arg):
+        """Evaluate comparison operators by calling function based on class."""
+        left = arg.left
+        for cmp_op, right in zip(arg.ops, arg.comparators):
+            name = "ast_cmpop_" + cmp_op.__class__.__name__.lower()
+            val = await getattr(self, name, self.ast_not_implemented)(left, right)
+            if not val:
+                return False
+            left = right
+        return True
+
+    async def ast_cmpop_eq(self, arg0, arg1):
+        """Evaluate comparison operator: ==."""
+        return (await self.aeval(arg0)) == (await self.aeval(arg1))
+
+    async def ast_cmpop_noteq(self, arg0, arg1):
+        """Evaluate comparison operator: !=."""
+        return (await self.aeval(arg0)) != (await self.aeval(arg1))
+
+    async def ast_cmpop_lt(self, arg0, arg1):
+        """Evaluate comparison operator: <."""
+        return (await self.aeval(arg0)) < (await self.aeval(arg1))
+
+    async def ast_cmpop_lte(self, arg0, arg1):
+        """Evaluate comparison operator: <=."""
+        return (await self.aeval(arg0)) <= (await self.aeval(arg1))
+
+    async def ast_cmpop_gt(self, arg0, arg1):
+        """Evaluate comparison operator: >."""
+        return (await self.aeval(arg0)) > (await self.aeval(arg1))
+
+    async def ast_cmpop_gte(self, arg0, arg1):
+        """Evaluate comparison operator: >=."""
+        return (await self.aeval(arg0)) >= (await self.aeval(arg1))
+
+    async def ast_cmpop_is(self, arg0, arg1):
+        """Evaluate comparison operator: is."""
+        return (await self.aeval(arg0)) is (await self.aeval(arg1))
+
+    async def ast_cmpop_isnot(self, arg0, arg1):
+        """Evaluate comparison operator: is not."""
+        return (await self.aeval(arg0)) is not (await self.aeval(arg1))
+
+    async def ast_cmpop_in(self, arg0, arg1):
+        """Evaluate comparison operator: in."""
+        return (await self.aeval(arg0)) in (await self.aeval(arg1))
+
+    async def ast_cmpop_notin(self, arg0, arg1):
+        """Evaluate comparison operator: not in."""
+        return (await self.aeval(arg0)) not in (await self.aeval(arg1))
+
+    async def ast_boolop(self, arg):
+        """Evaluate boolean operators and and or."""
+        if isinstance(arg.op, ast.And):
+            val = 1
+            for arg1 in arg.values:
+                this_val = await self.aeval(arg1)
+                if this_val == 0:
+                    return 0
+                val = this_val
+            return val
+        for arg1 in arg.values:
+            val = await self.aeval(arg1)
+            if val != 0:
+                return val
+        return 0
+
+    async def eval_elt_list(self, elts):
+        """Evaluate and star list elements."""
+        val = []
+        for arg in elts:
+            if isinstance(arg, ast.Starred):
+                for this_val in await self.aeval(arg.value):
+                    val.append(this_val)
+            else:
+                this_val = await self.aeval(arg)
+                val.append(this_val)
+        return val
+
+    async def ast_list(self, arg):
+        """Evaluate list."""
+        if isinstance(arg.ctx, ast.Load):
+            return await self.eval_elt_list(arg.elts)
+
+    async def ast_tuple(self, arg):
+        """Evaluate Tuple."""
+        if isinstance(arg.ctx, ast.Load):
+            return tuple(await self.eval_elt_list(arg.elts))
+
+    async def ast_dict(self, arg):
+        """Evaluate dict."""
+        val = {}
+        for key_ast, val_ast in zip(arg.keys, arg.values):
+            this_val = await self.aeval(val_ast)
+            if key_ast is None:
+                val.update(this_val)
+            else:
+                val[await self.aeval(key_ast)] = this_val
+        return val
+
+    async def ast_set(self, arg):
+        """Evaluate set."""
+        val = set()
+        for elt in await self.eval_elt_list(arg.elts):
+            val.add(elt)
+        return val
+
+    async def ast_subscript(self, arg):
+        """Evaluate subscript."""
+        var = await self.aeval(arg.value)
+        if isinstance(arg.ctx, ast.Load):
+            if isinstance(arg.slice, ast.Index):
+                return var[await self.aeval(arg.slice)]
+            if isinstance(arg.slice, ast.Slice):
+                lower = (await self.aeval(arg.slice.lower)) if arg.slice.lower else None
+                upper = (await self.aeval(arg.slice.upper)) if arg.slice.upper else None
+                step = (await self.aeval(arg.slice.step)) if arg.slice.step else None
+                if not lower and not upper and not step:
+                    return None
+                if not lower and not upper and step:
+                    return var[::step]
+                if not lower and upper and not step:
+                    return var[:upper]
+                if not lower and upper and step:
+                    return var[:upper:step]
+                if lower and not upper and not step:
+                    return var[lower]
+                if lower and not upper and step:
+                    return var[lower::step]
+                if lower and upper and not step:
+                    return var[lower:upper]
+                return var[lower:upper:step]
+        else:
+            return None
+
+    async def ast_index(self, arg):
+        """Evaluate index."""
+        return await self.aeval(arg.value)
+
+    async def ast_slice(self, arg):
+        """Evaluate slice."""
+        return await self.aeval(arg.value)
+
+    async def ast_call(self, arg):
+        """Evaluate function call."""
+        func = await self.aeval(arg.func)
+        kwargs = {}
+        for kw_arg in arg.keywords:
+            if kw_arg.arg is None:
+                kwargs.update(await self.aeval(kw_arg.value))
+            else:
+                kwargs[kw_arg.arg] = await self.aeval(kw_arg.value)
+        args = await self.eval_elt_list(arg.args)
+        arg_str = ", ".join(
+            ['"' + elt + '"' if isinstance(elt, str) else str(elt) for elt in args]
+        )
+
+        if isinstance(func, EvalFunc):
+            return await func.call(self, args, kwargs)
+        #
+        # try to deduce function name, although this only works in simple cases
+        #
+        if isinstance(arg.func, ast.Name):
+            func_name = arg.func.id
+        elif isinstance(arg.func, ast.Attribute):
+            func_name = arg.func.attr
+        else:
+            func_name = "<other>"
+        if callable(func):
+            _LOGGER.debug(
+                "%s: calling %s(%s, %s)", self.name, func_name, arg_str, kwargs
+            )
+            if asyncio.iscoroutinefunction(func):
+                return await func(*args, **kwargs)
+            return func(*args, **kwargs)
+        raise NameError(f"function '{func_name}' is not callable (got {func})")
+
+    async def ast_functiondef(self, arg):
+        """Evaluate function definition."""
+        func = EvalFunc(arg)
+        await func.eval_defaults(self)
+        await func.eval_decorators(self)
+        self.sym_table[func.get_name()] = func
+        return None
+
+    async def ast_ifexp(self, arg):
+        """Evaluate if expression."""
+        return (
+            await self.aeval(arg.body)
+            if (await self.aeval(arg.test))
+            else await self.aeval(arg.orelse)
+        )
+
+    async def ast_num(self, arg):
+        """Evaluate number."""
+        return arg.n
+
+    async def ast_str(self, arg):
+        """Evaluate string."""
+        return arg.s
+
+    async def ast_nameconstant(self, arg):
+        """Evaluate name constant."""
+        return arg.value
+
+    async def ast_constant(self, arg):
+        """Evaluate constant."""
+        return arg.value
+
+    async def ast_joinedstr(self, arg):
+        """Evaluate joined string."""
+        val = ""
+        for arg1 in arg.values:
+            this_val = await self.aeval(arg1)
+            val = val + str(this_val)
+        return val
+
+    async def ast_formattedvalue(self, arg):
+        """Evaluate formatted value."""
+        val = await self.aeval(arg.value)
+        if arg.format_spec is not None:
+            fmt = await self.aeval(arg.format_spec)
+            return f"{val:{fmt}}"
+        return f"{val}"
+
+    def ast_get_names2_dict(self, arg, names):
+        """Recursively find all the names mentioned in the AST tree."""
+        if isinstance(arg, ast.Attribute):
+            names[self.ast_attribute2_name(arg)] = 1
+        elif isinstance(arg, ast.Name):
+            names[arg.id] = 1
+        else:
+            for child in ast.iter_child_nodes(arg):
+                self.ast_get_names2_dict(child, names)
+
+    def ast_get_names(self):
+        """Return list of all the names mentioned in our AST tree."""
+        names = {}
+        if self.ast:
+            self.ast_get_names2_dict(self.ast, names)
+        return [*names]
+
+    def parse(self, code_str, filename="<unknown>"):
+        """Parse the code_str source code into an AST tree."""
+        self.ast = None
+        self.filename = filename
+        try:
+            if isinstance(code_str, list):
+                code_str = "\n".join(code_str)
+            self.str = code_str
+            self.ast = ast.parse(code_str, filename=self.filename)
+            return True
+        except SyntaxError as err:
+            self.exception = f"syntax error {err}"
+            self.exception_long = traceback.format_exc(0)
+            _LOGGER.error(
+                "syntax error file %s: %s", self.filename, traceback.format_exc(0)
+            )
+            return False
+        except asyncio.CancelledError:  # pylint: disable=try-except-raise
+            raise
+        except Exception as err:  # pylint: disable=broad-except
+            self.exception = f"parsing error {err}"
+            self.exception_long = traceback.format_exc(0)
+            _LOGGER.error(
+                "parsing error file %s: %s", self.filename, traceback.format_exc(0)
+            )
+            return False
+
+    def get_exception(self):
+        """Return the last exception."""
+        return self.exception
+
+    def get_exception_long(self):
+        """Return the last exception in a longer form."""
+        return self.exception_long
+
+    def set_local_sym_table(self, sym_table):
+        """Set the local symbol table."""
+        self.local_sym_table = sym_table
+
+    async def eval(self, new_state_vars=None):
+        """Execute parsed code, with the optional state variables added to the scope."""
+        self.exception = None
+        self.exception_long = None
+        if new_state_vars:
+            self.local_sym_table.update(new_state_vars)
+        if self.ast:
+            val = await self.aeval(self.ast)
+            if isinstance(val, EvalStopFlow):
+                return None
+            return val
+        return None
+
+    def dump(self):
+        """Dump the AST tree for debugging."""
+        return ast.dump(self.ast)

--- a/homeassistant/components/pyscript/event.py
+++ b/homeassistant/components/pyscript/event.py
@@ -1,0 +1,60 @@
+"""Handles event firing and notification."""
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Event:
+    """Defined event functions."""
+
+    def __init__(self, hass):
+        """Initialize Event."""
+
+        self.hass = hass
+        #
+        # notify message queues by event type
+        #
+        self.notify = {}
+        self.notify_remove = {}
+
+    async def event_listener(self, event):
+        """Listen callback for given event which updates any notifications."""
+
+        _LOGGER.debug("event_listener(%s)", event)
+        func_args = {
+            "trigger_type": "event",
+            "event_type": event.event_type,
+        }
+        func_args.update(event.data)
+        await self.update(event.event_type, func_args)
+
+    def notify_add(self, event_type, queue):
+        """Register to notify for events of given type to be sent to queue."""
+
+        if event_type not in self.notify:
+            self.notify[event_type] = set()
+            _LOGGER.debug("event.notify_add(%s) -> adding event listener", event_type)
+            self.notify_remove[event_type] = self.hass.bus.async_listen(
+                event_type, self.event_listener
+            )
+        self.notify[event_type].add(queue)
+
+    def notify_del(self, event_type, queue):
+        """Unregister to notify for events of given type for given queue."""
+
+        if event_type not in self.notify or queue not in self.notify[event_type]:
+            return
+        self.notify[event_type].discard(queue)
+        if len(self.notify[event_type]) == 0:
+            self.notify_remove[event_type]()
+            _LOGGER.debug("event.notify_del(%s) -> removing event listener", event_type)
+            del self.notify_remove[event_type]
+
+    async def update(self, event_type, func_args):
+        """Deliver all notifications for an event of the given type."""
+
+        _LOGGER.debug("event.update(%s, %s, %s)", event_type, vars, func_args)
+        if event_type in self.notify:
+            for queue in self.notify[event_type]:
+                await queue.put(["event", func_args])

--- a/homeassistant/components/pyscript/handler.py
+++ b/homeassistant/components/pyscript/handler.py
@@ -1,0 +1,189 @@
+"""Function call handling."""
+
+import asyncio
+import logging
+import traceback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def current_task():
+    """Return our asyncio current task."""
+    try:
+        # python >= 3.7
+        return asyncio.current_task()
+    except AttributeError:
+        # python <= 3.6
+        return asyncio.tasks.Task.current_task()
+
+
+class Handler:
+    """Define function handler functions."""
+
+    def __init__(self, hass):
+        """Initialize State."""
+        self.hass = hass
+        self.unique_task2_name = {}
+        self.unique_name2_task = {}
+
+        #
+        # initial list of available functions
+        #
+        self.functions = {
+            "event.fire": self.event_fire,
+            "task.sleep": self.async_sleep,
+            "task.unique": self.task_unique,
+            "service.call": self.service_call,
+            "service.has_service": self.service_has_service,
+        }
+
+        #
+        # Functions that take the AstEval context as a first argument,
+        # which is needed by a handful of special functions that need the
+        # ast context
+        #
+
+        self.ast_functions = {
+            "log.debug": self.get_logger_debug,
+            "log.error": self.get_logger_error,
+            "log.info": self.get_logger_info,
+            "log.warning": self.get_logger_warning,
+        }
+
+        #
+        # We create loggers for each top-level function that include
+        # that function's name.  We cache them here so we only create
+        # one for each function
+        #
+        self.loggers = {}
+
+    async def async_sleep(self, duration):
+        """Implement task.sleep()."""
+        await asyncio.sleep(float(duration))
+
+    async def event_fire(self, event_type, **kwargs):
+        """Implement event.fire()."""
+        self.hass.bus.async_fire(event_type, kwargs)
+
+    async def task_unique(self, name, kill_me=False):
+        """Implement task.unique()."""
+        task = current_task()
+        if name in self.unique_name2_task:
+            if not kill_me:
+                task = self.unique_name2_task[name]
+            try:
+                task.cancel()
+                await task
+            except asyncio.CancelledError:
+                pass
+            self.unique_task2_name.pop(self.unique_name2_task[name], None)
+            self.unique_name2_task.pop(name, None)
+        self.unique_name2_task[name] = task
+        self.unique_name2_task[task] = name
+
+    def service_has_service(self, domain, name):
+        """Implement service.has_service()."""
+        return self.hass.services.has_service(domain, name)
+
+    async def service_call(self, domain, name, **kwargs):
+        """Implement service.call()."""
+        await self.hass.services.async_call(domain, name, kwargs)
+
+    def get_logger(self, ast_ctx, log_type, *arg, **kw):
+        """Return a logger function tied to the execution context of a function."""
+
+        if ast_ctx.name not in self.loggers:
+            #
+            # Maintain a cache for efficiency.  Remove last name (handlers)
+            # and replace with "func.{name}".
+            #
+            name = __name__
+            i = name.rfind(".")
+            if i >= 0:
+                name = f"{name[0:i]}.func.{ast_ctx.name}"
+            self.loggers[ast_ctx.name] = logging.getLogger(name)
+        return getattr(self.loggers[ast_ctx.name], log_type)
+
+    def get_logger_debug(self, ast_ctx, *arg, **kw):
+        """Implement log.debug()."""
+        return self.get_logger(ast_ctx, "debug", *arg, **kw)
+
+    def get_logger_error(self, ast_ctx, *arg, **kw):
+        """Implement log.error()."""
+        return self.get_logger(ast_ctx, "error", *arg, **kw)
+
+    def get_logger_info(self, ast_ctx, *arg, **kw):
+        """Implement log.info()."""
+        return self.get_logger(ast_ctx, "info", *arg, **kw)
+
+    def get_logger_warning(self, ast_ctx, *arg, **kw):
+        """Implement log.warning()."""
+        return self.get_logger(ast_ctx, "warning", *arg, **kw)
+
+    def register(self, funcs):
+        """Register functions to be available for calling."""
+        for name, func in funcs.items():
+            self.functions[name] = func
+
+    def deregister(self, *names):
+        """Deregister functions."""
+        for name in names:
+            if name in self.functions:
+                del self.functions[name]
+
+    def register_ast(self, funcs):
+        """Register functions that need ast context to be available for calling."""
+        for name, func in funcs.items():
+            self.ast_functions[name] = func
+
+    def deregister_ast(self, *names):
+        """Deregister functions that need ast context."""
+        for name in names:
+            if name in self.ast_functions:
+                del self.ast_functions[name]
+
+    def install_ast_funcs(self, ast_ctx):
+        """Install ast functions into the local symbol table."""
+        sym_table = {}
+        for name, func in self.ast_functions.items():
+            sym_table[name] = func(ast_ctx)
+        ast_ctx.set_local_sym_table(sym_table)
+
+    def get(self, name):
+        """Lookup a function locally and then as a service."""
+        func = self.functions.get(name, None)
+        if func:
+            return func
+        parts = name.split(".", 1)
+        if len(parts) != 2:
+            return None
+        domain = parts[0]
+        service = parts[1]
+        if not self.hass.services.has_service(domain, service):
+            return None
+
+        async def service_call(*args, **kwargs):
+            await self.hass.services.async_call(domain, service, kwargs)
+
+        return service_call
+
+    async def run_coro(self, coro):
+        """Run coroutine task and update unique task on start and exit."""
+        try:
+            await coro
+        except asyncio.CancelledError:
+            task = current_task()
+            if task in self.unique_task2_name:
+                self.unique_name2_task.pop(self.unique_task2_name[task], None)
+                self.unique_task2_name.pop(task, None)
+            raise
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.error("run_coro: %s", traceback.format_exc(-1))
+        task = current_task()
+        if task in self.unique_task2_name:
+            self.unique_name2_task.pop(self.unique_task2_name[task], None)
+            self.unique_task2_name.pop(task, None)
+
+    def create_task(self, coro):
+        """Create a new task that runs a coroutine."""
+        return self.hass.loop.create_task(self.run_coro(coro))

--- a/homeassistant/components/pyscript/handler.py
+++ b/homeassistant/components/pyscript/handler.py
@@ -23,8 +23,8 @@ class Handler:
     def __init__(self, hass):
         """Initialize State."""
         self.hass = hass
-        self.unique_task2_name = {}
-        self.unique_name2_task = {}
+        self.unique_task2name = {}
+        self.unique_name2task = {}
 
         #
         # initial list of available functions
@@ -68,18 +68,18 @@ class Handler:
     async def task_unique(self, name, kill_me=False):
         """Implement task.unique()."""
         task = current_task()
-        if name in self.unique_name2_task:
+        if name in self.unique_name2task:
             if not kill_me:
-                task = self.unique_name2_task[name]
+                task = self.unique_name2task[name]
             try:
                 task.cancel()
                 await task
             except asyncio.CancelledError:
                 pass
-            self.unique_task2_name.pop(self.unique_name2_task[name], None)
-            self.unique_name2_task.pop(name, None)
-        self.unique_name2_task[name] = task
-        self.unique_name2_task[task] = name
+            self.unique_task2name.pop(self.unique_name2task[name], None)
+            self.unique_name2task.pop(name, None)
+        self.unique_name2task[name] = task
+        self.unique_name2task[task] = name
 
     def service_has_service(self, domain, name):
         """Implement service.has_service()."""
@@ -125,22 +125,10 @@ class Handler:
         for name, func in funcs.items():
             self.functions[name] = func
 
-    def deregister(self, *names):
-        """Deregister functions."""
-        for name in names:
-            if name in self.functions:
-                del self.functions[name]
-
     def register_ast(self, funcs):
         """Register functions that need ast context to be available for calling."""
         for name, func in funcs.items():
             self.ast_functions[name] = func
-
-    def deregister_ast(self, *names):
-        """Deregister functions that need ast context."""
-        for name in names:
-            if name in self.ast_functions:
-                del self.ast_functions[name]
 
     def install_ast_funcs(self, ast_ctx):
         """Install ast functions into the local symbol table."""
@@ -173,16 +161,16 @@ class Handler:
             await coro
         except asyncio.CancelledError:
             task = current_task()
-            if task in self.unique_task2_name:
-                self.unique_name2_task.pop(self.unique_task2_name[task], None)
-                self.unique_task2_name.pop(task, None)
+            if task in self.unique_task2name:
+                self.unique_name2task.pop(self.unique_task2name[task], None)
+                self.unique_task2name.pop(task, None)
             raise
         except Exception:  # pylint: disable=broad-except
             _LOGGER.error("run_coro: %s", traceback.format_exc(-1))
         task = current_task()
-        if task in self.unique_task2_name:
-            self.unique_name2_task.pop(self.unique_task2_name[task], None)
-            self.unique_task2_name.pop(task, None)
+        if task in self.unique_task2name:
+            self.unique_name2task.pop(self.unique_task2name[task], None)
+            self.unique_task2name.pop(task, None)
 
     def create_task(self, coro):
         """Create a new task that runs a coroutine."""

--- a/homeassistant/components/pyscript/manifest.json
+++ b/homeassistant/components/pyscript/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "pyscript",
+  "name": "Python scripting",
+  "config_flow": false,
+  "documentation": "https://www.home-assistant.io/integrations/pyscript",
+  "requirements": [],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@craigbarratt"
+  ]
+}

--- a/homeassistant/components/pyscript/services.yaml
+++ b/homeassistant/components/pyscript/services.yaml
@@ -1,0 +1,4 @@
+# Describes the format for available pyscript services
+
+reload:
+  description: Reload all available pyscripts and restart triggers

--- a/homeassistant/components/pyscript/state.py
+++ b/homeassistant/components/pyscript/state.py
@@ -1,0 +1,114 @@
+"""Handles state variable access and change notification."""
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class State:
+    """Class for state functions."""
+
+    def __init__(self, hass, handler_func):
+        """Initialize State."""
+
+        self.hass = hass
+        self.handler = handler_func
+        #
+        # notify message queues by variable
+        #
+        self.notify = {}
+
+        #
+        # Last value of state variable notifications.  We maintain this
+        # so that trigger evaluation can use the last notified value,
+        # rather than fetching the current value, which is subject to
+        # race conditions multiple state variables are set.
+        #
+        self.notify_var_last = {}
+
+    def notify_add(self, var_names, queue):
+        """Register to notify state variables changes to be sent to queue."""
+
+        for var_name in var_names if isinstance(var_names, list) else [var_names]:
+            parts = var_name.split(".")
+            if len(parts) != 2 and len(parts) != 3:
+                continue
+            state_var_name = f"{parts[0]}.{parts[1]}"
+            if state_var_name not in self.notify:
+                self.notify[state_var_name] = {}
+            self.notify[state_var_name][queue] = var_names
+
+    def notify_del(self, var_names, queue):
+        """Unregister notify of state variables changes for given queue."""
+
+        for var_name in var_names if isinstance(var_names, list) else [var_names]:
+            parts = var_name.split(".")
+            if len(parts) != 2 and len(parts) != 3:
+                continue
+            state_var_name = f"{parts[0]}.{parts[1]}"
+            if (
+                state_var_name not in self.notify
+                or queue not in self.notify[state_var_name]
+            ):
+                return
+            del self.notify[state_var_name][queue]
+
+    async def update(self, new_vars, func_args):
+        """Deliver all notifications for state variable changes."""
+
+        _LOGGER.debug("state.update(%s, %s)", new_vars, func_args)
+        notify = {}
+        for var_name, var_val in new_vars.items():
+            if var_name in self.notify:
+                self.notify_var_last[var_name] = var_val
+                notify.update(self.notify[var_name])
+
+        for queue, var_names in notify.items():
+            await queue.put(["state", [self.notify_var_get(var_names), func_args]])
+
+    def notify_var_get(self, var_names):
+        """Return the most recent value of a state variable change."""
+        new_vars = {}
+        for var_name in var_names if var_names is not None else []:
+            if var_name in self.notify_var_last:
+                new_vars[var_name] = self.notify_var_last[var_name]
+        return new_vars
+
+    def set(self, var_name, value, attributes=None):
+        """Set a state variable and optional attributes in hass."""
+        if len(var_name.split(".")) != 2:
+            _LOGGER.error(
+                "invalid variable name %s (should be 'domain.entity')", var_name
+            )
+            return
+        _LOGGER.debug("setting %s = %s, attr = %s", var_name, value, attributes)
+        self.hass.states.async_set(var_name, value, attributes)
+
+    def exist(self, var_name):
+        """Check if a state variable value or attribute exists in hass."""
+        parts = var_name.split(".")
+        if len(parts) != 2 and len(parts) != 3:
+            return False
+        value = self.hass.states.get(f"{parts[0]}.{parts[1]}")
+        return value and (len(parts) == 2 or value.attributes.get(parts[2]) is not None)
+
+    def get(self, var_name):
+        """Get a state variable value or attribute from hass."""
+        parts = var_name.split(".")
+        if len(parts) != 2 and len(parts) != 3:
+            return None
+        value = self.hass.states.get(f"{parts[0]}.{parts[1]}")
+        if not value:
+            return None
+        if len(parts) == 2:
+            _LOGGER.debug("state.get %s = %s", var_name, value.state)
+            return value.state
+        return value.attributes.get(parts[2])
+
+    def register_functions(self):
+        """Register state functions."""
+        functions = {
+            "state.get": self.get,
+            "state.set": self.set,
+        }
+        self.handler.register(functions)

--- a/homeassistant/components/pyscript/trigger.py
+++ b/homeassistant/components/pyscript/trigger.py
@@ -1,0 +1,861 @@
+"""Implements all the trigger logic."""
+
+import asyncio
+import datetime
+import locale
+import logging
+import math
+import re
+import time
+
+from homeassistant.components.pyscript.eval import AstEval
+from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
+import homeassistant.helpers.sun as sun
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def dt_now():
+    """Return current time."""
+    return datetime.datetime.now()
+
+
+def isleap(year):
+    """Return True or False if year is a leap year."""
+    return (year % 4) == 0 and (year % 100) != 0 or (year % 400) == 0
+
+
+def days_in_mon(month, year):
+    """Return numbers of days in month month of year year, 1 <= month <= 12."""
+    dom = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+    month -= 1
+    if month < 0 or month >= len(dom):
+        return -1
+    if (month == 1) and isleap(year):
+        return dom[month] + 1
+    return dom[month]
+
+
+def days_between(month1, day1, year1, month2, day2, year2):
+    """Calculate the number of days in between the two dates."""
+    delta = datetime.date(year2, month2, day2) - datetime.date(year1, month1, day1)
+    return round(delta.days)
+
+
+def cron_ge(cron, fld, curr):
+    """Return the next value which is >= curr and matches cron[fld]."""
+    min_ge = 1000
+    ret = 1000
+
+    if cron[fld] == "*":
+        return curr
+    for elt in cron[fld].split(","):
+        rng = elt.split("-")
+        if len(rng) == 2:
+            rng0, rng1 = [int(rng[0]), int(rng[1])]
+            if rng0 < ret:
+                ret = rng0
+            if rng0 > rng1:
+                # wrap case
+                if curr >= rng0 or curr < rng1:
+                    return curr
+            else:
+                if rng0 <= curr <= rng1:
+                    return curr
+                if curr <= rng0 < min_ge:
+                    min_ge = rng0
+        elif len(rng) == 1:
+            rng0 = int(rng[0])
+            if curr == rng0:
+                return curr
+            if rng0 < ret:
+                ret = rng0
+            if curr <= rng0 < min_ge:
+                min_ge = rng0
+        else:
+            _LOGGER.warning("can't parse field %s in cron entry %s", elt, cron[fld])
+            return curr
+    if min_ge < 1000:
+        return min_ge
+    return ret
+
+
+def parse_time_offset(offset_str):
+    """Parse a time offset."""
+    match = re.split(r"([-+]?\s*\d*\.?\d+(?:[eE][-+]?\d+)?)\s*(\w*)", offset_str)
+    scale = 1
+    value = 0
+    if len(match) == 4:
+        value = float(match[1].replace(" ", ""))
+        if match[2] == "m" or match[2] == "min" or match[2] == "minutes":
+            scale = 60
+        elif match[2] == "h" or match[2] == "hr" or match[2] == "hours":
+            scale = 60 * 60
+        elif match[2] == "d" or match[2] == "day" or match[2] == "days":
+            scale = 60 * 60 * 24
+        elif match[2] == "w" or match[2] == "week" or match[2] == "weeks":
+            scale = 60 * 60 * 24 * 7
+    return value * scale
+
+
+class TrigTime:
+    """Class for trigger time functions."""
+
+    def __init__(self, hass=None, handler_func=None):
+        """Create a new TrigTime."""
+        self.hass = hass
+
+        def wait_until_factory(ast_ctx):
+            """Return wapper to call to astFunction with the ast context."""
+
+            async def wait_until_call(*arg, **kw):
+                return await self.wait_until(ast_ctx, *arg, **kw)
+
+            return wait_until_call
+
+        self.ast_funcs = {
+            "task.wait_until": wait_until_factory,
+        }
+        handler_func.register_ast(self.ast_funcs)
+
+        #
+        # Mappings of day of week name to number, using US convention of sun is 0.
+        # Initialized based on locale at startup.
+        #
+        self.dow2int = {}
+        for i in range(0, 7):
+            self.dow2int[
+                locale.nl_langinfo(getattr(locale, f"ABDAY_{i+1}")).lower()
+            ] = i
+            self.dow2int[locale.nl_langinfo(getattr(locale, f"DAY_{i+1}")).lower()] = i
+
+    async def wait_until(
+        self,
+        ast_ctx,
+        state_trigger=None,
+        state_check_now=True,
+        time_trigger=None,
+        event_trigger=None,
+        timeout=None,
+        **kwargs,
+    ):
+        """Wait for zero or more triggers, until an optional timeout."""
+        if state_trigger is None and time_trigger is None and event_trigger is None:
+            if timeout is not None:
+                await asyncio.sleep(timeout)
+                return {"trigger_type": "timeout"}
+            return {"trigger_type": "none"}
+        state_trig_ident = None
+        state_trig_expr = None
+        event_trig_expr = None
+        notify_q = asyncio.Queue(0)
+        if state_trigger is not None:
+            state_trig_expr = AstEval(
+                f"{ast_ctx.name} wait_until state_trigger",
+                ast_ctx.global_sym_table,
+                state_func=ast_ctx.state,
+                event_func=ast_ctx.event,
+                handler_func=ast_ctx.handler,
+            )
+            ast_ctx.handler.install_ast_funcs(state_trig_expr)
+            state_trig_expr.parse(state_trigger)
+            #
+            # check straight away to see if the condition is met (to avoid race conditions)
+            #
+            if await state_trig_expr.eval():
+                return {"trigger_type": "state"}
+            state_trig_ident = state_trig_expr.ast_get_names()
+            _LOGGER.debug(
+                "trigger %s wait_until: watching vars %s",
+                ast_ctx.name,
+                state_trig_ident,
+            )
+            if len(state_trig_ident) > 0:
+                ast_ctx.state.notify_add(state_trig_ident, notify_q)
+        if event_trigger is not None:
+            if isinstance(event_trigger, str):
+                event_trigger = [event_trigger]
+            ast_ctx.event.notify_add(event_trigger[0], notify_q)
+            if len(event_trigger) > 1:
+                event_trig_expr = AstEval(
+                    f"trigger {ast_ctx.name} wait_until event_trigger",
+                    ast_ctx.global_sym_table,
+                    state_func=ast_ctx.state,
+                    event_func=ast_ctx.event,
+                    handler_func=ast_ctx.handler,
+                )
+                ast_ctx.handler.install_ast_funcs(event_trig_expr)
+                event_trig_expr.parse(event_trigger[1])
+        time0 = time.monotonic()
+        while 1:
+            this_timeout = None
+            if time_trigger is not None:
+                now = dt_now()
+                time_next = self.timer_trigger_next(time_trigger, now)
+                _LOGGER.debug(
+                    "trigger %s wait_until time_next = %s, now = %s",
+                    ast_ctx.name,
+                    time_next,
+                    now,
+                )
+                if time_next is not None:
+                    this_timeout = (time_next - now).total_seconds()
+            if timeout is not None:
+                time_left = time0 + timeout - time.monotonic()
+                if time_left <= 0:
+                    ret = {"trigger_type": "timeout"}
+                    break
+                if this_timeout is None or this_timeout > time_left:
+                    this_timeout = time_left
+            if this_timeout is None:
+                if state_trigger is None and event_trigger is None:
+                    _LOGGER.debug(
+                        "trigger %s wait_until no next time - returning with none",
+                        ast_ctx.name,
+                    )
+                    return {"trigger_type": "none"}
+                _LOGGER.debug("trigger %s wait_until no timeout", ast_ctx.name)
+                notify_type, notify_info = await notify_q.get()
+            else:
+                try:
+                    _LOGGER.debug(
+                        "trigger %s wait_until %s secs", ast_ctx.name, this_timeout
+                    )
+                    notify_type, notify_info = await asyncio.wait_for(
+                        notify_q.get(), timeout=this_timeout
+                    )
+                except asyncio.TimeoutError:
+                    ret = {"trigger_type": "time"}
+                    break
+            if notify_type == "state":
+                new_vars = notify_info[0] if notify_info else None
+                if state_trig_expr is None or await state_trig_expr.eval(new_vars):
+                    ret = notify_info[1] if notify_info else None
+                    break
+            elif notify_type == "event":
+                if event_trig_expr is None or await event_trig_expr.eval(notify_info):
+                    ret = notify_info
+                    break
+            else:
+                _LOGGER.error(
+                    "trigger %s wait_until got unexpected queue message %s",
+                    ast_ctx.name,
+                    notify_type,
+                )
+
+        if state_trig_ident:
+            for name in state_trig_ident:
+                ast_ctx.state.notify_del(name, notify_q)
+        if event_trigger is not None:
+            ast_ctx.event.notify_del(event_trigger[0], notify_q)
+        _LOGGER.debug("trigger %s wait_until returning %s", ast_ctx.name, ret)
+        return ret
+
+    def parse_date_time(self, date_time_str, day_offset, now):
+        """Parse a date time string, returning datetime."""
+        year = now.year
+        month = now.month
+        day = now.day
+
+        dt_str = date_time_str.strip().lower()
+        #
+        # parse the date
+        #
+        skip = True
+        match0 = re.split(r"^0*(\d+)[-/]0*(\d+)(?:[-/]0*(\d+))?", dt_str)
+        match1 = re.split(r"^(\w+).*", dt_str)
+        if len(match0) == 5:
+            year, month, day = int(match0[1]), int(match0[2]), int(match0[3])
+            day_offset = 0  # explicit date means no offset
+        elif len(match0) == 4:
+            month, day = int(match0[1]), int(match0[2])
+            day_offset = 0  # explicit date means no offset
+        elif len(match1) == 3:
+            if match1[1] in self.dow2int:
+                dow = self.dow2int[match1[1]]
+                if dow >= (now.isoweekday() % 7):
+                    day_offset = dow - (now.isoweekday() % 7)
+                else:
+                    day_offset = 7 + dow - (now.isoweekday() % 7)
+            elif match1[1] == "today":
+                day_offset = 0
+            elif match1[1] == "tomorrow":
+                day_offset = 1
+            else:
+                skip = False
+        else:
+            skip = False
+        if day_offset != 0:
+            now = datetime.datetime(year, month, day) + datetime.timedelta(
+                days=day_offset
+            )
+            year = now.year
+            month = now.month
+            day = now.day
+        else:
+            now = datetime.datetime(year, month, day)
+        if skip:
+            i = dt_str.find(" ")
+            if i >= 0:
+                dt_str = dt_str[i + 1 :].strip()
+            else:
+                return now
+
+        #
+        # parse the time
+        #
+        skip = True
+        match0 = re.split(
+            r"0*(\d+):0*(\d+)(?::0*(\d*\.?\d+(?:[eE][-+]?\d+)?))?", dt_str
+        )
+        if len(match0) == 5:
+            if match0[3] is not None:
+                hour, mins, sec = int(match0[1]), int(match0[2]), float(match0[3])
+            else:
+                hour, mins, sec = int(match0[1]), int(match0[2]), 0
+        elif dt_str.startswith("sunrise") or dt_str.startswith("sunset"):
+            if dt_str.startswith("sunrise"):
+                time_sun = sun.get_astral_event_date(self.hass, SUN_EVENT_SUNRISE)
+            else:
+                time_sun = sun.get_astral_event_date(self.hass, SUN_EVENT_SUNSET)
+            if time_sun is None:
+                _LOGGER.warning("'%s' not defined at this latitude", dt_str)
+                # return something in the past so it is ignored
+                return now - datetime.timedelta(days=100)
+            time_sun = dt_util.as_local(time_sun)
+            hour, mins, sec = time_sun.hour, time_sun.minute, time_sun.second
+            _LOGGER.debug(
+                "trigger: got %s = %02d:%02d:%02d (t = %s)",
+                dt_str,
+                hour,
+                mins,
+                sec,
+                time_sun,
+            )
+        elif dt_str.startswith("noon"):
+            hour, mins, sec = 12, 0, 0
+        elif dt_str.startswith("midnight"):
+            hour, mins, sec = 0, 0, 0
+        else:
+            hour, mins, sec = 0, 0, 0
+            skip = False
+        now = now + datetime.timedelta(seconds=sec + 60 * (mins + 60 * hour))
+        if skip:
+            i = dt_str.find(" ")
+            if i >= 0:
+                dt_str = dt_str[i + 1 :].strip()
+            else:
+                return now
+        #
+        # parse the offset
+        #
+        if len(dt_str) > 0 and (dt_str[0] == "+" or dt_str[0] == "-"):
+            now = now + datetime.timedelta(seconds=parse_time_offset(dt_str))
+        return now
+
+    def timer_active_check(self, time_spec, now):
+        """Check if the given time matches the time specification."""
+        pos_check = False
+        pos_cnt = 0
+        neg_check = True
+
+        for entry in time_spec if isinstance(time_spec, list) else [time_spec]:
+            this_match = False
+            neg = False
+            active_str = entry.strip()
+            if active_str.startswith("not"):
+                neg = True
+                active_str = active_str[3:].strip()
+            else:
+                pos_cnt = pos_cnt + 1
+            match0 = re.split(
+                r"cron\((\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\)", active_str
+            )
+            match1 = re.split(r"range\(([^,]*),(.*)\)", active_str)
+            if len(match0) == 7:
+                cron = match0[1:6]
+                check = [now.minute, now.hour, now.day, now.month, now.isoweekday() % 7]
+                this_match = True
+                for fld in range(5):
+                    if check[fld] != cron_ge(cron, fld, check[fld]):
+                        this_match = False
+                        break
+            elif len(match1) == 4:
+                start = self.parse_date_time(match1[1].strip(), 0, now)
+                end = self.parse_date_time(match1[2].strip(), 0, start)
+                if start < end:
+                    if start <= now <= end:
+                        this_match = True
+                else:
+                    if start <= now or now <= end:
+                        this_match = True
+            else:
+                this_match = False
+
+            if neg:
+                neg_check = neg_check and not this_match
+            else:
+                pos_check = pos_check or this_match
+        #
+        # An empty spec, or only neg specs, matches True
+        #
+        if pos_cnt == 0:
+            pos_check = True
+        return pos_check and neg_check
+
+    def timer_trigger_next(self, time_spec, now):
+        """Return the next trigger time based on the given time and time specification."""
+        next_time = None
+        if not isinstance(time_spec, list):
+            time_spec = [time_spec]
+        for spec in time_spec:  # pylint: disable=too-many-nested-blocks
+            match0 = re.split(r"cron\((\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\)", spec)
+            match1 = re.split(r"once\((.*)\)", spec)
+            match2 = re.split(r"period\(([^,]*),([^,]*)(?:,([^,]*))?\)", spec)
+            if len(match0) == 7:
+                cron = match0[1:6]
+                year_next = now.year
+                min_next = cron_ge(cron, 0, now.minute)
+                mon_next = cron_ge(cron, 3, now.month)  # 1-12
+                mday_next = cron_ge(cron, 2, now.day)  # 1-31
+                wday_next = cron_ge(cron, 4, now.isoweekday() % 7)  # 0-6
+                today = True
+                if (
+                    (cron[2] == "*" and (now.isoweekday() % 7) != wday_next)
+                    or (cron[4] == "*" and now.day != mday_next)
+                    or (now.day != mday_next and (now.isoweekday() % 7) != wday_next)
+                    or (now.month != mon_next)
+                ):
+                    today = False
+                min_next0 = now.minute + 1
+                if (now.hour + 1) <= cron_ge(cron, 1, now.hour):
+                    min_next0 = 0
+                min_next = cron_ge(cron, 0, min_next0 % 60)
+
+                carry = min_next < min_next0
+                hr_next0 = now.hour
+                if carry:
+                    hr_next0 = hr_next0 + 1
+                hr_next = cron_ge(cron, 1, hr_next0 % 24)
+                carry = hr_next < hr_next0
+
+                if carry or not today:
+                    # this event occurs after today
+
+                    min_next = cron_ge(cron, 0, 0)
+                    hr_next = cron_ge(cron, 1, 0)
+
+                    #
+                    # calculate the date of the next occurrence of this event, which
+                    # will be on a different day than the current
+                    #
+
+                    # check monthly day specification
+                    d1_next = now.day + 1
+                    day1 = cron_ge(
+                        cron, 2, (d1_next - 1) % days_in_mon(now.month, now.year) + 1
+                    )
+                    carry1 = day1 < d1_next
+
+                    # check weekly day specification
+                    wday_next2 = (now.isoweekday() % 7) + 1
+                    wday_next = cron_ge(cron, 4, wday_next2 % 7)
+                    if wday_next < wday_next2:
+                        days_ahead = 7 - wday_next2 + wday_next
+                    else:
+                        days_ahead = wday_next - wday_next2
+                    day2 = (d1_next + days_ahead - 1) % days_in_mon(
+                        now.month, now.year
+                    ) + 1
+                    carry2 = day2 < d1_next
+
+                    #
+                    # based on their respective specifications, day1, and day2 give
+                    # the day of the month for the next occurrence of this event.
+                    #
+                    if cron[2] == "*" and cron[4] != "*":
+                        day1 = day2
+                        carry1 = carry2
+                    if cron[2] != "*" and cron[4] == "*":
+                        day2 = day1
+                        carry2 = carry1
+
+                    if (carry1 and carry2) or (now.month != mon_next):
+                        # event does not occur in this month
+                        if now.month == 12:
+                            mon_next = cron_ge(cron, 3, 1)
+                            year_next = year_next + 1
+                        else:
+                            mon_next = cron_ge(cron, 3, now.month + 1)
+                        # recompute day1 and day2
+                        day1 = cron_ge(cron, 2, 1)
+                        days_btwn = (
+                            days_between(
+                                now.month, now.day, now.year, mon_next, 1, year_next
+                            )
+                            + 1
+                        )
+                        wd_next = ((now.isoweekday() % 7) + days_btwn) % 7
+                        # wd_next is the day of the week of the first of month mon
+                        wday_next = cron_ge(cron, 4, wd_next)
+                        if wday_next < wd_next:
+                            day2 = 1 + 7 - wd_next + wday_next
+                        else:
+                            day2 = 1 + wday_next - wd_next
+                        if cron[2] != "*" and cron[4] == "*":
+                            day2 = day1
+                        if cron[2] == "*" and cron[4] != "*":
+                            day1 = day2
+                        if day1 < day2:
+                            mday_next = day1
+                        else:
+                            mday_next = day2
+                    else:
+                        # event occurs in this month
+                        mon_next = now.month
+                        if not carry1 and not carry2:
+                            if day1 < day2:
+                                mday_next = day1
+                            else:
+                                mday_next = day2
+                        elif not carry1:
+                            mday_next = day1
+                        else:
+                            mday_next = day2
+
+                    #
+                    # now that we have the min, hr, day, mon, yr of the next event,
+                    # figure out what time that turns out to be.
+                    #
+                    this_t = datetime.datetime(
+                        year_next, mon_next, mday_next, hr_next, min_next, 0
+                    )
+                    if now < this_t and (next_time is None or this_t < next_time):
+                        next_time = this_t
+                else:
+                    # this event occurs today
+                    secs = (
+                        3600 * (hr_next - now.hour)
+                        + 60 * (min_next - now.minute)
+                        - now.second
+                        - 1e-6 * now.microsecond
+                    )
+                    this_t = now + datetime.timedelta(seconds=secs)
+                    if now < this_t and (next_time is None or this_t < next_time):
+                        next_time = this_t
+
+            elif len(match1) == 3:
+                this_t = self.parse_date_time(match1[1].strip(), 0, now)
+                if this_t <= now:
+                    #
+                    # Try tomorrow (won't make a difference if spec has full date)
+                    #
+                    this_t = self.parse_date_time(match1[1].strip(), 1, now)
+                if now < this_t and (next_time is None or this_t < next_time):
+                    next_time = this_t
+
+            elif len(match2) == 5:
+                start = self.parse_date_time(match2[1].strip(), 0, now)
+                if now < start and (next_time is None or start < next_time):
+                    next_time = start
+                period = parse_time_offset(match2[2].strip())
+                if now >= start and period > 0:
+                    secs = period * (
+                        1.0 + math.floor((now - start).total_seconds() / period)
+                    )
+                    this_t = start + datetime.timedelta(seconds=secs)
+                    if match2[3] is None:
+                        if now < this_t and (next_time is None or this_t < next_time):
+                            next_time = this_t
+                    else:
+                        end = self.parse_date_time(match2[3].strip(), 0, now)
+                        if end < start:
+                            #
+                            # end might be a time tomorrow
+                            #
+                            end = self.parse_date_time(match2[3].strip(), 1, now)
+                        if now < this_t <= end and (
+                            next_time is None or this_t < next_time
+                        ):
+                            next_time = this_t
+                        if next_time is None or now >= end:
+                            #
+                            # Try tomorrow's start (won't make a difference if spec has
+                            # full date)
+                            #
+                            start = self.parse_date_time(match2[3].strip(), 1, now)
+                            if now < start and (next_time is None or start < next_time):
+                                next_time = start
+            else:
+                _LOGGER.warning("Can't parse %s in time_trigger check", spec)
+        return next_time
+
+
+class TrigInfo:
+    """Class for all trigger-decorated functions."""
+
+    def __init__(
+        self,
+        name,
+        trig_cfg,
+        event_func=None,
+        state_func=None,
+        handler_func=None,
+        trig_time=None,
+    ):
+        """Create a new TrigInfo."""
+        self.name = name
+        self.task = None
+        self.trig_cfg = trig_cfg
+        self.state_trigger = trig_cfg.get("state_trigger", None)
+        self.time_trigger = trig_cfg.get("time_trigger", None)
+        self.event_trigger = trig_cfg.get("event_trigger", None)
+        self.state_active = trig_cfg.get("state_active", None)
+        self.time_active = trig_cfg.get("time_active", None)
+        self.action = trig_cfg.get("action")
+        self.action_ast_ctx = trig_cfg.get("action_ast_ctx")
+        self.global_sym_table = trig_cfg.get("global_sym_table", {})
+        self.notify_q = asyncio.Queue(0)
+        self.active_expr = None
+        self.state_trig_expr = None
+        self.state_trig_ident = None
+        self.event_trig_expr = None
+        self.have_trigger = False
+        self.event = event_func
+        self.state = state_func
+        self.handler = handler_func
+        self.trig_time = trig_time
+
+        _LOGGER.debug("trigger %s event_trigger = %s", self.name, self.event_trigger)
+
+        if self.state_active is not None:
+            self.active_expr = AstEval(
+                f"trigger {self.name} state_active",
+                self.global_sym_table,
+                state_func=self.state,
+                event_func=self.event,
+                handler_func=self.handler,
+            )
+            self.handler.install_ast_funcs(self.active_expr)
+            self.active_expr.parse(self.state_active)
+
+        if self.time_trigger is not None:
+            self.have_trigger = True
+
+        if self.state_trigger is not None:
+            self.state_trig_expr = AstEval(
+                f"trigger {self.name} state_trigger",
+                self.global_sym_table,
+                state_func=self.state,
+                event_func=self.event,
+                handler_func=self.handler,
+            )
+            self.handler.install_ast_funcs(self.state_trig_expr)
+            self.state_trig_expr.parse(self.state_trigger)
+            self.state_trig_ident = self.state_trig_expr.ast_get_names()
+            _LOGGER.debug(
+                "trigger %s: watching vars %s", self.name, self.state_trig_ident
+            )
+            if len(self.state_trig_ident) > 0:
+                self.state.notify_add(self.state_trig_ident, self.notify_q)
+            self.have_trigger = True
+
+        if self.event_trigger is not None:
+            _LOGGER.debug(
+                "trigger %s adding event_trigger %s", self.name, self.event_trigger[0]
+            )
+            self.event.notify_add(self.event_trigger[0], self.notify_q)
+            if len(self.event_trigger) == 2:
+                self.event_trig_expr = AstEval(
+                    f"trigger {self.name} event_trigger",
+                    self.global_sym_table,
+                    state_func=self.state,
+                    event_func=self.event,
+                    handler_func=self.handler,
+                )
+                self.handler.install_ast_funcs(self.event_trig_expr)
+                self.event_trig_expr.parse(self.event_trigger[1])
+            self.have_trigger = True
+
+    async def stop(self):
+        """Stop this trigger task."""
+
+        if self.task:
+            if self.state_trig_ident:
+                self.state.notify_del(self.state_trig_ident, self.notify_q)
+            if self.event_trigger is not None:
+                self.event.notify_del(self.event_trigger[0], self.notify_q)
+            if self.task:
+                try:
+                    self.task.cancel()
+                    await self.task
+                except asyncio.CancelledError:
+                    pass
+            self.task = None
+        _LOGGER.debug("trigger %s is stopped", self.name)
+
+    def start(self):
+        """Start this trigger task."""
+        self.task = self.handler.create_task(self.trigger_watch())
+        _LOGGER.debug("trigger %s is active", self.name)
+
+    async def trigger_watch(self):
+        """Task that runs for each trigger, waiting for the next trigger and calling the function."""
+
+        while 1:
+            try:
+                timeout = None
+                notify_info = None
+                notify_type = None
+                if self.time_trigger:
+                    now = dt_now()
+                    time_next = self.trig_time.timer_trigger_next(
+                        self.time_trigger, now
+                    )
+                    _LOGGER.debug(
+                        "trigger %s time_next = %s, now = %s", self.name, time_next, now
+                    )
+                    if time_next is not None:
+                        timeout = (time_next - now).total_seconds()
+                if timeout is None and self.have_trigger:
+                    _LOGGER.debug(
+                        "trigger %s waiting for state change or event", self.name
+                    )
+                    notify_type, notify_info = await self.notify_q.get()
+                elif timeout is not None:
+                    try:
+                        _LOGGER.debug(
+                            "trigger %s waiting for %s secs", self.name, timeout
+                        )
+                        notify_type, notify_info = await asyncio.wait_for(
+                            self.notify_q.get(), timeout=timeout
+                        )
+                    except asyncio.TimeoutError:
+                        notify_info = {"trigger_type": "time"}
+                        if (
+                            (not self.active_expr or await self.active_expr.eval())
+                            and (
+                                not self.time_active
+                                or self.trig_time.timer_active_check(
+                                    self.time_active, dt_now()
+                                )
+                            )
+                            and self.action
+                        ):
+                            _LOGGER.debug(
+                                "trigger %s got time_trigger, running action", self.name
+                            )
+                            self.handler.create_task(
+                                self.action.call(
+                                    self.action_ast_ctx, kwargs=notify_info
+                                )
+                            )
+                        else:
+                            _LOGGER.debug(
+                                "trigger %s got time_trigger, but not active", self.name
+                            )
+                        continue
+                if notify_type == "state" or notify_type is None:
+                    if notify_info:
+                        new_vars, func_args = notify_info
+                    else:
+                        new_vars, func_args = {}, {}
+                    if (
+                        (
+                            self.state_trig_expr is None
+                            or await self.state_trig_expr.eval(new_vars)
+                        )
+                        and (
+                            self.active_expr is None
+                            or await self.active_expr.eval(new_vars)
+                        )
+                        and (
+                            self.time_active is None
+                            or self.trig_time.timer_active_check(
+                                self.time_active, dt_now()
+                            )
+                        )
+                        and self.action
+                    ):
+                        _LOGGER.debug(
+                            "trigger %s state_trig_expr = %s based on %s",
+                            self.name,
+                            await self.state_trig_expr.eval(new_vars)
+                            if self.state_trig_expr
+                            else None,
+                            new_vars,
+                        )
+                        _LOGGER.debug(
+                            "trigger %s got state_trig_expr, running action (kwargs = %s)",
+                            self.name,
+                            func_args,
+                        )
+                        self.handler.create_task(
+                            self.action.call(self.action_ast_ctx, kwargs=func_args)
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "trigger %s got state_trig_expr, but not active", self.name
+                        )
+                        # _LOGGER.debug(f'state_trig_expr = {await self.state_trig_expr.eval(new_vars) if self.state_trig_expr else None}')
+                        # _LOGGER.debug(f'timerActive = {self.trig_time.timer_active_check(self.time_active, dt_now())
+                        #                                                       if self.time_active else None}')
+                elif notify_type == "event":
+                    if (
+                        (
+                            self.event_trig_expr is None
+                            or await self.event_trig_expr.eval(notify_info)
+                        )
+                        and (
+                            self.active_expr is None
+                            or await self.active_expr.eval(notify_info)
+                        )
+                        and (
+                            self.time_active is None
+                            or self.trig_time.timer_active_check(
+                                self.time_active, dt_now()
+                            )
+                        )
+                        and self.action
+                    ):
+                        _LOGGER.debug(
+                            "trigger %s got event_trig_expr, running action (kwargs = %s)",
+                            self.name,
+                            notify_info,
+                        )
+                        self.handler.create_task(
+                            self.action.call(self.action_ast_ctx, kwargs=notify_info)
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "trigger %s got event_trig_expr, but not active", self.name
+                        )
+                elif notify_type is not None:
+                    _LOGGER.error(
+                        "trigger %s got unexpected queue message %s",
+                        self.name,
+                        notify_type,
+                    )
+
+                #
+                # if there is no time, event or state trigger, then quit
+                # (empty triggers mean run the function once at startup)
+                #
+                if (
+                    self.state_trigger is None
+                    and self.time_trigger is None
+                    and self.event_trigger is None
+                ):
+                    _LOGGER.debug("trigger %s returning", self.name)
+                    return
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
+            except Exception:  # pylint: disable=broad-except
+                # _LOGGER.error(f"{self.name}: " + traceback.format_exc(-1))
+                if self.state_trig_ident:
+                    self.state.notify_del(self.state_trig_ident, self.notify_q)
+                if self.event_trigger is not None:
+                    self.event.notify_del(self.event_trigger[0], self.notify_q)
+                return

--- a/tests/components/pyscript/__init__.py
+++ b/tests/components/pyscript/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Python scripting integration."""

--- a/tests/components/pyscript/test_func.py
+++ b/tests/components/pyscript/test_func.py
@@ -1,0 +1,332 @@
+"""Test the pyscript component."""
+from ast import literal_eval
+import asyncio
+from datetime import datetime as dt
+import time
+
+import homeassistant.components.pyscript.trigger as trigger
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_STATE_CHANGED
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import mock_open, patch
+
+
+async def setup_script(hass, notify_q, now, source):
+    """Initialize and load the given pyscript."""
+    scripts = [
+        "/some/config/dir/pyscripts/hello.py",
+    ]
+    with patch(
+        "homeassistant.components.pyscript.os.path.isdir", return_value=True
+    ), patch(
+        "homeassistant.components.pyscript.glob.iglob", return_value=scripts
+    ), patch(
+        "homeassistant.components.pyscript.open",
+        mock_open(read_data=source),
+        create=True,
+    ), patch(
+        "homeassistant.components.pyscript.trigger.dt_now", return_value=now
+    ):
+        assert await async_setup_component(hass, "pyscript", {})
+
+    #
+    # I'm not sure how to run the mock all the time, so just force the dt_now()
+    # trigger function to return the fixed time, now.
+    #
+    trigger.__dict__["dt_now"] = lambda: now
+
+    if notify_q:
+
+        async def state_changed(event):
+            var_name = event.data["entity_id"]
+            if var_name != "pyscript.done":
+                return
+            value = event.data["new_state"].state
+            await notify_q.put(value)
+
+        hass.bus.async_listen(EVENT_STATE_CHANGED, state_changed)
+
+
+async def wait_until_done(notify_q):
+    """Wait for the done handshake."""
+    return await asyncio.wait_for(notify_q.get(), timeout=4)
+
+
+async def test_state_trigger(hass, caplog):
+    """Test state trigger."""
+    notify_q = asyncio.Queue(0)
+    await setup_script(
+        hass,
+        notify_q,
+        dt(2020, 7, 1, 11, 59, 59, 999999),
+        """
+
+from math import sqrt
+
+seq_num = 0
+
+@time_trigger
+def func_startup_sync():
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func_startup_sync setting pyscript.done = {seq_num}")
+    pyscript.done = seq_num
+
+@state_trigger("pyscript.f1var1 == '1'")
+def func1(var_name=None, value=None):
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func1 var = {var_name}, value = {value}")
+    pyscript.done = [seq_num, var_name, int(value), sqrt(1024)]
+
+@state_trigger("pyscript.f1var1 == '1' or pyscript.f2var2 == '2'")
+@state_active("pyscript.f2var3 == '3' and pyscript.f2var4 == '4'")
+def func2(var_name=None, value=None):
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func2 var = {var_name}, value = {value}")
+    pyscript.done = [seq_num, var_name, int(value), sqrt(4096)]
+
+@event_trigger("fire_event")
+def fire_event(**kwargs):
+    event.fire(kwargs["new_event"], arg1=kwargs["arg1"], arg2=kwargs["arg2"])
+
+@event_trigger("test_event3", "arg1 == 20 and arg2 == 30")
+def func3(trigger_type=None, event_type=None, **kwargs):
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func3 trigger_type = {trigger_type}, event_type = {event_type}, event_data = {kwargs}")
+    pyscript.done = [seq_num, trigger_type, event_type, kwargs]
+
+@event_trigger("test_event4", "arg1 == 20 and arg2 == 30")
+def func4(trigger_type=None, event_type=None, **kwargs):
+    global seq_num
+
+    seq_num += 1
+    res = task.wait_until(event_trigger=["test_event4b", "arg1 == 25 and arg2 == 35"], timeout=10)
+    log.info(f"func4 trigger_type = {res}, event_type = {event_type}, event_data = {kwargs}")
+    pyscript.done = [seq_num, res, event_type, kwargs]
+
+    seq_num += 1
+    res = task.wait_until(state_trigger="pyscript.f4var2 == '2'", timeout=10)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    pyscript.setVar1 = 1
+    pyscript.setVar2 = "var2"
+    state.set("pyscript.setVar3", {"foo": "bar"})
+    state.set("pyscript.setVar1", 1 + int(state.get("pyscript.setVar1")), {"attr1": 456, "attr2": 987})
+
+    seq_num += 1
+    res = task.wait_until(state_trigger="pyscript.f4var2 == '10'", timeout=10)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res, pyscript.setVar1, pyscript.setVar1.attr1, state.get("pyscript.setVar1.attr2"), pyscript.setVar2, state.get("pyscript.setVar3")]
+
+    seq_num += 1
+    #
+    # now() returns 1usec before 2020/7/1 12:00:00, so trigger right
+    # at noon
+    #
+    res = task.wait_until(time_trigger="once(2020/07/01 12:00:00)", timeout=10)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    seq_num += 1
+    #
+    # this should pick up the trigger interval at noon
+    #
+    res = task.wait_until(time_trigger="period(2020/07/01 11:00, 1 hour)", timeout=10)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    seq_num += 1
+    #
+    # cron triggers at 10am, 11am, noon, 1pm, 2pm, 3pm, so this
+    # should trigger at noon.
+    #
+    res = task.wait_until(time_trigger="cron(0 10-15 * * *)", timeout=10)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    seq_num += 1
+    #
+    # also add some month and day ranges; should still trigger at noon
+    # on 7/1.
+    #
+    res = task.wait_until(time_trigger="cron(0 10-15 1-5 6,7 *)", timeout=10)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    seq_num += 1
+    #
+    # make sure a short timeout works, for a trigger further out in time
+    # (7/5 at 3pm)
+    #
+    res = task.wait_until(time_trigger="cron(0 15 5 6,7 *)", timeout=1e-6)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    seq_num += 1
+    #
+    # make sure a short timeout works when there are no other triggers
+    #
+    res = task.wait_until(timeout=1e-6)
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    seq_num += 1
+    #
+    # make sure we return when there no triggers and no timeout
+    #
+    res = task.wait_until()
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    seq_num += 1
+    #
+    # make sure we return when there only past triggers and no timeout
+    #
+    res = task.wait_until(time_trigger="once(2020/7/1 11:59:59.999)")
+    log.info(f"func4 trigger_type = {res}")
+    pyscript.done = [seq_num, res]
+
+    #
+    # create a run-time exception
+    #
+    no_such_function("xyz")
+
+""",
+    )
+    seq_num = 0
+
+    seq_num += 1
+    # fire event to startup triggers, and handshake when they are running
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    assert literal_eval(await wait_until_done(notify_q)) == seq_num
+
+    seq_num += 1
+    # initialize the trigger and active variables
+    hass.states.async_set("pyscript.f1var1", 0)
+    hass.states.async_set("pyscript.f2var2", 0)
+    hass.states.async_set("pyscript.f2var3", 0)
+    hass.states.async_set("pyscript.f2var4", 0)
+
+    # try some values that shouldn't work, then one that does
+    hass.states.async_set("pyscript.f1var1", 0)
+    hass.states.async_set("pyscript.f1var1", "string")
+    hass.states.async_set("pyscript.f1var1", -1)
+    hass.states.async_set("pyscript.f1var1", 1)
+    assert literal_eval(await wait_until_done(notify_q)) == [
+        seq_num,
+        "pyscript.f1var1",
+        1,
+        32,
+    ]
+    assert "func1 var = pyscript.f1var1, value = 1" in caplog.text
+
+    seq_num += 1
+    hass.states.async_set("pyscript.f2var3", 3)
+    hass.states.async_set("pyscript.f2var4", 0)
+    hass.states.async_set("pyscript.f2var2", 0)
+    hass.states.async_set("pyscript.f1var1", 0)
+    hass.states.async_set("pyscript.f1var1", 1)
+    assert literal_eval(await wait_until_done(notify_q)) == [
+        seq_num,
+        "pyscript.f1var1",
+        1,
+        32,
+    ]
+
+    seq_num += 1
+    hass.states.async_set("pyscript.f2var4", 4)
+    hass.states.async_set("pyscript.f2var2", 2)
+    assert literal_eval(await wait_until_done(notify_q)) == [
+        seq_num,
+        "pyscript.f2var2",
+        2,
+        64,
+    ]
+    assert "func2 var = pyscript.f2var2, value = 2" in caplog.text
+
+    seq_num += 1
+    hass.bus.async_fire("test_event3", {"arg1": 12, "arg2": 34})
+    hass.bus.async_fire("test_event3", {"arg1": 20, "arg2": 29})
+    hass.bus.async_fire("test_event3", {"arg1": 12, "arg2": 30})
+    hass.bus.async_fire(
+        "fire_event", {"new_event": "test_event3", "arg1": 20, "arg2": 30}
+    )
+    assert literal_eval(await wait_until_done(notify_q)) == [
+        seq_num,
+        "event",
+        "test_event3",
+        {"arg1": 20, "arg2": 30},
+    ]
+
+    seq_num += 1
+    hass.states.async_set("pyscript.f4var2", 2)
+    hass.bus.async_fire("test_event4", {"arg1": 20, "arg2": 30})
+    t_now = time.monotonic()
+    while notify_q.empty() and time.monotonic() < t_now + 4:
+        hass.bus.async_fire("test_event4b", {"arg1": 15, "arg2": 25})
+        hass.bus.async_fire("test_event4b", {"arg1": 20, "arg2": 25})
+        hass.bus.async_fire("test_event4b", {"arg1": 25, "arg2": 35})
+        await asyncio.sleep(1e-3)
+    trig = {
+        "trigger_type": "event",
+        "event_type": "test_event4b",
+        "arg1": 25,
+        "arg2": 35,
+    }
+    assert literal_eval(await wait_until_done(notify_q)) == [
+        seq_num,
+        trig,
+        "test_event4",
+        {"arg1": 20, "arg2": 30},
+    ]
+
+    seq_num += 1
+    # the state_trigger wait_until should succeed immediately, since the expr is true
+    assert literal_eval(await wait_until_done(notify_q)) == [
+        seq_num,
+        {"trigger_type": "state"},
+    ]
+
+    seq_num += 1
+    # now try a few other values, then the correct one
+    hass.states.async_set("pyscript.f4var2", 4)
+    hass.states.async_set("pyscript.f4var2", 2)
+    hass.states.async_set("pyscript.f4var2", 10)
+    trig = {
+        "trigger_type": "state",
+        "var_name": "pyscript.f4var2",
+        "value": "10",
+        "old_value": "2",
+    }
+    result = literal_eval(await wait_until_done(notify_q))
+    assert result[0] == seq_num
+    assert result[1] == trig
+    assert result[2:5] == ["2", 456, 987]
+
+    assert hass.states.get("pyscript.setVar1").state == "2"
+    assert hass.states.get("pyscript.setVar1").attributes == {
+        "attr1": 456,
+        "attr2": 987,
+    }
+    assert hass.states.get("pyscript.setVar2").state == "var2"
+    assert literal_eval(hass.states.get("pyscript.setVar3").state) == {"foo": "bar"}
+
+    #
+    # check for the three time triggers, two timeouts and two none
+    #
+    for trig_type in ["time"] * 4 + ["timeout"] * 2 + ["none"] * 2:
+        seq_num += 1
+        assert literal_eval(await wait_until_done(notify_q)) == [
+            seq_num,
+            {"trigger_type": trig_type},
+        ]
+
+    assert "name 'no_such_function' is not defined" in caplog.text

--- a/tests/components/pyscript/test_init.py
+++ b/tests/components/pyscript/test_init.py
@@ -1,0 +1,337 @@
+"""Test the pyscript component."""
+from ast import literal_eval
+import asyncio
+from datetime import datetime as dt
+
+from homeassistant.components.pyscript import DOMAIN
+import homeassistant.components.pyscript.trigger as trigger
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_STATE_CHANGED
+from homeassistant.helpers.service import async_get_all_descriptions
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import mock_open, patch
+
+
+async def setup_script(hass, notify_q, now, source):
+    """Initialize and load the given pyscript."""
+    scripts = [
+        "/some/config/dir/pyscript/hello.py",
+    ]
+    with patch(
+        "homeassistant.components.pyscript.os.path.isdir", return_value=True
+    ), patch(
+        "homeassistant.components.pyscript.glob.iglob", return_value=scripts
+    ), patch(
+        "homeassistant.components.pyscript.open",
+        mock_open(read_data=source),
+        create=True,
+    ), patch(
+        "homeassistant.components.pyscript.trigger.dt_now", return_value=now
+    ):
+        assert await async_setup_component(hass, "pyscript", {})
+
+    #
+    # I'm not sure how to run the mock all the time, so just force the dt_now()
+    # trigger function to return the fixed time, now.
+    #
+    trigger.__dict__["dt_now"] = lambda: now
+
+    if notify_q:
+
+        async def state_changed(event):
+            var_name = event.data["entity_id"]
+            if var_name != "pyscript.done":
+                return
+            value = event.data["new_state"].state
+            await notify_q.put(value)
+
+        hass.bus.async_listen(EVENT_STATE_CHANGED, state_changed)
+
+
+async def wait_until_done(notify_q):
+    """Wait for the done handshake."""
+    return await asyncio.wait_for(notify_q.get(), timeout=4)
+
+
+async def test_setup_fails_on_no_dir(hass, caplog):
+    """Test we fail setup when no dir found."""
+    with patch("homeassistant.components.pyscript.os.path.isdir", return_value=False):
+        res = await async_setup_component(hass, "pyscript", {})
+
+    assert not res
+    assert "Folder pyscript not found in configuration folder" in caplog.text
+
+
+async def test_service_exists(hass):
+    """Test discover, compile script and install a service."""
+
+    await setup_script(
+        hass,
+        None,
+        dt(2020, 7, 1, 11, 59, 59, 999999),
+        """
+@service
+def func1():
+    pass
+
+def func2():
+    pass
+""",
+    )
+    assert hass.services.has_service("pyscript", "func1")
+    assert hass.services.has_service("pyscript", "reload")
+    assert not hass.services.has_service("pyscript", "func2")
+
+
+async def test_service_description(hass):
+    """Test service description defined in doc_string."""
+
+    await setup_script(
+        hass,
+        None,
+        dt(2020, 7, 1, 11, 59, 59, 999999),
+        """
+@service
+def func_no_doc_string(param1=None):
+    pass
+
+@service
+def func_simple_doc_string(param2=None, param3=None):
+    \"\"\"This is func2_simple_doc_string.\"\"\"
+    pass
+
+@service
+def func_yaml_doc_string(param2=None, param3=None):
+    \"\"\"yaml
+description: This is func_yaml_doc_string.
+fields:
+  param1:
+    description: first argument
+    example: 12
+  param2:
+    description: second argument
+    example: 34
+\"\"\"
+    pass
+""",
+    )
+    descriptions = await async_get_all_descriptions(hass)
+
+    assert descriptions[DOMAIN]["func_no_doc_string"] == {
+        "description": "pyscript function func_no_doc_string()",
+        "fields": {"param1": {"description": "argument param1"}},
+    }
+
+    assert descriptions[DOMAIN]["func_simple_doc_string"] == {
+        "description": "This is func2_simple_doc_string.",
+        "fields": {
+            "param2": {"description": "argument param2"},
+            "param3": {"description": "argument param3"},
+        },
+    }
+
+    assert descriptions[DOMAIN]["func_yaml_doc_string"] == {
+        "description": "This is func_yaml_doc_string.",
+        "fields": {
+            "param1": {"description": "first argument", "example": "12"},
+            "param2": {"description": "second argument", "example": "34"},
+        },
+    }
+
+
+async def test_service_run(hass, caplog):
+    """Test running a service with keyword arguments."""
+    notify_q = asyncio.Queue(0)
+    await setup_script(
+        hass,
+        notify_q,
+        dt(2020, 7, 1, 11, 59, 59, 999999),
+        """
+
+@service
+def func1(arg1=1, arg2=2):
+    x = 1
+    x = 2 * x + 3
+    log.info(f"this is func1 x = {x}, arg1 = {arg1}, arg2 = {arg2}")
+    pyscript.done = [x, arg1, arg2]
+
+@service
+def func2(**kwargs):
+    x = 1
+    x = 2 * x + 3
+    log.info(f"this is func1 x = {x}, kwargs = {kwargs}")
+    has2 = service.has_service("pyscript", "func2")
+    has3 = service.has_service("pyscript", "func3")
+    pyscript.done = [x, kwargs, has2, has3]
+
+@service
+def call_service(domain=None, name=None, **kwargs):
+    service.call(domain, name, **kwargs)
+
+""",
+    )
+    await hass.services.async_call("pyscript", "func1", {})
+    ret = await wait_until_done(notify_q)
+    assert literal_eval(ret) == [5, 1, 2]
+    assert "this is func1 x = 5" in caplog.text
+
+    await hass.services.async_call(
+        "pyscript",
+        "call_service",
+        {"domain": "pyscript", "name": "func1", "arg1": "string1"},
+    )
+    ret = await wait_until_done(notify_q)
+    assert literal_eval(ret) == [5, "string1", 2]
+
+    await hass.services.async_call(
+        "pyscript", "func1", {"arg1": "string1", "arg2": 123}
+    )
+    ret = await wait_until_done(notify_q)
+    assert literal_eval(ret) == [5, "string1", 123]
+
+    await hass.services.async_call(
+        "pyscript", "call_service", {"domain": "pyscript", "name": "func2"}
+    )
+    ret = await wait_until_done(notify_q)
+    assert literal_eval(ret) == [5, {}, 1, 0]
+
+    await hass.services.async_call(
+        "pyscript",
+        "call_service",
+        {"domain": "pyscript", "name": "func2", "arg1": "string1"},
+    )
+    ret = await wait_until_done(notify_q)
+    assert literal_eval(ret) == [5, {"arg1": "string1"}, 1, 0]
+
+    await hass.services.async_call(
+        "pyscript", "func2", {"arg1": "string1", "arg2": 123}
+    )
+    ret = await wait_until_done(notify_q)
+    assert literal_eval(ret) == [5, {"arg1": "string1", "arg2": 123}, 1, 0]
+
+
+async def test_reload(hass, caplog):
+    """Test reload."""
+    notify_q = asyncio.Queue(0)
+    now = dt(2020, 7, 1, 11, 59, 59, 999999)
+    source0 = """
+seq_num = 0
+
+@time_trigger
+def func_startup_sync():
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func_startup_sync setting pyscript.done = {seq_num}")
+    pyscript.done = seq_num
+
+@service
+@state_trigger("pyscript.f1var1 == '1'")
+def func1(var_name=None, value=None):
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func1 var = {var_name}, value = {value}")
+    pyscript.done = [seq_num, var_name, int(value)]
+
+"""
+    source1 = """
+seq_num = 10
+
+@time_trigger
+def func_startup_sync():
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func_startup_sync setting pyscript.done = {seq_num}")
+    pyscript.done = seq_num
+
+@service
+@state_trigger("pyscript.f5var1 == '1'")
+def func5(var_name=None, value=None):
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func5 var = {var_name}, value = {value}")
+    pyscript.done = [seq_num, var_name, int(value)]
+
+"""
+
+    await setup_script(hass, notify_q, now, source0)
+
+    #
+    # run and reload 6 times with different sournce files to make sure seqNum
+    # gets reset, autostart of func_startup_sync happens and triggers work each time
+    #
+    # first time: fire event to startup triggers and run func_startup_sync
+    #
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    for i in range(6):
+        if i & 1:
+            seq_num = 10
+
+            assert not hass.services.has_service("pyscript", "func1")
+            assert hass.services.has_service("pyscript", "reload")
+            assert hass.services.has_service("pyscript", "func5")
+
+            seq_num += 1
+            assert literal_eval(await wait_until_done(notify_q)) == seq_num
+
+            seq_num += 1
+            # initialize the trigger and active variables
+            hass.states.async_set("pyscript.f5var1", 0)
+
+            # try some values that shouldn't work, then one that does
+            hass.states.async_set("pyscript.f5var1", "string")
+            hass.states.async_set("pyscript.f5var1", 1)
+            assert literal_eval(await wait_until_done(notify_q)) == [
+                seq_num,
+                "pyscript.f5var1",
+                1,
+            ]
+            assert "func5 var = pyscript.f5var1, value = 1" in caplog.text
+            next_source = source0
+
+        else:
+            seq_num = 0
+
+            assert hass.services.has_service("pyscript", "func1")
+            assert hass.services.has_service("pyscript", "reload")
+            assert not hass.services.has_service("pyscript", "func5")
+
+            seq_num += 1
+            assert literal_eval(await wait_until_done(notify_q)) == seq_num
+
+            seq_num += 1
+            # initialize the trigger and active variables
+            hass.states.async_set("pyscript.f1var1", 0)
+
+            # try some values that shouldn't work, then one that does
+            hass.states.async_set("pyscript.f1var1", "string")
+            hass.states.async_set("pyscript.f1var1", 1)
+            assert literal_eval(await wait_until_done(notify_q)) == [
+                seq_num,
+                "pyscript.f1var1",
+                1,
+            ]
+            assert "func1 var = pyscript.f1var1, value = 1" in caplog.text
+            next_source = source1
+
+        #
+        # now reload the other source file
+        #
+        scripts = [
+            "/some/config/dir/pyscript/hello.py",
+        ]
+        with patch(
+            "homeassistant.components.pyscript.os.path.isdir", return_value=True
+        ), patch(
+            "homeassistant.components.pyscript.glob.iglob", return_value=scripts
+        ), patch(
+            "homeassistant.components.pyscript.open",
+            mock_open(read_data=next_source),
+            create=True,
+        ), patch(
+            "homeassistant.components.pyscript.trigger.dt_now", return_value=now
+        ):
+            await hass.services.async_call("pyscript", "reload", {}, blocking=True)

--- a/tests/components/pyscript/test_unique.py
+++ b/tests/components/pyscript/test_unique.py
@@ -1,0 +1,162 @@
+"""Test the pyscript component."""
+from ast import literal_eval
+import asyncio
+from datetime import datetime as dt
+
+import homeassistant.components.pyscript.trigger as trigger
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_STATE_CHANGED
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import mock_open, patch
+
+
+async def setup_script(hass, notify_q, now, source):
+    """Initialize and load the given pyscript."""
+    scripts = [
+        "/some/config/dir/pyscripts/hello.py",
+    ]
+    with patch(
+        "homeassistant.components.pyscript.os.path.isdir", return_value=True
+    ), patch(
+        "homeassistant.components.pyscript.glob.iglob", return_value=scripts
+    ), patch(
+        "homeassistant.components.pyscript.open",
+        mock_open(read_data=source),
+        create=True,
+    ), patch(
+        "homeassistant.components.pyscript.trigger.dt_now", return_value=now
+    ):
+        assert await async_setup_component(hass, "pyscript", {})
+
+    #
+    # I'm not sure how to run the mock all the time, so just force the dt_now()
+    # trigger function to return the fixed time, now.
+    #
+    trigger.__dict__["dt_now"] = lambda: now
+
+    if notify_q:
+
+        async def state_changed(event):
+            var_name = event.data["entity_id"]
+            if var_name != "pyscript.done":
+                return
+            value = event.data["new_state"].state
+            await notify_q.put(value)
+
+        hass.bus.async_listen(EVENT_STATE_CHANGED, state_changed)
+
+
+async def wait_until_done(notify_q):
+    """Wait for the done handshake."""
+    return await asyncio.wait_for(notify_q.get(), timeout=4)
+
+
+async def test_task_unique(hass, caplog):
+    """Test task.unique ."""
+    notify_q = asyncio.Queue(0)
+    await setup_script(
+        hass,
+        notify_q,
+        dt(2020, 7, 1, 11, 59, 59, 999999),
+        """
+
+seq_num = 0
+
+@time_trigger
+def funcStartupSync():
+    global seq_num
+
+    seq_num += 1
+    log.info(f"funcStartupSync setting pyscript.done = {seq_num}")
+    pyscript.done = seq_num
+
+@state_trigger("pyscript.f1var1 == '1'")
+def func1(var_name=None, value=None):
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func1 var = {var_name}, value = {value}")
+    task.unique("func1")
+    pyscript.done = [seq_num, var_name]
+    # this should terminate our task, so the 2nd done won't happen
+    # if it did, we would get out of sequence in the assert
+    task.unique("func1")
+    pyscript.done = [seq_num, var_name]
+
+@state_trigger("pyscript.f2var1 == '1'")
+def func2(var_name=None, value=None):
+    global seq_num
+
+    seq_num += 1
+    mySeqNum = seq_num
+    log.info(f"func2 var = {var_name}, value = {value}")
+    task.unique("func2")
+    while 1:
+        task.wait_until(state_trigger="pyscript.f2var1 == '2'")
+        pyscript.f2var1 = 0
+        pyscript.done = [mySeqNum, var_name]
+
+@state_trigger("pyscript.f3var1 == '1'")
+def func3(var_name=None, value=None):
+    global seq_num
+
+    seq_num += 1
+    log.info(f"func3 var = {var_name}, value = {value}")
+    task.unique("func2")
+    pyscript.done = [seq_num, var_name]
+""",
+    )
+
+    seq_num = 0
+
+    hass.states.async_set("pyscript.f1var1", 0)
+    hass.states.async_set("pyscript.f2var1", 0)
+    hass.states.async_set("pyscript.f3var1", 0)
+
+    seq_num += 1
+    # fire event to startup triggers, and handshake when they are running
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    assert literal_eval(await wait_until_done(notify_q)) == seq_num
+
+    seq_num += 1
+    hass.states.async_set("pyscript.f1var1", 1)
+    assert literal_eval(await wait_until_done(notify_q)) == [seq_num, "pyscript.f1var1"]
+
+    for _ in range(5):
+        #
+        # repeat this test 5 times
+        #
+        seq_num += 1
+        hass.states.async_set("pyscript.f1var1", 0)
+        hass.states.async_set("pyscript.f1var1", 1)
+        assert literal_eval(await wait_until_done(notify_q)) == [
+            seq_num,
+            "pyscript.f1var1",
+        ]
+
+    # get func2() through wait_notify and get reply; should be in wait_notify()
+    seq_num += 1
+    hass.states.async_set("pyscript.f2var1", 1)
+    hass.states.async_set("pyscript.f2var1", 2)
+    assert literal_eval(await wait_until_done(notify_q)) == [seq_num, "pyscript.f2var1"]
+
+    # now run func3() which will kill func2()
+    seq_num += 1
+    hass.states.async_set("pyscript.f3var1", 1)
+    assert literal_eval(await wait_until_done(notify_q)) == [seq_num, "pyscript.f3var1"]
+
+    # now run func3() a few more times, and also try to re-trigger func2()
+    # should be no more acks from func2()
+    for _ in range(10):
+        #
+        # repeat this test 10 times
+        #
+        seq_num += 1
+        hass.states.async_set("pyscript.f2var1", 2)
+        hass.states.async_set("pyscript.f2var1", 0)
+        hass.states.async_set("pyscript.f3var1", 0)
+        hass.states.async_set("pyscript.f3var1", 1)
+        assert literal_eval(await wait_until_done(notify_q)) == [
+            seq_num,
+            "pyscript.f3var1",
+        ]

--- a/tests/components/pyscript/test_unit_eval.py
+++ b/tests/components/pyscript/test_unit_eval.py
@@ -1,0 +1,187 @@
+"""Unit tests for Python interpreter."""
+import asyncio
+
+from homeassistant.components.pyscript.eval import AstEval
+import homeassistant.components.pyscript.handler as handler
+import homeassistant.components.pyscript.state as state
+
+evalTests = [
+    ["1", 1],
+    ["1+1", 2],
+    ["1+2*3-2", 5],
+    ["1-1", 0],
+    ["z = 1+2+3; a = z + 1; a + 3", 10],
+    ["z = 1+2+3; a = z + 1; a - 3", 4],
+    ["x = 1; -x", -1],
+    ["x = 1; x < 2", 1],
+    ["x = 1; 0 < x < 2", 1],
+    ["x = 1; 0 < x < 2 < -x", 0],
+    ["1 and 2", 2],
+    ["1 and 0", 0],
+    ["0 or 1", 1],
+    ["0 or 0", 0],
+    ["z = 'foo'; z + 'bar'", "foobar"],
+    ["xyz.y = 5; xyz.y = 2 + int(xyz.y); int(xyz.y)", 7],
+    ["z = 'abcd'; z.find('c')", 2],
+    ["'abcd'.upper().lower().upper()", "ABCD"],
+    ["len('abcd')", 4],
+    ["6 if 1-1 else 2", 2],
+    ["x = 1; x += 3; x", 4],
+    ["'{1} {0}'.format('one', 'two')", "two one"],
+    ["'%d, %d' % (23, 45)", "23, 45"],
+    ["args = [1, 5, 10]; {6, *args, 15}", {1, 5, 6, 10, 15}],
+    ["args = [1, 5, 10]; [6, *args, 15]", [6, 1, 5, 10, 15]],
+    ["kw = {'x': 1, 'y': 5}; {**kw}", {"x": 1, "y": 5}],
+    [
+        "kw = {'x': 1, 'y': 5}; kw2 = {'z': 10}; {**kw, **kw2}",
+        {"x": 1, "y": 5, "z": 10},
+    ],
+    ["[*iter([1, 2, 3])]", [1, 2, 3]],
+    ["{*iter([1, 2, 3])}", {1, 2, 3}],
+    ["if 1: x = 10\nelse: x = 20\nx", 10],
+    ["if 0: x = 10\nelse: x = 20\nx", 20],
+    ["i = 0\nwhile i < 5: i += 1\ni", 5],
+    ["i = 0\nwhile i < 5: i += 2\ni", 6],
+    ["i = 0\nwhile i < 5:\n    i += 1\n    if i == 3: break\n2 * i", 6],
+    [
+        "i = 0; k = 10\nwhile i < 5:\n    i += 1\n    if i <= 2: continue\n    k += 1\nk + i",
+        18,
+    ],
+    ["i = 1; break; i = 1/0", None],
+    ["s = 0;\nfor i in range(5):\n    s += i\ns", 10],
+    ["s = 0;\nfor i in iter([10,20,30]):\n    s += i\ns", 60],
+    [
+        "z = {'foo': 'bar', 'foo2': 12}; z['foo'] = 'bar2'; z",
+        {"foo": "bar2", "foo2": 12},
+    ],
+    ["z = {'foo': 'bar', 'foo2': 12}; z['foo'] = 'bar2'; z.keys()", {"foo", "foo2"}],
+    ["z = {'foo', 'bar', 12}; z", {"foo", "bar", 12}],
+    [
+        "x = dict(key1 = 'value1', key2 = 'value2'); x",
+        {"key1": "value1", "key2": "value2"},
+    ],
+    [
+        "x = dict(key1 = 'value1', key2 = 'value2', key3 = 'value3'); del x['key1']; x",
+        {"key2": "value2", "key3": "value3"},
+    ],
+    [
+        "x = dict(key1 = 'value1', key2 = 'value2', key3 = 'value3'); del x[['key1', 'key2']]; x",
+        {"key3": "value3"},
+    ],
+    ["z = {'foo', 'bar', 12}; z.remove(12); z.add(20); z", {"foo", "bar", 20}],
+    ["z = [0, 1, 2, 3, 4, 5, 6]; z[1:5:2] = [4, 5]; z", [0, 4, 2, 5, 4, 5, 6]],
+    ["import random as rand, math as m\n[rand.uniform(10,10), m.sqrt(1024)]", [10, 32]],
+    ["from math import sqrt as sqroot\nsqroot(1024)", 32],
+    [
+        """
+bar = 100
+def foo(bar=6):
+    bar += 2
+    return bar
+    bar += 5
+    return 1000
+[foo(), foo(5), bar]
+""",
+        [8, 7, 100],
+    ],
+    [
+        """
+def foo(cnt=4):
+    sum = 0
+    for i in range(cnt):
+        sum += i
+        if i == 6:
+            return 1000 + sum
+        if i == 7:
+            break
+    return sum
+[foo(3), foo(6), foo(10), foo(20), foo()]
+""",
+        [
+            sum(range(3)),
+            sum(range(6)),
+            1000 + sum(range(7)),
+            1000 + sum(range(7)),
+            sum(range(4)),
+        ],
+    ],
+    [
+        """
+def foo(cnt):
+    sum = 0
+    for i in range(cnt):
+        sum += i
+        if i != 6:
+            pass
+        else:
+            return 1000 + sum
+        if i == 7:
+            break
+    return sum
+[foo(3), foo(6), foo(10), foo(20)]
+""",
+        [sum(range(3)), sum(range(6)), 1000 + sum(range(7)), 1000 + sum(range(7))],
+    ],
+    [
+        """
+def foo(cnt):
+    sum = 0
+    i = 0
+    while i < cnt:
+        sum += i
+        if i != 6:
+            pass
+        else:
+            return 1000 + sum
+        if i == 7:
+            break
+        i += 1
+    return sum
+[foo(3), foo(6), foo(10), foo(20)]
+""",
+        [sum(range(3)), sum(range(6)), 1000 + sum(range(7)), 1000 + sum(range(7))],
+    ],
+    [
+        """
+def foo(x=30, *args, y = 123, **kwargs):
+    return [x, y, args, kwargs]
+[foo(a = 10, b = 3), foo(40, 7, 8, 9, a = 10, y = 3), foo(x=42)]
+""",
+        [
+            [30, 123, (), {"a": 10, "b": 3}],
+            [40, 3, (7, 8, 9), {"a": 10}],
+            [42, 123, (), {}],
+        ],
+    ],
+    [
+        """
+def foo(*args):
+    return [*args]
+lst = [6, 10]
+[foo(2, 3, 10) + [*lst], [foo(*lst), *lst]]
+""",
+        [[2, 3, 10, 6, 10], [[6, 10], 6, 10]],
+    ],
+]
+
+
+async def run_one_test(test_data, state_func, handler_func):
+    """Run one interpreter test."""
+    source, expect = test_data
+    ast = AstEval("test", state_func=state_func, handler_func=handler_func)
+    ast.parse(source)
+    if ast.get_exception() is not None:
+        print(f"Parsing {source} failed: {ast.get_exception()}")
+    # print(ast.dump())
+    result = await ast.eval()
+    assert result == expect
+
+
+def test_eval(hass):
+    """Test interpreter."""
+    handler_func = handler.Handler(hass)
+    state_func = state.State(hass, handler_func)
+    state_func.register_functions()
+
+    for test_data in evalTests:
+        asyncio.run(run_one_test(test_data, state_func, handler_func))

--- a/tests/components/pyscript/test_unit_eval.py
+++ b/tests/components/pyscript/test_unit_eval.py
@@ -10,23 +10,48 @@ evalTests = [
     ["1+1", 2],
     ["1+2*3-2", 5],
     ["1-1", 0],
+    ["4/2", 2],
+    ["4**2", 16],
+    ["4<<2", 16],
+    ["16>>2", 4],
+    ["18 ^ 2", 16],
+    ["16 | 2", 18],
+    ["0x37 & 0x6c ", 0x24],
+    ["11 // 2", 5],
+    ["not True", False],
+    ["not False", True],
     ["z = 1+2+3; a = z + 1; a + 3", 10],
     ["z = 1+2+3; a = z + 1; a - 3", 4],
     ["x = 1; -x", -1],
+    ["z = 5; +z", 5],
+    ["~0xff", -256],
     ["x = 1; x < 2", 1],
+    ["x = 1; x <= 1", 1],
     ["x = 1; 0 < x < 2", 1],
+    ["x = 1; 2 > x > 0", 1],
+    ["x = 1; 2 > x >= 1", 1],
     ["x = 1; 0 < x < 2 < -x", 0],
+    ["x = [1,2,3]; del x[1:2]; x", [1, 3]],
+    ["x = [1,2,3]; del x[1::]; x", [1]],
     ["1 and 2", 2],
     ["1 and 0", 0],
     ["0 or 1", 1],
     ["0 or 0", 0],
+    ["f'{1} {2:02d} {3:.1f}'", "1 02 3.0"],
+    [["x = None", "x is None"], True],
+    ["None is not None", False],
+    ["10 in {5, 9, 10, 20}", True],
+    ["10 not in {5, 9, 10, 20}", False],
+    ["sym_local + 10", 20],
     ["z = 'foo'; z + 'bar'", "foobar"],
     ["xyz.y = 5; xyz.y = 2 + int(xyz.y); int(xyz.y)", 7],
+    ["xyz.y = 'bar'; xyz.y += '2'; xyz.y", "bar2"],
     ["z = 'abcd'; z.find('c')", 2],
     ["'abcd'.upper().lower().upper()", "ABCD"],
     ["len('abcd')", 4],
     ["6 if 1-1 else 2", 2],
     ["x = 1; x += 3; x", 4],
+    ["z = [1,2,3]; [z[1], z[-1]]", [2, 3]],
     ["'{1} {0}'.format('one', 'two')", "two one"],
     ["'%d, %d' % (23, 45)", "23, 45"],
     ["args = [1, 5, 10]; {6, *args, 15}", {1, 5, 6, 10, 15}],
@@ -70,7 +95,50 @@ evalTests = [
     ],
     ["z = {'foo', 'bar', 12}; z.remove(12); z.add(20); z", {"foo", "bar", 20}],
     ["z = [0, 1, 2, 3, 4, 5, 6]; z[1:5:2] = [4, 5]; z", [0, 4, 2, 5, 4, 5, 6]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][1:5:2]", [1, 3]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][1:5]", [1, 2, 3, 4]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][1::3]", [1, 4, 7]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][4::]", [4, 5, 6, 7, 8]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][4:]", [4, 5, 6, 7, 8]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][:6:2]", [0, 2, 4]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][:4:]", [0, 1, 2, 3]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][::2]", [0, 2, 4, 6, 8]],
+    ["[0, 1, 2, 3, 4, 5, 6, 7, 8][::]", [0, 1, 2, 3, 4, 5, 6, 7, 8]],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[1:5:2] = [6, 8]; z",
+        [0, 6, 2, 8, 4, 5, 6, 7, 8],
+    ],
+    ["z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[1:5] = [10, 11]; z", [0, 10, 11, 5, 6, 7, 8]],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[1::3] = [10, 11, 12]; z",
+        [0, 10, 2, 3, 11, 5, 6, 12, 8],
+    ],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[4::] = [10, 11, 12, 13]; z",
+        [0, 1, 2, 3, 10, 11, 12, 13],
+    ],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[4:] = [10, 11, 12, 13, 14]; z",
+        [0, 1, 2, 3, 10, 11, 12, 13, 14],
+    ],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[:6:2] = [10, 11, 12]; z",
+        [10, 1, 11, 3, 12, 5, 6, 7, 8],
+    ],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[:4:] = [10, 11, 12, 13]; z",
+        [10, 11, 12, 13, 4, 5, 6, 7, 8],
+    ],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[::2] = [10, 11, 12, 13, 14]; z",
+        [10, 1, 11, 3, 12, 5, 13, 7, 14],
+    ],
+    [
+        "z = [0, 1, 2, 3, 4, 5, 6, 7, 8]; z[::] = [10, 11, 12, 13, 14, 15, 16, 17]; z",
+        [10, 11, 12, 13, 14, 15, 16, 17],
+    ],
     ["import random as rand, math as m\n[rand.uniform(10,10), m.sqrt(1024)]", [10, 32]],
+    ["import cmath\ncmath.sqrt(complex(3, 4))", 2 + 1j],
     ["from math import sqrt as sqroot\nsqroot(1024)", 32],
     [
         """
@@ -86,6 +154,54 @@ def foo(bar=6):
     ],
     [
         """
+bar = 100
+def foo(bar=6):
+    bar += 2
+    del bar
+    return bar
+    bar += 5
+    return 1000
+[foo(), foo(5), bar]
+""",
+        [100, 100, 100],
+    ],
+    [
+        """
+bar = 100
+bar2 = 1000
+bar3 = 100
+def foo(arg=6):
+    global bar, bar2, bar3
+    bar += arg
+    bar2 = 1001
+    del bar3
+    return bar
+    bar += arg
+    return 1000
+[foo(), foo(5), bar, bar2]
+""",
+        [106, 111, 111, 1001],
+    ],
+    [
+        """
+bar = 100
+bar2 = 1000
+bar3 = 100
+def foo(arg=6):
+    nonlocal bar, bar2, bar3
+    bar += arg
+    bar2 = 1001
+    del bar3
+    return bar
+    bar += arg
+    return 1000
+[foo(), foo(5), bar, bar2]
+""",
+        [106, 111, 111, 1001],
+    ],
+    [
+        """
+@dec_test("abc")
 def foo(cnt=4):
     sum = 0
     for i in range(cnt):
@@ -103,6 +219,71 @@ def foo(cnt=4):
             1000 + sum(range(7)),
             1000 + sum(range(7)),
             sum(range(4)),
+        ],
+    ],
+    [
+        """
+def foo(cnt=5):
+    sum = 0
+    for i in range(cnt):
+        if i == 4:
+            continue
+        if i == 8:
+            break
+        sum += i
+    return sum
+[foo(3), foo(6), foo(10), foo(20), foo()]
+""",
+        [
+            sum(range(3)),
+            sum(range(6)) - 4,
+            sum(range(9)) - 4 - 8,
+            sum(range(9)) - 4 - 8,
+            sum(range(5)) - 4,
+        ],
+    ],
+    [
+        """
+def foo(cnt=5):
+    sum = 0
+    for i in range(cnt):
+        if i == 8:
+            break
+        sum += i
+    else:
+        return 1000 + sum
+    return sum
+[foo(3), foo(6), foo(10), foo(20), foo()]
+""",
+        [
+            sum(range(3)) + 1000,
+            sum(range(6)) + 1000,
+            sum(range(9)) - 8,
+            sum(range(9)) - 8,
+            sum(range(5)) + 1000,
+        ],
+    ],
+    [
+        """
+def foo(cnt=5):
+    sum = 0
+    i = 0
+    while i < cnt:
+        if i == 8:
+            break
+        sum += i
+        i += 1
+    else:
+        return 1000 + sum
+    return sum
+[foo(3), foo(6), foo(10), foo(20), foo()]
+""",
+        [
+            sum(range(3)) + 1000,
+            sum(range(6)) + 1000,
+            sum(range(9)) - 8,
+            sum(range(9)) - 8,
+            sum(range(5)) + 1000,
         ],
     ],
     [
@@ -162,6 +343,20 @@ lst = [6, 10]
 """,
         [[2, 3, 10, 6, 10], [[6, 10], 6, 10]],
     ],
+    [
+        """
+def foo(arg1=None, **kwargs):
+    return [arg1, kwargs]
+[foo(), foo(arg1=1), foo(arg2=20), foo(arg1=10, arg2=20), foo(**{'arg2': 30})]
+""",
+        [
+            [None, {}],
+            [1, {}],
+            [None, {"arg2": 20}],
+            [10, {"arg2": 20}],
+            [None, {"arg2": 30}],
+        ],
+    ],
 ]
 
 
@@ -173,7 +368,7 @@ async def run_one_test(test_data, state_func, handler_func):
     if ast.get_exception() is not None:
         print(f"Parsing {source} failed: {ast.get_exception()}")
     # print(ast.dump())
-    result = await ast.eval()
+    result = await ast.eval({"sym_local": 10})
     assert result == expect
 
 
@@ -185,3 +380,108 @@ def test_eval(hass):
 
     for test_data in evalTests:
         asyncio.run(run_one_test(test_data, state_func, handler_func))
+
+
+evalTestsExceptions = [
+    [None, "parsing error compile() arg 1 must be a string, bytes or AST object"],
+    ["1+", "syntax error invalid syntax (<unknown>, line 1)"],
+    [
+        "1+'x'",
+        "Exception in <unknown> line 1 column 0: unsupported operand type(s) for +: 'int' and 'str'",
+    ],
+    ["xx", "Exception in <unknown> line 1 column 0: name 'xx' is not defined"],
+    [
+        "xx.yy",
+        "Exception in <unknown> line 1 column 0: 'EvalName' object has no attribute 'yy'",
+    ],
+    [
+        "del xx",
+        "Exception in <unknown> line 1 column 0: name 'xx' is not defined in del",
+    ],
+    [
+        "with None:\n    pass\n",
+        "Exception in <unknown> line 1 column 0: test: not implemented ast ast_with",
+    ],
+    [
+        "func1(1)",
+        "Exception in <unknown> line 1 column 0: function 'func1' is not callable (got None)",
+    ],
+    [
+        "def func(a):\n    pass\nfunc()",
+        "Exception in <unknown> line 3 column 0: func() missing 1 required positional arguments",
+    ],
+    [
+        "def func(a):\n    pass\nfunc(1, 2)",
+        "Exception in <unknown> line 3 column 0: func() called with too many positional arguments",
+    ],
+    [
+        "def func(a=1):\n    pass\nfunc(1, a=3)",
+        "Exception in <unknown> line 3 column 0: func() got multiple values for argument 'a'",
+    ],
+    [
+        "def func(*a, b):\n    pass\nfunc(1, 2)",
+        "Exception in <unknown> line 3 column 0: func() missing required keyword-only arguments",
+    ],
+    [
+        "import asyncio",
+        "Exception in <unknown> line 1 column 0: import of asyncio not allowed",
+    ],
+    [
+        "from asyncio import xyz",
+        "Exception in <unknown> line 1 column 0: import from asyncio not allowed",
+    ],
+    [
+        """
+def func():
+    nonlocal x
+    x = 1
+func()
+""",
+        "Exception in func(), <unknown> line 4 column 4: can't find nonlocal 'x' for assignment",
+    ],
+    [
+        """
+def func():
+    nonlocal x
+    x += 1
+func()
+""",
+        "Exception in func(), <unknown> line 4 column 4: can't find nonlocal 'x' for assignment",
+    ],
+    [
+        """
+def func():
+    global x
+    return x
+func()
+""",
+        "Exception in func(), <unknown> line 4 column 11: global name 'x' is not defined",
+    ],
+]
+
+
+async def run_one_test_exception(test_data, state_func, handler_func):
+    """Run one interpreter test that generates an exception."""
+    source, expect = test_data
+    ast = AstEval("test", state_func=state_func, handler_func=handler_func)
+    ast.parse(source)
+    exc = ast.get_exception()
+    if exc is not None:
+        assert exc == expect
+        return
+    await ast.eval()
+    exc = ast.get_exception()
+    if exc is not None:
+        assert exc == expect
+        return
+    assert False
+
+
+def test_eval_exceptions(hass):
+    """Test interpreter exceptions."""
+    handler_func = handler.Handler(hass)
+    state_func = state.State(hass, handler_func)
+    state_func.register_functions()
+
+    for test_data in evalTestsExceptions:
+        asyncio.run(run_one_test_exception(test_data, state_func, handler_func))

--- a/tests/components/pyscript/test_unit_trigger.py
+++ b/tests/components/pyscript/test_unit_trigger.py
@@ -1,0 +1,277 @@
+"""Unit tests for time trigger functions."""
+from datetime import datetime as dt
+
+import homeassistant.components.pyscript.handler as handler
+import homeassistant.components.pyscript.trigger as trigger
+
+from tests.async_mock import patch
+
+parseDateTimeTests = [
+    ["2019/9/12 13:45", 0, dt(2019, 9, 12, 13, 45, 0, 0)],
+    ["2019/9/12 13:45:23", 0, dt(2019, 9, 12, 13, 45, 23, 0)],
+    ["2019/9/12", 0, dt(2019, 9, 12, 0, 0, 0, 0)],
+    ["2019/9/12 noon", 1, dt(2019, 9, 12, 12, 0, 0, 0)],
+    ["2019/9/12 noon +1 min", 2, dt(2019, 9, 12, 12, 1, 0, 0)],
+    ["2019/9/12 noon +2.5min", 1, dt(2019, 9, 12, 12, 2, 30, 0)],
+    ["2019/9/12 noon +3 hr", 4, dt(2019, 9, 12, 15, 0, 0, 0)],
+    ["2019/9/12 noon - 30 sec", 3, dt(2019, 9, 12, 11, 59, 30, 0)],
+    ["tomorrow", 0, dt(2019, 9, 2, 0, 0, 0, 0)],
+    ["tomorrow 9:23:00", 0, dt(2019, 9, 2, 9, 23, 0, 0)],
+    ["tomorrow 9:23", 0, dt(2019, 9, 2, 9, 23, 0, 0)],
+    ["tomorrow noon", 0, dt(2019, 9, 2, 12, 0, 0, 0)],
+    ["sunday", 0, dt(2019, 9, 1, 0, 0, 0, 0)],
+    ["monday + 2.5 hours", 0, dt(2019, 9, 2, 2, 30, 0, 0)],
+    ["tuesday", 0, dt(2019, 9, 3, 0, 0, 0, 0)],
+    ["wednesday", 0, dt(2019, 9, 4, 0, 0, 0, 0)],
+    ["thursday", 0, dt(2019, 9, 5, 0, 0, 0, 0)],
+    ["friday", 0, dt(2019, 9, 6, 0, 0, 0, 0)],
+    ["saturday", 0, dt(2019, 9, 7, 0, 0, 0, 0)],
+    ["sun", 0, dt(2019, 9, 1, 0, 0, 0, 0)],
+    ["mon", 0, dt(2019, 9, 2, 0, 0, 0, 0)],
+    ["tue", 0, dt(2019, 9, 3, 0, 0, 0, 0)],
+    ["wed 9:45 + 42 sec", 0, dt(2019, 9, 4, 9, 45, 42, 0)],
+    ["thu", 0, dt(2019, 9, 5, 0, 0, 0, 0)],
+    ["fri 16:11:15.5", 0, dt(2019, 9, 6, 16, 11, 15, 500000)],
+    ["sat", 0, dt(2019, 9, 7, 0, 0, 0, 0)],
+    ["14:56", 0, dt(2019, 9, 1, 14, 56, 0, 0)],
+    ["8:00", 0, dt(2019, 9, 1, 8, 0, 0, 0)],
+    ["16:01", 0, dt(2019, 9, 1, 16, 1, 0, 0)],
+    ["14:56", 1, dt(2019, 9, 2, 14, 56, 0, 0)],
+    ["8:00:23.6", 1, dt(2019, 9, 2, 8, 0, 23, 600000)],
+    # ["sunrise",                 0, dt(2019, 9, 1,  6, 39, 6, 0)],
+    # ["sunrise",                 1, dt(2019, 9, 2,  6, 39, 55, 0)],
+    # ["sunrise",                 2, dt(2019, 9, 3,  6, 40, 45, 0)],
+    # ["sunrise + 1hr",           0, dt(2019, 9, 1,  7, 39, 6, 0)],
+    # ["sunset",                  0, dt(2019, 9, 1,  19, 37, 25, 0)],
+    # ["2019/11/4 sunset + 1min", 0, dt(2019, 11, 4,  17, 8, 10, 0)],
+]
+
+
+async def test_parse_date_time(hass):
+    """Run time parse datetime tests."""
+    #
+    # Unable to get sunrise/sunset to provide reasonable values for
+    # an artificial date and location, so can't test sunrise/sunset.
+    #
+    hass.config.latitude = 54
+    hass.config.longitude = 0
+    hass.config.elevation = 0
+    hass.config.time_zone = "GMT"
+
+    handler_func = handler.Handler(hass)
+    trig = trigger.TrigTime(hass, handler_func)
+
+    now = dt(2019, 9, 1, 13, 0, 0, 0)
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.utcnow", return_value=now
+    ), patch("homeassistant.util.dt.utcnow", return_value=now):
+        # await async_setup_component(hass, "pyscript", {})
+        for test_data in parseDateTimeTests:
+            spec, date_offset, expect = test_data
+            out = trig.parse_date_time(spec, date_offset, now)
+            assert out == expect
+
+
+timerActiveCheckTests = [
+    [["range(2019/9/1 8:00, 2019/9/1 18:00)"], dt(2019, 8, 31, 8, 0, 0, 0), False],
+    [["range(2019/9/1 8:00, 2019/9/1 18:00)"], dt(2019, 9, 1, 7, 59, 59, 0), False],
+    [["range(2019/9/1 8:00, 2019/9/1 18:00)"], dt(2019, 9, 1, 8, 0, 0, 0), True],
+    [["range(2019/9/1 8:00, 2019/9/1 18:00)"], dt(2019, 9, 1, 18, 0, 0, 0), True],
+    [["range(2019/9/1 8:00, 2019/9/1 18:00)"], dt(2019, 9, 1, 18, 0, 0, 1), False],
+    [["range(2019/9/1 8:00, 2019/9/3  6:00)"], dt(2019, 8, 31, 8, 0, 0, 0), False],
+    [["range(2019/9/1 8:00, 2019/9/3  6:00)"], dt(2019, 9, 1, 7, 59, 59, 0), False],
+    [["range(2019/9/1 8:00, 2019/9/3  6:00)"], dt(2019, 9, 1, 8, 0, 0, 0), True],
+    [["range(2019/9/1 8:00, 2019/9/3  6:00)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
+    [["range(2019/9/1 8:00, 2019/9/3  6:00)"], dt(2019, 9, 3, 6, 0, 0, 1), False],
+    [["range(10:00, 20:00)"], dt(2019, 9, 3, 9, 59, 59, 999999), False],
+    [["range(10:00, 20:00)"], dt(2019, 9, 3, 10, 0, 0, 0), True],
+    [["range(10:00, 20:00)"], dt(2019, 9, 3, 20, 0, 0, 0), True],
+    [["range(10:00, 20:00)"], dt(2019, 9, 3, 20, 0, 0, 1), False],
+    [["range(20:00, 10:00)"], dt(2019, 9, 3, 9, 59, 59, 999999), True],
+    [["range(20:00, 10:00)"], dt(2019, 9, 3, 10, 0, 0, 0), True],
+    [["range(20:00, 10:00)"], dt(2019, 9, 3, 10, 0, 0, 1), False],
+    [["range(20:00, 10:00)"], dt(2019, 9, 3, 9, 59, 59, 999999), True],
+    [["range(20:00, 10:00)"], dt(2019, 9, 3, 20, 0, 0, 1), True],
+    [["cron(* * * * *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
+    [["cron(* * * 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
+    [["cron(* * 3 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
+    [["cron(* 6 3 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
+    [["cron(0 6 3 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
+    [["cron(* * 4 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), False],
+]
+
+
+def test_timer_active_check(hass):
+    """Run time active check tests."""
+    handler_func = handler.Handler(hass)
+    trig = trigger.TrigTime(hass, handler_func)
+    for test_data in timerActiveCheckTests:
+        spec, now, expect = test_data
+        out = trig.timer_active_check(spec, now)
+        if out != expect:
+            print(
+                f"trigger.timer_active_check({spec}, {now}) -> {out} vs expect {expect}"
+            )
+        assert out == expect
+
+
+timerTriggerNextTests = [
+    [["once(2019/9/1 8:00)"], [None]],
+    [["once(2019/9/1 15:00)"], [dt(2019, 9, 1, 15, 0, 0, 0)]],
+    [["once(15:00)"], [dt(2019, 9, 1, 15, 0, 0, 0)]],
+    [["once(13:00:0.1)"], [dt(2019, 9, 2, 13, 0, 0, 100000)]],
+    [["once(9:00)"], [dt(2019, 9, 2, 9, 0, 0, 0)]],
+    [["once(wed 9:00)"], [dt(2019, 9, 4, 9, 0, 0, 0)]],
+    [["once(2019/9/10 23:59:13)"], [dt(2019, 9, 10, 23, 59, 13, 0)]],
+    [
+        ["period(2019/9/1 13:00, 120s)"],
+        [
+            dt(2019, 9, 1, 13, 2, 0, 0),
+            dt(2019, 9, 1, 13, 4, 0, 0),
+            dt(2019, 9, 1, 13, 6, 0, 0),
+        ],
+    ],
+    [
+        ["period(13:01, 120s)"],
+        [
+            dt(2019, 9, 1, 13, 1, 0, 0),
+            dt(2019, 9, 1, 13, 3, 0, 0),
+            dt(2019, 9, 1, 13, 5, 0, 0),
+        ],
+    ],
+    [["period(2019/9/1 12:59, 180s)"], [dt(2019, 9, 1, 13, 2, 0, 0)]],
+    [["period(2019/9/1 12:50, 180s)"], [dt(2019, 9, 1, 13, 2, 0, 0)]],
+    [
+        ["period(2019/9/1 0:50, 180s)"],
+        [
+            dt(2019, 9, 1, 13, 2, 0, 0),
+            dt(2019, 9, 1, 13, 5, 0, 0),
+            dt(2019, 9, 1, 13, 8, 0, 0),
+            dt(2019, 9, 1, 13, 11, 0, 0),
+        ],
+    ],
+    [
+        ["period(2019/9/1 13:00, 120s, 2019/9/1 13:04)"],
+        [dt(2019, 9, 1, 13, 2, 0, 0), dt(2019, 9, 1, 13, 4, 0, 0), None],
+    ],
+    [
+        ["cron(0 14 * * *)"],
+        [
+            dt(2019, 9, 1, 14, 0, 0, 0),
+            dt(2019, 9, 2, 14, 0, 0, 0),
+            dt(2019, 9, 3, 14, 0, 0, 0),
+            dt(2019, 9, 4, 14, 0, 0, 0),
+        ],
+    ],
+    [
+        ["cron(0 14 10-13 * *)"],
+        [
+            dt(2019, 9, 10, 14, 0, 0, 0),
+            dt(2019, 9, 11, 14, 0, 0, 0),
+            dt(2019, 9, 12, 14, 0, 0, 0),
+            dt(2019, 9, 13, 14, 0, 0, 0),
+            dt(2019, 10, 10, 14, 0, 0, 0),
+            dt(2019, 10, 11, 14, 0, 0, 0),
+            dt(2019, 10, 12, 14, 0, 0, 0),
+            dt(2019, 10, 13, 14, 0, 0, 0),
+            dt(2019, 11, 10, 14, 0, 0, 0),
+        ],
+    ],
+    [
+        ["cron(0 14 10,11-12,13 * *)"],
+        [
+            dt(2019, 9, 10, 14, 0, 0, 0),
+            dt(2019, 9, 11, 14, 0, 0, 0),
+            dt(2019, 9, 12, 14, 0, 0, 0),
+            dt(2019, 9, 13, 14, 0, 0, 0),
+            dt(2019, 10, 10, 14, 0, 0, 0),
+            dt(2019, 10, 11, 14, 0, 0, 0),
+            dt(2019, 10, 12, 14, 0, 0, 0),
+            dt(2019, 10, 13, 14, 0, 0, 0),
+            dt(2019, 11, 10, 14, 0, 0, 0),
+        ],
+    ],
+    [
+        ["cron(23 8 * * 2,4-5)"],
+        [
+            dt(2019, 9, 3, 8, 23, 0, 0),
+            dt(2019, 9, 5, 8, 23, 0, 0),
+            dt(2019, 9, 6, 8, 23, 0, 0),
+            dt(2019, 9, 10, 8, 23, 0, 0),
+            dt(2019, 9, 12, 8, 23, 0, 0),
+        ],
+    ],
+    [
+        ["cron(23 8 3-4 * 5-6)"],
+        [
+            dt(2019, 9, 3, 8, 23, 0, 0),
+            dt(2019, 9, 4, 8, 23, 0, 0),
+            dt(2019, 9, 6, 8, 23, 0, 0),
+            dt(2019, 9, 7, 8, 23, 0, 0),
+            dt(2019, 9, 13, 8, 23, 0, 0),
+            dt(2019, 9, 14, 8, 23, 0, 0),
+        ],
+    ],
+]
+
+
+def test_timer_trigger_next(hass):
+    """Run trigger next tests."""
+    handler_func = handler.Handler(hass)
+    trig = trigger.TrigTime(hass, handler_func)
+    for test_data in timerTriggerNextTests:
+        now = dt(2019, 9, 1, 13, 0, 0, 100000)
+        spec, expect_seq = test_data
+        for expect in expect_seq:
+            t_next = trig.timer_trigger_next(spec, now)
+            assert t_next == expect
+            now = t_next
+
+
+timerTriggerNextTestsMonthRollover = [
+    [
+        "cron(0 13 * * *)",
+        [
+            dt(2020, 7, 1, 13, 0, 0, 0),
+            dt(2020, 7, 2, 13, 0, 0, 0),
+            dt(2020, 7, 3, 13, 0, 0, 0),
+        ],
+    ],
+    [
+        "cron(0 13 4-6 * *)",
+        [
+            dt(2020, 7, 4, 13, 0, 0, 0),
+            dt(2020, 7, 5, 13, 0, 0, 0),
+            dt(2020, 7, 6, 13, 0, 0, 0),
+            dt(2020, 8, 4, 13, 0, 0, 0),
+            dt(2020, 8, 5, 13, 0, 0, 0),
+        ],
+    ],
+    [
+        "cron(0 13 10 * *)",
+        [
+            dt(2020, 7, 10, 13, 0, 0, 0),
+            dt(2020, 8, 10, 13, 0, 0, 0),
+            dt(2020, 9, 10, 13, 0, 0, 0),
+            dt(2020, 10, 10, 13, 0, 0, 0),
+            dt(2020, 11, 10, 13, 0, 0, 0),
+            dt(2020, 12, 10, 13, 0, 0, 0),
+            dt(2021, 1, 10, 13, 0, 0, 0),
+            dt(2021, 2, 10, 13, 0, 0, 0),
+        ],
+    ],
+]
+
+
+def test_timer_trigger_next_month_rollover(hass):
+    """Run month rollover tests."""
+    handler_func = handler.Handler(hass)
+    trig = trigger.TrigTime(hass, handler_func)
+    for test_data in timerTriggerNextTestsMonthRollover:
+        now = dt(2020, 6, 30, 13, 0, 0, 100000)
+        spec, expect_seq = test_data
+        for expect in expect_seq:
+            t_next = trig.timer_trigger_next(spec, now)
+            assert t_next == expect
+            now = t_next

--- a/tests/components/pyscript/test_unit_trigger.py
+++ b/tests/components/pyscript/test_unit_trigger.py
@@ -8,6 +8,7 @@ from tests.async_mock import patch
 
 parseDateTimeTests = [
     ["2019/9/12 13:45", 0, dt(2019, 9, 12, 13, 45, 0, 0)],
+    ["9/12 13:45", 0, dt(2019, 9, 12, 13, 45, 0, 0)],
     ["2019/9/12 13:45:23", 0, dt(2019, 9, 12, 13, 45, 23, 0)],
     ["2019/9/12", 0, dt(2019, 9, 12, 0, 0, 0, 0)],
     ["2019/9/12 noon", 1, dt(2019, 9, 12, 12, 0, 0, 0)],
@@ -15,12 +16,17 @@ parseDateTimeTests = [
     ["2019/9/12 noon +2.5min", 1, dt(2019, 9, 12, 12, 2, 30, 0)],
     ["2019/9/12 noon +3 hr", 4, dt(2019, 9, 12, 15, 0, 0, 0)],
     ["2019/9/12 noon - 30 sec", 3, dt(2019, 9, 12, 11, 59, 30, 0)],
+    ["2019/9/12 midnight", 3, dt(2019, 9, 12, 0, 0, 0, 0)],
+    ["2019/9/12 midnight + 30 min", 3, dt(2019, 9, 12, 0, 30, 0, 0)],
     ["tomorrow", 0, dt(2019, 9, 2, 0, 0, 0, 0)],
     ["tomorrow 9:23:00", 0, dt(2019, 9, 2, 9, 23, 0, 0)],
     ["tomorrow 9:23", 0, dt(2019, 9, 2, 9, 23, 0, 0)],
     ["tomorrow noon", 0, dt(2019, 9, 2, 12, 0, 0, 0)],
+    ["today", 0, dt(2019, 9, 1, 0, 0, 0, 0)],
     ["sunday", 0, dt(2019, 9, 1, 0, 0, 0, 0)],
     ["monday + 2.5 hours", 0, dt(2019, 9, 2, 2, 30, 0, 0)],
+    ["monday + 1 day", 0, dt(2019, 9, 3, 0, 0, 0, 0)],
+    ["monday + 1 week", 0, dt(2019, 9, 9, 0, 0, 0, 0)],
     ["tuesday", 0, dt(2019, 9, 3, 0, 0, 0, 0)],
     ["wednesday", 0, dt(2019, 9, 4, 0, 0, 0, 0)],
     ["thursday", 0, dt(2019, 9, 5, 0, 0, 0, 0)],
@@ -38,12 +44,18 @@ parseDateTimeTests = [
     ["16:01", 0, dt(2019, 9, 1, 16, 1, 0, 0)],
     ["14:56", 1, dt(2019, 9, 2, 14, 56, 0, 0)],
     ["8:00:23.6", 1, dt(2019, 9, 2, 8, 0, 23, 600000)],
-    # ["sunrise",                 0, dt(2019, 9, 1,  6, 39, 6, 0)],
-    # ["sunrise",                 1, dt(2019, 9, 2,  6, 39, 55, 0)],
-    # ["sunrise",                 2, dt(2019, 9, 3,  6, 40, 45, 0)],
-    # ["sunrise + 1hr",           0, dt(2019, 9, 1,  7, 39, 6, 0)],
-    # ["sunset",                  0, dt(2019, 9, 1,  19, 37, 25, 0)],
-    # ["2019/11/4 sunset + 1min", 0, dt(2019, 11, 4,  17, 8, 10, 0)],
+    ["sunrise", 0, dt(2019, 9, 1, 6, 39, 6, 0)],
+    ["sunrise", 1, dt(2019, 9, 2, 6, 39, 6, 0)],
+    ["sunrise", 2, dt(2019, 9, 3, 6, 39, 6, 0)],
+    ["sunrise + 1hr", 0, dt(2019, 9, 1, 7, 39, 6, 0)],
+    ["sunset", 0, dt(2019, 9, 1, 6, 39, 6, 0)],
+    ["2019/11/4 sunset + 1min", 0, dt(2019, 11, 4, 6, 40, 6, 0)],
+    ["+5 min", 0, dt(2019, 9, 1, 0, 5, 0, 0)],
+]
+
+parseDateTimeTests2 = [
+    ["sunday", 0, dt(2019, 9, 8, 0, 0, 0, 0)],
+    ["monday", 0, dt(2019, 9, 9, 0, 0, 0, 0)],
 ]
 
 
@@ -62,12 +74,29 @@ async def test_parse_date_time(hass):
     trig = trigger.TrigTime(hass, handler_func)
 
     now = dt(2019, 9, 1, 13, 0, 0, 0)
+    #
+    # the mock forces sunrise and sunset to be the same
+    #
+    sunrise = dt(2019, 9, 1, 6, 39, 6, 0)
 
     with patch(
         "homeassistant.helpers.condition.dt_util.utcnow", return_value=now
-    ), patch("homeassistant.util.dt.utcnow", return_value=now):
+    ), patch("homeassistant.util.dt.utcnow", return_value=now), patch(
+        "homeassistant.helpers.sun.get_astral_event_date", return_value=sunrise
+    ):
         # await async_setup_component(hass, "pyscript", {})
         for test_data in parseDateTimeTests:
+            spec, date_offset, expect = test_data
+            out = trig.parse_date_time(spec, date_offset, now)
+            assert out == expect
+
+    now = dt(2019, 9, 3, 13, 0, 0, 0)
+    with patch(
+        "homeassistant.helpers.condition.dt_util.utcnow", return_value=now
+    ), patch("homeassistant.util.dt.utcnow", return_value=now), patch(
+        "homeassistant.helpers.sun.get_astral_event_date", return_value=sunrise
+    ):
+        for test_data in parseDateTimeTests2:
             spec, date_offset, expect = test_data
             out = trig.parse_date_time(spec, date_offset, now)
             assert out == expect
@@ -93,12 +122,18 @@ timerActiveCheckTests = [
     [["range(20:00, 10:00)"], dt(2019, 9, 3, 10, 0, 0, 1), False],
     [["range(20:00, 10:00)"], dt(2019, 9, 3, 9, 59, 59, 999999), True],
     [["range(20:00, 10:00)"], dt(2019, 9, 3, 20, 0, 0, 1), True],
+    ["not range(20:00, 10:00)", dt(2019, 9, 3, 10, 0, 0, 0), False],
+    ["not range(20:00, 10:00)", dt(2019, 9, 3, 10, 0, 0, 1), True],
+    ["not range(20:00, 10:00)", dt(2019, 9, 3, 9, 59, 59, 999999), False],
+    ["not range(20:00, 10:00)", dt(2019, 9, 3, 20, 0, 0, 1), False],
     [["cron(* * * * *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
     [["cron(* * * 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
     [["cron(* * 3 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
     [["cron(* 6 3 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
     [["cron(0 6 3 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
     [["cron(* * 4 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), False],
+    [["not cron(0 6 3 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), False],
+    [["not cron(* * 4 9 *)"], dt(2019, 9, 3, 6, 0, 0, 0), True],
 ]
 
 
@@ -140,6 +175,14 @@ timerTriggerNextTests = [
             dt(2019, 9, 1, 13, 5, 0, 0),
         ],
     ],
+    [
+        ["period(10:01, 120s, 12:00)"],
+        [
+            dt(2019, 9, 2, 10, 1, 0, 0),
+            dt(2019, 9, 2, 10, 3, 0, 0),
+            dt(2019, 9, 2, 10, 5, 0, 0),
+        ],
+    ],
     [["period(2019/9/1 12:59, 180s)"], [dt(2019, 9, 1, 13, 2, 0, 0)]],
     [["period(2019/9/1 12:50, 180s)"], [dt(2019, 9, 1, 13, 2, 0, 0)]],
     [
@@ -154,6 +197,17 @@ timerTriggerNextTests = [
     [
         ["period(2019/9/1 13:00, 120s, 2019/9/1 13:04)"],
         [dt(2019, 9, 1, 13, 2, 0, 0), dt(2019, 9, 1, 13, 4, 0, 0), None],
+    ],
+    [
+        ["period(18:00, 4 hr, 6:00)"],
+        [
+            dt(2019, 9, 1, 18, 0, 0, 0),
+            dt(2019, 9, 1, 22, 0, 0, 0),
+            dt(2019, 9, 2, 2, 0, 0, 0),
+            dt(2019, 9, 2, 6, 0, 0, 0),
+            dt(2019, 9, 2, 18, 0, 0, 0),
+            dt(2019, 9, 2, 22, 0, 0, 0),
+        ],
     ],
     [
         ["cron(0 14 * * *)"],
@@ -213,6 +267,16 @@ timerTriggerNextTests = [
             dt(2019, 9, 14, 8, 23, 0, 0),
         ],
     ],
+    [
+        # invalid fields treated as "*" (warning to log)
+        ["cron(0 14 1-2-3 x *)"],
+        [
+            dt(2019, 9, 1, 14, 0, 0, 0),
+            dt(2019, 9, 2, 14, 0, 0, 0),
+            dt(2019, 9, 3, 14, 0, 0, 0),
+            dt(2019, 9, 4, 14, 0, 0, 0),
+        ],
+    ],
 ]
 
 
@@ -231,6 +295,7 @@ def test_timer_trigger_next(hass):
 
 timerTriggerNextTestsMonthRollover = [
     [
+        # 1pm every day
         "cron(0 13 * * *)",
         [
             dt(2020, 7, 1, 13, 0, 0, 0),
@@ -239,6 +304,7 @@ timerTriggerNextTestsMonthRollover = [
         ],
     ],
     [
+        # 1pm on 4th, 5th, 6th of each month
         "cron(0 13 4-6 * *)",
         [
             dt(2020, 7, 4, 13, 0, 0, 0),
@@ -249,17 +315,79 @@ timerTriggerNextTestsMonthRollover = [
         ],
     ],
     [
-        "cron(0 13 10 * *)",
+        # 1pm on 10th of month except nov
+        "cron(0 13 10 1-10,12 *)",
         [
             dt(2020, 7, 10, 13, 0, 0, 0),
             dt(2020, 8, 10, 13, 0, 0, 0),
             dt(2020, 9, 10, 13, 0, 0, 0),
             dt(2020, 10, 10, 13, 0, 0, 0),
-            dt(2020, 11, 10, 13, 0, 0, 0),
             dt(2020, 12, 10, 13, 0, 0, 0),
             dt(2021, 1, 10, 13, 0, 0, 0),
             dt(2021, 2, 10, 13, 0, 0, 0),
+            dt(2021, 3, 10, 13, 0, 0, 0),
         ],
+    ],
+    [
+        # 1pm on monday
+        ["cron(0 13 * * 1)"],
+        [
+            dt(2020, 7, 6, 13, 0, 0, 0),
+            dt(2020, 7, 13, 13, 0, 0, 0),
+            dt(2020, 7, 20, 13, 0, 0, 0),
+            dt(2020, 7, 27, 13, 0, 0, 0),
+            dt(2020, 8, 3, 13, 0, 0, 0),
+        ],
+    ],
+    [
+        # 1pm on monday, or 28th
+        ["cron(0 13 28 * 1)"],
+        [
+            dt(2020, 7, 6, 13, 0, 0, 0),
+            dt(2020, 7, 13, 13, 0, 0, 0),
+            dt(2020, 7, 20, 13, 0, 0, 0),
+            dt(2020, 7, 27, 13, 0, 0, 0),
+            dt(2020, 7, 28, 13, 0, 0, 0),
+            dt(2020, 8, 3, 13, 0, 0, 0),
+        ],
+    ],
+    [
+        # 1pm on sunday and tuesday in feb & dec
+        "cron(0 13 1 2,12 0,2)",
+        [
+            dt(2020, 12, 1, 13, 0, 0, 0),
+            dt(2020, 12, 6, 13, 0, 0, 0),
+            dt(2020, 12, 8, 13, 0, 0, 0),
+            dt(2020, 12, 13, 13, 0, 0, 0),
+            dt(2020, 12, 15, 13, 0, 0, 0),
+            dt(2020, 12, 20, 13, 0, 0, 0),
+            dt(2020, 12, 22, 13, 0, 0, 0),
+            dt(2020, 12, 27, 13, 0, 0, 0),
+            dt(2020, 12, 29, 13, 0, 0, 0),
+            dt(2021, 2, 1, 13, 0, 0, 0),
+            dt(2021, 2, 2, 13, 0, 0, 0),
+            dt(2021, 2, 7, 13, 0, 0, 0),
+            dt(2021, 2, 9, 13, 0, 0, 0),
+            dt(2021, 2, 14, 13, 0, 0, 0),
+        ],
+    ],
+    [
+        # 1pm on 29th of Jan & Feb (only leap years)
+        "cron(0 13 29 1,2 *)",
+        [
+            dt(2021, 1, 29, 13, 0, 0, 0),
+            dt(2022, 1, 29, 13, 0, 0, 0),
+            dt(2023, 1, 29, 13, 0, 0, 0),
+            dt(2024, 1, 29, 13, 0, 0, 0),
+            dt(2024, 2, 29, 13, 0, 0, 0),
+            dt(2025, 1, 29, 13, 0, 0, 0),
+            dt(2026, 1, 29, 13, 0, 0, 0),
+        ],
+    ],
+    [
+        # 1pm on 33rd of Jan & Feb -> no such time
+        "cron(0 13 33 1,2 *)",
+        [None],
     ],
 ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new integration, pyscript, that adds rich Python scripting to HA.
State variables are bound to Python variables, functions can be registered as
services or called based on flexible triggers (time, state or events) and services
can be called or events fired.  Pyscript implements an async Python interpreter which
runs each top-level pyscript function in its own async task, which can sleep or wait
for additional triggers without delaying other services.

This complements the existing automations and templates, and provides greater
simplicity and flexibility compared to the existing [Python Scripts](https://www.home-assistant.io/integrations/python_script/), which requires
more understanding of HA internals.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
`pycript` takes no configuration parameters.  Scripts are read from `<config>/pyscript`.
```yaml
# Example configuration.yaml
pyscript:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue: N/A
- Link to documentation pull request: [home-assistant.io PR #14054](https://github.com/home-assistant/home-assistant.io/pull/14054)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: see above

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all` (none).
- [x] Untested files have been added to `.coveragerc` (none).

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

This is my first PR, so please provide feedback if I can fix or add anything.

I do have a question for any HA expert.  Pyscript creates async tasks using `self.hass.loop.create_task()`,
and listens for state changed and other events by registering callbacks using  `self.hass.bus.async_listen()`.
Are those callbacks and tasks all guaranteed to run in the same (main) thread?  Pyscript assumes the answer
is "yes", since the code isn't thread safe and the communication between async tasks (eg, using asyncio queues)
requires all those tasks belong to the same event loop.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
