### PR TITLE
Make rfxtrx RfyDevices have sun automation switches

### DIFF
--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -7,12 +7,14 @@ COMMAND_ON_LIST = [
     "Stop",
     "Open (inline relay)",
     "Stop (inline relay)",
+    "Enable sun automation",
 ]
 
 COMMAND_OFF_LIST = [
     "Off",
     "Down",
     "Close (inline relay)",
+    "Disable sun automation",
 ]
 
 ATTR_EVENT = "event"

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -37,6 +37,7 @@ async def async_setup_entry(
             isinstance(event.device, rfxtrxmod.LightingDevice)
             and not event.device.known_to_be_dimmable
             and not event.device.known_to_be_rollershutter
+            or isinstance(event.device, rfxtrxmod.RfyDevice)
         )
 
     # Add switch from config file

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -8,6 +8,9 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import mock_restore_cache
 
+EVENT_RFY_ENABLE_SUN_AUTO = "081a00000301010113"
+EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
+
 
 async def test_one_switch(hass, rfxtrx):
     """Test with 1 switch."""
@@ -131,5 +134,20 @@ async def test_discover_switch(hass, rfxtrx_automatic):
 
     await rfxtrx.signal("0b1100100118cdeb02010f70")
     state = hass.states.get("switch.ac_118cdeb_2")
+    assert state
+    assert state.state == "on"
+
+
+async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
+    """Test with discovery of switches."""
+    rfxtrx = rfxtrx_automatic
+
+    await rfxtrx.signal(EVENT_RFY_DISABLE_SUN_AUTO)
+    state = hass.states.get("switch.rfy_030101_1")
+    assert state
+    assert state.state == "off"
+
+    await rfxtrx.signal(EVENT_RFY_ENABLE_SUN_AUTO)
+    state = hass.states.get("switch.rfy_030101_1")
     assert state
     assert state.state == "on"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rfy Roller Covers also should expose a switch for sun automation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38198

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
