### PR TITLE
Add ValueType.SHORT to list of integer value types

### DIFF
--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -114,7 +114,7 @@ class ZWaveServices:
             if value.type == ValueType.STRING:
                 payload = selection
 
-            if value.type == ValueType.INT or value.type == ValueType.BYTE:
+            if value.type == ValueType.INT or value.type == ValueType.BYTE or value.type == ValueType.SHORT:
                 if selection > value.max or selection < value.min:
                     _LOGGER.error(
                         "Value %s out of range for parameter %s (Min: %s Max: %s)",

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -114,7 +114,11 @@ class ZWaveServices:
             if value.type == ValueType.STRING:
                 payload = selection
 
-            if value.type == ValueType.INT or value.type == ValueType.BYTE or value.type == ValueType.SHORT:
+            if (
+                value.type == ValueType.INT
+                or value.type == ValueType.BYTE
+                or value.type == ValueType.SHORT
+            ):
                 if selection > value.max or selection < value.min:
                     _LOGGER.error(
                         "Value %s out of range for parameter %s (Min: %s Max: %s)",


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/38307
Depends on https://github.com/cgarwood/python-openzwave-mqtt/pull/81

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the SHORT integer value type and allows config parameters that use this type to be set. Also see additional information for bugs this resolves.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [-] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

Note: this change depends on merge and release of an updated version of openzwavemqtt:
https://github.com/cgarwood/python-openzwave-mqtt/pull/81

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38307
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed: N/A

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [-] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
Awaiting merge and release of https://github.com/cgarwood/python-openzwave-mqtt/pull/81
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
