### PR TITLE
Change devolo Home Control entity naming

### DIFF
--- a/homeassistant/components/devolo_home_control/binary_sensor.py
+++ b/homeassistant/components/devolo_home_control/binary_sensor.py
@@ -58,13 +58,13 @@ class DevoloBinaryDeviceEntity(DevoloDeviceEntity, BinarySensorEntity):
             self._binary_sensor_property.sub_type
             or self._binary_sensor_property.sensor_type
         )
+        name = device_instance.itemName
+
         if self._device_class is None:
             if device_instance.binary_sensor_property.get(element_uid).sub_type != "":
-                name = f"{device_instance.itemName} {device_instance.binary_sensor_property.get(element_uid).sub_type}"
+                name += f" {device_instance.binary_sensor_property.get(element_uid).sub_type}"
             else:
-                name = f"{device_instance.itemName} {device_instance.binary_sensor_property.get(element_uid).sensor_type}"
-        else:
-            name = device_instance.itemName
+                name += f" {device_instance.binary_sensor_property.get(element_uid).sensor_type}"
 
         super().__init__(
             homecontrol=homecontrol,

--- a/homeassistant/components/devolo_home_control/binary_sensor.py
+++ b/homeassistant/components/devolo_home_control/binary_sensor.py
@@ -50,10 +50,21 @@ class DevoloBinaryDeviceEntity(DevoloDeviceEntity, BinarySensorEntity):
 
     def __init__(self, homecontrol, device_instance, element_uid):
         """Initialize a devolo binary sensor."""
-        if device_instance.binary_sensor_property.get(element_uid).sub_type != "":
-            name = f"{device_instance.itemName} {device_instance.binary_sensor_property.get(element_uid).sub_type}"
+        self._binary_sensor_property = device_instance.binary_sensor_property.get(
+            element_uid
+        )
+
+        self._device_class = DEVICE_CLASS_MAPPING.get(
+            self._binary_sensor_property.sub_type
+            or self._binary_sensor_property.sensor_type
+        )
+        if self._device_class is None:
+            if device_instance.binary_sensor_property.get(element_uid).sub_type != "":
+                name = f"{device_instance.itemName} {device_instance.binary_sensor_property.get(element_uid).sub_type}"
+            else:
+                name = f"{device_instance.itemName} {device_instance.binary_sensor_property.get(element_uid).sensor_type}"
         else:
-            name = f"{device_instance.itemName} {device_instance.binary_sensor_property.get(element_uid).sensor_type}"
+            name = device_instance.itemName
 
         super().__init__(
             homecontrol=homecontrol,
@@ -61,15 +72,6 @@ class DevoloBinaryDeviceEntity(DevoloDeviceEntity, BinarySensorEntity):
             element_uid=element_uid,
             name=name,
             sync=self._sync,
-        )
-
-        self._binary_sensor_property = self._device_instance.binary_sensor_property.get(
-            self._unique_id
-        )
-
-        self._device_class = DEVICE_CLASS_MAPPING.get(
-            self._binary_sensor_property.sub_type
-            or self._binary_sensor_property.sensor_type
         )
 
         self._state = self._binary_sensor_property.state

--- a/homeassistant/components/devolo_home_control/sensor.py
+++ b/homeassistant/components/devolo_home_control/sensor.py
@@ -54,10 +54,10 @@ class DevoloMultiLevelDeviceEntity(DevoloDeviceEntity):
             self._multi_level_sensor_property.sensor_type
         )
 
+        name = device_instance.itemName
+
         if self._device_class is None:
-            name = f"{device_instance.itemName} {self._multi_level_sensor_property.sensor_type}"
-        else:
-            name = device_instance.itemName
+            name += f" {self._multi_level_sensor_property.sensor_type}"
 
         self._unit = self._multi_level_sensor_property.unit
 

--- a/homeassistant/components/devolo_home_control/sensor.py
+++ b/homeassistant/components/devolo_home_control/sensor.py
@@ -53,13 +53,19 @@ class DevoloMultiLevelDeviceEntity(DevoloDeviceEntity):
         self._device_class = DEVICE_CLASS_MAPPING.get(
             self._multi_level_sensor_property.sensor_type
         )
+
+        if self._device_class is None:
+            name = f"{device_instance.itemName} {self._multi_level_sensor_property.sensor_type}"
+        else:
+            name = device_instance.itemName
+
         self._unit = self._multi_level_sensor_property.unit
 
         super().__init__(
             homecontrol=homecontrol,
             device_instance=device_instance,
             element_uid=element_uid,
-            name=f"{device_instance.itemName} {self._multi_level_sensor_property.sensor_type}",
+            name=name,
             sync=self._sync,
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will change the naming of entities within the devolo Home Control Integration. Just in case the device class is not known, a suffix will be added after the entity name, that the user know which type of sensor it is. If the device class is known, the user knows it because of the matching icon and value

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
