### PR TITLE
Avoid using implementation internal to trigger events

### DIFF
--- a/tests/components/rfxtrx/__init__.py
+++ b/tests/components/rfxtrx/__init__.py
@@ -1,14 +1,1 @@
 """Tests for the rfxtrx component."""
-from homeassistant.components import rfxtrx
-
-
-async def _signal_event(hass, packet_id):
-    event = rfxtrx.get_rfx_object(packet_id)
-
-    await hass.async_add_executor_job(
-        hass.data[rfxtrx.DATA_RFXOBJECT].event_callback, event,
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
-    return event

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -3,10 +3,26 @@ from unittest import mock
 
 import pytest
 
+from homeassistant.components import rfxtrx
+
 
 @pytest.fixture(autouse=True, name="rfxtrx")
-async def rfxtrx(hass):
+async def rfxtrx_fixture(hass):
     """Fixture that cleans up threads from integration."""
 
     with mock.patch("RFXtrx.Connect") as connect, mock.patch("RFXtrx.DummyTransport2"):
-        yield connect.return_value
+        rfx = connect.return_value
+
+        async def _signal_event(packet_id):
+            event = rfxtrx.get_rfx_object(packet_id)
+            await hass.async_add_executor_job(
+                rfx.event_callback, event,
+            )
+
+            await hass.async_block_till_done()
+            await hass.async_block_till_done()
+            return event
+
+        rfx.signal = _signal_event
+
+        yield rfx

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -4,8 +4,6 @@ from datetime import timedelta
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from . import _signal_event
-
 from tests.common import async_fire_time_changed
 
 
@@ -50,11 +48,11 @@ async def test_one_pt2262(hass, rfxtrx):
     assert state.state == "off"  # probably aught to be unknown
     assert state.attributes.get("friendly_name") == "PT2262 22670e"
 
-    await _signal_event(hass, "0913000022670e013970")
+    await rfxtrx.signal("0913000022670e013970")
     state = hass.states.get("binary_sensor.pt2262_22670e")
     assert state.state == "on"
 
-    await _signal_event(hass, "09130000226707013d70")
+    await rfxtrx.signal("09130000226707013d70")
     state = hass.states.get("binary_sensor.pt2262_22670e")
     assert state.state == "off"
 
@@ -113,12 +111,12 @@ async def test_discover(hass, rfxtrx):
     await hass.async_block_till_done()
     await hass.async_start()
 
-    await _signal_event(hass, "0b1100100118cdea02010f70")
+    await rfxtrx.signal("0b1100100118cdea02010f70")
     state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
     assert state.state == "on"
 
-    await _signal_event(hass, "0b1100100118cdeb02010f70")
+    await rfxtrx.signal("0b1100100118cdeb02010f70")
     state = hass.states.get("binary_sensor.ac_118cdeb_2")
     assert state
     assert state.state == "on"
@@ -143,7 +141,7 @@ async def test_off_delay(hass, rfxtrx):
     assert state
     assert state.state == "off"
 
-    await _signal_event(hass, "0b1100100118cdea02010f70")
+    await rfxtrx.signal("0b1100100118cdea02010f70")
     state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
     assert state.state == "on"

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -3,8 +3,6 @@ from unittest.mock import call
 
 from homeassistant.setup import async_setup_component
 
-from . import _signal_event
-
 
 async def test_one_cover(hass, rfxtrx):
     """Test with 1 cover."""
@@ -88,12 +86,12 @@ async def test_discover_covers(hass, rfxtrx):
     await hass.async_block_till_done()
     await hass.async_start()
 
-    await _signal_event(hass, "0a140002f38cae010f0070")
+    await rfxtrx.signal("0a140002f38cae010f0070")
     state = hass.states.get("cover.lightwaverf_siemens_f38cae_1")
     assert state
     assert state.state == "open"
 
-    await _signal_event(hass, "0a1400adf394ab020e0060")
+    await rfxtrx.signal("0a1400adf394ab020e0060")
     state = hass.states.get("cover.lightwaverf_siemens_f394ab_2")
     assert state
     assert state.state == "open"

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,10 +1,8 @@
 """The tests for the Rfxtrx component."""
 
-from homeassistant.components import rfxtrx
+from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
-
-from . import _signal_event
 
 from tests.async_mock import call
 
@@ -55,7 +53,7 @@ async def test_invalid_config(hass):
     )
 
 
-async def test_fire_event(hass):
+async def test_fire_event(hass, rfxtrx):
     """Test fire event."""
     assert await async_setup_component(
         hass,
@@ -66,8 +64,8 @@ async def test_fire_event(hass):
                 + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
                 "automatic_add": True,
                 "devices": {
-                    "0b1100cd0213c7f210010f51": {rfxtrx.CONF_FIRE_EVENT: True},
-                    "0716000100900970": {rfxtrx.CONF_FIRE_EVENT: True},
+                    "0b1100cd0213c7f210010f51": {"fire_event": True},
+                    "0716000100900970": {"fire_event": True},
                 },
             }
         },
@@ -83,10 +81,10 @@ async def test_fire_event(hass):
         assert event.event_type == "rfxtrx_event"
         calls.append(event.data)
 
-    hass.bus.async_listen(rfxtrx.const.EVENT_RFXTRX_EVENT, record_event)
+    hass.bus.async_listen(EVENT_RFXTRX_EVENT, record_event)
 
-    await _signal_event(hass, "0b1100cd0213c7f210010f51")
-    await _signal_event(hass, "0716000100900970")
+    await rfxtrx.signal("0b1100cd0213c7f210010f51")
+    await rfxtrx.signal("0716000100900970")
 
     assert calls == [
         {

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -5,8 +5,6 @@ import pytest
 
 from homeassistant.setup import async_setup_component
 
-from . import _signal_event
-
 
 async def test_one_light(hass, rfxtrx):
     """Test with 1 light."""
@@ -150,13 +148,13 @@ async def test_discover_light(hass, rfxtrx):
     await hass.async_block_till_done()
     await hass.async_start()
 
-    await _signal_event(hass, "0b11009e00e6116202020070")
+    await rfxtrx.signal("0b11009e00e6116202020070")
     state = hass.states.get("light.ac_0e61162_2")
     assert state
     assert state.state == "on"
     assert state.attributes.get("friendly_name") == "AC 0e61162:2"
 
-    await _signal_event(hass, "0b1100120118cdea02020070")
+    await rfxtrx.signal("0b1100120118cdea02020070")
     state = hass.states.get("light.ac_118cdea_2")
     assert state
     assert state.state == "on"

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -2,8 +2,6 @@
 from homeassistant.const import TEMP_CELSIUS, UNIT_PERCENTAGE
 from homeassistant.setup import async_setup_component
 
-from . import _signal_event
-
 
 async def test_default_config(hass, rfxtrx):
     """Test with 0 sensor."""
@@ -132,7 +130,7 @@ async def test_discover_sensor(hass, rfxtrx):
     await hass.async_start()
 
     # 1
-    await _signal_event(hass, "0a520801070100b81b0279")
+    await rfxtrx.signal("0a520801070100b81b0279")
     base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_07_01"
 
     state = hass.states.get(f"{base_id}_humidity")
@@ -161,7 +159,7 @@ async def test_discover_sensor(hass, rfxtrx):
     assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
 
     # 2
-    await _signal_event(hass, "0a52080405020095240279")
+    await rfxtrx.signal("0a52080405020095240279")
     base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02"
     state = hass.states.get(f"{base_id}_humidity")
 
@@ -190,7 +188,7 @@ async def test_discover_sensor(hass, rfxtrx):
     assert state.attributes.get("unit_of_measurement") == UNIT_PERCENTAGE
 
     # 1 Update
-    await _signal_event(hass, "0a52085e070100b31b0279")
+    await rfxtrx.signal("0a52085e070100b31b0279")
     base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_07_01"
 
     state = hass.states.get(f"{base_id}_humidity")
@@ -251,8 +249,8 @@ async def test_update_of_sensors(hass, rfxtrx):
     assert state
     assert state.state == "unknown"
 
-    await _signal_event(hass, "0a520802060101ff0f0269")
-    await _signal_event(hass, "0a52080705020085220269")
+    await rfxtrx.signal("0a520802060101ff0f0269")
+    await rfxtrx.signal("0a52080705020085220269")
 
     state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02_temperature")
     assert state

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -5,8 +5,6 @@ import pytest
 
 from homeassistant.setup import async_setup_component
 
-from . import _signal_event
-
 
 async def test_one_switch(hass, rfxtrx):
     """Test with 1 switch."""
@@ -109,12 +107,12 @@ async def test_discover_switch(hass, rfxtrx):
     await hass.async_block_till_done()
     await hass.async_start()
 
-    await _signal_event(hass, "0b1100100118cdea02010f70")
+    await rfxtrx.signal("0b1100100118cdea02010f70")
     state = hass.states.get("switch.ac_118cdea_2")
     assert state
     assert state.state == "on"
 
-    await _signal_event(hass, "0b1100100118cdeb02010f70")
+    await rfxtrx.signal("0b1100100118cdeb02010f70")
     state = hass.states.get("switch.ac_118cdeb_2")
     assert state
     assert state.state == "on"


### PR DESCRIPTION
This uses the mocking in fixture to trigger events.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of depending on internal behaviour of component in tests, trigger the events from the library mock.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
