### PR TITLE
Mark event tests to run as callbacks

### DIFF
--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -422,7 +422,7 @@ async def test_track_same_state_simple_trigger(hass):
         hass,
         period,
         thread_run_callback,
-        callback(lambda _, _2, to_s: to_s.state == "on"),
+        lambda _, _2, to_s: to_s.state == "on",
         entity_ids="light.Bowl",
     )
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -422,7 +422,7 @@ async def test_track_same_state_simple_trigger(hass):
         hass,
         period,
         thread_run_callback,
-        lambda _, _2, to_s: to_s.state == "on",
+        callback(lambda _, _2, to_s: to_s.state == "on"),
         entity_ids="light.Bowl",
     )
 
@@ -434,7 +434,7 @@ async def test_track_same_state_simple_trigger(hass):
         hass,
         period,
         callback_run_callback,
-        lambda _, _2, to_s: to_s.state == "on",
+        callback(lambda _, _2, to_s: to_s.state == "on"),
         entity_ids="light.Bowl",
     )
 
@@ -442,7 +442,10 @@ async def test_track_same_state_simple_trigger(hass):
         coroutine_runs.append(1)
 
     async_track_same_state(
-        hass, period, coroutine_run_callback, lambda _, _2, to_s: to_s.state == "on"
+        hass,
+        period,
+        coroutine_run_callback,
+        callback(lambda _, _2, to_s: to_s.state == "on"),
     )
 
     # Adding state to state machine
@@ -474,7 +477,7 @@ async def test_track_same_state_simple_no_trigger(hass):
         hass,
         period,
         callback_run_callback,
-        lambda _, _2, to_s: to_s.state == "on",
+        callback(lambda _, _2, to_s: to_s.state == "on"),
         entity_ids="light.Bowl",
     )
 
@@ -539,7 +542,7 @@ async def test_track_time_interval(hass):
 
     utc_now = dt_util.utcnow()
     unsub = async_track_time_interval(
-        hass, lambda x: specific_runs.append(x), timedelta(seconds=10)
+        hass, callback(lambda x: specific_runs.append(x)), timedelta(seconds=10)
     )
 
     async_fire_time_changed(hass, utc_now + timedelta(seconds=5))
@@ -590,12 +593,14 @@ async def test_track_sunrise(hass, legacy_patchable_time):
     # Track sunrise
     runs = []
     with patch("homeassistant.util.dt.utcnow", return_value=utc_now):
-        unsub = async_track_sunrise(hass, lambda: runs.append(1))
+        unsub = async_track_sunrise(hass, callback(lambda: runs.append(1)))
 
     offset_runs = []
     offset = timedelta(minutes=30)
     with patch("homeassistant.util.dt.utcnow", return_value=utc_now):
-        unsub2 = async_track_sunrise(hass, lambda: offset_runs.append(1), offset)
+        unsub2 = async_track_sunrise(
+            hass, callback(lambda: offset_runs.append(1)), offset
+        )
 
     # run tests
     async_fire_time_changed(hass, next_rising - offset)
@@ -648,7 +653,7 @@ async def test_track_sunrise_update_location(hass, legacy_patchable_time):
     # Track sunrise
     runs = []
     with patch("homeassistant.util.dt.utcnow", return_value=utc_now):
-        async_track_sunrise(hass, lambda: runs.append(1))
+        async_track_sunrise(hass, callback(lambda: runs.append(1)))
 
     # Mimic sunrise
     async_fire_time_changed(hass, next_rising)
@@ -711,12 +716,14 @@ async def test_track_sunset(hass, legacy_patchable_time):
     # Track sunset
     runs = []
     with patch("homeassistant.util.dt.utcnow", return_value=utc_now):
-        unsub = async_track_sunset(hass, lambda: runs.append(1))
+        unsub = async_track_sunset(hass, callback(lambda: runs.append(1)))
 
     offset_runs = []
     offset = timedelta(minutes=30)
     with patch("homeassistant.util.dt.utcnow", return_value=utc_now):
-        unsub2 = async_track_sunset(hass, lambda: offset_runs.append(1), offset)
+        unsub2 = async_track_sunset(
+            hass, callback(lambda: offset_runs.append(1)), offset
+        )
 
     # Run tests
     async_fire_time_changed(hass, next_setting - offset)
@@ -750,14 +757,18 @@ async def test_async_track_time_change(hass):
 
     now = dt_util.utcnow()
 
-    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 11, 59, 55)
+    time_that_will_not_match_right_away = datetime(
+        now.year + 1, 5, 24, 11, 59, 55, tzinfo=dt_util.UTC
+    )
 
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
-        unsub = async_track_time_change(hass, lambda x: wildcard_runs.append(x))
+        unsub = async_track_time_change(
+            hass, callback(lambda x: wildcard_runs.append(x))
+        )
         unsub_utc = async_track_utc_time_change(
-            hass, lambda x: specific_runs.append(x), second=[0, 30]
+            hass, callback(lambda x: specific_runs.append(x)), second=[0, 30]
         )
 
     async_fire_time_changed(
@@ -798,13 +809,15 @@ async def test_periodic_task_minute(hass):
 
     now = dt_util.utcnow()
 
-    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 11, 59, 55)
+    time_that_will_not_match_right_away = datetime(
+        now.year + 1, 5, 24, 11, 59, 55, tzinfo=dt_util.UTC
+    )
 
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_utc_time_change(
-            hass, lambda x: specific_runs.append(x), minute="/5", second=0
+            hass, callback(lambda x: specific_runs.append(x)), minute="/5", second=0
         )
 
     async_fire_time_changed(
@@ -840,13 +853,19 @@ async def test_periodic_task_hour(hass):
 
     now = dt_util.utcnow()
 
-    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 21, 59, 55)
+    time_that_will_not_match_right_away = datetime(
+        now.year + 1, 5, 24, 21, 59, 55, tzinfo=dt_util.UTC
+    )
 
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_utc_time_change(
-            hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
+            hass,
+            callback(lambda x: specific_runs.append(x)),
+            hour="/2",
+            minute=0,
+            second=0,
         )
 
     async_fire_time_changed(
@@ -896,7 +915,7 @@ async def test_periodic_task_wrong_input(hass):
 
     with pytest.raises(ValueError):
         async_track_utc_time_change(
-            hass, lambda x: specific_runs.append(x), hour="/two"
+            hass, callback(lambda x: specific_runs.append(x)), hour="/two"
         )
 
     async_fire_time_changed(
@@ -912,13 +931,19 @@ async def test_periodic_task_clock_rollback(hass):
 
     now = dt_util.utcnow()
 
-    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 21, 59, 55)
+    time_that_will_not_match_right_away = datetime(
+        now.year + 1, 5, 24, 21, 59, 55, tzinfo=dt_util.UTC
+    )
 
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_utc_time_change(
-            hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
+            hass,
+            callback(lambda x: specific_runs.append(x)),
+            hour="/2",
+            minute=0,
+            second=0,
         )
 
     async_fire_time_changed(
@@ -970,13 +995,19 @@ async def test_periodic_task_duplicate_time(hass):
 
     now = dt_util.utcnow()
 
-    time_that_will_not_match_right_away = datetime(now.year + 1, 5, 24, 21, 59, 55)
+    time_that_will_not_match_right_away = datetime(
+        now.year + 1, 5, 24, 21, 59, 55, tzinfo=dt_util.UTC
+    )
 
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_utc_time_change(
-            hass, lambda x: specific_runs.append(x), hour="/2", minute=0, second=0
+            hass,
+            callback(lambda x: specific_runs.append(x)),
+            hour="/2",
+            minute=0,
+            second=0,
         )
 
     async_fire_time_changed(
@@ -1015,7 +1046,11 @@ async def test_periodic_task_entering_dst(hass):
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_time_change(
-            hass, lambda x: specific_runs.append(x), hour=2, minute=30, second=0
+            hass,
+            callback(lambda x: specific_runs.append(x)),
+            hour=2,
+            minute=30,
+            second=0,
         )
 
     async_fire_time_changed(
@@ -1061,7 +1096,11 @@ async def test_periodic_task_leaving_dst(hass):
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
         unsub = async_track_time_change(
-            hass, lambda x: specific_runs.append(x), hour=2, minute=30, second=0
+            hass,
+            callback(lambda x: specific_runs.append(x)),
+            hour=2,
+            minute=30,
+            second=0,
         )
 
     async_fire_time_changed(


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mark event tests to run as callbacks

Followup from https://github.com/home-assistant/core/pull/38178
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
