### PR TITLE
Add ability to retrieve WLAN clients from Ruckus Unleashed APs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -715,6 +715,7 @@ omit =
     homeassistant/components/rpi_pfio/*
     homeassistant/components/rpi_rf/switch.py
     homeassistant/components/rtorrent/sensor.py
+    homeassistant/components/ruckus_unleashed/device_tracker.py
     homeassistant/components/russound_rio/media_player.py
     homeassistant/components/russound_rnet/media_player.py
     homeassistant/components/sabnzbd/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -343,6 +343,7 @@ homeassistant/components/ring/* @balloob
 homeassistant/components/rmvtransport/* @cgtobi
 homeassistant/components/roku/* @ctalkington
 homeassistant/components/roomba/* @pschmitt @cyr-ius @shenxn
+homeassistant/components/ruckus_unleashed/* @cvhoang
 homeassistant/components/safe_mode/* @home-assistant/core
 homeassistant/components/saj/* @fredericvl
 homeassistant/components/salt/* @bjornorri

--- a/homeassistant/components/ruckus_unleashed/__init__.py
+++ b/homeassistant/components/ruckus_unleashed/__init__.py
@@ -1,0 +1,1 @@
+"""The ruckus_unleashed component."""

--- a/homeassistant/components/ruckus_unleashed/device_tracker.py
+++ b/homeassistant/components/ruckus_unleashed/device_tracker.py
@@ -1,0 +1,106 @@
+"""Support for Ruckus Unleashed APs."""
+import logging
+
+import pexpect
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    DeviceScanner,
+)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend(
+        {
+            vol.Required(CONF_HOST): cv.string,
+            vol.Required(CONF_USERNAME): cv.string,
+            vol.Optional(CONF_PASSWORD, default=""): cv.string,
+        }
+    )
+)
+
+RUCKUS_PROMPT = "ruckus>"
+RUCKUS_PROMPT_ENABLE = "ruckus#"
+RUCKUS_MAC_ADDRESS = "Mac Address="
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Unleashed scanner."""
+    scanner = UnleashedDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+class UnleashedDeviceScanner(DeviceScanner):
+    """This class queries a wireless router running Unleashed IOS firmware."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        self.host = config[CONF_HOST]
+        self.username = config[CONF_USERNAME]
+        self.port = config.get(CONF_PORT)
+        self.password = config[CONF_PASSWORD]
+
+        self.last_results = {}
+
+        self.success_init = self._update_info()
+        _LOGGER.info("ruckus_unleashed scanner initialized")
+
+    def get_device_name(self, device):
+        """Get the firmware doesn't save the name of the wireless device."""
+        return None
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return self.last_results
+
+    def _update_info(self):
+        """
+        Ensure the information from the Unleashed APs is up to date.
+
+        Returns boolean if scanning successful.
+        """
+        string_result = self._get_wlan_clients()
+
+        if string_result:
+            lines = string_result.splitlines()
+            mac_addresses = [
+                line.replace(RUCKUS_MAC_ADDRESS, "").strip()
+                for line in lines
+                if RUCKUS_MAC_ADDRESS in line
+            ]
+
+            self.last_results = mac_addresses
+            return True
+
+        return False
+
+    def _get_wlan_clients(self):
+        """Open connection to the router and get the list of clients."""
+
+        try:
+            child = pexpect.spawn(f"ssh {self.host}")
+            child.expect("Please login:")
+            child.sendline(self.username)
+            child.expect("Password:")
+            child.sendline(self.password)
+            child.expect(RUCKUS_PROMPT)
+            child.sendline("enable")
+            child.expect(RUCKUS_PROMPT_ENABLE)
+            child.sendline("show current-active-clients all")
+            child.expect(RUCKUS_PROMPT_ENABLE)
+            child.close()
+
+            return child.before.decode("utf-8")
+        except pexpect.ExceptionPexpect as ex:
+            _LOGGER.error("Failed to retrieve WLAN client list")
+            _LOGGER.error(ex)
+
+        return None

--- a/homeassistant/components/ruckus_unleashed/manifest.json
+++ b/homeassistant/components/ruckus_unleashed/manifest.json
@@ -1,0 +1,15 @@
+{
+  "domain": "ruckus_unleashed",
+  "name": "Ruckus Unleashed",
+  "documentation": "https://www.home-assistant.io/integrations/ruckus_unleashed",
+  "requirements": [
+    "pexpect==4.6.0"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@cvhoang"
+  ]
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1050,6 +1050,7 @@ pencompy==0.0.3
 # homeassistant.components.aruba
 # homeassistant.components.cisco_ios
 # homeassistant.components.pandora
+# homeassistant.components.ruckus_unleashed
 # homeassistant.components.unifi_direct
 pexpect==4.6.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -482,6 +482,7 @@ pdunehd==1.3.2
 # homeassistant.components.aruba
 # homeassistant.components.cisco_ios
 # homeassistant.components.pandora
+# homeassistant.components.ruckus_unleashed
 # homeassistant.components.unifi_direct
 pexpect==4.6.0
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None
## Proposed change

This pull request enables the ability to query Ruckus Unleashed Access Points for the list of connected clients. There seems to be no way to do that via API or SNMP. Therefore SSH connection needs to be made to the main Unleashed Access Point.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
device_tracker:
  - platform: ruckus_unleashed
    host: 192.168.0.12
    username: test
    password: testing
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
