### PR TITLE
Change http to auto for cast media image url

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -602,7 +602,7 @@ class CastDevice(MediaPlayerEntity):
 
         images = media_status.images
 
-        return images[0].url if images and images[0].url else None
+        return images[0].url.replace("http://", "//") if images and images[0].url else None
 
     @property
     def media_image_remotely_accessible(self) -> bool:

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -602,7 +602,9 @@ class CastDevice(MediaPlayerEntity):
 
         images = media_status.images
 
-        return images[0].url.replace("http://", "//") if images and images[0].url else None
+        return (
+            images[0].url.replace("http://", "//") if images and images[0].url else None
+        )
 
     @property
     def media_image_remotely_accessible(self) -> bool:

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -459,11 +459,10 @@ async def test_url_replace(hass: HomeAssistantType):
     assert state.state == "unknown"
     assert entity.unique_id == full_info.uuid
 
-    media_status = MagicMock(images=None)
-    media_status.player_is_playing = True
-    class TestImage:
+    class FakeImage:
         url = "http://example.com/test.png"
-    media_status.images = [TestImage()]
+    media_status = MagicMock(images=[FakeImage()])
+    media_status.player_is_playing = True
     entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -460,6 +460,7 @@ async def test_url_replace(hass: HomeAssistantType):
     assert entity.unique_id == full_info.uuid
 
     media_status = MagicMock(images=[{"url": "http://example.com/test.png"}])
+    media_status.player_is_playing = True
     entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -461,6 +461,7 @@ async def test_url_replace(hass: HomeAssistantType):
 
     class FakeImage:
         url = "http://example.com/test.png"
+
     media_status = MagicMock(images=[FakeImage()])
     media_status.player_is_playing = True
     entity.new_media_status(media_status)

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -459,15 +459,23 @@ async def test_url_replace(hass: HomeAssistantType):
     assert state.state == "unknown"
     assert entity.unique_id == full_info.uuid
 
-    class FakeImage:
+    class FakeHTTPImage:
         url = "http://example.com/test.png"
+    class FakeHTTPSImage:
+        url = "https://example.com/test.png"
 
-    media_status = MagicMock(images=[FakeImage()])
+    media_status = MagicMock(images=[FakeHTTPImage()])
     media_status.player_is_playing = True
     entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")
     assert state.attributes.get("entity_picture") == "//example.com/test.png"
+    
+    media_status.images = [FakeHTTPSImage()]
+    entity.new_media_status(media_status)
+    await hass.async_block_till_done()
+    state = hass.states.get("media_player.speaker")
+    assert state.attributes.get("entity_picture") == "https://example.com/test.png"
 
 
 async def test_group_media_states(hass: HomeAssistantType):

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -461,6 +461,7 @@ async def test_url_replace(hass: HomeAssistantType):
 
     class FakeHTTPImage:
         url = "http://example.com/test.png"
+
     class FakeHTTPSImage:
         url = "https://example.com/test.png"
 
@@ -470,7 +471,7 @@ async def test_url_replace(hass: HomeAssistantType):
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")
     assert state.attributes.get("entity_picture") == "//example.com/test.png"
-    
+
     media_status.images = [FakeHTTPSImage()]
     entity.new_media_status(media_status)
     await hass.async_block_till_done()

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -467,7 +467,7 @@ async def test_url_replace(hass: HomeAssistantType):
     entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")
-    assert state.media_image_url == "//example.com/test.png"
+    assert state.attributes.get("entity_picture") == "//example.com/test.png"
 
 
 async def test_group_media_states(hass: HomeAssistantType):

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -461,11 +461,12 @@ async def test_url_replace(hass: HomeAssistantType):
 
     media_status = MagicMock(images=None)
     media_status.player_is_playing = True
-    media_status.images = [{"url": "http://example.com/test.png"}]
+    class TestImage:
+        url = "http://example.com/test.png"
+    media_status.images = [TestImage()]
     entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")
-    assert state.state == "playing"
     assert state.media_image_url == "//example.com/test.png"
 
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -459,11 +459,13 @@ async def test_url_replace(hass: HomeAssistantType):
     assert state.state == "unknown"
     assert entity.unique_id == full_info.uuid
 
-    media_status = MagicMock(images=[{"url": "http://example.com/test.png"}])
+    media_status = MagicMock(images=None)
     media_status.player_is_playing = True
+    media_status.images = [{"url": "http://example.com/test.png"}]
     entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")
+    assert state.state == "playing"
     assert state.media_image_url == "//example.com/test.png"
 
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -438,6 +438,32 @@ async def test_entity_media_states(hass: HomeAssistantType):
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")
     assert state.state == "unknown"
+ 
+
+async def test_url_replace(hass: HomeAssistantType):
+    """Test functionality of replacing URL for HTTPS."""
+    info = get_fake_chromecast_info()
+    full_info = attr.evolve(
+        info, model_name="google home", friendly_name="Speaker", uuid=FakeUUID
+    )
+
+    chromecast, entity = await async_setup_media_player_cast(hass, info)
+
+    entity._available = True
+    entity.schedule_update_ha_state()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.speaker")
+    assert state is not None
+    assert state.name == "Speaker"
+    assert state.state == "unknown"
+    assert entity.unique_id == full_info.uuid
+
+    media_status = MagicMock(images=[{"url": "http://example.com/test.png"}])
+    entity.new_media_status(media_status)
+    await hass.async_block_till_done()
+    state = hass.states.get("media_player.speaker")
+    assert state.media_image_url == "//example.com/test.png"
 
 
 async def test_group_media_states(hass: HomeAssistantType):

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -438,7 +438,7 @@ async def test_entity_media_states(hass: HomeAssistantType):
     await hass.async_block_till_done()
     state = hass.states.get("media_player.speaker")
     assert state.state == "unknown"
- 
+
 
 async def test_url_replace(hass: HomeAssistantType):
     """Test functionality of replacing URL for HTTPS."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change replaces http images with the auto `\\`, to remove mixed content warnings on https.
*Can anyone verify what happens if you try to load an http-only image over https using `\\`?*

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
cast:
  media_player:
    - host: 192.168.1.10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37417
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
