### PR TITLE
Improve setup retry logic to handle inconsistent powerview hub availability

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -112,21 +112,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         async with async_timeout.timeout(10):
             device_info = await async_get_device_info(pv_request)
+
+        async with async_timeout.timeout(10):
+            rooms = Rooms(pv_request)
+            room_data = _async_map_data_by_id((await rooms.get_resources())[ROOM_DATA])
+
+        async with async_timeout.timeout(10):
+            scenes = Scenes(pv_request)
+            scene_data = _async_map_data_by_id(
+                (await scenes.get_resources())[SCENE_DATA]
+            )
+
+        async with async_timeout.timeout(10):
+            shades = Shades(pv_request)
+            shade_data = _async_map_data_by_id(
+                (await shades.get_resources())[SHADE_DATA]
+            )
     except HUB_EXCEPTIONS:
         _LOGGER.error("Connection error to PowerView hub: %s", hub_address)
         raise ConfigEntryNotReady
+
     if not device_info:
         _LOGGER.error("Unable to initialize PowerView hub: %s", hub_address)
         raise ConfigEntryNotReady
-
-    rooms = Rooms(pv_request)
-    room_data = _async_map_data_by_id((await rooms.get_resources())[ROOM_DATA])
-
-    scenes = Scenes(pv_request)
-    scene_data = _async_map_data_by_id((await scenes.get_resources())[SCENE_DATA])
-
-    shades = Shades(pv_request)
-    shade_data = _async_map_data_by_id((await shades.get_resources())[SHADE_DATA])
 
     async def async_update_data():
         """Fetch data from shade endpoint."""

--- a/homeassistant/components/hunterdouglas_powerview/const.py
+++ b/homeassistant/components/hunterdouglas_powerview/const.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from aiohttp.client_exceptions import ServerDisconnectedError
 from aiopvapi.helpers.aiorequest import PvApiConnectionError
 
 DOMAIN = "hunterdouglas_powerview"
@@ -64,7 +65,7 @@ PV_SHADE_DATA = "pv_shade_data"
 PV_ROOM_DATA = "pv_room_data"
 COORDINATOR = "coordinator"
 
-HUB_EXCEPTIONS = (asyncio.TimeoutError, PvApiConnectionError)
+HUB_EXCEPTIONS = (ServerDisconnectedError, asyncio.TimeoutError, PvApiConnectionError)
 
 LEGACY_DEVICE_SUB_REVISION = 1
 LEGACY_DEVICE_REVISION = 0


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The powerview hubs are notorious for being a bit flakey.  This change adjusts
the setup to assume any command could fails during setup and now
retries later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38233
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
