### PR TITLE
Fix lookup by Plex media key when playing on Sonos

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -222,6 +222,9 @@ def play_on_sonos(hass, service_call):
 
     if isinstance(content, int):
         content = {"plex_key": content}
+        content_type = PLEX_DOMAIN
+    else:
+        content_type = "music"
 
     plex_server_name = content.get("plex_server")
     shuffle = content.pop("shuffle", 0)
@@ -246,7 +249,7 @@ def play_on_sonos(hass, service_call):
         )
         return
 
-    media = plex_server.lookup_media("music", **content)
+    media = plex_server.lookup_media(content_type, **content)
     if media is None:
         _LOGGER.error("Media could not be found: %s", content)
         return

--- a/tests/components/plex/test_playback.py
+++ b/tests/components/plex/test_playback.py
@@ -1,4 +1,6 @@
 """Tests for Plex player playback methods/services."""
+from plexapi.exceptions import NotFound
+
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
@@ -52,7 +54,7 @@ async def test_sonos_playback(hass):
             True,
         )
 
-    # Test success with dict
+    # Test success with plex_key
     with patch.object(
         hass.components.sonos,
         "get_coordinator_name",
@@ -69,7 +71,7 @@ async def test_sonos_playback(hass):
             True,
         )
 
-    # Test success with plex_key
+    # Test success with dict
     with patch.object(
         hass.components.sonos,
         "get_coordinator_name",
@@ -82,6 +84,23 @@ async def test_sonos_playback(hass):
                 ATTR_ENTITY_ID: "media_player.sonos_kitchen",
                 ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
                 ATTR_MEDIA_CONTENT_ID: '{"library_name": "Music", "artist_name": "Artist", "album_name": "Album"}',
+            },
+            True,
+        )
+
+    # Test media lookup failure
+    with patch.object(
+        hass.components.sonos,
+        "get_coordinator_name",
+        return_value="media_player.sonos_kitchen",
+    ), patch.object(mock_plex_server, "fetchItem", side_effect=NotFound):
+        assert await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PLAY_ON_SONOS,
+            {
+                ATTR_ENTITY_ID: "media_player.sonos_kitchen",
+                ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+                ATTR_MEDIA_CONTENT_ID: "999",
             },
             True,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Similar to #34412 for `media_player.play_media`, this fixes the ability to play media using a Plex-specific identifier when casting to Sonos speakers using `plex.play_on_sonos`. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
