### PR TITLE
Support 'stop' action for covers in device automation

### DIFF
--- a/homeassistant/components/cover/device_action.py
+++ b/homeassistant/components/cover/device_action.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
+    SERVICE_STOP_COVER,
 )
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry
@@ -31,9 +32,10 @@ from . import (
     SUPPORT_OPEN_TILT,
     SUPPORT_SET_POSITION,
     SUPPORT_SET_TILT_POSITION,
+    SUPPORT_STOP,
 )
 
-CMD_ACTION_TYPES = {"open", "close", "open_tilt", "close_tilt"}
+CMD_ACTION_TYPES = {"open", "close", "stop", "open_tilt", "close_tilt"}
 POSITION_ACTION_TYPES = {"set_position", "set_tilt_position"}
 
 CMD_ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
@@ -99,6 +101,15 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
                         CONF_TYPE: "close",
                     }
                 )
+            if supported_features & SUPPORT_STOP:
+                actions.append(
+                    {
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_ENTITY_ID: entry.entity_id,
+                        CONF_TYPE: "stop",
+                    }
+                )
 
         if supported_features & SUPPORT_SET_TILT_POSITION:
             actions.append(
@@ -160,6 +171,8 @@ async def async_call_action_from_config(
         service = SERVICE_OPEN_COVER
     elif config[CONF_TYPE] == "close":
         service = SERVICE_CLOSE_COVER
+    elif config[CONF_TYPE] == "stop":
+        service = SERVICE_STOP_COVER
     elif config[CONF_TYPE] == "open_tilt":
         service = SERVICE_OPEN_COVER_TILT
     elif config[CONF_TYPE] == "close_tilt":

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -4,6 +4,7 @@
     "action_type": {
       "open": "Open {entity_name}",
       "close": "Close {entity_name}",
+      "stop": "Stop {entity_name}",
       "open_tilt": "Open {entity_name} tilt",
       "close_tilt": "Close {entity_name} tilt",
       "set_position": "Set {entity_name} position",

--- a/homeassistant/components/cover/translations/en.json
+++ b/homeassistant/components/cover/translations/en.json
@@ -6,7 +6,8 @@
             "open": "Open {entity_name}",
             "open_tilt": "Open {entity_name} tilt",
             "set_position": "Set {entity_name} position",
-            "set_tilt_position": "Set {entity_name} tilt position"
+            "set_tilt_position": "Set {entity_name} tilt position",
+            "stop": "Stop {entity_name}"
         },
         "condition_type": {
             "is_closed": "{entity_name} is closed",
@@ -27,9 +28,9 @@
     },
     "state": {
         "_": {
-            "closed": "Closed",
+            "closed": "[%key:common::state::closed%]",
             "closing": "Closing",
-            "open": "Open",
+            "open": "[%key:common::state::open%]",
             "opening": "Opening",
             "stopped": "Stopped"
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a cover supports 'stop' action, show it in device automation UI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
