### PR TITLE
Update tests that track time to account for microsecond precision

### DIFF
--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -755,17 +755,17 @@ async def test_async_track_time_change(hass):
         hass, lambda x: specific_runs.append(1), second=[0, 30]
     )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 15))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 15, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 2
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
@@ -773,7 +773,7 @@ async def test_async_track_time_change(hass):
     unsub()
     unsub_utc()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
@@ -789,21 +789,21 @@ async def test_periodic_task_minute(hass):
         hass, lambda x: specific_runs.append(1), minute="/5", second=0
     )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 3, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 3, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
@@ -818,23 +818,23 @@ async def test_periodic_task_hour(hass):
         hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
     )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 1, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 1, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
@@ -856,7 +856,7 @@ async def test_periodic_task_wrong_input(hass):
             hass, lambda x: specific_runs.append(1), hour="/two"
         )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 2, 0, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 2, 0, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
@@ -871,31 +871,33 @@ async def test_periodic_task_clock_rollback(hass):
         hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
     )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 5, 24, 22, 0, 0), fire_all=True
+        hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999), fire_all=True
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 0, 0, 0), fire_all=True)
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 0, 0, 0, 999999), fire_all=True
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 
@@ -910,15 +912,15 @@ async def test_periodic_task_duplicate_time(hass):
         hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
     )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0))
+    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0, 999999))
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
@@ -944,25 +946,25 @@ async def test_periodic_task_entering_dst(hass):
         )
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 1, 3, 25, 1, 50, 0))
+        hass, timezone.localize(datetime(now.year + 1, 3, 25, 1, 50, 0, 999999))
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 1, 3, 25, 3, 50, 0))
+        hass, timezone.localize(datetime(now.year + 1, 3, 25, 3, 50, 0, 999999))
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 1, 3, 26, 1, 50, 0))
+        hass, timezone.localize(datetime(now.year + 1, 3, 26, 1, 50, 0, 999999))
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 1, 3, 26, 2, 50, 0))
+        hass, timezone.localize(datetime(now.year + 1, 3, 26, 2, 50, 0, 999999))
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
@@ -990,31 +992,46 @@ async def test_periodic_task_leaving_dst(hass):
         )
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 1, 10, 28, 2, 5, 0), is_dst=False)
+        hass,
+        timezone.localize(
+            datetime(now.year + 1, 10, 28, 2, 5, 0, 999999), is_dst=False
+        ),
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 1, 10, 28, 2, 55, 0), is_dst=False)
+        hass,
+        timezone.localize(
+            datetime(now.year + 1, 10, 28, 2, 55, 0, 999999), is_dst=False
+        ),
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 2, 10, 28, 2, 45, 0), is_dst=True)
+        hass,
+        timezone.localize(
+            datetime(now.year + 2, 10, 28, 2, 45, 0, 999999), is_dst=True
+        ),
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 2, 10, 28, 2, 55, 0), is_dst=True)
+        hass,
+        timezone.localize(
+            datetime(now.year + 2, 10, 28, 2, 55, 0, 999999), is_dst=True
+        ),
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     async_fire_time_changed(
-        hass, timezone.localize(datetime(now.year + 2, 10, 28, 2, 55, 0), is_dst=True)
+        hass,
+        timezone.localize(
+            datetime(now.year + 2, 10, 28, 2, 55, 0, 999999), is_dst=True
+        ),
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the timer can be scheduled any time within the second now that we have microsecond precision on timers, we need to make sure we call `async_fire_time_changed` with microseconds=999999 to ensure we match the timer.

Spreading out timers between 0 and 999999 microseconds is a feature as it avoids having everything fire at .000000 and monopolizing the event loop.

Also fixes two of the automation tests that could fire between when the integration was setup and when we force the time fast forward.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
