### PR TITLE
Fix updates of Rssi for control devices in rfxtrx

### DIFF
--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
     def supported(event):
         return isinstance(event, rfxtrxmod.ControlEvent)
 
-    for packet_id, entity in discovery_info[CONF_DEVICES].items():
+    for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
@@ -56,7 +56,9 @@ async def async_setup_entry(
         if not supported(event):
             continue
 
-        device_id = get_device_id(event.device, data_bits=entity.get(CONF_DATA_BITS))
+        device_id = get_device_id(
+            event.device, data_bits=entity_info.get(CONF_DATA_BITS)
+        )
         if device_id in device_ids:
             continue
         device_ids.add(device_id)
@@ -68,11 +70,11 @@ async def async_setup_entry(
         device = RfxtrxBinarySensor(
             event.device,
             device_id,
-            entity.get(CONF_DEVICE_CLASS),
-            entity.get(CONF_OFF_DELAY),
-            entity.get(CONF_DATA_BITS),
-            entity.get(CONF_COMMAND_ON),
-            entity.get(CONF_COMMAND_OFF),
+            entity_info.get(CONF_DEVICE_CLASS),
+            entity_info.get(CONF_OFF_DELAY),
+            entity_info.get(CONF_DATA_BITS),
+            entity_info.get(CONF_COMMAND_ON),
+            entity_info.get(CONF_COMMAND_OFF),
         )
         sensors.append(device)
 

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -65,7 +65,7 @@ async def async_setup_entry(
         return isinstance(event, (ControlEvent, SensorEvent))
 
     entities = []
-    for packet_id, entity in discovery_info[CONF_DEVICES].items():
+    for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)
         if event is None:
             _LOGGER.error("Invalid device: %s", packet_id)
@@ -73,7 +73,9 @@ async def async_setup_entry(
         if not supported(event):
             continue
 
-        device_id = get_device_id(event.device, data_bits=entity.get(CONF_DATA_BITS))
+        device_id = get_device_id(
+            event.device, data_bits=entity_info.get(CONF_DATA_BITS)
+        )
         for data_type in set(event.values) & set(DATA_TYPES):
             data_id = (*device_id, data_type)
             if data_id in data_ids:

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -171,9 +171,6 @@ class RfxtrxSensor(RfxtrxEntity):
     @callback
     def _handle_event(self, event, device_id):
         """Check if event applies to me and update."""
-        if not isinstance(event, SensorEvent):
-            return
-
         if device_id != self._device_id:
             return
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -290,3 +290,60 @@ async def test_update_of_sensors(hass, rfxtrx):
     state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_06_01_humidity")
     assert state
     assert state.state == "15"
+
+
+async def test_rssi_sensor(hass, rfxtrx):
+    """Test with 1 sensor."""
+    assert await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "abcd",
+                "devices": {
+                    "0913000022670e013b70": {
+                        "data_bits": 4,
+                        "command_on": 0xE,
+                        "command_off": 0x7,
+                    },
+                    "0b1100cd0213c7f230010f71": {},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+    state = hass.states.get("sensor.pt2262_22670e_rssi_numeric")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == "PT2262 22670e Rssi numeric"
+    assert state.attributes.get("unit_of_measurement") == "dBm"
+
+    state = hass.states.get("sensor.ac_213c7f2_48_rssi_numeric")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48 Rssi numeric"
+    assert state.attributes.get("unit_of_measurement") == "dBm"
+
+    await rfxtrx.signal("0913000022670e013b70")
+    await rfxtrx.signal("0b1100cd0213c7f230010f71")
+
+    state = hass.states.get("sensor.pt2262_22670e_rssi_numeric")
+    assert state
+    assert state.state == "-64"
+
+    state = hass.states.get("sensor.ac_213c7f2_48_rssi_numeric")
+    assert state
+    assert state.state == "-64"
+
+    await rfxtrx.signal("0913000022670e013b60")
+    await rfxtrx.signal("0b1100cd0213c7f230010f61")
+
+    state = hass.states.get("sensor.pt2262_22670e_rssi_numeric")
+    assert state
+    assert state.state == "-72"
+
+    state = hass.states.get("sensor.ac_213c7f2_48_rssi_numeric")
+    assert state
+    assert state.state == "-72"


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For sensors it is checked whether an event is of type SensorEvent. Control devices however also send sensor data in a ControlEvent, which is ignored. As a consequense, mainly Rssi from control devices never get state updates. This PR fixes that and adds tests for it.
Furthermore, includes small cleanup mentioned in #38074

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
