### PR TITLE
Add binary sensor support to the Flo integration

### DIFF
--- a/homeassistant/components/flo/__init__.py
+++ b/homeassistant/components/flo/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["binary_sensor", "sensor"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -26,9 +26,7 @@ class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):
 
     def __init__(self, device):
         """Initialize the pending alerts binary sensor."""
-        super().__init__(
-            f"{device.mac_address}_daily_consumption", "Pending System Alerts", device
-        )
+        super().__init__("daily_consumption", "Pending System Alerts", device)
 
     @property
     def is_on(self):

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -38,9 +38,9 @@ class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):
         """Return the state attributes."""
         attr = {}
         if self._device.has_alerts:
-            attr["Info Alerts"] = self._device.pending_info_alerts_count
-            attr["Warning Alerts"] = self._device.pending_warning_alerts_count
-            attr["Critical Alerts"] = self._device.pending_critical_alerts_count
+            attr["info"] = self._device.pending_info_alerts_count
+            attr["warning"] = self._device.pending_warning_alerts_count
+            attr["critical"] = self._device.pending_critical_alerts_count
         return attr
 
     @property

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -18,7 +18,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Flo sensors from config entry."""
     devices: List[FloDeviceDataUpdateCoordinator] = hass.data[FLO_DOMAIN]["devices"]
     entities = [FloPendingAlertsBinarySensor(device) for device in devices]
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -26,7 +26,7 @@ class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):
 
     def __init__(self, device):
         """Initialize the pending alerts binary sensor."""
-        super().__init__("daily_consumption", "Pending System Alerts", device)
+        super().__init__("pending_system_alerts", "Pending System Alerts", device)
 
     @property
     def is_on(self):

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
 )
 
 from .const import DOMAIN as FLO_DOMAIN
-from .device import FloDevice
+from .device import FloDeviceDataUpdateCoordinator
 from .entity import FloEntity
 
 DEPENDENCIES = ["flo"]
@@ -16,7 +16,7 @@ DEPENDENCIES = ["flo"]
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Flo sensors from config entry."""
-    devices: List[FloDevice] = hass.data[FLO_DOMAIN]["devices"]
+    devices: List[FloDeviceDataUpdateCoordinator] = hass.data[FLO_DOMAIN]["devices"]
     entities = [FloPendingAlertsBinarySensor(device) for device in devices]
     async_add_entities(entities, True)
 

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -1,0 +1,51 @@
+"""Support for Flo Water Monitor binary sensors."""
+
+from typing import List
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_PROBLEM,
+    BinarySensorEntity,
+)
+
+from .const import DOMAIN as FLO_DOMAIN
+from .device import FloDevice
+from .entity import FloEntity
+
+DEPENDENCIES = ["flo"]
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Flo sensors from config entry."""
+    devices: List[FloDevice] = hass.data[FLO_DOMAIN]["devices"]
+    entities = [FloPendingAlertsBinarySensor(device) for device in devices]
+    async_add_entities(entities, True)
+
+
+class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):
+    """Binary sensor that reports on if there are any pending system alerts."""
+
+    def __init__(self, device):
+        """Initialize the pending alerts binary sensor."""
+        super().__init__(
+            f"{device.mac_address}_daily_consumption", "Pending System Alerts", device
+        )
+
+    @property
+    def is_on(self):
+        """Return true if the Flo device has pending alerts."""
+        return self._device.has_alerts
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+        if self._device.has_alerts:
+            attr["Info Alerts"] = self._device.pending_info_alerts_count
+            attr["Warning Alerts"] = self._device.pending_warning_alerts_count
+            attr["Critical Alerts"] = self._device.pending_critical_alerts_count
+        return attr
+
+    @property
+    def device_class(self):
+        """Return the device class for the binary sensor."""
+        return DEVICE_CLASS_PROBLEM

--- a/homeassistant/components/flo/device.py
+++ b/homeassistant/components/flo/device.py
@@ -157,9 +157,9 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
     def has_alerts(self) -> bool:
         """Return True if any alert counts are greater than zero."""
         return bool(
-            self._pending_info_alerts_count
-            or self._pending_warning_alerts_count
-            or self._pending_warning_alerts_count
+            self.pending_info_alerts_count
+            or self.pending_warning_alerts_count
+            or self.pending_warning_alerts_count
         )
 
     async def _update_device(self, *_) -> None:

--- a/homeassistant/components/flo/device.py
+++ b/homeassistant/components/flo/device.py
@@ -138,6 +138,30 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         """Return the serial number for the device."""
         return self._device_information["serialNumber"]
 
+    @property
+    def pending_info_alerts_count(self) -> int:
+        """Return the number of pending info alerts for the device."""
+        return self._device_information["notifications"]["pending"]["infoCount"]
+
+    @property
+    def pending_warning_alerts_count(self) -> int:
+        """Return the number of pending warning alerts for the device."""
+        return self._device_information["notifications"]["pending"]["warningCount"]
+
+    @property
+    def pending_critical_alerts_count(self) -> int:
+        """Return the number of pending critical alerts for the device."""
+        return self._device_information["notifications"]["pending"]["criticalCount"]
+
+    @property
+    def has_alerts(self) -> bool:
+        """Return True if any alert counts are greater than zero."""
+        return bool(
+            self._pending_info_alerts_count
+            or self._pending_warning_alerts_count
+            or self._pending_warning_alerts_count
+        )
+
     async def _update_device(self, *_) -> None:
         """Update the device information from the API."""
         self._device_information = await self.api_client.device.get_info(

--- a/tests/components/flo/test_binary_sensor.py
+++ b/tests/components/flo/test_binary_sensor.py
@@ -24,7 +24,7 @@ async def test_binary_sensors(hass, config_entry, aioclient_mock_fixture):
     # we should have 6 entities for the device
     state = hass.states.get("binary_sensor.pending_system_alerts")
     assert state.state == STATE_ON
-    assert state.attributes.get("Info Alerts") == 0
-    assert state.attributes.get("Warning Alerts") == 2
-    assert state.attributes.get("Critical Alerts") == 0
+    assert state.attributes.get("info") == 0
+    assert state.attributes.get("warning") == 2
+    assert state.attributes.get("critical") == 0
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Pending System Alerts"

--- a/tests/components/flo/test_binary_sensor.py
+++ b/tests/components/flo/test_binary_sensor.py
@@ -1,0 +1,30 @@
+"""Test Flo by Moen binary sensor entities."""
+from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    STATE_ON,
+)
+from homeassistant.setup import async_setup_component
+
+from .common import TEST_PASSWORD, TEST_USER_ID
+
+
+async def test_binary_sensors(hass, config_entry, aioclient_mock_fixture):
+    """Test Flo by Moen sensors."""
+    config_entry.add_to_hass(hass)
+    assert await async_setup_component(
+        hass, FLO_DOMAIN, {CONF_USERNAME: TEST_USER_ID, CONF_PASSWORD: TEST_PASSWORD}
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.data[FLO_DOMAIN]["devices"]) == 1
+
+    # we should have 6 entities for the device
+    state = hass.states.get("binary_sensor.pending_system_alerts")
+    assert state.state == STATE_ON
+    assert state.attributes.get("Info Alerts") == 0
+    assert state.attributes.get("Warning Alerts") == 2
+    assert state.attributes.get("Critical Alerts") == 0
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Pending System Alerts"

--- a/tests/components/flo/test_device.py
+++ b/tests/components/flo/test_device.py
@@ -41,6 +41,10 @@ async def test_device(hass, config_entry, aioclient_mock_fixture, aioclient_mock
     assert device.manufacturer == "Flo by Moen"
     assert device.device_name == "Flo by Moen flo_device_075_v2"
     assert device.rssi == -47
+    assert device.pending_info_alerts_count == 0
+    assert device.pending_critical_alerts_count == 0
+    assert device.pending_warning_alerts_count == 2
+    assert device.has_alerts is True
 
     call_count = aioclient_mock.call_count
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is number 2 in a series of PR's to add support for Flo by Moen devices to HA. This PR adds binary sensor support. A binary sensor is exposed that reports true if there are any system alerts that haven't been addressed. This depends on #38171 and it will need to be rebased after that PR is merged. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
