### PR TITLE
Fix Lutron Caseta devices loading when missing serials

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -130,14 +130,12 @@ class LutronCasetaDevice(Entity):
     @property
     def device_info(self):
         """Return the device info."""
-        if "serial" in self._device:
-            return {
-                "identifiers": {(DOMAIN, self._device["serial"])},
-                "name": self.name,
-                "manufacturer": "Lutron",
-                "model": self._device.get("model"),
-            }
-        return None
+        return {
+            "identifiers": {(DOMAIN, self.serial)},
+            "name": self.name,
+            "manufacturer": "Lutron",
+            "model": self._device["model"],
+        }
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -137,8 +137,7 @@ class LutronCasetaDevice(Entity):
                 "manufacturer": "Lutron",
                 "model": self._device.get("model"),
             }
-        else:
-            return None
+        return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -130,12 +130,15 @@ class LutronCasetaDevice(Entity):
     @property
     def device_info(self):
         """Return the device info."""
-        return {
-            "identifiers": {(DOMAIN, self.serial)},
-            "name": self.name,
-            "manufacturer": "Lutron",
-            "model": self._device["model"],
-        }
+        if "serial" in self._device:
+            return {
+                "identifiers": {(DOMAIN, self._device["serial"])},
+                "name": self.name,
+                "manufacturer": "Lutron",
+                "model": self._device.get("model"),
+            }
+        else:
+            return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -58,12 +58,12 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
 
     @property
     def device_info(self):
-        """Return the device info."""
-        """Sensor entities are aggregated from one or more physical
+        """Return the device info.
+
+        Sensor entities are aggregated from one or more physical
         sensors by each room. Therefore, there shouldn't be devices
         related to any sensor entities.
         """
-        return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -64,6 +64,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
         sensors by each room. Therefore, there shouldn't be devices
         related to any sensor entities.
         """
+        return None  # pylint: disable=useless-return
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -57,6 +57,15 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
         return f"occupancygroup_{self.device_id}"
 
     @property
+    def device_info(self):
+        """Return the device info."""
+        """Sensor entities are aggregated from one or more physical
+        sensors by each room. Therefore, there shouldn't be devices
+        related to any sensor entities.
+        """
+        return None
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes."""
         return {"device_id": self.device_id}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
**This PR fixes the issue that some Lutron Caseta devices won't load because they don't have serials.
For an example, Lutron Caseta aggregates sensors in the same room into a single sensor entity, in this case, the single sensor entity won't have a serial.**
The issue is https://github.com/home-assistant/core/issues/37449

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
lutron_caseta:
  - host: IP_ADDRESS
    keyfile: caseta.key
    certfile: caseta.crt
    ca_certs: caseta-bridge.crt
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37449 
- This PR is related to issue: https://github.com/home-assistant/core/issues/37449
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
