### PR TITLE
Add 'alarm_event_occurred' property from AlarmDecoder

### DIFF
--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -84,6 +84,7 @@ class AlarmDecoderAlarmPanel(AlarmControlPanelEntity):
         self._name = "Alarm Panel"
         self._state = None
         self._ac_power = None
+        self._alarm_event_occurred = None
         self._backlight_on = None
         self._battery_low = None
         self._check_zone = None
@@ -117,6 +118,7 @@ class AlarmDecoderAlarmPanel(AlarmControlPanelEntity):
             self._state = STATE_ALARM_DISARMED
 
         self._ac_power = message.ac_power
+        self._alarm_event_occurred = message.alarm_event_occurred
         self._backlight_on = message.backlight_on
         self._battery_low = message.battery_low
         self._check_zone = message.check_zone
@@ -163,6 +165,7 @@ class AlarmDecoderAlarmPanel(AlarmControlPanelEntity):
         """Return the state attributes."""
         return {
             "ac_power": self._ac_power,
+            "alarm_event_occurred": self._alarm_event_occurred,
             "backlight_on": self._backlight_on,
             "battery_low": self._battery_low,
             "check_zone": self._check_zone,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the `alarm_event_occurred` attribute to the AlarmDecoder alarm panel entity, one of the only parameters left that HA did not use. See [AlarmDecoder's website](http://www.alarmdecoder.com/wiki/index.php/Protocol#Keypad).

My [PR on the HA documentation for AlarmDecoder](https://github.com/home-assistant/home-assistant.io/pull/14058) was recently merged, where I noted a possible mistake when these attributes were first created in HA: the `alarm_event_occurred` and `check_zone` parameters were conflated. This may be the reason why it was missed the first time. After that, I decided to add the other missing parameter concerned, for true this time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

No changes

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14060

Some of these parameters from AlarmDecoder like `alarm_event_occurred` and `check_zone` are made less potent by the lack of a mechanism by which the zone concerned can be reported to the user (which zone triggered the last alarm and which zone must be checked, respectively). I'm not sure of the convention on how to do that (maybe an attribute on the `binary_sensor` zones that are created by the integration), so I have left it alone for now. I may make a formal Q&A later to gather information on that point.

Other future additions can include creating entities for some of the AlarmDecoder attributes, like the battery level and AC power ("charging") statuses of the alarm panel, as was done with the Roomba integration's battery sensor recently.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
