### PR TITLE
Prevent kodi from blocking startup

### DIFF
--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -7,7 +7,7 @@ import socket
 import urllib
 
 import aiohttp
-from datatime import timedelta
+from datetime import timedelta
 import jsonrpc_async
 import jsonrpc_base
 import jsonrpc_websocket

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -454,7 +454,7 @@ class KodiDevice(MediaPlayerEntity):
             )
         )
 
-    async def _async_connect_websocket_if_disconnected(self):
+    async def _async_connect_websocket_if_disconnected(self, *_):
         """Reconnect the websocket if it fails."""
         if not self._ws_server.connected:
             await self.hass.async_create_task(self.async_ws_connect())

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -444,7 +444,7 @@ class KodiDevice(MediaPlayerEntity):
         if not self._enable_websocket:
             return
 
-        await self._async_connect_websocket_if_disconnected()
+        self.hass.loop.create_task(self.async_ws_connect())
 
         self.async_on_remove(
             async_track_time_interval(
@@ -457,7 +457,7 @@ class KodiDevice(MediaPlayerEntity):
     async def _async_connect_websocket_if_disconnected(self, *_):
         """Reconnect the websocket if it fails."""
         if not self._ws_server.connected:
-            await self.hass.async_create_task(self.async_ws_connect())
+            await self.async_ws_connect()
 
     async def async_update(self):
         """Retrieve latest state."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -1,5 +1,6 @@
 """Support for interfacing with the XBMC/Kodi JSON-RPC API."""
 from collections import OrderedDict
+from datetime import timedelta
 from functools import wraps
 import logging
 import re
@@ -7,7 +8,6 @@ import socket
 import urllib
 
 import aiohttp
-from datetime import timedelta
 import jsonrpc_async
 import jsonrpc_base
 import jsonrpc_websocket

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -1,4 +1,5 @@
 """Support for interfacing with the XBMC/Kodi JSON-RPC API."""
+import asyncio
 from collections import OrderedDict
 from datetime import timedelta
 from functools import wraps
@@ -444,7 +445,7 @@ class KodiDevice(MediaPlayerEntity):
         if not self._enable_websocket:
             return
 
-        self.hass.loop.create_task(self.async_ws_connect())
+        asyncio.create_task(self.async_ws_connect())
 
         self.async_on_remove(
             async_track_time_interval(


### PR DESCRIPTION
I have no way to test this as I don't have a kodi.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

async_update was trying to reconnect the websocket every time.
If it took a while or had to timeout, it would block forever.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38160
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
