### PR TITLE
Make assumed state conditional for bond devices

### DIFF
--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -46,7 +46,7 @@ class BondEntity(Entity):
     @property
     def assumed_state(self) -> bool:
         """Let HA know this entity relies on an assumed state tracked by Bond."""
-        return True
+        return self._hub.is_bridge and not self._device.trust_state
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -24,6 +24,11 @@ class BondDevice:
         """Get the type of this device."""
         return self._attrs["type"]
 
+    @property
+    def trust_state(self) -> bool:
+        """Check if Trust State is turned on."""
+        return self.props.get("trust_state", False)
+
     def supports_speed(self) -> bool:
         """Return True if this device supports any of the speed related commands."""
         actions: List[str] = self._attrs["actions"]
@@ -89,3 +94,8 @@ class BondHub:
     def devices(self) -> List[BondDevice]:
         """Return a list of all devices controlled by this hub."""
         return self._devices
+
+    @property
+    def is_bridge(self) -> bool:
+        """Return if the Bond is a Bond Bridge. If False, it means that it is a Smart by Bond product. Assumes that it is if the model is not available."""
+        return self._version.get("model", "BD-").startswith("BD-")

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -51,6 +51,7 @@ async def setup_platform(
     discovered_device: Dict[str, Any],
     bond_device_id: str = "bond-device-id",
     props: Dict[str, Any] = None,
+    bond_version: Dict[str, Any] = None,
 ):
     """Set up the specified Bond platform."""
     mock_entry = MockConfigEntry(
@@ -60,7 +61,7 @@ async def setup_platform(
     mock_entry.add_to_hass(hass)
 
     with patch("homeassistant.components.bond.PLATFORMS", [platform]):
-        with patch_bond_version(), patch_bond_device_ids(
+        with patch_bond_version(return_value=bond_version), patch_bond_device_ids(
             return_value=[bond_device_id]
         ), patch_bond_device(
             return_value=discovered_device

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -6,7 +6,12 @@ from bond_api import Action, DeviceType
 
 from homeassistant import core
 from homeassistant.components.light import ATTR_BRIGHTNESS, DOMAIN as LIGHT_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -42,6 +47,47 @@ async def test_entity_registry(hass: core.HomeAssistant):
 
     registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
     assert [key for key in registry.entities] == ["light.name_1"]
+
+
+async def test_sbb_trust_state(hass: core.HomeAssistant):
+    """Assumed state should be False if device is a Smart by Bond."""
+    version = {
+        "model": "MR123A",
+        "bondid": "test-bond-id",
+    }
+    await setup_platform(
+        hass, LIGHT_DOMAIN, ceiling_fan("name-1"), bond_version=version
+    )
+
+    device = hass.states.get("light.name_1")
+    assert device.attributes.get(ATTR_ASSUMED_STATE) is not True
+
+
+async def test_trust_state_not_specified(hass: core.HomeAssistant):
+    """Assumed state should be True if Trust State is not specified."""
+    await setup_platform(hass, LIGHT_DOMAIN, ceiling_fan("name-1"))
+
+    device = hass.states.get("light.name_1")
+    assert device.attributes.get(ATTR_ASSUMED_STATE) is True
+
+
+async def test_trust_state(hass: core.HomeAssistant):
+    """Assumed state should be True if Trust State is False."""
+    await setup_platform(
+        hass, LIGHT_DOMAIN, ceiling_fan("name-1"), props={"trust_state": False}
+    )
+
+    device = hass.states.get("light.name_1")
+    assert device.attributes.get(ATTR_ASSUMED_STATE) is True
+
+
+async def test_no_trust_state(hass: core.HomeAssistant):
+    """Assumed state should be False if Trust State is True."""
+    await setup_platform(
+        hass, LIGHT_DOMAIN, ceiling_fan("name-1"), props={"trust_state": True}
+    )
+    device = hass.states.get("light.name_1")
+    assert device.attributes.get(ATTR_ASSUMED_STATE) is not True
 
 
 async def test_turn_on_light(hass: core.HomeAssistant):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Assumed state should depend on two things:
- If the device is a Smart by Bond device, it should always be false, since the Bond always knows the correct state
- If the device is a remote recorded on a Bond Bridge, then it should depend on the device's `trust_state` flag. If it's set to `true`, then `assumed_state` should be `false`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
