### PR TITLE
Fix ozw light color values check

### DIFF
--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -80,7 +80,7 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
         if self.values.dimming_duration is not None:
             self._supported_features |= SUPPORT_TRANSITION
 
-        if self.values.color is None and self.values.color_channels is None:
+        if self.values.color is None or self.values.color_channels is None:
             return
 
         if self.values.color is not None:

--- a/homeassistant/components/ozw/light.py
+++ b/homeassistant/components/ozw/light.py
@@ -83,8 +83,7 @@ class ZwaveLight(ZWaveDeviceEntity, LightEntity):
         if self.values.color is None or self.values.color_channels is None:
             return
 
-        if self.values.color is not None:
-            self._supported_features |= SUPPORT_COLOR
+        self._supported_features |= SUPPORT_COLOR
 
         # Support Color Temp if both white channels
         if (self.values.color_channels.value & COLOR_CHANNEL_WARM_WHITE) and (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- I tested the ozw light color platform with an aotec color light and got an exception.
The order of the value presentation is not the same for all devices. Work around that by adjusting the color values check.
- See stack trace below.

```
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [NODE ADDED] node_id: 21
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Dimming Duration - value: 255 - value_id: 1407375249080337 - CC: CommandClass.SWITCH_MULTILEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Level - value: 99 - value_id: 357138449 - CC: CommandClass.SWITCH_MULTILEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw.entity] Adding Node_id=21 Generic_command_class=17, Specific_command_class=1, Command_class=CommandClass.SWITCH_MULTILEVEL, Index=ValueIndex.ALARM_TYPE, Value type=ValueType.BYTE, Genre=ValueGenre.USER as light
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Bright - value: False - value_id: 281475333849112 - CC: CommandClass.SWITCH_MULTILEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Dim - value: False - value_id: 562950310559768 - CC: CommandClass.SWITCH_MULTILEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Ignore Start Level - value: True - value_id: 844425295659024 - CC: CommandClass.SWITCH_MULTILEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Start Level - value: 0 - value_id: 1125900272369681 - CC: CommandClass.SWITCH_MULTILEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Switch All - value: {'List': [{'Value': 0, 'Label': 'Disabled'}, {'Value': 1, 'Label': 'Off Enabled'}, {'Value': 2, 'Label': 'On Enabled'}, {'Value': 255, 'Label': 'On and Off Enabled'}], 'Selected': 'On and Off Enabled', 'Selected_id': 255} - value_id: 365543444 - CC: CommandClass.SWITCH_ALL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Color Channels - value: 31 - value_id: 562950319161363 - CC: CommandClass.SWITCH_COLOR
2020-07-21 13:53:30 ERROR (MainThread) [homeassistant.util.logging] Exception in _value_added when dispatching 'ozw_1-21-357138449_value_added': ()
Traceback (most recent call last):
  File "/home/martin/Dev/home-assistant/home-assistant/homeassistant/components/ozw/entity.py", line 239, in _value_added
    self.on_value_update()
  File "/home/martin/Dev/home-assistant/home-assistant/homeassistant/components/ozw/light.py", line 101, in on_value_update
    self._calculate_rgb_values()
  File "/home/martin/Dev/home-assistant/home-assistant/homeassistant/components/ozw/light.py", line 231, in _calculate_rgb_values
    data = self.values.color.data[ATTR_VALUE]
AttributeError: 'NoneType' object has no attribute 'data'

2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Color - value: #000000FF00 - value_id: 357351447 - CC: CommandClass.SWITCH_COLOR
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Color Index - value: {'List': [{'Value': 0, 'Label': 'Off'}, {'Value': 1, 'Label': 'Cool White'}, {'Value': 2, 'Label': 'Warm White'}, {'Value': 3, 'Label': 'Red'}, {'Value': 4, 'Label': 'Lime'}, {'Value': 5, 'Label': 'Blue'}, {'Value': 6, 'Label': 'Yellow'}, {'Value': 7, 'Label': 'Cyan'}, {'Value': 8, 'Label': 'Magenta'}, {'Value': 9, 'Label': 'Silver'}, {'Value': 10, 'Label': 'Gray'}, {'Value': 11, 'Label': 'Maroon'}, {'Value': 12, 'Label': 'Olive'}, {'Value': 13, 'Label': 'Green'}, {'Value': 14, 'Label': 'Purple'}, {'Value': 15, 'Label': 'Teal'}, {'Value': 16, 'Label': 'Navy'}, {'Value': 17, 'Label': 'Custom'}], 'Selected': 'Warm White', 'Selected_id': 2} - value_id: 281475334062100 - CC: CommandClass.SWITCH_COLOR
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: ZWave+ Version - value: 1 - value_id: 366444561 - CC: CommandClass.ZWAVEPLUS_INFO
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: InstallerIcon - value: 1536 - value_id: 281475343155222 - CC: CommandClass.ZWAVEPLUS_INFO
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: UserIcon - value: 1536 - value_id: 562950319865878 - CC: CommandClass.ZWAVEPLUS_INFO
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Powerlevel - value: {'List': [{'Value': 0, 'Label': 'Normal'}, {'Value': 1, 'Label': '-1dB'}, {'Value': 2, 'Label': '-2dB'}, {'Value': 3, 'Label': '-3dB'}, {'Value': 4, 'Label': '-4dB'}, {'Value': 5, 'Label': '-5dB'}, {'Value': 6, 'Label': '-6dB'}, {'Value': 7, 'Label': '-7dB'}, {'Value': 8, 'Label': '-8dB'}, {'Value': 9, 'Label': '-9dB'}], 'Selected': 'Normal', 'Selected_id': 0} - value_id: 366788628 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Timeout - value: 0 - value_id: 281475343499281 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Set Powerlevel - value: False - value_id: 562950320209944 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Test Node - value: 0 - value_id: 844425296920593 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Test Powerlevel - value: {'List': [{'Value': 0, 'Label': 'Normal'}, {'Value': 1, 'Label': '-1dB'}, {'Value': 2, 'Label': '-2dB'}, {'Value': 3, 'Label': '-3dB'}, {'Value': 4, 'Label': '-4dB'}, {'Value': 5, 'Label': '-5dB'}, {'Value': 6, 'Label': '-6dB'}, {'Value': 7, 'Label': '-7dB'}, {'Value': 8, 'Label': '-8dB'}, {'Value': 9, 'Label': '-9dB'}], 'Selected': 'Normal', 'Selected_id': 0} - value_id: 1125900273631252 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Frame Count - value: 0 - value_id: 1407375250341910 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Test - value: False - value_id: 1688850227052568 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Report - value: False - value_id: 1970325203763224 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Test Status - value: {'List': [{'Value': 0, 'Label': 'Failed'}, {'Value': 1, 'Label': 'Success'}, {'Value': 2, 'Label': 'In Progress'}], 'Selected': 'Failed', 'Selected_id': 0} - value_id: 2251800180473876 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Acked Frames - value: 0 - value_id: 2533275157184534 - CC: CommandClass.POWERLEVEL
2020-07-21 13:53:30 DEBUG (MainThread) [homeassistant.components.ozw] [VALUE ADDED] node_id: 21 - label: Secured - value: True - value_id: 367394832 - CC: CommandClass.SECURITY
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/37636
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
