### PR TITLE
Allow hdmi_cec to recover from lost connection to adapter without restart

### DIFF
--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -343,7 +343,7 @@ def setup(hass: HomeAssistant, base_config):
     def _shutdown(call):
         hdmi_network.stop()
 
-    def _start_cec(event):
+    def _start_cec(callback_event):
         """Register services and start HDMI network to watch for devices."""
         hass.services.register(
             DOMAIN, SERVICE_SEND_COMMAND, _tx, SERVICE_SEND_COMMAND_SCHEMA
@@ -380,7 +380,7 @@ class CecEntity(Entity):
         self._logical_address = logical
         self.entity_id = "%s.%d" % (DOMAIN, self._logical_address)
 
-    def _hdmi_cec_unavailable(self, event):
+    def _hdmi_cec_unavailable(self, callback_event):
         # Change state to unavailable. Without this, entity would remain in
         # its last state, since the state changes are pushed.
         self._state = STATE_UNAVAILABLE

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -393,11 +393,7 @@ class CecEntity(Entity):
         """
         Return false.
 
-<<<<<<< HEAD
         CecEntity.update() is called by the HDMI network when there is new data.
-=======
-        CecDevice.update() is called by the HDMI network when there is new data.
->>>>>>> Only update CecDevice state when there is new data
         """
         return False
 

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -213,21 +213,18 @@ def setup(hass: HomeAssistant, base_config):
     else:
         adapter = CecAdapter(name=display_name[:12], activate_source=False)
     hdmi_network = HDMINetwork(adapter, loop=loop)
-    if host:
 
-        def _tcpadapter_watchdog(now=None):
-            _LOGGER.debug("Reached _tcpadapter_watchdog")
-            event.async_call_later(hass, WATCHDOG_INTERVAL, _tcpadapter_watchdog)
-            if not adapter.initialized:
-                _LOGGER.info("Adapter not initialized. Trying to restart.")
-                hass.bus.fire(EVENT_HDMI_CEC_UNAVAILABLE)
-                adapter.init()
+    def _adapter_watchdog(now=None):
+        _LOGGER.debug("Reached _adapter_watchdog")
+        event.async_call_later(hass, WATCHDOG_INTERVAL, _adapter_watchdog)
+        if not adapter.initialized:
+            _LOGGER.info("Adapter not initialized. Trying to restart.")
+            hass.bus.fire(EVENT_HDMI_CEC_UNAVAILABLE)
+            adapter.init()
 
-        hdmi_network.set_initialized_callback(
-            partial(
-                event.async_call_later, hass, WATCHDOG_INTERVAL, _tcpadapter_watchdog
-            )
-        )
+    hdmi_network.set_initialized_callback(
+        partial(event.async_call_later, hass, WATCHDOG_INTERVAL, _adapter_watchdog)
+    )
 
     def _volume(call):
         """Increase/decrease volume and mute/unmute system."""

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -393,7 +393,11 @@ class CecEntity(Entity):
         """
         Return false.
 
+<<<<<<< HEAD
         CecEntity.update() is called by the HDMI network when there is new data.
+=======
+        CecDevice.update() is called by the HDMI network when there is new data.
+>>>>>>> Only update CecDevice state when there is new data
         """
         return False
 

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -418,7 +418,11 @@ class CecEntity(Entity):
         """
         Return false.
 
+<<<<<<< HEAD
         CecEntity.update() is called by the HDMI network when there is new data.
+=======
+        CecDevice.update() is called by the HDMI network when there is new data.
+>>>>>>> Only update CecDevice state when there is new data
         """
         return False
 

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -418,11 +418,7 @@ class CecEntity(Entity):
         """
         Return false.
 
-<<<<<<< HEAD
         CecEntity.update() is called by the HDMI network when there is new data.
-=======
-        CecDevice.update() is called by the HDMI network when there is new data.
->>>>>>> Only update CecDevice state when there is new data
         """
         return False
 

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -383,8 +383,6 @@ class CecEntity(Entity):
         self._logical_address = logical
         self.entity_id = "%s.%d" % (DOMAIN, self._logical_address)
 
-        self.hass.bus.listen(EVENT_HDMI_CEC_UNAVAILABLE, self._hdmi_cec_unavailable)
-
     def _hdmi_cec_unavailable(self, event):
         # Change state to unavailable. Without this, entity would remain in
         # its last state, since the state changes are pushed.
@@ -410,6 +408,9 @@ class CecEntity(Entity):
     async def async_added_to_hass(self):
         """Register HDMI callbacks after initialization."""
         self._device.set_update_callback(self._update)
+        self.hass.bus.async_listen(
+            EVENT_HDMI_CEC_UNAVAILABLE, self._hdmi_cec_unavailable
+        )
 
     def _update(self, device=None):
         """Device status changed, schedule an update."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, if a CEC adapter (whether physically connected or linked over TCP) is disconnected, it will never recover without restarting HA.

This fix implements a watchdog function that marks entities that depend on adapters that are no longer initialized unavailable, and attempts to re-initialize the adapter.

This is a draft, because there are some bugs in how `pycec` handles disconnected TCP adapters that need to be fixed for this to work. See https://github.com/konikvranik/pyCEC/pull/54.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #20480
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
