### PR TITLE
Make ozw CCT use device attributes instead of hard coded values

### DIFF
--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -114,7 +114,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         # Filter out CommandClasses we're definitely not interested in.
         if value.command_class in [
-            CommandClass.CONFIGURATION,
             CommandClass.VERSION,
             CommandClass.MANUFACTURER_SPECIFIC,
         ]:

--- a/homeassistant/components/ozw/discovery.py
+++ b/homeassistant/components/ozw/discovery.py
@@ -250,6 +250,16 @@ DISCOVERY_SCHEMAS = (
                 const.DISC_INDEX: ValueIndex.SWITCH_COLOR_CHANNELS,
                 const.DISC_OPTIONAL: True,
             },
+            "min_kelvin": {
+                const.DISC_COMMAND_CLASS: (CommandClass.CONFIGURATION,),
+                const.DISC_INDEX: ValueIndex.SENSOR_MULTILEVEL_OZONE,  # PR for upstream to add LIGHT_COLOR_KELVIN_MIN
+                const.DISC_OPTIONAL: True,
+            },
+            "max_kelvin": {
+                const.DISC_COMMAND_CLASS: (CommandClass.CONFIGURATION,),
+                const.DISC_INDEX: ValueIndex.SENSOR_MULTILEVEL_SULFUR_DIOXIDE,  # PR for upstream to add LIGHT_COLOR_KELVIN_MAX
+                const.DISC_OPTIONAL: True,
+            },
         },
     },
     {  # All other text/numeric sensors

--- a/homeassistant/components/ozw/discovery.py
+++ b/homeassistant/components/ozw/discovery.py
@@ -252,12 +252,12 @@ DISCOVERY_SCHEMAS = (
             },
             "min_kelvin": {
                 const.DISC_COMMAND_CLASS: (CommandClass.CONFIGURATION,),
-                const.DISC_INDEX: ValueIndex.SENSOR_MULTILEVEL_OZONE,  # PR for upstream to add LIGHT_COLOR_KELVIN_MIN
+                const.DISC_INDEX: 81,  # PR for upstream to add SWITCH_COLOR_CT_WARM
                 const.DISC_OPTIONAL: True,
             },
             "max_kelvin": {
                 const.DISC_COMMAND_CLASS: (CommandClass.CONFIGURATION,),
-                const.DISC_INDEX: ValueIndex.SENSOR_MULTILEVEL_SULFUR_DIOXIDE,  # PR for upstream to add LIGHT_COLOR_KELVIN_MAX
+                const.DISC_INDEX: 82,  # PR for upstream to add SWITCH_COLOR_CT_COLD
                 const.DISC_OPTIONAL: True,
             },
         },

--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -213,16 +213,6 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
             else:
                 rgbw = f"#00000000{white:02x}"
 
-        # Update color temp limits.
-        if self.values.min_kelvin:
-            self._max_mireds = color_util.color_temperature_kelvin_to_mired(
-                self.values.min_kelvin.data[ATTR_VALUE]
-            )
-        if self.values.max_kelvin:
-            self._min_mireds = color_util.color_temperature_kelvin_to_mired(
-                self.values.max_kelvin.data[ATTR_VALUE]
-            )
-
         elif color_temp is not None:
             # Limit color temp to min/max values
             cold = max(
@@ -274,6 +264,16 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
         index = 7
         temp_warm = 0
         temp_cold = 0
+
+        # Update color temp limits.
+        if self.values.min_kelvin:
+            self._max_mireds = color_util.color_temperature_kelvin_to_mired(
+                self.values.min_kelvin.data[ATTR_VALUE]
+            )
+        if self.values.max_kelvin:
+            self._min_mireds = color_util.color_temperature_kelvin_to_mired(
+                self.values.max_kelvin.data[ATTR_VALUE]
+            )
 
         # Warm white
         if self._color_channels & COLOR_CHANNEL_WARM_WHITE:

--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -30,9 +30,6 @@ COLOR_CHANNEL_COLD_WHITE = 0x02
 COLOR_CHANNEL_RED = 0x04
 COLOR_CHANNEL_GREEN = 0x08
 COLOR_CHANNEL_BLUE = 0x10
-TEMP_COLOR_MAX = 500  # mired equivalent to 2000K
-TEMP_COLOR_MIN = 154  # mired equivalent to 6500K
-TEMP_COLOR_DIFF = TEMP_COLOR_MAX - TEMP_COLOR_MIN
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -71,6 +68,8 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
         self._white = None
         self._ct = None
         self._supported_features = SUPPORT_BRIGHTNESS
+        self._min_mireds = 154
+        self._max_mireds = 370
         # make sure that supported features is correctly set
         self.on_value_update()
 
@@ -135,6 +134,16 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
     def color_temp(self):
         """Return the color temperature."""
         return self._ct
+
+    @property
+    def min_mireds(self):
+        """Return the coldest color_temp that this light supports."""
+        return self._min_mireds
+
+    @property
+    def max_mireds(self):
+        """Return the warmest color_temp that this light supports."""
+        return self._max_mireds
 
     @callback
     def async_set_duration(self, **kwargs):
@@ -209,7 +218,11 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
                 0,
                 min(
                     255,
-                    round((TEMP_COLOR_MAX - round(color_temp)) / TEMP_COLOR_DIFF * 255),
+                    round(
+                        (self._max_mireds - color_temp)
+                        / (self._max_mireds - self._min_mireds)
+                        * 255
+                    ),
                 ),
             )
             warm = 255 - cold
@@ -264,13 +277,12 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
             temp_cold = self._white
 
         # Calculate color temps based on white LED status
-        if temp_cold > 0:
-            self._ct = round(TEMP_COLOR_MAX - ((temp_cold / 255) * TEMP_COLOR_DIFF))
-        # Only used if CW channel missing
-        elif temp_warm > 0:
-            self._ct = round(TEMP_COLOR_MAX - temp_warm)
+        if temp_cold or temp_warm:
+            self._ct = round(
+                self._max_mireds
+                - ((temp_cold / 255) * (self._max_mireds - self._min_mireds))
+            )
 
-        # If no rgb channels supported, report None.
         if not (
             self._color_channels & COLOR_CHANNEL_RED
             or self._color_channels & COLOR_CHANNEL_GREEN

--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -213,17 +213,17 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
             else:
                 rgbw = f"#00000000{white:02x}"
 
-        elif color_temp is not None:
-            # Update color temp limits.
-            if self.values.min_kelvin:
-                self._max_mireds = color_util.color_temperature_kelvin_to_mired(
-                    self.values.min_kelvin.data[ATTR_VALUE]
-                )
-            if self.values.max_kelvin:
-                self._min_mireds = color_util.color_temperature_kelvin_to_mired(
-                    self.values.max_kelvin.data[ATTR_VALUE]
-                )
+        # Update color temp limits.
+        if self.values.min_kelvin:
+            self._max_mireds = color_util.color_temperature_kelvin_to_mired(
+                self.values.min_kelvin.data[ATTR_VALUE]
+            )
+        if self.values.max_kelvin:
+            self._min_mireds = color_util.color_temperature_kelvin_to_mired(
+                self.values.max_kelvin.data[ATTR_VALUE]
+            )
 
+        elif color_temp is not None:
             # Limit color temp to min/max values
             cold = max(
                 0,

--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -255,11 +255,11 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
         # Color Data String
         data = self.values.color.data[ATTR_VALUE]
 
-        # RGB is always present in the openzwave color data string.
+        # RGB is always present in the OpenZWave color data string.
         rgb = [int(data[1:3], 16), int(data[3:5], 16), int(data[5:7], 16)]
         self._hs = color_util.color_RGB_to_hs(*rgb)
 
-        # Parse remaining color channels. Openzwave appends white channels
+        # Parse remaining color channels. OpenZWave appends white channels
         # that are present.
         index = 7
         temp_warm = 0

--- a/tests/components/ozw/test_light.py
+++ b/tests/components/ozw/test_light.py
@@ -513,8 +513,7 @@ async def test_wc_light(hass, light_wc_data, light_msg, light_rgb_msg, sent_mess
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "on"
-<<<<<<< HEAD
-    assert state.attributes["color_temp"] == 191
+    assert state.attributes["color_temp"] == 190
 
 
 async def test_new_ozw_light(hass, light_new_ozw_data, light_msg, sent_messages):

--- a/tests/components/ozw/test_light.py
+++ b/tests/components/ozw/test_light.py
@@ -486,6 +486,9 @@ async def test_wc_light(hass, light_wc_data, light_msg, light_rgb_msg, sent_mess
     assert state is not None
     assert state.state == "off"
 
+    assert state.attributes["min_mireds"] == 153
+    assert state.attributes["max_mireds"] == 370
+
     # Turn on the light
     new_color = 190
     await hass.services.async_call(

--- a/tests/components/ozw/test_light.py
+++ b/tests/components/ozw/test_light.py
@@ -284,7 +284,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state.attributes["xy_color"] == (0.519, 0.429)
 
     # Test setting color temp
-    new_color = 465
+    new_color = 200
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -298,14 +298,14 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
 
     msg = sent_messages[-2]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": "#000000e51a", "ValueIDKey": 659341335}
+    assert msg["payload"] == {"Value": "#00000036c9", "ValueIDKey": 659341335}
 
     # Feedback on state
     light_msg.decode()
     light_msg.payload["Value"] = byte_to_zwave_brightness(255)
     light_msg.encode()
     light_rgb_msg.decode()
-    light_rgb_msg.payload["Value"] = "#000000e51a"
+    light_rgb_msg.payload["Value"] = "#00000036c9"
     light_rgb_msg.encode()
     receive_message(light_msg)
     receive_message(light_rgb_msg)
@@ -314,7 +314,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "on"
-    assert state.attributes["color_temp"] == 465
+    assert state.attributes["color_temp"] == 200
 
     # Test setting invalid color temp
     new_color = 120
@@ -497,14 +497,14 @@ async def test_wc_light(hass, light_wc_data, light_msg, light_rgb_msg, sent_mess
     assert len(sent_messages) == 2
     msg = sent_messages[-2]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": "#0000001be4", "ValueIDKey": 659341335}
+    assert msg["payload"] == {"Value": "#0000002bd4", "ValueIDKey": 659341335}
 
     # Feedback on state
     light_msg.decode()
     light_msg.payload["Value"] = byte_to_zwave_brightness(255)
     light_msg.encode()
     light_rgb_msg.decode()
-    light_rgb_msg.payload["Value"] = "#0000001be4"
+    light_rgb_msg.payload["Value"] = "#0000002bd4"
     light_rgb_msg.encode()
     receive_message(light_msg)
     receive_message(light_rgb_msg)
@@ -513,6 +513,7 @@ async def test_wc_light(hass, light_wc_data, light_msg, light_rgb_msg, sent_mess
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "on"
+<<<<<<< HEAD
     assert state.attributes["color_temp"] == 191
 
 

--- a/tests/components/ozw/test_light.py
+++ b/tests/components/ozw/test_light.py
@@ -298,14 +298,14 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
 
     msg = sent_messages[-2]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": "#00000036c9", "ValueIDKey": 659341335}
+    assert msg["payload"] == {"Value": "#00000037c8", "ValueIDKey": 659341335}
 
     # Feedback on state
     light_msg.decode()
     light_msg.payload["Value"] = byte_to_zwave_brightness(255)
     light_msg.encode()
     light_rgb_msg.decode()
-    light_rgb_msg.payload["Value"] = "#00000036c9"
+    light_rgb_msg.payload["Value"] = "#00000037c8"
     light_rgb_msg.encode()
     receive_message(light_msg)
     receive_message(light_rgb_msg)
@@ -347,7 +347,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "on"
-    assert state.attributes["color_temp"] == 154
+    assert state.attributes["color_temp"] == 153
 
 
 async def test_no_rgb_light(hass, light_no_rgb_data, light_no_rgb_msg, sent_messages):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is to address https://github.com/home-assistant/core/issues/38042 at least for the ozw component.
Hardcoded values for max/min color temp mean that setting any overrides are ignored, or worse, output invalid color temps.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #38042 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
