### PR TITLE
Timer make attribute format always h:mm:ss

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -72,14 +72,6 @@ def _format_timedelta(delta: timedelta):
     return f"{int(hours)}:{int(minutes):02}:{int(seconds):02}"
 
 
-def _parse_duration(duration: str) -> timedelta:
-    parts = duration.split(":")
-    hours = int(parts[0])
-    minutes = int(parts[1])
-    seconds = int(parts[2])
-    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
-
-
 def _none_to_empty_dict(value):
     if value is None:
         return {}
@@ -201,7 +193,7 @@ class Timer(RestoreEntity):
         self._config: dict = config
         self.editable: bool = True
         self._state: str = STATUS_IDLE
-        self._duration = _parse_duration(config[CONF_DURATION])
+        self._duration = cv.time_period_str(config[CONF_DURATION])
         self._remaining: Optional[timedelta] = None
         self._end: Optional[datetime] = None
         self._listener = None
@@ -358,5 +350,5 @@ class Timer(RestoreEntity):
     async def async_update_config(self, config: Dict) -> None:
         """Handle when the config is updated."""
         self._config = config
-        self._duration = _parse_duration(config[CONF_DURATION])
+        self._duration = cv.time_period_str(config[CONF_DURATION])
         self.async_write_ha_state()

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -1,6 +1,7 @@
 """Support for Timers."""
+from datetime import datetime, timedelta
 import logging
-import typing
+from typing import Dict, Optional
 
 import voluptuous as vol
 
@@ -62,6 +63,18 @@ UPDATE_FIELDS = {
     vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_DURATION): cv.time_period,
 }
+
+
+def _format_timedelta(delta):
+    if isinstance(delta, str):
+        return delta
+    if isinstance(delta, int):
+        total_seconds = delta
+    else:
+        total_seconds = delta.total_seconds()
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{int(hours)}:{int(minutes):02}:{int(seconds):02}"
 
 
 def _none_to_empty_dict(value):
@@ -156,40 +169,40 @@ class TimerStorageCollection(collection.StorageCollection):
     CREATE_SCHEMA = vol.Schema(CREATE_FIELDS)
     UPDATE_SCHEMA = vol.Schema(UPDATE_FIELDS)
 
-    async def _process_create_data(self, data: typing.Dict) -> typing.Dict:
+    async def _process_create_data(self, data: Dict) -> Dict:
         """Validate the config is valid."""
         data = self.CREATE_SCHEMA(data)
         # make duration JSON serializeable
-        data[CONF_DURATION] = str(data[CONF_DURATION])
+        data[CONF_DURATION] = _format_timedelta(data[CONF_DURATION])
         return data
 
     @callback
-    def _get_suggested_id(self, info: typing.Dict) -> str:
+    def _get_suggested_id(self, info: Dict) -> str:
         """Suggest an ID based on the config."""
         return info[CONF_NAME]
 
-    async def _update_data(self, data: dict, update_data: typing.Dict) -> typing.Dict:
+    async def _update_data(self, data: dict, update_data: Dict) -> Dict:
         """Return a new updated data object."""
         data = {**data, **self.UPDATE_SCHEMA(update_data)}
         # make duration JSON serializeable
-        data[CONF_DURATION] = str(data[CONF_DURATION])
+        data[CONF_DURATION] = _format_timedelta(data[CONF_DURATION])
         return data
 
 
 class Timer(RestoreEntity):
     """Representation of a timer."""
 
-    def __init__(self, config: typing.Dict):
+    def __init__(self, config: Dict):
         """Initialize a timer."""
-        self._config = config
-        self.editable = True
-        self._state = STATUS_IDLE
-        self._remaining = None
-        self._end = None
+        self._config: dict = config
+        self.editable: bool = True
+        self._state: str = STATUS_IDLE
+        self._remaining: Optional[timedelta] = None
+        self._end: Optional[datetime] = None
         self._listener = None
 
     @classmethod
-    def from_yaml(cls, config: typing.Dict) -> "Timer":
+    def from_yaml(cls, config: Dict) -> "Timer":
         """Return entity instance initialized from yaml storage."""
         timer = cls(config)
         timer.entity_id = ENTITY_ID_FORMAT.format(config[CONF_ID])
@@ -225,18 +238,18 @@ class Timer(RestoreEntity):
     def state_attributes(self):
         """Return the state attributes."""
         attrs = {
-            ATTR_DURATION: str(self._config[CONF_DURATION]),
+            ATTR_DURATION: _format_timedelta(self._config[CONF_DURATION]),
             ATTR_EDITABLE: self.editable,
         }
         if self._end is not None:
-            attrs[ATTR_FINISHES_AT] = str(self._end)
+            attrs[ATTR_FINISHES_AT] = self._end.isoformat()
         if self._remaining is not None:
-            attrs[ATTR_REMAINING] = str(self._remaining)
+            attrs[ATTR_REMAINING] = _format_timedelta(self._remaining)
 
         return attrs
 
     @property
-    def unique_id(self) -> typing.Optional[str]:
+    def unique_id(self) -> Optional[str]:
         """Return unique id for the entity."""
         return self._config[CONF_ID]
 
@@ -250,7 +263,7 @@ class Timer(RestoreEntity):
         self._state = state and state.state == state
 
     @callback
-    def async_start(self, duration):
+    def async_start(self, duration: timedelta):
         """Start a timer."""
         if self._listener:
             self._listener()
@@ -334,7 +347,7 @@ class Timer(RestoreEntity):
         self.hass.bus.async_fire(EVENT_TIMER_FINISHED, {"entity_id": self.entity_id})
         self.async_write_ha_state()
 
-    async def async_update_config(self, config: typing.Dict) -> None:
+    async def async_update_config(self, config: Dict) -> None:
         """Handle when the config is updated."""
         self._config = config
         self.async_write_ha_state()

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.components.timer import (
     STATUS_ACTIVE,
     STATUS_IDLE,
     STATUS_PAUSED,
+    _format_timedelta,
 )
 from homeassistant.const import (
     ATTR_EDITABLE,
@@ -544,7 +545,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
     assert resp["success"]
 
     state = hass.states.get(timer_entity_id)
-    assert state.attributes[ATTR_DURATION] == str(cv.time_period(33))
+    assert state.attributes[ATTR_DURATION] == _format_timedelta(cv.time_period(33))
 
 
 async def test_ws_create(hass, hass_ws_client, storage_setup):
@@ -574,7 +575,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     state = hass.states.get(timer_entity_id)
     assert state.state == STATUS_IDLE
-    assert state.attributes[ATTR_DURATION] == str(cv.time_period(42))
+    assert state.attributes[ATTR_DURATION] == _format_timedelta(cv.time_period(42))
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) == timer_entity_id
 
 

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -62,7 +62,7 @@ def storage_setup(hass, hass_storage):
                         {
                             ATTR_ID: "from_storage",
                             ATTR_NAME: "timer from storage",
-                            ATTR_DURATION: 0,
+                            ATTR_DURATION: "0:00:00",
                         }
                     ]
                 },


### PR DESCRIPTION
## Breaking Change

Timers with a duration longer than a day would format as "1 day, 1:00:00" and that is difficult to use in templates or for the frontend to render. Now it will render as "25:00:00".

## Proposed change

A time delta of more than 24 hours is shown as `1 day, 1:00:00` or `2 days, 16:34:12` this is hard for the frontend to deal with.

This PR will always show it in the format `h:mm:ss`.

I also made an alternative PR for the frontend, one of the 2 should be merged. <https://github.com/home-assistant/frontend/pull/6475>

Fixes https://github.com/home-assistant/frontend/issues/5235


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
