### PR TITLE
Prevent speedtest from blocking startup or causing other intergation to fail setup

### DIFF
--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -6,7 +6,12 @@ import speedtest
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_SCAN_INTERVAL
+from homeassistant.const import (
+    CONF_MONITORED_CONDITIONS,
+    CONF_SCAN_INTERVAL,
+    EVENT_HOMEASSISTANT_STARTED,
+)
+from homeassistant.core import CoreState
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -70,10 +75,25 @@ async def async_setup_entry(hass, config_entry):
     coordinator = SpeedTestDataCoordinator(hass, config_entry)
     await coordinator.async_setup()
 
-    if not config_entry.options[CONF_MANUAL]:
+    async def _enable_scheduled_speedtests(*_):
+        """Activate the data update coordinator."""
+        coordinator.update_interval = timedelta(
+            minutes=config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        )
         await coordinator.async_refresh()
-        if not coordinator.last_update_success:
-            raise ConfigEntryNotReady
+
+    if not config_entry.options[CONF_MANUAL]:
+        if hass.state == CoreState.running:
+            await _enable_scheduled_speedtests()
+            if not coordinator.last_update_success:
+                raise ConfigEntryNotReady
+        else:
+            # Running a speed test during startup can prevent
+            # integrations from being able to setup because it
+            # can saturate the network interface.
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED, _enable_scheduled_speedtests
+            )
 
     hass.data[DOMAIN] = coordinator
 
@@ -107,12 +127,6 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator):
         super().__init__(
             self.hass, _LOGGER, name=DOMAIN, update_method=self.async_update,
         )
-        if not self.config_entry.options.get(CONF_MANUAL):
-            self.update_interval = timedelta(
-                minutes=self.config_entry.options.get(
-                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                )
-            )
 
     def update_servers(self):
         """Update list of test servers."""

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -12,7 +12,6 @@ from .const import (
     ATTR_SERVER_ID,
     ATTR_SERVER_NAME,
     ATTRIBUTION,
-    CONF_MANUAL,
     DEFAULT_NAME,
     DOMAIN,
     ICON,
@@ -97,10 +96,9 @@ class SpeedtestSensor(RestoreEntity):
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         await super().async_added_to_hass()
-        if self.coordinator.config_entry.options[CONF_MANUAL]:
-            state = await self.async_get_last_state()
-            if state:
-                self._state = state.state
+        state = await self.async_get_last_state()
+        if state:
+            self._state = state.state
 
         @callback
         def update():


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When speedtest starts up, it would saturate the network interface and cause other
integrations to randomly fail to setup. We now wait to do the first speed test
until after the started event is fired.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
