### PR TITLE
Support unavailable state in template fan

### DIFF
--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -346,7 +346,6 @@ class TemplateFan(FanEntity):
         if state in _VALID_STATES:
             self._state = state
         elif state == STATE_UNAVAILABLE:
-            self._state = state
             self._available = False
         elif state == STATE_UNKNOWN:
             self._state = None

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -345,9 +345,7 @@ class TemplateFan(FanEntity):
         # Validate state
         if state in _VALID_STATES:
             self._state = state
-        elif state == STATE_UNAVAILABLE:
-            self._available = False
-        elif state == STATE_UNKNOWN:
+        elif state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
             self._state = None
         else:
             _LOGGER.error(

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     MATCH_ALL,
     STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import callback
@@ -344,6 +345,9 @@ class TemplateFan(FanEntity):
         # Validate state
         if state in _VALID_STATES:
             self._state = state
+        elif state == STATE_UNAVAILABLE:
+            self._state = state
+            self._available = False
         elif state == STATE_UNKNOWN:
             self._state = None
         else:
@@ -366,7 +370,7 @@ class TemplateFan(FanEntity):
             # Validate speed
             if speed in self._speed_list:
                 self._speed = speed
-            elif speed == STATE_UNKNOWN:
+            elif speed in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
                 self._speed = None
             else:
                 _LOGGER.error(
@@ -388,7 +392,7 @@ class TemplateFan(FanEntity):
                 self._oscillating = True
             elif oscillating == "False" or oscillating is False:
                 self._oscillating = False
-            elif oscillating == STATE_UNKNOWN:
+            elif oscillating in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
                 self._oscillating = None
             else:
                 _LOGGER.error(
@@ -409,7 +413,7 @@ class TemplateFan(FanEntity):
             # Validate speed
             if direction in _VALID_DIRECTIONS:
                 self._direction = direction
-            elif direction == STATE_UNKNOWN:
+            elif direction in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
                 self._direction = None
             else:
                 _LOGGER.error(

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -246,8 +246,7 @@ async def test_template_with_unavailable_entities(hass, calls):
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
-
-    assert hass.states.get(_TEST_FAN).state == STATE_UNKNOWN
+    assert hass.states.get(_TEST_FAN).state == STATE_OFF
 
 
 async def test_template_with_unavailable_parameters(hass, calls):

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -253,6 +253,7 @@ async def test_template_with_unavailable_entities(hass, calls):
 
     _verify(hass, STATE_UNAVAILABLE, None, None, None)
 
+
 async def test_template_with_unavailable_parameters(hass, calls):
     """Test unavailability of speed, direction and oscillating parameters."""
 

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -247,7 +247,7 @@ async def test_template_with_unavailable_entities(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.get(_TEST_FAN).state == STATE_UNAVAILABLE
+    assert hass.states.get(_TEST_FAN).state == STATE_UNKNOWN
 
 
 async def test_template_with_unavailable_parameters(hass, calls):

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -223,7 +223,7 @@ async def test_templates_with_entities(hass, calls):
 
 
 async def test_template_with_unavailable_entities(hass, calls):
-    """Test availability tempalates with values from other entities."""
+    """Test unavailability with value_template."""
 
     with assert_setup_component(1, "fan"):
         assert await setup.async_setup_component(
@@ -252,6 +252,37 @@ async def test_template_with_unavailable_entities(hass, calls):
     await hass.async_block_till_done()
 
     _verify(hass, STATE_UNAVAILABLE, None, None, None)
+
+async def test_template_with_unavailable_parameters(hass, calls):
+    """Test unavailability of speed, direction and oscillating parameters."""
+
+    with assert_setup_component(1, "fan"):
+        assert await setup.async_setup_component(
+            hass,
+            "fan",
+            {
+                "fan": {
+                    "platform": "template",
+                    "fans": {
+                        "test_fan": {
+                            "availability_template": "{{ is_state('availability_boolean.state', 'on') }}",
+                            "value_template": "{{ 'on' }}",
+                            "speed_template": "{{ 'unavailable' }}",
+                            "oscillating_template": "{{ 'unavailable' }}",
+                            "direction_template": "{{ 'unavailable' }}",
+                            "turn_on": {"service": "script.fan_on"},
+                            "turn_off": {"service": "script.fan_off"},
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    _verify(hass, STATE_ON, None, None, None)
 
 
 async def test_availability_template_with_entities(hass, calls):

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -15,7 +15,7 @@ from homeassistant.components.fan import (
     SPEED_LOW,
     SPEED_MEDIUM,
 )
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 
 from tests.common import assert_setup_component, async_mock_service
 from tests.components.fan import common

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -235,9 +235,6 @@ async def test_template_with_unavailable_entities(hass, calls):
                     "fans": {
                         "test_fan": {
                             "value_template": "{{ 'unavailable' }}",
-                            "speed_template": "{{ 'unavailable' }}",
-                            "oscillating_template": "{{ 'unavailable' }}",
-                            "direction_template": "{{ 'unavailable' }}",
                             "turn_on": {"service": "script.fan_on"},
                             "turn_off": {"service": "script.fan_off"},
                         }

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -15,7 +15,7 @@ from homeassistant.components.fan import (
     SPEED_LOW,
     SPEED_MEDIUM,
 )
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
 from tests.common import assert_setup_component, async_mock_service
 from tests.components.fan import common

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -222,6 +222,38 @@ async def test_templates_with_entities(hass, calls):
     _verify(hass, STATE_ON, SPEED_MEDIUM, True, DIRECTION_FORWARD)
 
 
+async def test_template_with_unavailable_entities(hass, calls):
+    """Test availability tempalates with values from other entities."""
+
+    with assert_setup_component(1, "fan"):
+        assert await setup.async_setup_component(
+            hass,
+            "fan",
+            {
+                "fan": {
+                    "platform": "template",
+                    "fans": {
+                        "test_fan": {
+                            "availability_template": "{{ is_state('availability_boolean.state', 'on') }}",
+                            "value_template": "{{ 'unavailable' }}",
+                            "speed_template": "{{ 'unavailable' }}",
+                            "oscillating_template": "{{ 'unavailable' }}",
+                            "direction_template": "{{ 'unavailable' }}",
+                            "turn_on": {"service": "script.fan_on"},
+                            "turn_off": {"service": "script.fan_off"},
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    _verify(hass, STATE_UNAVAILABLE, None, None, None)
+
+
 async def test_availability_template_with_entities(hass, calls):
     """Test availability tempalates with values from other entities."""
 

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -234,7 +234,6 @@ async def test_template_with_unavailable_entities(hass, calls):
                     "platform": "template",
                     "fans": {
                         "test_fan": {
-                            "availability_template": "{{ is_state('availability_boolean.state', 'on') }}",
                             "value_template": "{{ 'unavailable' }}",
                             "speed_template": "{{ 'unavailable' }}",
                             "oscillating_template": "{{ 'unavailable' }}",
@@ -251,7 +250,7 @@ async def test_template_with_unavailable_entities(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    _verify(hass, STATE_UNAVAILABLE, None, None, None)
+    assert hass.states.get(_TEST_FAN).state == STATE_UNAVAILABLE
 
 
 async def test_template_with_unavailable_parameters(hass, calls):

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -266,7 +266,6 @@ async def test_template_with_unavailable_parameters(hass, calls):
                     "platform": "template",
                     "fans": {
                         "test_fan": {
-                            "availability_template": "{{ is_state('availability_boolean.state', 'on') }}",
                             "value_template": "{{ 'on' }}",
                             "speed_template": "{{ 'unavailable' }}",
                             "oscillating_template": "{{ 'unavailable' }}",


### PR DESCRIPTION
## Proposed change

This change introduces support for unavailable state in the template fan.

This fixes issue #31170


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes #31170

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
