### PR TITLE
Remove AdGuard version check

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -1,5 +1,4 @@
 """Support for AdGuard Home."""
-from distutils.version import LooseVersion
 import logging
 from typing import Any, Dict
 
@@ -11,7 +10,6 @@ from homeassistant.components.adguard.const import (
     DATA_ADGUARD_CLIENT,
     DATA_ADGUARD_VERION,
     DOMAIN,
-    MIN_ADGUARD_HOME_VERSION,
     SERVICE_ADD_URL,
     SERVICE_DISABLE_URL,
     SERVICE_ENABLE_URL,
@@ -67,15 +65,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     hass.data.setdefault(DOMAIN, {})[DATA_ADGUARD_CLIENT] = adguard
 
     try:
-        version = await adguard.version()
+        await adguard.version()
     except AdGuardHomeConnectionError as exception:
         raise ConfigEntryNotReady from exception
-
-    if version and LooseVersion(MIN_ADGUARD_HOME_VERSION) > LooseVersion(version):
-        _LOGGER.error(
-            "This integration requires AdGuard Home v0.99.0 or higher to work correctly"
-        )
-        raise ConfigEntryNotReady
 
     for component in "sensor", "switch":
         hass.async_create_task(

--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -1,12 +1,11 @@
 """Config flow to configure the AdGuard Home integration."""
-from distutils.version import LooseVersion
 import logging
 
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.adguard.const import DOMAIN, MIN_ADGUARD_HOME_VERSION
+from homeassistant.components.adguard.const import DOMAIN
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import (
     CONF_HOST,
@@ -79,19 +78,10 @@ class AdGuardHomeFlowHandler(ConfigFlow):
         )
 
         try:
-            version = await adguard.version()
+            await adguard.version()
         except AdGuardHomeConnectionError:
             errors["base"] = "connection_error"
             return await self._show_setup_form(errors)
-
-        if version and LooseVersion(MIN_ADGUARD_HOME_VERSION) > LooseVersion(version):
-            return self.async_abort(
-                reason="adguard_home_outdated",
-                description_placeholders={
-                    "current_version": version,
-                    "minimal_version": MIN_ADGUARD_HOME_VERSION,
-                },
-            )
 
         return self.async_create_entry(
             title=user_input[CONF_HOST],
@@ -160,19 +150,10 @@ class AdGuardHomeFlowHandler(ConfigFlow):
         )
 
         try:
-            version = await adguard.version()
+            await adguard.version()
         except AdGuardHomeConnectionError:
             errors["base"] = "connection_error"
             return await self._show_hassio_form(errors)
-
-        if LooseVersion(MIN_ADGUARD_HOME_VERSION) > LooseVersion(version):
-            return self.async_abort(
-                reason="adguard_home_addon_outdated",
-                description_placeholders={
-                    "current_version": version,
-                    "minimal_version": MIN_ADGUARD_HOME_VERSION,
-                },
-            )
 
         return self.async_create_entry(
             title=self._hassio_discovery["addon"],

--- a/homeassistant/components/adguard/const.py
+++ b/homeassistant/components/adguard/const.py
@@ -7,8 +7,6 @@ DATA_ADGUARD_VERION = "adguard_version"
 
 CONF_FORCE = "force"
 
-MIN_ADGUARD_HOME_VERSION = "v0.99.0"
-
 SERVICE_ADD_URL = "add_url"
 SERVICE_DISABLE_URL = "disable_url"
 SERVICE_ENABLE_URL = "enable_url"

--- a/homeassistant/components/adguard/strings.json
+++ b/homeassistant/components/adguard/strings.json
@@ -19,8 +19,6 @@
     },
     "error": { "connection_error": "Failed to connect." },
     "abort": {
-      "adguard_home_outdated": "This integration requires AdGuard Home {minimal_version} or higher, you have {current_version}.",
-      "adguard_home_addon_outdated": "This integration requires AdGuard Home {minimal_version} or higher, you have {current_version}. Please update your Hass.io AdGuard Home add-on.",
       "existing_instance_updated": "Updated existing configuration.",
       "single_instance_allowed": "Only a single configuration of AdGuard Home is allowed."
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR removes a version check for the AdGuard Home integration. It was originally introduced around the era, AdGuard Home started introducing an API. Over a year has passed now, it should be safe to remove.

Furthermore, due to recent changes in the building process in AdGuard Home, recent versions of AdGuard Home can no longer use this integration (as of AdGuard Home 0.103.0+), because their version numbering changes. This changed version number, causes this check to fail and the integration to crash.

For people using the AdGuard Home add-on, the version is locked onto Home Assistant from the add-on end.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38112
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
