### PR TITLE
Remove YAML configuration support for IQVIA

### DIFF
--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -5,12 +5,10 @@ import logging
 
 from pyiqvia import Client
 from pyiqvia.errors import InvalidZipError, IQVIAError
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS
+from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import callback
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -18,13 +16,11 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 
-from .config_flow import configured_instances
 from .const import (
     CONF_ZIP_CODE,
     DATA_CLIENT,
     DATA_LISTENER,
     DOMAIN,
-    SENSORS,
     TOPIC_DATA_UPDATE,
     TYPE_ALLERGY_FORECAST,
     TYPE_ALLERGY_INDEX,
@@ -56,23 +52,6 @@ DATA_CONFIG = "config"
 DEFAULT_ATTRIBUTION = "Data provided by IQVIA™"
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.deprecated(CONF_MONITORED_CONDITIONS, invalidation_version="0.114.0"),
-            vol.Schema(
-                {
-                    vol.Required(CONF_ZIP_CODE): str,
-                    vol.Optional(
-                        CONF_MONITORED_CONDITIONS, default=list(SENSORS)
-                    ): vol.All(cv.ensure_list, [vol.In(SENSORS)]),
-                }
-            ),
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
 
 @callback
 def async_get_api_category(sensor_type):
@@ -85,20 +64,6 @@ async def async_setup(hass, config):
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][DATA_CLIENT] = {}
     hass.data[DOMAIN][DATA_LISTENER] = {}
-
-    if DOMAIN not in config:
-        return True
-
-    conf = config[DOMAIN]
-
-    if conf[CONF_ZIP_CODE] in configured_instances(hass):
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-        )
-    )
 
     return True
 

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -72,6 +72,12 @@ async def async_setup_entry(hass, config_entry):
     """Set up IQVIA as config entry."""
     websession = aiohttp_client.async_get_clientsession(hass)
 
+    if not config_entry.unique_id:
+        # If the config entry doesn't already have a unique ID, set one:
+        hass.config_entries.async_update_entry(
+            config_entry, **{"unique_id": config_entry.data[CONF_ZIP_CODE]}
+        )
+
     iqvia = IQVIAData(hass, Client(config_entry.data[CONF_ZIP_CODE], websession))
 
     try:

--- a/homeassistant/components/iqvia/config_flow.py
+++ b/homeassistant/components/iqvia/config_flow.py
@@ -1,28 +1,15 @@
 """Config flow to configure the IQVIA component."""
-
-from collections import OrderedDict
-
 from pyiqvia import Client
 from pyiqvia.errors import InvalidZipError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
-from .const import CONF_ZIP_CODE, DOMAIN
+from .const import CONF_ZIP_CODE, DOMAIN  # pylint:disable=unused-import
 
 
-@callback
-def configured_instances(hass):
-    """Return a set of configured IQVIA instances."""
-    return {
-        entry.data[CONF_ZIP_CODE] for entry in hass.config_entries.async_entries(DOMAIN)
-    }
-
-
-@config_entries.HANDLERS.register(DOMAIN)
-class IQVIAFlowHandler(config_entries.ConfigFlow):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle an IQVIA config flow."""
 
     VERSION = 1
@@ -30,34 +17,25 @@ class IQVIAFlowHandler(config_entries.ConfigFlow):
 
     def __init__(self):
         """Initialize the config flow."""
-        self.data_schema = OrderedDict()
-        self.data_schema[vol.Required(CONF_ZIP_CODE)] = str
-
-    async def _show_form(self, errors=None):
-        """Show the form to the user."""
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(self.data_schema),
-            errors=errors if errors else {},
-        )
-
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user(import_config)
+        self.data_schema = vol.Schema({vol.Required(CONF_ZIP_CODE): str})
 
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
         if not user_input:
-            return await self._show_form()
+            return self.async_show_form(step_id="user", data_schema=self.data_schema)
 
-        if user_input[CONF_ZIP_CODE] in configured_instances(self.hass):
-            return await self._show_form({CONF_ZIP_CODE: "identifier_exists"})
+        await self.async_set_unique_id(user_input[CONF_ZIP_CODE])
+        self._abort_if_unique_id_configured()
 
         websession = aiohttp_client.async_get_clientsession(self.hass)
 
         try:
             Client(user_input[CONF_ZIP_CODE], websession)
         except InvalidZipError:
-            return await self._show_form({CONF_ZIP_CODE: "invalid_zip_code"})
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.data_schema,
+                errors={CONF_ZIP_CODE: "invalid_zip_code"},
+            )
 
         return self.async_create_entry(title=user_input[CONF_ZIP_CODE], data=user_input)

--- a/homeassistant/components/iqvia/strings.json
+++ b/homeassistant/components/iqvia/strings.json
@@ -4,12 +4,16 @@
       "user": {
         "title": "IQVIA",
         "description": "Fill out your U.S. or Canadian ZIP code.",
-        "data": { "zip_code": "ZIP Code" }
+        "data": {
+          "zip_code": "ZIP Code"
+        }
       }
     },
     "error": {
-      "identifier_exists": "ZIP code already registered",
       "invalid_zip_code": "ZIP code is invalid"
+    },
+    "abort": {
+      "already_configured": "This ZIP code has already been configured."
     }
   }
 }

--- a/homeassistant/components/iqvia/translations/en.json
+++ b/homeassistant/components/iqvia/translations/en.json
@@ -1,7 +1,9 @@
 {
     "config": {
+        "abort": {
+            "already_configured": "This ZIP code has already been configured."
+        },
         "error": {
-            "identifier_exists": "ZIP code already registered",
             "invalid_zip_code": "ZIP code is invalid"
         },
         "step": {

--- a/tests/components/iqvia/test_config_flow.py
+++ b/tests/components/iqvia/test_config_flow.py
@@ -1,7 +1,9 @@
 """Define tests for the IQVIA config flow."""
 from homeassistant import data_entry_flow
-from homeassistant.components.iqvia import CONF_ZIP_CODE, DOMAIN, config_flow
+from homeassistant.components.iqvia import CONF_ZIP_CODE, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 
@@ -9,57 +11,49 @@ async def test_duplicate_error(hass):
     """Test that errors are shown when duplicates are added."""
     conf = {CONF_ZIP_CODE: "12345"}
 
-    MockConfigEntry(domain=DOMAIN, data=conf).add_to_hass(hass)
-    flow = config_flow.IQVIAFlowHandler()
-    flow.hass = hass
+    MockConfigEntry(domain=DOMAIN, unique_id="12345", data=conf).add_to_hass(hass)
 
-    result = await flow.async_step_user(user_input=conf)
-    assert result["errors"] == {CONF_ZIP_CODE: "identifier_exists"}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_invalid_zip_code(hass):
     """Test that an invalid ZIP code key throws an error."""
     conf = {CONF_ZIP_CODE: "abcde"}
 
-    flow = config_flow.IQVIAFlowHandler()
-    flow.hass = hass
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
 
-    result = await flow.async_step_user(user_input=conf)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {CONF_ZIP_CODE: "invalid_zip_code"}
 
 
 async def test_show_form(hass):
     """Test that the form is served with no input."""
-    flow = config_flow.IQVIAFlowHandler()
-    flow.hass = hass
-
-    result = await flow.async_step_user(user_input=None)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
 
-async def test_step_import(hass):
-    """Test that the import step works."""
-    conf = {CONF_ZIP_CODE: "12345"}
-
-    flow = config_flow.IQVIAFlowHandler()
-    flow.hass = hass
-
-    result = await flow.async_step_import(import_config=conf)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "12345"
-    assert result["data"] == {CONF_ZIP_CODE: "12345"}
-
-
 async def test_step_user(hass):
-    """Test that the user step works."""
+    """Test that the user step works (without MFA)."""
     conf = {CONF_ZIP_CODE: "12345"}
 
-    flow = config_flow.IQVIAFlowHandler()
-    flow.hass = hass
+    with patch(
+        "homeassistant.components.simplisafe.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=conf
+        )
 
-    result = await flow.async_step_user(user_input=conf)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "12345"
-    assert result["data"] == {CONF_ZIP_CODE: "12345"}
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "12345"
+        assert result["data"] == {CONF_ZIP_CODE: "12345"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Per ADR-0010, IQVIA can no longer be configured via YAML and must be configured from the UI. Existing IQVIA users have already had their integrations imported and only need to remove IQVIA-related items from `configuration.yaml`.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We deprecated `monitored_conditions` YAML support for IQVIA in 0.107.0 and were schedule to remove it in 0.114.0. Since ADR-0010 was approved in the intervening time, this PR goes a step further by removing YAML configuration support for IQVIA.

Additionally, the IQVIA config entry was using a lot of old code; this PR brings it to modern standards.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14073

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
