### PR TITLE
Restore ability to set name from rfxtrx config

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -513,7 +513,7 @@ class RfxtrxCommandEntity(RfxtrxEntity):
     Contains the common logic for Rfxtrx lights and switches.
     """
 
-    def __init__(self, device, device_id, signal_repetitions=1, event=None, name=None):
+    def __init__(self, device, device_id, signal_repetitions=1, event=None):
         """Initialzie a switch or light device."""
         super().__init__(device, device_id, event=event)
         self.signal_repetitions = signal_repetitions

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DEVICES,
     CONF_HOST,
+    CONF_NAME,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
     POWER_WATT,
@@ -113,6 +114,7 @@ DEVICE_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_COMMAND_ON): cv.byte,
         vol.Optional(CONF_COMMAND_OFF): cv.byte,
         vol.Optional(CONF_SIGNAL_REPETITIONS, default=1): cv.positive_int,
+        vol.Optional(CONF_NAME): cv.string,
     }
 )
 
@@ -411,9 +413,12 @@ class RfxtrxEntity(RestoreEntity):
     Contains the common logic for Rfxtrx lights and switches.
     """
 
-    def __init__(self, device, device_id, event=None):
+    def __init__(self, device, device_id, event=None, name=None):
         """Initialize the device."""
-        self._name = f"{device.type_string} {device.id_string}"
+        if name:
+            self._name = name
+        else:
+            self._name = f"{device.type_string} {device.id_string}"
         self._device = device
         self._event = event
         self._device_id = device_id
@@ -481,9 +486,9 @@ class RfxtrxCommandEntity(RfxtrxEntity):
     Contains the common logic for Rfxtrx lights and switches.
     """
 
-    def __init__(self, device, device_id, signal_repetitions=1, event=None):
+    def __init__(self, device, device_id, signal_repetitions=1, event=None, name=None):
         """Initialzie a switch or light device."""
-        super().__init__(device, device_id, event=event)
+        super().__init__(device, device_id, event=event, name=name)
         self.signal_repetitions = signal_repetitions
         self._state = None
 

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -26,6 +26,7 @@ from . import (
     SIGNAL_EVENT,
     RfxtrxEntity,
     find_possible_pt2262_device,
+    force_entity_name,
     get_device_id,
     get_pt2262_cmd,
     get_rfx_object,
@@ -113,8 +114,13 @@ async def async_setup_entry(
             entity_info.get(CONF_DATA_BITS),
             entity_info.get(CONF_COMMAND_ON),
             entity_info.get(CONF_COMMAND_OFF),
-            name=entity_info.get(CONF_NAME),
         )
+
+        if entity_info.get(CONF_NAME):
+            await force_entity_name(
+                hass, "binary_sensor", device.unique_id, entity_info.get(CONF_NAME)
+            )
+
         sensors.append(device)
 
     async_add_entities(sensors)
@@ -164,10 +170,9 @@ class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):
         cmd_on=None,
         cmd_off=None,
         event=None,
-        name=None,
     ):
         """Initialize the RFXtrx sensor."""
-        super().__init__(device, device_id, event=event, name=name)
+        super().__init__(device, device_id, event=event)
         self._device_class = device_class
         self._data_bits = data_bits
         self._off_delay = off_delay

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_COMMAND_ON,
     CONF_DEVICE_CLASS,
     CONF_DEVICES,
+    CONF_NAME,
     STATE_ON,
 )
 from homeassistant.core import callback
@@ -112,6 +113,7 @@ async def async_setup_entry(
             entity_info.get(CONF_DATA_BITS),
             entity_info.get(CONF_COMMAND_ON),
             entity_info.get(CONF_COMMAND_OFF),
+            name=entity_info.get(CONF_NAME),
         )
         sensors.append(device)
 
@@ -162,9 +164,10 @@ class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):
         cmd_on=None,
         cmd_off=None,
         event=None,
+        name=None,
     ):
         """Initialize the RFXtrx sensor."""
-        super().__init__(device, device_id, event=event)
+        super().__init__(device, device_id, event=event, name=name)
         self._device_class = device_class
         self._data_bits = data_bits
         self._off_delay = off_delay

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -12,6 +12,7 @@ from . import (
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    force_entity_name,
     get_device_id,
     get_rfx_object,
 )
@@ -47,11 +48,14 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxCover(
-            event.device,
-            device_id,
-            entity_info[CONF_SIGNAL_REPETITIONS],
-            name=entity_info.get(CONF_NAME),
+            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS],
         )
+
+        if entity_info.get(CONF_NAME):
+            await force_entity_name(
+                hass, "cover", entity.unique_id, entity_info.get(CONF_NAME)
+            )
+
         entities.append(entity)
 
     async_add_entities(entities)
@@ -77,6 +81,7 @@ async def async_setup_entry(
         entity = RfxtrxCover(
             event.device, device_id, DEFAULT_SIGNAL_REPETITIONS, event=event
         )
+
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.cover import CoverEntity
-from homeassistant.const import CONF_DEVICES, STATE_OPEN
+from homeassistant.const import CONF_DEVICES, CONF_NAME, STATE_OPEN
 from homeassistant.core import callback
 
 from . import (
@@ -47,7 +47,10 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxCover(
-            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS]
+            event.device,
+            device_id,
+            entity_info[CONF_SIGNAL_REPETITIONS],
+            name=entity_info.get(CONF_NAME),
         )
         entities.append(entity)
 

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxCover(
-            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS],
+            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS]
         )
 
         if entity_info.get(CONF_NAME):
@@ -81,7 +81,6 @@ async def async_setup_entry(
         entity = RfxtrxCover(
             event.device, device_id, DEFAULT_SIGNAL_REPETITIONS, event=event
         )
-
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -60,7 +60,7 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxLight(
-            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS],
+            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS]
         )
 
         if entity_info.get(CONF_NAME):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -18,6 +18,7 @@ from . import (
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    force_entity_name,
     get_device_id,
     get_rfx_object,
 )
@@ -59,11 +60,13 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxLight(
-            event.device,
-            device_id,
-            entity_info[CONF_SIGNAL_REPETITIONS],
-            name=entity_info.get(CONF_NAME),
+            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS],
         )
+
+        if entity_info.get(CONF_NAME):
+            await force_entity_name(
+                hass, "light", entity.unique_id, entity_info.get(CONF_NAME)
+            )
 
         entities.append(entity)
 

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -8,7 +8,7 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS,
     LightEntity,
 )
-from homeassistant.const import CONF_DEVICES, STATE_ON
+from homeassistant.const import CONF_DEVICES, CONF_NAME, STATE_ON
 from homeassistant.core import callback
 
 from . import (
@@ -59,7 +59,10 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxLight(
-            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS]
+            event.device,
+            device_id,
+            entity_info[CONF_SIGNAL_REPETITIONS],
+            name=entity_info.get(CONF_NAME),
         )
 
         entities.append(entity)

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
 )
-from homeassistant.const import CONF_DEVICES
+from homeassistant.const import CONF_DEVICES, CONF_NAME
 from homeassistant.core import callback
 
 from . import (
@@ -82,7 +82,9 @@ async def async_setup_entry(
                 continue
             data_ids.add(data_id)
 
-            entity = RfxtrxSensor(event.device, device_id, data_type)
+            entity = RfxtrxSensor(
+                event.device, device_id, data_type, name=entity_info.get(CONF_NAME)
+            )
             entities.append(entity)
 
     async_add_entities(entities)
@@ -118,12 +120,15 @@ async def async_setup_entry(
 class RfxtrxSensor(RfxtrxEntity):
     """Representation of a RFXtrx sensor."""
 
-    def __init__(self, device, device_id, data_type, event=None):
+    def __init__(self, device, device_id, data_type, event=None, name=None):
         """Initialize the sensor."""
         super().__init__(device, device_id, event=event)
         self.data_type = data_type
         self._unit_of_measurement = DATA_TYPES.get(data_type, "")
-        self._name = f"{device.type_string} {device.id_string} {data_type}"
+        if name:
+            self._name = f"{name} {data_type}"
+        else:
+            self._name = f"{device.type_string} {device.id_string} {data_type}"
         self._unique_id = "_".join(x for x in (*self._device_id, data_type))
 
         self._device_class = DEVICE_CLASSES.get(data_type)

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -59,7 +59,7 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxSwitch(
-            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS],
+            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS]
         )
 
         if entity_info.get(CONF_NAME):

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -4,7 +4,7 @@ import logging
 import RFXtrx as rfxtrxmod
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import CONF_DEVICES, STATE_ON
+from homeassistant.const import CONF_DEVICES, CONF_NAME, STATE_ON
 from homeassistant.core import callback
 
 from . import (
@@ -58,7 +58,10 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxSwitch(
-            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS]
+            event.device,
+            device_id,
+            entity_info[CONF_SIGNAL_REPETITIONS],
+            name=entity_info.get(CONF_NAME),
         )
         entities.append(entity)
 

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -15,6 +15,7 @@ from . import (
     DOMAIN,
     SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    force_entity_name,
     get_device_id,
     get_rfx_object,
 )
@@ -58,11 +59,14 @@ async def async_setup_entry(
         device_ids.add(device_id)
 
         entity = RfxtrxSwitch(
-            event.device,
-            device_id,
-            entity_info[CONF_SIGNAL_REPETITIONS],
-            name=entity_info.get(CONF_NAME),
+            event.device, device_id, entity_info[CONF_SIGNAL_REPETITIONS],
         )
+
+        if entity_info.get(CONF_NAME):
+            await force_entity_name(
+                hass, "switch", entity.unique_id, entity_info.get(CONF_NAME)
+            )
+
         entities.append(entity)
 
     async_add_entities(entities)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Restore ability to set initial name of entities from config file to ease migration of previous configurations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
rfxtrx:
  automatic_add: True
  devices:
    0a14000101f20302010080:
      name: Dining Room Light
    0a14000000f20302010080:
      name: Livingroom Light
    0a14000202f20302010080:
      name: Bedroom Light
    0a14000104f20302010080:
      name: "Isabellas Bedroom Light"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This is a temporary measure to ease transitions into config entries and will go away once that transition is completed.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
