### PR TITLE
Use event loop scheduling for tracking time patterns

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -564,6 +564,9 @@ def async_track_sunset(
 
 track_sunset = threaded_listener_factory(async_track_sunset)
 
+# For targeted patching in tests
+pattern_utc_now = dt_util.utcnow
+
 
 @callback
 @bind_hass
@@ -613,7 +616,7 @@ def async_track_utc_time_change(
         """Listen for matching time_changed events."""
         nonlocal next_time, last_now, cancel_callback
 
-        now = dt_util.utcnow()
+        now = pattern_utc_now()
 
         if now < last_now:
             # Time rolled back

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -615,10 +615,10 @@ def async_track_utc_time_change(
         now = pattern_utc_now()
         hass.async_run_job(action, dt_util.as_local(now) if local else now)
 
-        # We only want second level precision for time patterns
-        # as we do not want to fire them multiple times in
-        # the same second.
-        next_time = calculate_next(now + timedelta(seconds=1))
+        if next_time <= now:
+            next_time = calculate_next(now + timedelta(seconds=1))
+        else:
+            next_time = calculate_next(now)
 
         cancel_callback = hass.loop.call_at(
             hass.loop.time() + next_time.timestamp() - time.time(),

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -618,10 +618,7 @@ def async_track_utc_time_change(
         now = pattern_utc_now()
         hass.async_run_job(action, dt_util.as_local(now) if local else now)
 
-        if next_time <= now:
-            calculate_next(now + timedelta(seconds=1))
-        else:
-            calculate_next(now)
+        calculate_next(now + timedelta(seconds=1))
 
         cancel_callback = hass.loop.call_at(
             hass.loop.time() + next_time.timestamp() - time.time(),

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -615,10 +615,10 @@ def async_track_utc_time_change(
         now = pattern_utc_now()
         hass.async_run_job(action, dt_util.as_local(now) if local else now)
 
-        if next_time <= now:
-            next_time = calculate_next(now + timedelta(seconds=1))
-        else:
-            next_time = calculate_next(now)
+        # We only want second level precision for time patterns
+        # as we do not want to fire them multiple times in
+        # the same second.
+        next_time = calculate_next(now + timedelta(seconds=1))
 
         cancel_callback = hass.loop.call_at(
             hass.loop.time() + next_time.timestamp() - time.time(),

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -617,14 +617,12 @@ def async_track_utc_time_change(
         nonlocal next_time, last_now, cancel_callback
 
         now = pattern_utc_now()
-
-        if now < last_now:
-            # Time rolled back
-            calculate_next(now)
+        hass.async_run_job(action, dt_util.as_local(now) if local else now)
 
         if next_time <= now:
-            hass.async_run_job(action, dt_util.as_local(now) if local else now)
             calculate_next(now + timedelta(seconds=1))
+        else:
+            calculate_next(now)
 
         last_now = now
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -594,8 +594,7 @@ def async_track_utc_time_change(
     matching_minutes = dt_util.parse_time_expression(minute, 0, 59)
     matching_hours = dt_util.parse_time_expression(hour, 0, 23)
 
-    last_now: datetime = dt_util.utcnow()
-    next_time: datetime = last_now
+    next_time: datetime = dt_util.utcnow()
 
     def calculate_next(now: datetime) -> None:
         """Calculate and set the next time the trigger should fire."""
@@ -609,12 +608,12 @@ def async_track_utc_time_change(
     # Make sure rolling back the clock doesn't prevent the timer from
     # triggering.
     cancel_callback: Optional[asyncio.TimerHandle] = None
-    calculate_next(last_now)
+    calculate_next(next_time)
 
     @callback
     def pattern_time_change_listener() -> None:
         """Listen for matching time_changed events."""
-        nonlocal next_time, last_now, cancel_callback
+        nonlocal next_time, cancel_callback
 
         now = pattern_utc_now()
         hass.async_run_job(action, dt_util.as_local(now) if local else now)
@@ -623,8 +622,6 @@ def async_track_utc_time_change(
             calculate_next(now + timedelta(seconds=1))
         else:
             calculate_next(now)
-
-        last_now = now
 
         cancel_callback = hass.loop.call_at(
             hass.loop.time() + next_time.timestamp() - time.time(),

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -615,10 +615,13 @@ def async_track_utc_time_change(
         now = pattern_utc_now()
         hass.async_run_job(action, dt_util.as_local(now) if local else now)
 
-        # We only want second level precision for time patterns
-        # as we do not want to fire them multiple times in
-        # the same second.
-        next_time = calculate_next(now + timedelta(seconds=1))
+        if next_time <= now:
+            # We only want second level precision for time patterns
+            # as we do not want to fire them multiple times in
+            # the same second.
+            next_time = calculate_next(now + timedelta(seconds=1))
+        else:
+            next_time = calculate_next(now)
 
         cancel_callback = hass.loop.call_at(
             hass.loop.time() + next_time.timestamp() - time.time(),

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -594,31 +594,37 @@ def async_track_utc_time_change(
     matching_minutes = dt_util.parse_time_expression(minute, 0, 59)
     matching_hours = dt_util.parse_time_expression(hour, 0, 23)
 
-    def calculate_next(now: datetime) -> datetime:
+    last_now: datetime = dt_util.utcnow()
+    next_time: datetime = last_now
+
+    def calculate_next(now: datetime) -> None:
         """Calculate and set the next time the trigger should fire."""
+        nonlocal next_time
 
         localized_now = dt_util.as_local(now) if local else now
-        return dt_util.find_next_time_expression_time(
+        next_time = dt_util.find_next_time_expression_time(
             localized_now, matching_seconds, matching_minutes, matching_hours
         )
 
     # Make sure rolling back the clock doesn't prevent the timer from
     # triggering.
     cancel_callback: Optional[asyncio.TimerHandle] = None
-    next_time: datetime = calculate_next(dt_util.utcnow())
+    calculate_next(last_now)
 
     @callback
     def pattern_time_change_listener() -> None:
         """Listen for matching time_changed events."""
-        nonlocal next_time, cancel_callback
+        nonlocal next_time, last_now, cancel_callback
 
         now = pattern_utc_now()
         hass.async_run_job(action, dt_util.as_local(now) if local else now)
 
         if next_time <= now:
-            next_time = calculate_next(now + timedelta(seconds=1))
+            calculate_next(now + timedelta(seconds=1))
         else:
-            next_time = calculate_next(now)
+            calculate_next(now)
+
+        last_now = now
 
         cancel_callback = hass.loop.call_at(
             hass.loop.time() + next_time.timestamp() - time.time(),

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -615,13 +615,10 @@ def async_track_utc_time_change(
         now = pattern_utc_now()
         hass.async_run_job(action, dt_util.as_local(now) if local else now)
 
-        if next_time <= now:
-            # We only want second level precision for time patterns
-            # as we do not want to fire them multiple times in
-            # the same second.
-            next_time = calculate_next(now + timedelta(seconds=1))
-        else:
-            next_time = calculate_next(now)
+        # We only want second level precision for time patterns
+        # as we do not want to fire them multiple times in
+        # the same second.
+        next_time = calculate_next(now + timedelta(seconds=1))
 
         cancel_callback = hass.loop.call_at(
             hass.loop.time() + next_time.timestamp() - time.time(),

--- a/tests/common.py
+++ b/tests/common.py
@@ -299,8 +299,11 @@ def async_fire_time_changed(hass, datetime_):
         mock_seconds_into_future = datetime_.timestamp() - time.time()
 
         if mock_seconds_into_future >= future_seconds:
-            task._run()
-            task.cancel()
+            with patch(
+                "homeassistant.util.dt.utcnow", return_value=date_util.as_utc(datetime_)
+            ):
+                task._run()
+                task.cancel()
 
 
 fire_time_changed = threadsafe_callback_factory(async_fire_time_changed)

--- a/tests/common.py
+++ b/tests/common.py
@@ -300,7 +300,8 @@ def async_fire_time_changed(hass, datetime_):
 
         if mock_seconds_into_future >= future_seconds:
             with patch(
-                "homeassistant.util.dt.utcnow", return_value=date_util.as_utc(datetime_)
+                "homeassistant.helpers.event.pattern_utc_now",
+                return_value=date_util.as_utc(datetime_),
             ):
                 task._run()
                 task.cancel()

--- a/tests/common.py
+++ b/tests/common.py
@@ -285,7 +285,7 @@ fire_mqtt_message = threadsafe_callback_factory(async_fire_mqtt_message)
 
 
 @ha.callback
-def async_fire_time_changed(hass, datetime_):
+def async_fire_time_changed(hass, datetime_, fire_all=False):
     """Fire a time changes event."""
     hass.bus.async_fire(EVENT_TIME_CHANGED, {"now": date_util.as_utc(datetime_)})
 
@@ -298,7 +298,7 @@ def async_fire_time_changed(hass, datetime_):
         future_seconds = task.when() - hass.loop.time()
         mock_seconds_into_future = datetime_.timestamp() - time.time()
 
-        if mock_seconds_into_future >= future_seconds:
+        if fire_all or mock_seconds_into_future >= future_seconds:
             with patch(
                 "homeassistant.helpers.event.pattern_utc_now",
                 return_value=date_util.as_utc(datetime_),

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -46,7 +46,11 @@ async def test_if_fires_using_at(hass, calls):
         },
     )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=5, minute=0, second=0))
+    now = dt_util.utcnow()
+
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 1, hour=5, minute=0, second=0)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 1

--- a/tests/components/automation/test_time_pattern.py
+++ b/tests/components/automation/test_time_pattern.py
@@ -1,4 +1,5 @@
 """The tests for the time_pattern automation."""
+from asynctest.mock import patch
 import pytest
 
 import homeassistant.components.automation as automation
@@ -23,53 +24,67 @@ def setup_comp(hass):
 
 async def test_if_fires_when_hour_matches(hass, calls):
     """Test for firing if hour is matching."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "time_pattern",
-                    "hours": 0,
-                    "minutes": "*",
-                    "seconds": "*",
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, hour=3
     )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": 0,
+                        "minutes": "*",
+                        "seconds": "*",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 2, hour=0))
     await hass.async_block_till_done()
     assert len(calls) == 1
 
     await common.async_turn_off(hass)
     await hass.async_block_till_done()
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 1, hour=0))
     await hass.async_block_till_done()
     assert len(calls) == 1
 
 
 async def test_if_fires_when_minute_matches(hass, calls):
     """Test for firing if minutes are matching."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "time_pattern",
-                    "hours": "*",
-                    "minutes": 0,
-                    "seconds": "*",
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, minute=30
     )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": "*",
+                        "minutes": 0,
+                        "seconds": "*",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(minute=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 2, minute=0))
 
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -77,23 +92,30 @@ async def test_if_fires_when_minute_matches(hass, calls):
 
 async def test_if_fires_when_second_matches(hass, calls):
     """Test for firing if seconds are matching."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "time_pattern",
-                    "hours": "*",
-                    "minutes": "*",
-                    "seconds": 0,
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, second=30
     )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": "*",
+                        "minutes": "*",
+                        "seconds": 0,
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(second=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 2, second=0))
 
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -101,23 +123,32 @@ async def test_if_fires_when_second_matches(hass, calls):
 
 async def test_if_fires_when_all_matches(hass, calls):
     """Test for firing if everything matches."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "time_pattern",
-                    "hours": 1,
-                    "minutes": 2,
-                    "seconds": 3,
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, hour=4
     )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": 1,
+                        "minutes": 2,
+                        "seconds": 3,
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=1, minute=2, second=3))
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 2, hour=1, minute=2, second=3)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -125,47 +156,66 @@ async def test_if_fires_when_all_matches(hass, calls):
 
 async def test_if_fires_periodic_seconds(hass, calls):
     """Test for firing periodically every second."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "time_pattern",
-                    "hours": "*",
-                    "minutes": "*",
-                    "seconds": "/2",
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, second=1
+    )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": "*",
+                        "minutes": "*",
+                        "seconds": "/10",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
+
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 2, hour=0, minute=0, second=10)
     )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=0, minute=0, second=2))
-
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) >= 1
 
 
 async def test_if_fires_periodic_minutes(hass, calls):
     """Test for firing periodically every minute."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "time_pattern",
-                    "hours": "*",
-                    "minutes": "/2",
-                    "seconds": "*",
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
-    )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=0, minute=2, second=0))
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, minute=1
+    )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": "*",
+                        "minutes": "/2",
+                        "seconds": "*",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
+
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 2, hour=0, minute=2, second=0)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -173,23 +223,32 @@ async def test_if_fires_periodic_minutes(hass, calls):
 
 async def test_if_fires_periodic_hours(hass, calls):
     """Test for firing periodically every hour."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "time_pattern",
-                    "hours": "/2",
-                    "minutes": "*",
-                    "seconds": "*",
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, hour=1
     )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": "/2",
+                        "minutes": "*",
+                        "seconds": "*",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=2, minute=0, second=0))
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 2, hour=2, minute=0, second=0)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -197,28 +256,41 @@ async def test_if_fires_periodic_hours(hass, calls):
 
 async def test_default_values(hass, calls):
     """Test for firing at 2 minutes every hour."""
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {"platform": "time_pattern", "minutes": "2"},
-                "action": {"service": "test.automation"},
-            }
-        },
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, minute=1
+    )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {"platform": "time_pattern", "minutes": "2"},
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
+
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 2, hour=1, minute=2, second=0)
     )
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=1, minute=2, second=0))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 2, hour=1, minute=2, second=1)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 1
 
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=1, minute=2, second=1))
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    async_fire_time_changed(hass, dt_util.utcnow().replace(hour=2, minute=2, second=0))
+    async_fire_time_changed(
+        hass, now.replace(year=now.year + 2, hour=2, minute=2, second=0)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 2

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -260,49 +260,49 @@ async def _test_self_reset(hass, config, start_time, expect_reset=True):
         assert state.state == "5"
 
 
-async def test_self_reset_hourly(hass):
+async def test_self_reset_hourly(hass, legacy_patchable_time):
     """Test hourly reset of meter."""
     await _test_self_reset(
         hass, gen_config("hourly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_daily(hass):
+async def test_self_reset_daily(hass, legacy_patchable_time):
     """Test daily reset of meter."""
     await _test_self_reset(
         hass, gen_config("daily"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_weekly(hass):
+async def test_self_reset_weekly(hass, legacy_patchable_time):
     """Test weekly reset of meter."""
     await _test_self_reset(
         hass, gen_config("weekly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_monthly(hass):
+async def test_self_reset_monthly(hass, legacy_patchable_time):
     """Test monthly reset of meter."""
     await _test_self_reset(
         hass, gen_config("monthly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_quarterly(hass):
+async def test_self_reset_quarterly(hass, legacy_patchable_time):
     """Test quarterly reset of meter."""
     await _test_self_reset(
         hass, gen_config("quarterly"), "2017-03-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_yearly(hass):
+async def test_self_reset_yearly(hass, legacy_patchable_time):
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass, gen_config("yearly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_no_reset_yearly(hass):
+async def test_self_no_reset_yearly(hass, legacy_patchable_time):
     """Test yearly reset of meter does not occur after 1st January."""
     await _test_self_reset(
         hass,
@@ -312,7 +312,7 @@ async def test_self_no_reset_yearly(hass):
     )
 
 
-async def test_reset_yearly_offset(hass):
+async def test_reset_yearly_offset(hass, legacy_patchable_time):
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass,
@@ -321,7 +321,7 @@ async def test_reset_yearly_offset(hass):
     )
 
 
-async def test_no_reset_yearly_offset(hass):
+async def test_no_reset_yearly_offset(hass, legacy_patchable_time):
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass,

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -119,7 +119,7 @@ async def test_erronous_network_key_fails_validation(hass, mock_openzwave):
             zwave.CONFIG_SCHEMA({"zwave": {"network_key": value}})
 
 
-async def test_auto_heal_midnight(hass, mock_openzwave):
+async def test_auto_heal_midnight(hass, mock_openzwave, legacy_patchable_time):
     """Test network auto-heal at midnight."""
     await async_setup_component(hass, "zwave", {"zwave": {"autoheal": True}})
     await hass.async_block_till_done()

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -748,22 +748,24 @@ async def test_async_track_time_change(hass):
     wildcard_runs = []
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     unsub = async_track_time_change(hass, lambda x: wildcard_runs.append(1))
     unsub_utc = async_track_utc_time_change(
         hass, lambda x: specific_runs.append(1), second=[0, 30]
     )
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 0, 15))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 15))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 2
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 0, 30))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
@@ -771,7 +773,7 @@ async def test_async_track_time_change(hass):
     unsub()
     unsub_utc()
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 0, 30))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
@@ -781,25 +783,27 @@ async def test_periodic_task_minute(hass):
     """Test periodic tasks per minute."""
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     unsub = async_track_utc_time_change(
         hass, lambda x: specific_runs.append(1), minute="/5", second=0
     )
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 3, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 3, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 5, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 12, 5, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
@@ -808,33 +812,35 @@ async def test_periodic_task_hour(hass):
     """Test periodic tasks per hour."""
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     unsub = async_track_utc_time_change(
         hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
     )
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 23, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 25, 0, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(2014, 5, 25, 1, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 1, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(2014, 5, 25, 2, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(2014, 5, 25, 2, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
@@ -843,12 +849,14 @@ async def test_periodic_task_wrong_input(hass):
     """Test periodic tasks with wrong input."""
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     with pytest.raises(ValueError):
         async_track_utc_time_change(
             hass, lambda x: specific_runs.append(1), hour="/two"
         )
 
-    async_fire_time_changed(hass, datetime(2014, 5, 2, 0, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 2, 0, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
@@ -857,33 +865,35 @@ async def test_periodic_task_clock_rollback(hass):
     """Test periodic tasks with the time rolling backwards."""
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     unsub = async_track_utc_time_change(
         hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
     )
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 23, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 0, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 0, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
-    async_fire_time_changed(hass, datetime(2014, 5, 25, 2, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(2014, 5, 25, 2, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 
@@ -892,19 +902,21 @@ async def test_periodic_task_duplicate_time(hass):
     """Test periodic tasks not triggering on duplicate time."""
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     unsub = async_track_utc_time_change(
         hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
     )
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(2014, 5, 25, 0, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
@@ -917,23 +929,33 @@ async def test_periodic_task_entering_dst(hass):
     dt_util.set_default_time_zone(timezone)
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     unsub = async_track_time_change(
         hass, lambda x: specific_runs.append(1), hour=2, minute=30, second=0
     )
 
-    async_fire_time_changed(hass, timezone.localize(datetime(2018, 3, 25, 1, 50, 0)))
+    async_fire_time_changed(
+        hass, timezone.localize(datetime(now.year + 1, 3, 25, 1, 50, 0))
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
-    async_fire_time_changed(hass, timezone.localize(datetime(2018, 3, 25, 3, 50, 0)))
+    async_fire_time_changed(
+        hass, timezone.localize(datetime(now.year + 1, 3, 25, 3, 50, 0))
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
-    async_fire_time_changed(hass, timezone.localize(datetime(2018, 3, 26, 1, 50, 0)))
+    async_fire_time_changed(
+        hass, timezone.localize(datetime(now.year + 1, 3, 26, 1, 50, 0))
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
-    async_fire_time_changed(hass, timezone.localize(datetime(2018, 3, 26, 2, 50, 0)))
+    async_fire_time_changed(
+        hass, timezone.localize(datetime(now.year + 1, 3, 26, 2, 50, 0))
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
@@ -946,30 +968,32 @@ async def test_periodic_task_leaving_dst(hass):
     dt_util.set_default_time_zone(timezone)
     specific_runs = []
 
+    now = dt_util.utcnow()
+
     unsub = async_track_time_change(
         hass, lambda x: specific_runs.append(1), hour=2, minute=30, second=0
     )
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(2018, 10, 28, 2, 5, 0), is_dst=False)
+        hass, timezone.localize(datetime(now.year + 1, 10, 28, 2, 5, 0), is_dst=False)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(2018, 10, 28, 2, 55, 0), is_dst=False)
+        hass, timezone.localize(datetime(now.year + 1, 10, 28, 2, 55, 0), is_dst=False)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(2018, 10, 28, 2, 5, 0), is_dst=True)
+        hass, timezone.localize(datetime(now.year + 1, 10, 28, 2, 5, 0), is_dst=True)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(2018, 10, 28, 2, 55, 0), is_dst=True)
+        hass, timezone.localize(datetime(now.year + 1, 10, 28, 2, 55, 0), is_dst=True)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -978,7 +978,6 @@ async def test_periodic_task_leaving_dst(hass):
 
     now = dt_util.utcnow()
 
-    now = dt_util.utcnow()
     time_that_will_not_match_right_away = timezone.localize(
         datetime(now.year + 1, 10, 28, 2, 28, 0), is_dst=True
     )

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -889,13 +889,13 @@ async def test_periodic_task_clock_rollback(hass):
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0), fire_all=True)
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0), fire_all=True)
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 


### PR DESCRIPTION
## Breaking change

If time abruptly moves forward or backwards, time pattern listeners will only be adjusted after they were previously scheduled to fire.  This avoids the need for every time pattern listener to check for this every second. 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Same as #37184 for tracking time patterns

`time_changed (24 listeners)` -> gone!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
