### PR TITLE
Gracefully handle bond API errors and timeouts through available state

### DIFF
--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -1,17 +1,20 @@
 """The Bond integration."""
 import asyncio
 
+from aiohttp import ClientTimeout
 from bond_api import Bond
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import SLOW_UPDATE_WARNING
 
 from .const import DOMAIN
 from .utils import BondHub
 
 PLATFORMS = ["cover", "fan", "light", "switch"]
+_API_TIMEOUT = SLOW_UPDATE_WARNING - 1
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -25,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     host = entry.data[CONF_HOST]
     token = entry.data[CONF_ACCESS_TOKEN]
 
-    bond = Bond(host=host, token=token)
+    bond = Bond(host=host, token=token, timeout=ClientTimeout(total=_API_TIMEOUT))
     hub = BondHub(bond)
     await hub.setup()
     hass.data[DOMAIN][entry.entry_id] = hub

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -1,7 +1,10 @@
 """An abstract class common to all Bond entities."""
 from abc import abstractmethod
+from asyncio import TimeoutError as AsyncIOTimeoutError
 import logging
 from typing import Any, Dict, Optional
+
+from aiohttp import ClientError
 
 from homeassistant.const import ATTR_NAME
 from homeassistant.helpers.entity import Entity
@@ -54,7 +57,7 @@ class BondEntity(Entity):
         """Fetch assumed state of the cover from the hub using API."""
         try:
             state: dict = await self._hub.bond.device_state(self._device.device_id)
-        except Exception as error:
+        except (ClientError, AsyncIOTimeoutError, OSError) as error:
             if self._available:
                 _LOGGER.warning(
                     "Entity %s has become unavailable", self.entity_id, exc_info=error

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -1,5 +1,6 @@
 """An abstract class common to all Bond entities."""
 from abc import abstractmethod
+import logging
 from typing import Any, Dict, Optional
 
 from homeassistant.const import ATTR_NAME
@@ -7,6 +8,8 @@ from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 from .utils import BondDevice, BondHub
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class BondEntity(Entity):
@@ -16,6 +19,7 @@ class BondEntity(Entity):
         """Initialize entity with API and device info."""
         self._hub = hub
         self._device = device
+        self._available = True
 
     @property
     def unique_id(self) -> Optional[str]:
@@ -41,10 +45,26 @@ class BondEntity(Entity):
         """Let HA know this entity relies on an assumed state tracked by Bond."""
         return True
 
+    @property
+    def available(self) -> bool:
+        """Report availability of this entity based on last API call results."""
+        return self._available
+
     async def async_update(self):
         """Fetch assumed state of the cover from the hub using API."""
-        state: dict = await self._hub.bond.device_state(self._device.device_id)
-        self._apply_state(state)
+        try:
+            state: dict = await self._hub.bond.device_state(self._device.device_id)
+        except Exception as error:
+            if self._available:
+                _LOGGER.warning(
+                    "Entity %s has become unavailable", self.entity_id, exc_info=error
+                )
+            self._available = False
+        else:
+            if not self._available:
+                _LOGGER.info("Entity %s has come back", self.entity_id)
+            self._available = True
+            self._apply_state(state)
 
     @abstractmethod
     def _apply_state(self, state: dict):

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -1,4 +1,5 @@
 """Common methods used across tests for Bond."""
+from asyncio import TimeoutError as AsyncIOTimeoutError
 from datetime import timedelta
 from typing import Any, Dict
 
@@ -96,7 +97,7 @@ async def help_test_entity_available(
 
     assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
 
-    with patch_bond_device_state(side_effect=Exception()):
+    with patch_bond_device_state(side_effect=AsyncIOTimeoutError()):
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -1,13 +1,15 @@
 """Common methods used across tests for Bond."""
+from datetime import timedelta
 from typing import Any, Dict
 
 from homeassistant import core
 from homeassistant.components.bond.const import DOMAIN as BOND_DOMAIN
-from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, STATE_UNAVAILABLE
 from homeassistant.setup import async_setup_component
+from homeassistant.util import utcnow
 
 from tests.async_mock import patch
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 MOCK_HUB_VERSION: dict = {"bondid": "test-bond-id"}
 
@@ -74,11 +76,32 @@ def patch_bond_action():
     return patch("homeassistant.components.bond.Bond.action")
 
 
-def patch_bond_device_state(return_value=None):
+def patch_bond_device_state(return_value=None, side_effect=None):
     """Patch Bond API device state endpoint."""
     if return_value is None:
         return_value = {}
 
     return patch(
-        "homeassistant.components.bond.Bond.device_state", return_value=return_value
+        "homeassistant.components.bond.Bond.device_state",
+        return_value=return_value,
+        side_effect=side_effect,
     )
+
+
+async def help_test_entity_available(
+    hass: core.HomeAssistant, domain: str, device: Dict[str, Any], entity_id: str
+):
+    """Run common test to verify available property."""
+    await setup_platform(hass, domain, device)
+
+    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+    with patch_bond_device_state(side_effect=Exception()):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+        await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    with patch_bond_device_state(return_value={}):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+        await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -15,7 +15,12 @@ from homeassistant.const import (
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
-from .common import patch_bond_action, patch_bond_device_state, setup_platform
+from .common import (
+    help_test_entity_available,
+    patch_bond_action,
+    patch_bond_device_state,
+    setup_platform,
+)
 
 from tests.common import async_fire_time_changed
 
@@ -109,3 +114,10 @@ async def test_update_reports_closed_cover(hass: core.HomeAssistant):
         await hass.async_block_till_done()
 
     assert hass.states.get("cover.name_1").state == "closed"
+
+
+async def test_cover_available(hass: core.HomeAssistant):
+    """Tests that available state is updated based on API errors."""
+    await help_test_entity_available(
+        hass, COVER_DOMAIN, shades("name-1"), "cover.name_1"
+    )

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -18,7 +18,12 @@ from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_O
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
-from .common import patch_bond_action, patch_bond_device_state, setup_platform
+from .common import (
+    help_test_entity_available,
+    patch_bond_action,
+    patch_bond_device_state,
+    setup_platform,
+)
 
 from tests.common import async_fire_time_changed
 
@@ -191,4 +196,11 @@ async def test_set_fan_direction(hass: core.HomeAssistant):
 
     mock_set_direction.assert_called_once_with(
         "test-device-id", Action.set_direction(Direction.FORWARD)
+    )
+
+
+async def test_fan_available(hass: core.HomeAssistant):
+    """Tests that available state is updated based on API errors."""
+    await help_test_entity_available(
+        hass, FAN_DOMAIN, ceiling_fan("name-1"), "fan.name_1"
     )

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -10,7 +10,12 @@ from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_O
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
-from .common import patch_bond_action, patch_bond_device_state, setup_platform
+from .common import (
+    help_test_entity_available,
+    patch_bond_action,
+    patch_bond_device_state,
+    setup_platform,
+)
 
 from tests.common import async_fire_time_changed
 
@@ -162,3 +167,10 @@ async def test_flame_converted_to_brightness(hass: core.HomeAssistant):
         await hass.async_block_till_done()
 
     assert hass.states.get("light.name_1").attributes[ATTR_BRIGHTNESS] == 128
+
+
+async def test_light_available(hass: core.HomeAssistant):
+    """Tests that available state is updated based on API errors."""
+    await help_test_entity_available(
+        hass, LIGHT_DOMAIN, ceiling_fan("name-1"), "light.name_1"
+    )

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -10,7 +10,12 @@ from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_O
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
-from .common import patch_bond_action, patch_bond_device_state, setup_platform
+from .common import (
+    help_test_entity_available,
+    patch_bond_action,
+    patch_bond_device_state,
+    setup_platform,
+)
 
 from tests.common import async_fire_time_changed
 
@@ -86,3 +91,10 @@ async def test_update_reports_switch_is_off(hass: core.HomeAssistant):
         await hass.async_block_till_done()
 
     assert hass.states.get("switch.name_1").state == "off"
+
+
+async def test_switch_available(hass: core.HomeAssistant):
+    """Tests that available state is updated based on API errors."""
+    await help_test_entity_available(
+        hass, SWITCH_DOMAIN, generic_device("name-1"), "switch.name_1"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Report to HA if Bond devices are available or not based on API calls status

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
