### PR TITLE
Support dual stack IP support (IPv4 and IPv6)

### DIFF
--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -10,7 +10,6 @@ from homeassistant.components.http import (
     CONF_SERVER_HOST,
     CONF_SERVER_PORT,
     CONF_SSL_CERTIFICATE,
-    DEFAULT_SERVER_HOST,
 )
 from homeassistant.const import HTTP_BAD_REQUEST, HTTP_OK, SERVER_PORT
 
@@ -142,10 +141,7 @@ class HassIO:
             "refresh_token": refresh_token.token,
         }
 
-        if (
-            http_config.get(CONF_SERVER_HOST, DEFAULT_SERVER_HOST)
-            != DEFAULT_SERVER_HOST
-        ):
+        if http_config.get(CONF_SERVER_HOST) is not None:
             options["watchdog"] = False
             _LOGGER.warning(
                 "Found incompatible HTTP option 'server_host'. Watchdog feature disabled"

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -30,6 +30,7 @@ from .cors import setup_cors
 from .real_ip import setup_real_ip
 from .static import CACHE_HEADERS, CachingStaticResource
 from .view import HomeAssistantView  # noqa: F401
+from .web_runner import HomeAssistantTCPSite
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -53,7 +54,6 @@ SSL_INTERMEDIATE = "intermediate"
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_DEVELOPMENT = "0"
 # To be able to load custom cards.
 DEFAULT_CORS = "https://cast.home-assistant.io"
@@ -69,7 +69,9 @@ HTTP_SCHEMA = vol.All(
     cv.deprecated(CONF_BASE_URL),
     vol.Schema(
         {
-            vol.Optional(CONF_SERVER_HOST, default=DEFAULT_SERVER_HOST): cv.string,
+            vol.Optional(CONF_SERVER_HOST): vol.All(
+                cv.ensure_list, vol.Length(min=1), [cv.string]
+            ),
             vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port,
             vol.Optional(CONF_BASE_URL): cv.string,
             vol.Optional(CONF_SSL_CERTIFICATE): cv.isfile,
@@ -190,7 +192,7 @@ async def async_setup(hass, config):
     if conf is None:
         conf = HTTP_SCHEMA({})
 
-    server_host = conf[CONF_SERVER_HOST]
+    server_host = conf.get(CONF_SERVER_HOST)
     server_port = conf[CONF_SERVER_PORT]
     ssl_certificate = conf.get(CONF_SSL_CERTIFICATE)
     ssl_peer_certificate = conf.get(CONF_SSL_PEER_CERTIFICATE)
@@ -255,8 +257,9 @@ async def async_setup(hass, config):
 
     if host:
         port = None
-    elif server_host != DEFAULT_SERVER_HOST:
-        host = server_host
+    elif server_host is not None:
+        # Assume the first server host name provided as API host
+        host = server_host[0]
         port = server_port
     else:
         host = local_ip
@@ -412,7 +415,13 @@ class HomeAssistantHTTP:
 
         self.runner = web.AppRunner(self.app)
         await self.runner.setup()
-        self.site = web.TCPSite(
+
+        # The default of server_host is None, which enables dual-stack,
+        # from asyncio's create_server() documentation:
+        # "If host is an empty string or None, all interfaces are assumed
+        # and a list of multiple sockets will be returned (most likely one
+        # for IPv4 and another one for IPv6)."
+        self.site = HomeAssistantTCPSite(
             self.runner, self.server_host, self.server_port, ssl_context=context
         )
         try:

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -416,11 +416,6 @@ class HomeAssistantHTTP:
         self.runner = web.AppRunner(self.app)
         await self.runner.setup()
 
-        # The default of server_host is None, which enables dual-stack,
-        # from asyncio's create_server() documentation:
-        # "If host is an empty string or None, all interfaces are assumed
-        # and a list of multiple sockets will be returned (most likely one
-        # for IPv4 and another one for IPv6)."
         self.site = HomeAssistantTCPSite(
             self.runner, self.server_host, self.server_port, ssl_context=context
         )

--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -15,6 +15,9 @@ class HomeAssistantTCPSite(web.BaseSite):
     host IP's. To support multiple server_host entries (e.g. to enable dual-stack
     explicitly), we would like to pass an array of strings. Bring our own
     implementation inspired by TCPSite.
+
+    Custom TCPSite can be dropped when https://github.com/aio-libs/aiohttp/pull/4894
+    is merged.
     """
 
     __slots__ = ("_host", "_port", "_reuse_address", "_reuse_port", "_hosturl")

--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -1,0 +1,64 @@
+"""HomeAssistant specific aiohttp Site."""
+import asyncio
+from ssl import SSLContext
+from typing import List, Optional, Union
+
+from aiohttp import web
+from yarl import URL
+
+
+class HomeAssistantTCPSite(web.BaseSite):
+    """HomeAssistant specific aiohttp Site.
+
+    Vanilla TCPSite accepts only str as host. However, the underlying asyncio's
+    create_server() implementation does take a list of strings to bind to multiple
+    host IP's. To support multiple server_host entries (e.g. to enable dual-stack
+    explicitly), we would like to pass an array of strings. Bring our own
+    implementation inspired by TCPSite.
+    """
+
+    __slots__ = ("_host", "_port", "_reuse_address", "_reuse_port", "_hosturl")
+
+    def __init__(
+        self,
+        runner: "web.BaseRunner",
+        host: Union[Optional[str], List[str]],
+        port: int,
+        *,
+        shutdown_timeout: float = 60.0,
+        ssl_context: Optional[SSLContext] = None,
+        backlog: int = 128,
+        reuse_address: Optional[bool] = None,
+        reuse_port: Optional[bool] = None,
+    ) -> None:  # noqa: D107
+        super().__init__(
+            runner,
+            shutdown_timeout=shutdown_timeout,
+            ssl_context=ssl_context,
+            backlog=backlog,
+        )
+        self._host = host
+        self._port = port
+        self._reuse_address = reuse_address
+        self._reuse_port = reuse_port
+
+    @property
+    def name(self) -> str:  # noqa: D102
+        scheme = "https" if self._ssl_context else "http"
+        host = self._host[0] if isinstance(self._host, list) else "0.0.0.0"
+        return str(URL.build(scheme=scheme, host=host, port=self._port))
+
+    async def start(self) -> None:  # noqa: D102
+        await super().start()
+        loop = asyncio.get_running_loop()
+        server = self._runner.server
+        assert server is not None
+        self._server = await loop.create_server(
+            server,
+            self._host,
+            self._port,
+            ssl=self._ssl_context,
+            backlog=self._backlog,
+            reuse_address=self._reuse_address,
+            reuse_port=self._reuse_port,
+        )

--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -22,7 +22,7 @@ class HomeAssistantTCPSite(web.BaseSite):
     def __init__(
         self,
         runner: "web.BaseRunner",
-        host: Union[Optional[str], List[str]],
+        host: Union[None, str, List[str]],
         port: int,
         *,
         shutdown_timeout: float = 60.0,

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -113,7 +113,6 @@ def test_secrets(isfile_patch, loop):
             "cors_allowed_origins": ["http://google.com"],
             "ip_ban_enabled": True,
             "login_attempts_threshold": -1,
-            "server_host": "0.0.0.0",
             "server_port": 8123,
             "ssl_profile": "modern",
         }


### PR DESCRIPTION
## Proposed change

Change the default setting of server_host to be None, which will make
asyncio's start_server bind to all interfaces and (IP) families. This
by default makes Home Assistant Core accessible via IPv4 and IPv6.

Also allow to specify a list of hosts to listen on. This allows to
listen to multiple host/IP addresses explicitly (e.g. IPv4 and IPv6
addresses).

Note that on Linux dual-stack can also be archived by just listening to
::0. However, Python's asyncio by default disables dual-stack option by
setting the IPV6_V6ONLY socket option. But asyncio does allow to pass a
sequence of host names to bind to multiple protocols or use None to bind
to IPv4 and IPv6 (if supported) by default. This patch makes use of
those features.

See also: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_server



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [?] Breaking change (fix/feature causing existing functionality to break) **changing default, is this considered breaking?**
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
# Example configuration.yaml
http:
  server_host:
    - ::0
    - 0.0.0.0
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14125

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
