### PR TITLE
Implement unload entry for rfxtrx integration

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -186,6 +186,9 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
         )
     )
 
+    if unload_ok:
+        hass.data.pop(DOMAIN)
+
     return unload_ok
 
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -175,8 +175,6 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
 
 async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
     """Unload RFXtrx component."""
-    await hass.async_add_executor_job(unload_internal, hass, entry.data)
-
     unload_ok = all(
         await asyncio.gather(
             *[
@@ -185,6 +183,8 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
             ]
         )
     )
+
+    await hass.async_add_executor_job(unload_internal, hass, entry.data)
 
     if unload_ok:
         hass.data.pop(DOMAIN)

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -191,7 +191,7 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
 
 def unload_internal(hass, config):
     """Unload the RFXtrx component."""
-    hass.services.async_remove(DOMAIN, SERVICE_SEND)
+    hass.services.remove(DOMAIN, SERVICE_SEND)
 
     listener = hass.data[DOMAIN][DATA_LISTENER]
     listener()

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -184,9 +184,9 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
         )
     )
 
-    await hass.async_add_executor_job(unload_internal, hass, entry.data)
-
     if unload_ok:
+        await hass.async_add_executor_job(unload_internal, hass, entry.data)
+
         hass.data.pop(DOMAIN)
 
     return unload_ok

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -1,4 +1,5 @@
 """Support for RFXtrx devices."""
+import asyncio
 import binascii
 from collections import OrderedDict
 import logging
@@ -82,6 +83,7 @@ DATA_TYPES = OrderedDict(
 
 _LOGGER = logging.getLogger(__name__)
 DATA_RFXOBJECT = "rfxobject"
+DATA_LISTENER = "ha_stop"
 
 
 def _bytearray_string(data):
@@ -132,6 +134,8 @@ CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: vol.Any(DEVICE_SCHEMA, PORT_SCHEMA)}, extra=vol.ALLOW_EXTRA
 )
 
+DOMAINS = ["switch", "sensor", "light", "binary_sensor", "cover"]
+
 
 async def async_setup(hass, config):
     """Set up the RFXtrx component."""
@@ -157,14 +161,43 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     """Set up the RFXtrx component."""
+    hass.data.setdefault(DOMAIN, {})
+
     await hass.async_add_executor_job(setup_internal, hass, entry.data)
 
-    for domain in ["switch", "sensor", "light", "binary_sensor", "cover"]:
+    for domain in DOMAINS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, domain)
         )
 
     return True
+
+
+async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
+    """Unload RFXtrx component."""
+    await hass.async_add_executor_job(unload_internal, hass, entry.data)
+
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in DOMAINS
+            ]
+        )
+    )
+
+    return unload_ok
+
+
+def unload_internal(hass, config):
+    """Unload the RFXtrx component."""
+    hass.services.async_remove(DOMAIN, SERVICE_SEND)
+
+    listener = hass.data[DOMAIN][DATA_LISTENER]
+    listener()
+
+    rfx_object = hass.data[DOMAIN][DATA_RFXOBJECT]
+    rfx_object.close_connection()
 
 
 def setup_internal(hass, config):
@@ -234,9 +267,10 @@ def setup_internal(hass, config):
         """Close connection with RFXtrx."""
         rfx_object.close_connection()
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
+    listener = hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
 
-    hass.data[DATA_RFXOBJECT] = rfx_object
+    hass.data[DOMAIN][DATA_LISTENER] = listener
+    hass.data[DOMAIN][DATA_RFXOBJECT] = rfx_object
 
     def send(call):
         event = call.data[ATTR_EVENT]
@@ -432,7 +466,7 @@ class RfxtrxCommandEntity(RfxtrxEntity):
         self._state = None
 
     def _send_command(self, command, brightness=0):
-        rfx_object = self.hass.data[DATA_RFXOBJECT]
+        rfx_object = self.hass.data[DOMAIN][DATA_RFXOBJECT]
 
         if command == "turn_on":
             for _ in range(self.signal_repetitions):

--- a/tests/components/rfxtrx/__init__.py
+++ b/tests/components/rfxtrx/__init__.py
@@ -6,7 +6,7 @@ async def _signal_event(hass, packet_id):
     event = rfxtrx.get_rfx_object(packet_id)
 
     await hass.async_add_executor_job(
-        hass.data[rfxtrx.DATA_RFXOBJECT].event_callback, event,
+        hass.data[rfxtrx.DOMAIN][rfxtrx.DATA_RFXOBJECT].event_callback, event,
     )
 
     await hass.async_block_till_done()


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implementation of unload entry for rfxtrx integration. This allows users to remove the integration without restarting and it makes it easier to reload entries when options need to be changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
