### PR TITLE
Improve scene restore for media players

### DIFF
--- a/homeassistant/components/media_player/reproduce_state.py
+++ b/homeassistant/components/media_player/reproduce_state.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     STATE_IDLE,
     STATE_OFF,
+    STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
 )
@@ -50,8 +51,6 @@ async def _async_reproduce_states(
 ) -> None:
     """Reproduce component states."""
 
-    _LOGGER.debug("Restoring state: %s", state)
-
     async def call_service(service: str, keys: Iterable) -> None:
         """Call service with set of attributes given."""
         data = {"entity_id": state.entity_id}
@@ -73,8 +72,13 @@ async def _async_reproduce_states(
         # entities that are off have no other attributes to restore
         return
 
-    await call_service(SERVICE_TURN_ON, [])
-    already_playing = False
+    if state.state in [
+        STATE_ON,
+        STATE_PLAYING,
+        STATE_IDLE,
+        STATE_PAUSED,
+    ]:
+        await call_service(SERVICE_TURN_ON, [])
 
     if ATTR_MEDIA_VOLUME_LEVEL in state.attributes:
         await call_service(SERVICE_VOLUME_SET, [ATTR_MEDIA_VOLUME_LEVEL])
@@ -87,6 +91,8 @@ async def _async_reproduce_states(
 
     if ATTR_SOUND_MODE in state.attributes:
         await call_service(SERVICE_SELECT_SOUND_MODE, [ATTR_SOUND_MODE])
+
+    already_playing = False
 
     if (ATTR_MEDIA_CONTENT_TYPE in state.attributes) and (
         ATTR_MEDIA_CONTENT_ID in state.attributes

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -6,7 +6,7 @@
     "@rajlaud"
   ],
   "requirements": [
-    "pysqueezebox==0.3.0"
+    "pysqueezebox==0.3.1"
   ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/manifest.json
+++ b/homeassistant/components/squeezebox/manifest.json
@@ -6,7 +6,7 @@
     "@rajlaud"
   ],
   "requirements": [
-    "pysqueezebox==0.2.4"
+    "pysqueezebox==0.3.0"
   ],
   "config_flow": true
 }

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -338,7 +338,7 @@ class SqueezeBoxEntity(MediaPlayerEntity):
             return None
         if len(self._player.playlist) > 1:
             urls = [{"url": track["url"]} for track in self._player.playlist]
-            return json.dumps(urls)
+            return json.dumps({"index": self._player.current_index, "urls": urls})
         return self._player.url
 
     @property
@@ -472,9 +472,9 @@ class SqueezeBoxEntity(MediaPlayerEntity):
             cmd = "add"
 
         if media_type == MEDIA_TYPE_PLAYLIST:
-            playlist = json.loads(media_id)
-            _LOGGER.debug("Loading playlist: %s", playlist)
-            await self._player.async_load_playlist(playlist, cmd)
+            content = json.loads(media_id)
+            await self._player.async_load_playlist(content["urls"], cmd)
+            await self._player.async_index(content["index"])
         else:
             await self._player.async_load_url(media_id, cmd)
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -20,6 +20,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SEEK,
     SUPPORT_SHUFFLE_SET,
+    SUPPORT_STOP,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
@@ -82,6 +83,7 @@ SUPPORT_SQUEEZEBOX = (
     | SUPPORT_PLAY
     | SUPPORT_SHUFFLE_SET
     | SUPPORT_CLEAR_PLAYLIST
+    | SUPPORT_STOP
 )
 
 PLATFORM_SCHEMA = vol.All(
@@ -432,6 +434,10 @@ class SqueezeBoxEntity(MediaPlayerEntity):
     async def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
         await self._player.async_set_muting(mute)
+
+    async def async_media_stop(self):
+        """Send stop command to media player."""
+        await self._player.async_stop()
 
     async def async_media_play_pause(self):
         """Send pause command to media player."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1644,7 +1644,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.3.0
+pysqueezebox==0.3.1
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1644,7 +1644,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.4
+pysqueezebox==0.3.0
 
 # homeassistant.components.stiebel_eltron
 pystiebeleltron==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -764,7 +764,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.2.4
+pysqueezebox==0.3.0
 
 # homeassistant.components.syncthru
 pysyncthru==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -764,7 +764,7 @@ pysonos==0.0.32
 pyspcwebgw==0.4.0
 
 # homeassistant.components.squeezebox
-pysqueezebox==0.3.0
+pysqueezebox==0.3.1
 
 # homeassistant.components.syncthru
 pysyncthru==0.5.0

--- a/tests/components/media_player/test_reproduce_state.py
+++ b/tests/components/media_player/test_reproduce_state.py
@@ -7,6 +7,7 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_ENQUEUE,
+    ATTR_MEDIA_POSITION,
     ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
@@ -53,6 +54,8 @@ ENTITY_2 = "media_player.test2"
 async def test_state(hass, service, state):
     """Test that we can turn a state into a service call."""
     calls_1 = async_mock_service(hass, DOMAIN, service)
+    if service != SERVICE_TURN_ON:
+        async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
 
     await async_reproduce_states(hass, [State(ENTITY_1, state)])
 
@@ -149,7 +152,7 @@ async def test_attribute_no_state(hass):
     [
         (SERVICE_VOLUME_SET, ATTR_MEDIA_VOLUME_LEVEL),
         (SERVICE_VOLUME_MUTE, ATTR_MEDIA_VOLUME_MUTED),
-        (SERVICE_MEDIA_SEEK, ATTR_MEDIA_SEEK_POSITION),
+        (SERVICE_MEDIA_SEEK, ATTR_MEDIA_POSITION),
         (SERVICE_SELECT_SOURCE, ATTR_INPUT_SOURCE),
         (SERVICE_SELECT_SOUND_MODE, ATTR_SOUND_MODE),
     ],
@@ -165,7 +168,13 @@ async def test_attribute(hass, service, attribute):
     await hass.async_block_till_done()
 
     assert len(calls_1) == 1
-    assert calls_1[0].data == {"entity_id": ENTITY_1, attribute: value}
+    if attribute == ATTR_MEDIA_POSITION:
+        assert calls_1[0].data == {
+            "entity_id": ENTITY_1,
+            ATTR_MEDIA_SEEK_POSITION: value,
+        }
+    else:
+        assert calls_1[0].data == {"entity_id": ENTITY_1, attribute: value}
 
 
 async def test_play_media(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not exactly a breaking change, but executing a `scene` including a media player will now restore the playing content, the position, and the `playing`/`paused`/`idle state`. It is possible that some have come to expected the existing, broken behavior.

Previously, `async_reproduce_state` would look for the current position in property `seek_position`. No core integration stores the current position there. It is possible that a custom integration might have mistakenly used `seek_position`, and this fix would break that. 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Because of the order that attributes were restored, a media player with loaded content would always start playing (as that command was run *after* the `playing`/`paused`/`idle` state was restored). This fixes that behavior.

In addition, media players report their current position as `media_position`, but `async_reproduce_state` was looking for this information at `seek_position`. As a result, the position was not being restored.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
