### PR TITLE
Ensure all track time change tests mock a specific start time

### DIFF
--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -50,7 +50,7 @@ async def test_track_point_in_time(hass):
     runs = []
 
     async_track_point_in_utc_time(
-        hass, callback(lambda x: runs.append(1)), birthday_paulus
+        hass, callback(lambda x: runs.append(x)), birthday_paulus
     )
 
     async_fire_time_changed(hass, before_birthday)
@@ -67,7 +67,7 @@ async def test_track_point_in_time(hass):
     assert len(runs) == 1
 
     async_track_point_in_utc_time(
-        hass, callback(lambda x: runs.append(1)), birthday_paulus
+        hass, callback(lambda x: runs.append(x)), birthday_paulus
     )
 
     async_fire_time_changed(hass, after_birthday)
@@ -75,7 +75,7 @@ async def test_track_point_in_time(hass):
     assert len(runs) == 2
 
     unsub = async_track_point_in_time(
-        hass, callback(lambda x: runs.append(1)), birthday_paulus
+        hass, callback(lambda x: runs.append(x)), birthday_paulus
     )
     unsub()
 
@@ -539,7 +539,7 @@ async def test_track_time_interval(hass):
 
     utc_now = dt_util.utcnow()
     unsub = async_track_time_interval(
-        hass, lambda x: specific_runs.append(1), timedelta(seconds=10)
+        hass, lambda x: specific_runs.append(x), timedelta(seconds=10)
     )
 
     async_fire_time_changed(hass, utc_now + timedelta(seconds=5))
@@ -750,10 +750,15 @@ async def test_async_track_time_change(hass):
 
     now = dt_util.utcnow()
 
-    unsub = async_track_time_change(hass, lambda x: wildcard_runs.append(1))
-    unsub_utc = async_track_utc_time_change(
-        hass, lambda x: specific_runs.append(1), second=[0, 30]
-    )
+    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 11, 59, 55)
+
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        unsub = async_track_time_change(hass, lambda x: wildcard_runs.append(x))
+        unsub_utc = async_track_utc_time_change(
+            hass, lambda x: specific_runs.append(x), second=[0, 30]
+        )
 
     async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999))
     await hass.async_block_till_done()
@@ -785,9 +790,14 @@ async def test_periodic_task_minute(hass):
 
     now = dt_util.utcnow()
 
-    unsub = async_track_utc_time_change(
-        hass, lambda x: specific_runs.append(1), minute="/5", second=0
-    )
+    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 11, 59, 55)
+
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        unsub = async_track_utc_time_change(
+            hass, lambda x: specific_runs.append(x), minute="/5", second=0
+        )
 
     async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999))
     await hass.async_block_till_done()
@@ -814,9 +824,14 @@ async def test_periodic_task_hour(hass):
 
     now = dt_util.utcnow()
 
-    unsub = async_track_utc_time_change(
-        hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
-    )
+    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 21, 59, 55)
+
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        unsub = async_track_utc_time_change(
+            hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
+        )
 
     async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
     await hass.async_block_till_done()
@@ -853,7 +868,7 @@ async def test_periodic_task_wrong_input(hass):
 
     with pytest.raises(ValueError):
         async_track_utc_time_change(
-            hass, lambda x: specific_runs.append(1), hour="/two"
+            hass, lambda x: specific_runs.append(x), hour="/two"
         )
 
     async_fire_time_changed(hass, datetime(now.year + 1, 5, 2, 0, 0, 0, 999999))
@@ -867,9 +882,14 @@ async def test_periodic_task_clock_rollback(hass):
 
     now = dt_util.utcnow()
 
-    unsub = async_track_utc_time_change(
-        hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
-    )
+    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 21, 59, 55)
+
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        unsub = async_track_utc_time_change(
+            hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
+        )
 
     async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
     await hass.async_block_till_done()
@@ -908,9 +928,14 @@ async def test_periodic_task_duplicate_time(hass):
 
     now = dt_util.utcnow()
 
-    unsub = async_track_utc_time_change(
-        hass, lambda x: specific_runs.append(1), hour="/2", minute=0, second=0
-    )
+    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 21, 59, 55)
+
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        unsub = async_track_utc_time_change(
+            hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
+        )
 
     async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
     await hass.async_block_till_done()
@@ -942,7 +967,7 @@ async def test_periodic_task_entering_dst(hass):
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_time_change(
-            hass, lambda x: specific_runs.append(1), hour=2, minute=30, second=0
+            hass, lambda x: specific_runs.append(x), hour=2, minute=30, second=0
         )
 
     async_fire_time_changed(
@@ -988,7 +1013,7 @@ async def test_periodic_task_leaving_dst(hass):
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_time_change(
-            hass, lambda x: specific_runs.append(1), hour=2, minute=30, second=0
+            hass, lambda x: specific_runs.append(x), hour=2, minute=30, second=0
         )
 
     async_fire_time_changed(

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -760,17 +760,23 @@ async def test_async_track_time_change(hass):
             hass, lambda x: specific_runs.append(x), second=[0, 30]
         )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 15, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 0, 15, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 2
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
@@ -778,7 +784,9 @@ async def test_async_track_time_change(hass):
     unsub()
     unsub_utc()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
@@ -799,21 +807,29 @@ async def test_periodic_task_minute(hass):
             hass, lambda x: specific_runs.append(x), minute="/5", second=0
         )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 3, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 3, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 5, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 12, 5, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 12, 5, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
@@ -833,29 +849,41 @@ async def test_periodic_task_hour(hass):
             hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
         )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 23, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 25, 0, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 1, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 25, 1, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 25, 2, 0, 0, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
@@ -871,7 +899,9 @@ async def test_periodic_task_wrong_input(hass):
             hass, lambda x: specific_runs.append(x), hour="/two"
         )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 2, 0, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 2, 0, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
@@ -891,33 +921,45 @@ async def test_periodic_task_clock_rollback(hass):
             hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
         )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
-    await hass.async_block_till_done()
-    assert len(specific_runs) == 1
-
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 23, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999), fire_all=True
+        hass, datetime(now.year + 1, 5, 24, 23, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 1
+
+    async_fire_time_changed(
+        hass,
+        datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC),
+        fire_all=True,
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 5, 24, 0, 0, 0, 999999), fire_all=True
+        hass,
+        datetime(now.year + 1, 5, 24, 0, 0, 0, 999999, tzinfo=dt_util.UTC),
+        fire_all=True,
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 
     unsub()
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 25, 2, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 
@@ -937,15 +979,21 @@ async def test_periodic_task_duplicate_time(hass):
             hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
         )
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
-    async_fire_time_changed(hass, datetime(now.year + 1, 5, 25, 0, 0, 0, 999999))
+    async_fire_time_changed(
+        hass, datetime(now.year + 1, 5, 25, 0, 0, 0, 999999, tzinfo=dt_util.UTC)
+    )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This should fix the test failures that @pnbruckner reported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
