### PR TITLE
Restore rfxtrx state to off when delay off is in effect

### DIFF
--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_COMMAND_ON,
     CONF_DEVICE_CLASS,
     CONF_DEVICES,
+    STATE_ON,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import event as evt
@@ -28,12 +29,7 @@ from . import (
     get_pt2262_cmd,
     get_rfx_object,
 )
-from .const import (
-    ATTR_EVENT,
-    COMMAND_OFF_LIST,
-    COMMAND_ON_LIST,
-    DEVICE_PACKET_TYPE_LIGHTING4,
-)
+from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST, DEVICE_PACKET_TYPE_LIGHTING4
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -184,9 +180,10 @@ class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):
         if self._event is None:
             old_state = await self.async_get_last_state()
             if old_state is not None:
-                event = old_state.attributes.get(ATTR_EVENT)
-                if event:
-                    self._apply_event(get_rfx_object(event))
+                self._state = old_state.state == STATE_ON
+
+        if self._state and self._off_delay is not None:
+            self._state = False
 
     @property
     def force_update(self) -> bool:

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -16,6 +16,8 @@ EVENT_MOTION_DETECTOR_NO_MOTION = "08200100a109000570"
 EVENT_LIGHT_DETECTOR_LIGHT = "08200100a109001570"
 EVENT_LIGHT_DETECTOR_DARK = "08200100a109001470"
 
+EVENT_AC_118CDEA_2_ON = "0b1100100118cdea02010f70"
+
 
 async def test_one(hass, rfxtrx):
     """Test with 1 sensor."""
@@ -135,6 +137,37 @@ async def test_discover(hass, rfxtrx_automatic):
     state = hass.states.get("binary_sensor.ac_118cdeb_2")
     assert state
     assert state.state == "on"
+
+
+async def test_off_delay_restore(hass, rfxtrx):
+    """Make sure binary sensor restore as off, if off delay is active."""
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                "binary_sensor.ac_118cdea_2",
+                "on",
+                attributes={ATTR_EVENT: EVENT_AC_118CDEA_2_ON},
+            )
+        ],
+    )
+
+    assert await async_setup_component(
+        hass,
+        "rfxtrx",
+        {
+            "rfxtrx": {
+                "device": "abcd",
+                "devices": {EVENT_AC_118CDEA_2_ON: {"off_delay": 5}},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
+    assert state
+    assert state.state == "off"
 
 
 async def test_off_delay(hass, rfxtrx, timestep):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correctly restore binary sensors as off when delay_off is active.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38186

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
