### PR TITLE
Refactor bond unit tests to reduce boilerplate

### DIFF
--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -30,19 +30,16 @@ async def setup_bond_entity(
     """Set up Bond entity."""
     config_entry.add_to_hass(hass)
 
-    with patch_bond_version() if patch_version else nullcontext():
-        with patch_bond_device_ids() if patch_device_ids else nullcontext():
-            with patch_setup_entry("cover") if patch_platforms else nullcontext():
-                with patch_setup_entry("fan") if patch_platforms else nullcontext():
-                    with patch_setup_entry(
-                        "light"
-                    ) if patch_platforms else nullcontext():
-                        with patch_setup_entry(
-                            "switch"
-                        ) if patch_platforms else nullcontext():
-                            return await hass.config_entries.async_setup(
-                                config_entry.entry_id
-                            )
+    with patch_bond_version() if patch_version else nullcontext(), patch_bond_device_ids() if patch_device_ids else nullcontext(), patch_setup_entry(
+        "cover"
+    ) if patch_platforms else nullcontext(), patch_setup_entry(
+        "fan"
+    ) if patch_platforms else nullcontext(), patch_setup_entry(
+        "light"
+    ) if patch_platforms else nullcontext(), patch_setup_entry(
+        "switch"
+    ) if patch_platforms else nullcontext():
+        return await hass.config_entries.async_setup(config_entry.entry_id)
 
 
 async def setup_platform(
@@ -60,16 +57,15 @@ async def setup_platform(
     mock_entry.add_to_hass(hass)
 
     with patch("homeassistant.components.bond.PLATFORMS", [platform]):
-        with patch_bond_version():
-            with patch_bond_device_ids(return_value=[bond_device_id]):
-                with patch_bond_device(return_value=discovered_device):
-                    with patch_bond_device_state():
-                        with patch_bond_device_properties(return_value=props):
-                            with patch_bond_device_state():
-                                assert await async_setup_component(
-                                    hass, BOND_DOMAIN, {}
-                                )
-                                await hass.async_block_till_done()
+        with patch_bond_version(), patch_bond_device_ids(
+            return_value=[bond_device_id]
+        ), patch_bond_device(
+            return_value=discovered_device
+        ), patch_bond_device_state(), patch_bond_device_properties(
+            return_value=props
+        ), patch_bond_device_state():
+            assert await async_setup_component(hass, BOND_DOMAIN, {})
+            await hass.async_block_till_done()
 
     return mock_entry
 

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -14,8 +14,11 @@ from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-def patch_setup_entry(domain: str):
+def patch_setup_entry(domain: str, *, enabled: bool = True):
     """Patch async_setup_entry for specified domain."""
+    if not enabled:
+        return nullcontext()
+
     return patch(f"homeassistant.components.bond.{domain}.async_setup_entry")
 
 
@@ -30,15 +33,15 @@ async def setup_bond_entity(
     """Set up Bond entity."""
     config_entry.add_to_hass(hass)
 
-    with patch_bond_version() if patch_version else nullcontext(), patch_bond_device_ids() if patch_device_ids else nullcontext(), patch_setup_entry(
-        "cover"
-    ) if patch_platforms else nullcontext(), patch_setup_entry(
-        "fan"
-    ) if patch_platforms else nullcontext(), patch_setup_entry(
-        "light"
-    ) if patch_platforms else nullcontext(), patch_setup_entry(
-        "switch"
-    ) if patch_platforms else nullcontext():
+    with patch_bond_version(enabled=patch_version), patch_bond_device_ids(
+        enabled=patch_device_ids
+    ), patch_setup_entry("cover", enabled=patch_platforms), patch_setup_entry(
+        "fan", enabled=patch_platforms
+    ), patch_setup_entry(
+        "light", enabled=patch_platforms
+    ), patch_setup_entry(
+        "switch", enabled=patch_platforms
+    ):
         return await hass.config_entries.async_setup(config_entry.entry_id)
 
 
@@ -70,8 +73,11 @@ async def setup_platform(
     return mock_entry
 
 
-def patch_bond_version(return_value: Optional[dict] = None):
+def patch_bond_version(enabled: bool = True, return_value: Optional[dict] = None):
     """Patch Bond API version endpoint."""
+    if not enabled:
+        return nullcontext()
+
     if return_value is None:
         return_value = {"bondid": "test-bond-id"}
 
@@ -80,8 +86,11 @@ def patch_bond_version(return_value: Optional[dict] = None):
     )
 
 
-def patch_bond_device_ids(return_value=None, side_effect=None):
+def patch_bond_device_ids(enabled: bool = True, return_value=None, side_effect=None):
     """Patch Bond API devices endpoint."""
+    if not enabled:
+        return nullcontext()
+
     if return_value is None:
         return_value = []
 

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -6,6 +6,8 @@ from homeassistant import config_entries, core, setup
 from homeassistant.components.bond.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
 
+from .common import patch_bond_device_ids
+
 from tests.async_mock import Mock, patch
 
 
@@ -18,21 +20,20 @@ async def test_form(hass: core.HomeAssistant):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.bond.config_flow.Bond.devices", return_value=[],
-    ), patch(
+    with patch_bond_device_ids(), patch(
         "homeassistant.components.bond.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.bond.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "1.1.1.1", CONF_ACCESS_TOKEN: "test-token"},
+            result["flow_id"],
+            {CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
         )
 
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "1.1.1.1"
+    assert result2["title"] == "some host"
     assert result2["data"] == {
-        CONF_HOST: "1.1.1.1",
+        CONF_HOST: "some host",
         CONF_ACCESS_TOKEN: "test-token",
     }
     await hass.async_block_till_done()
@@ -46,12 +47,12 @@ async def test_form_invalid_auth(hass: core.HomeAssistant):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.bond.config_flow.Bond.devices",
+    with patch_bond_device_ids(
         side_effect=ClientResponseError(Mock(), Mock(), status=401),
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "1.1.1.1", CONF_ACCESS_TOKEN: "test-token"},
+            result["flow_id"],
+            {CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
         )
 
     assert result2["type"] == "form"
@@ -64,12 +65,10 @@ async def test_form_cannot_connect(hass: core.HomeAssistant):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.bond.config_flow.Bond.devices",
-        side_effect=ClientConnectionError(),
-    ):
+    with patch_bond_device_ids(side_effect=ClientConnectionError()):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "1.1.1.1", CONF_ACCESS_TOKEN: "test-token"},
+            result["flow_id"],
+            {CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
         )
 
     assert result2["type"] == "form"
@@ -82,12 +81,12 @@ async def test_form_unexpected_error(hass: core.HomeAssistant):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.bond.config_flow.Bond.devices",
-        side_effect=ClientResponseError(Mock(), Mock(), status=500),
+    with patch_bond_device_ids(
+        side_effect=ClientResponseError(Mock(), Mock(), status=500)
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "1.1.1.1", CONF_ACCESS_TOKEN: "test-token"},
+            result["flow_id"],
+            {CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
         )
 
     assert result2["type"] == "form"

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -6,15 +6,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from .common import patch_bond_device_ids, setup_bond_entity
+from .common import patch_bond_version, patch_setup_entry, setup_bond_entity
 
-from tests.async_mock import patch
 from tests.common import MockConfigEntry
-
-
-def patch_setup_entry(domain: str):
-    """Patch async_setup_entry for specified domain."""
-    return patch(f"homeassistant.components.bond.{domain}.async_setup_entry")
 
 
 async def test_async_setup_no_domain_config(hass: HomeAssistant):
@@ -27,29 +21,25 @@ async def test_async_setup_no_domain_config(hass: HomeAssistant):
 async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAssistant):
     """Test that configuring entry sets up cover domain."""
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "1.1.1.1", CONF_ACCESS_TOKEN: "test-token"},
+        domain=DOMAIN, data={CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
     )
 
-    with patch_bond_device_ids(), patch_setup_entry(
-        "cover"
-    ) as mock_cover_async_setup_entry, patch_setup_entry(
-        "fan"
-    ) as mock_fan_async_setup_entry, patch_setup_entry(
-        "light"
-    ) as mock_light_async_setup_entry, patch_setup_entry(
-        "switch"
-    ) as mock_switch_async_setup_entry:
-        result = await setup_bond_entity(
-            hass,
-            config_entry,
-            hub_version={
-                "bondid": "test-bond-id",
-                "target": "test-model",
-                "fw_ver": "test-version",
-            },
-        )
-        assert result is True
-        await hass.async_block_till_done()
+    with patch_bond_version(
+        return_value={
+            "bondid": "test-bond-id",
+            "target": "test-model",
+            "fw_ver": "test-version",
+        }
+    ):
+        with patch_setup_entry("cover") as mock_cover_async_setup_entry:
+            with patch_setup_entry("fan") as mock_fan_async_setup_entry:
+                with patch_setup_entry("light") as mock_light_async_setup_entry:
+                    with patch_setup_entry("switch") as mock_switch_async_setup_entry:
+                        result = await setup_bond_entity(
+                            hass, config_entry, patch_device_ids=True
+                        )
+                        assert result is True
+                        await hass.async_block_till_done()
 
     assert config_entry.entry_id in hass.data[DOMAIN]
     assert config_entry.state == ENTRY_STATE_LOADED
@@ -74,15 +64,18 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
 async def test_unload_config_entry(hass: HomeAssistant):
     """Test that configuration entry supports unloading."""
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "1.1.1.1", CONF_ACCESS_TOKEN: "test-token"},
+        domain=DOMAIN, data={CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
     )
 
-    with patch_bond_device_ids(), patch_setup_entry("cover"), patch_setup_entry(
-        "fan"
-    ), patch_setup_entry("light"), patch_setup_entry("switch"):
-        result = await setup_bond_entity(hass, config_entry)
-        assert result is True
-        await hass.async_block_till_done()
+    result = await setup_bond_entity(
+        hass,
+        config_entry,
+        patch_version=True,
+        patch_device_ids=True,
+        patch_platforms=True,
+    )
+    assert result is True
+    await hass.async_block_till_done()
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -31,15 +31,18 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
             "fw_ver": "test-version",
         }
     ):
-        with patch_setup_entry("cover") as mock_cover_async_setup_entry:
-            with patch_setup_entry("fan") as mock_fan_async_setup_entry:
-                with patch_setup_entry("light") as mock_light_async_setup_entry:
-                    with patch_setup_entry("switch") as mock_switch_async_setup_entry:
-                        result = await setup_bond_entity(
-                            hass, config_entry, patch_device_ids=True
-                        )
-                        assert result is True
-                        await hass.async_block_till_done()
+        with patch_setup_entry(
+            "cover"
+        ) as mock_cover_async_setup_entry, patch_setup_entry(
+            "fan"
+        ) as mock_fan_async_setup_entry, patch_setup_entry(
+            "light"
+        ) as mock_light_async_setup_entry, patch_setup_entry(
+            "switch"
+        ) as mock_switch_async_setup_entry:
+            result = await setup_bond_entity(hass, config_entry, patch_device_ids=True)
+            assert result is True
+            await hass.async_block_till_done()
 
     assert config_entry.entry_id in hass.data[DOMAIN]
     assert config_entry.state == ENTRY_STATE_LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

No changes, just reducing boilerplate in tests to prepare for more tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
