### PR TITLE
Implement resilient startup for bond integration (ConfigEntryNotReady)

### DIFF
--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -73,7 +73,9 @@ async def setup_platform(
     return mock_entry
 
 
-def patch_bond_version(enabled: bool = True, return_value: Optional[dict] = None):
+def patch_bond_version(
+    enabled: bool = True, return_value: Optional[dict] = None, side_effect=None
+):
     """Patch Bond API version endpoint."""
     if not enabled:
         return nullcontext()
@@ -82,7 +84,9 @@ def patch_bond_version(enabled: bool = True, return_value: Optional[dict] = None
         return_value = {"bondid": "test-bond-id"}
 
     return patch(
-        "homeassistant.components.bond.Bond.version", return_value=return_value
+        "homeassistant.components.bond.Bond.version",
+        return_value=return_value,
+        side_effect=side_effect,
     )
 
 

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -1,8 +1,13 @@
 """Tests for the Bond module."""
+from aiohttp import ClientConnectionError
+import pytest
+
+from homeassistant.components.bond import async_setup_entry
 from homeassistant.components.bond.const import DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -16,6 +21,17 @@ async def test_async_setup_no_domain_config(hass: HomeAssistant):
     result = await async_setup_component(hass, DOMAIN, {})
 
     assert result is True
+
+
+async def test_async_setup_raises_entry_not_ready(hass: HomeAssistant):
+    """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
+    )
+
+    with patch_bond_version(side_effect=ClientConnectionError()):
+        with pytest.raises(ConfigEntryNotReady):
+            await async_setup_entry(hass, config_entry)
 
 
 async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAssistant):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Handle hub-not-available on startup gracefully, throw ConfigEntryNotReady

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
