### PR TITLE
Fix state automation trigger (#38014)

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -73,16 +73,13 @@ async def async_attach_trigger(
 
         from_s = event.data.get("old_state")
         to_s = event.data.get("new_state")
+        old_state = getattr(from_s, "state", None)
+        new_state = getattr(to_s, "state", None)
 
         if (
-            (from_s is not None and not match_from_state(from_s.state))
-            or (to_s is not None and not match_to_state(to_s.state))
-            or (
-                not match_all
-                and from_s is not None
-                and to_s is not None
-                and from_s.state == to_s.state
-            )
+            not match_from_state(old_state)
+            or not match_to_state(new_state)
+            or (not match_all and old_state == new_state)
         ):
             return
 

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -101,15 +101,6 @@ async def async_attach_trigger(
                 )
             )
 
-        # Ignore changes to state attributes if from/to is in use
-        if (
-            not match_all
-            and from_s is not None
-            and to_s is not None
-            and from_s.state == to_s.state
-        ):
-            return
-
         if not time_delta:
             call_action()
             return

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -519,28 +519,69 @@ async def test_if_fires_on_entity_change_with_for(hass, calls):
     assert 1 == len(calls)
 
 
-async def test_if_fires_on_entity_removal(hass, calls):
-    """Test for firing on entity removal, when new_state is None."""
-    context = Context()
-    hass.states.async_set("test.entity", "hello")
-    await hass.async_block_till_done()
-
+async def test_if_fires_on_entity_creation_and_removal(hass, calls):
+    """Test for firing on entity creation and removal, with to/from constraints."""
+    # set automations for multiple combinations to/from
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
         {
-            automation.DOMAIN: {
-                "trigger": {"platform": "state", "entity_id": "test.entity"},
-                "action": {"service": "test.automation"},
-            }
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "state", "entity_id": "test.entity_0"},
+                    "action": {"service": "test.automation"},
+                },
+                {
+                    "trigger": {
+                        "platform": "state",
+                        "from": "hello",
+                        "entity_id": "test.entity_1",
+                    },
+                    "action": {"service": "test.automation"},
+                },
+                {
+                    "trigger": {
+                        "platform": "state",
+                        "to": "world",
+                        "entity_id": "test.entity_2",
+                    },
+                    "action": {"service": "test.automation"},
+                },
+            ],
         },
     )
     await hass.async_block_till_done()
 
-    assert hass.states.async_remove("test.entity", context=context)
+    # use contexts to identify trigger entities
+    context_0 = Context()
+    context_1 = Context()
+    context_2 = Context()
+
+    # automation with match_all triggers on creation
+    hass.states.async_set("test.entity_0", "any", context=context_0)
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].context.parent_id == context.id
+    assert calls[0].context.parent_id == context_0.id
+
+    # create entities, trigger on test.entity_2 ('to' matches, no 'from')
+    hass.states.async_set("test.entity_1", "hello", context=context_1)
+    hass.states.async_set("test.entity_2", "world", context=context_2)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].context.parent_id == context_2.id
+
+    # removal of both, trigger on test.entity_1 ('from' matches, no 'to')
+    assert hass.states.async_remove("test.entity_1", context=context_1)
+    assert hass.states.async_remove("test.entity_2", context=context_2)
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[2].context.parent_id == context_1.id
+
+    # automation with match_all triggers on removal
+    assert hass.states.async_remove("test.entity_0", context=context_0)
+    await hass.async_block_till_done()
+    assert len(calls) == 4
+    assert calls[3].context.parent_id == context_0.id
 
 
 async def test_if_fires_on_for_condition(hass, calls):


### PR DESCRIPTION
for scenarios of enabling/disabling (~ creating/removing) entities,
so it does not trigger in removal if a `to: xxx` is defined, and also
does not trigger in creation if a `from: xxx` is present.

The trigger behavior for those scenarios should follow this table:

| event | 'from' constraint | 'to' constraint | triggers |
|---|---|---|---|
| entity creation  | ---   | --- | YES |
| entity creation  | ---   | match | YES |
| entity creation  | any   | any | NO |
|||||
| entity removal  | ---   | --- | YES |
| entity removal  | match | --- | YES |
| entity removal  | any   | any | NO |

cc @pnbruckner 

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38014
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
