### PR TITLE
Squeezebox scene fixes

### DIFF
--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -6,7 +6,7 @@
     "@rajlaud"
   ],
   "requirements": [
-    "pysqueezebox==0.3.0"
+    "pysqueezebox==0.3.1"
   ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -6,7 +6,7 @@
     "@rajlaud"
   ],
   "requirements": [
-    "pysqueezebox==0.2.4"
+    "pysqueezebox==0.3.0"
   ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -338,7 +338,7 @@ class SqueezeBoxEntity(MediaPlayerEntity):
             return None
         if len(self._player.playlist) > 1:
             urls = [{"url": track["url"]} for track in self._player.playlist]
-            return json.dumps(urls)
+            return json.dumps({"index": self._player.current_index, "urls": urls})
         return self._player.url
 
     @property
@@ -472,9 +472,9 @@ class SqueezeBoxEntity(MediaPlayerEntity):
             cmd = "add"
 
         if media_type == MEDIA_TYPE_PLAYLIST:
-            playlist = json.loads(media_id)
-            _LOGGER.debug("Loading playlist: %s", playlist)
-            await self._player.async_load_playlist(playlist, cmd)
+            content = json.loads(media_id)
+            await self._player.async_load_playlist(content["urls"], cmd)
+            await self._player.async_index(content["index"])
         else:
             await self._player.async_load_url(media_id, cmd)
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -20,6 +20,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SEEK,
     SUPPORT_SHUFFLE_SET,
+    SUPPORT_STOP,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
@@ -82,6 +83,7 @@ SUPPORT_SQUEEZEBOX = (
     | SUPPORT_PLAY
     | SUPPORT_SHUFFLE_SET
     | SUPPORT_CLEAR_PLAYLIST
+    | SUPPORT_STOP
 )
 
 PLATFORM_SCHEMA = vol.All(
@@ -432,6 +434,10 @@ class SqueezeBoxEntity(MediaPlayerEntity):
     async def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
         await self._player.async_set_muting(mute)
+
+    async def async_media_stop(self):
+        """Send stop command to media player."""
+        await self._player.async_stop()
 
     async def async_media_play_pause(self):
         """Send pause command to media player."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1644,7 +1644,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.3.0
+pysqueezebox==0.3.1
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1644,7 +1644,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.4
+pysqueezebox==0.3.0
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -764,7 +764,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.4
+pysqueezebox==0.3.0
 
 # homeassistant.components.syncthru
 pysyncthru==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -764,7 +764,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.3.0
+pysqueezebox==0.3.1
 
 # homeassistant.components.syncthru
 pysyncthru==0.5.0


### PR DESCRIPTION
## Breaking Change
`media_content_id` for the `squeezebox` integration may be either a single url or a list of them. If a single url, `media_content_type` is `music`. If a playlist, `media_content_type` is a `playlist`. Automations using `media_content_id` should check if the `media_content_type` is `music` or `playlist`.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The `squeezebox` integration previously always gave only the current track as the `media_content_id` and gave the `media_content_type` as `music`. This leads to unexpected behavior when saving and loading scenes, because only the current track is saved and loaded. 

Now, if a playlist is loaded, the `media_content_id` will contain enough information to restore the playlist, and the `media_content_type` will be `playlist`.

Bumps version of `pysqueezebox` because we need the `current_index` property, which wasn't exposed in earlier versions.

Added support for the `media_player.media_stop` service, which is needed to restore player state to `idle`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38154
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
