### PR TITLE
Intelligent timeout handler for setup/bootstrap

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -531,5 +531,5 @@ async def _async_set_up_integrations(
     try:
         async with hass.timeout.asnyc_timeout(300, cool_down=60):
             await hass.async_block_till_done()
-        except asyncio.TimeoutError:
-            _LOGGER.warning("Setup timeout on bootstrap - moving forward")
+    except asyncio.TimeoutError:
+        _LOGGER.warning("Setup timeout on bootstrap - moving forward")

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -495,10 +495,12 @@ async def _async_set_up_integrations(
     stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
 
     # Kick off loading the registries. They don't need to be awaited.
-    asyncio.gather(
-        hass.helpers.device_registry.async_get_registry(),
-        hass.helpers.entity_registry.async_get_registry(),
-        hass.helpers.area_registry.async_get_registry(),
+    asyncio.create_task(
+        (
+            hass.helpers.device_registry.async_get_registry(),
+            hass.helpers.entity_registry.async_get_registry(),
+            hass.helpers.area_registry.async_get_registry(),
+        )
     )
 
     # Start setup

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -507,7 +507,7 @@ async def _async_set_up_integrations(
     if stage_1_domains:
         _LOGGER.info("Setting up stage 1: %s", stage_1_domains)
         try:
-            async with hass.timeout.asnyc_timeout(120, cool_down=60):
+            async with hass.timeout.async_timeout(120, cool_down=60):
                 await async_setup_multi_components(
                     hass, stage_1_domains, config, setup_started
                 )
@@ -520,7 +520,7 @@ async def _async_set_up_integrations(
     if stage_2_domains:
         _LOGGER.info("Setting up stage 2: %s", stage_2_domains)
         try:
-            async with hass.timeout.asnyc_timeout(300, cool_down=60):
+            async with hass.timeout.async_timeout(300, cool_down=60):
                 await async_setup_multi_components(
                     hass, stage_2_domains, config, setup_started
                 )
@@ -530,7 +530,7 @@ async def _async_set_up_integrations(
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
     try:
-        async with hass.timeout.asnyc_timeout(300, cool_down=60):
+        async with hass.timeout.async_timeout(300, cool_down=60):
             await hass.async_block_till_done()
     except asyncio.TimeoutError:
         _LOGGER.warning("Setup timeout on bootstrap - moving forward")

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -515,7 +515,7 @@ async def _async_set_up_integrations(
                     hass, stage_1_domains, config, setup_started
                 )
         except asyncio.TimeoutError:
-            _LOGGER.warning("Setup timeout on stage 1 - moving forward")
+            _LOGGER.warning("Setup timed out for stage 1 - moving forward")
 
     # Enables after dependencies
     async_set_domains_to_be_loaded(hass, stage_1_domains | stage_2_domains)
@@ -530,7 +530,7 @@ async def _async_set_up_integrations(
                     hass, stage_2_domains, config, setup_started
                 )
         except asyncio.TimeoutError:
-            _LOGGER.warning("Setup timeout on stage 2 - moving forward")
+            _LOGGER.warning("Setup timed out for stage 2 - moving forward")
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
@@ -538,4 +538,4 @@ async def _async_set_up_integrations(
         async with hass.timeout.async_timeout(WRAP_UP_TIMEOUT, cool_down=COOLDOWN_TIME):
             await hass.async_block_till_done()
     except asyncio.TimeoutError:
-        _LOGGER.warning("Setup timeout on bootstrap - moving forward")
+        _LOGGER.warning("Setup timed out for bootstrap - moving forward")

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -9,7 +9,6 @@ import sys
 from time import monotonic
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set
 
-from async_timeout import timeout
 import voluptuous as vol
 import yarl
 
@@ -136,7 +135,7 @@ async def async_setup_hass(
         hass.async_track_tasks()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP, {})
         with contextlib.suppress(asyncio.TimeoutError):
-            async with timeout(10):
+            async with hass.timeout.async_timeout(10):
                 await hass.async_block_till_done()
 
         safe_mode = True

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -495,13 +495,9 @@ async def _async_set_up_integrations(
     stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
 
     # Kick off loading the registries. They don't need to be awaited.
-    asyncio.create_task(
-        (
-            hass.helpers.device_registry.async_get_registry(),
-            hass.helpers.entity_registry.async_get_registry(),
-            hass.helpers.area_registry.async_get_registry(),
-        )
-    )
+    asyncio.create_task(hass.helpers.device_registry.async_get_registry())
+    asyncio.create_task(hass.helpers.entity_registry.async_get_registry())
+    asyncio.create_task(hass.helpers.area_registry.async_get_registry())
 
     # Start setup
     if stage_1_domains:

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -43,6 +43,11 @@ DATA_LOGGING = "logging"
 
 LOG_SLOW_STARTUP_INTERVAL = 60
 
+STAGE_1_TIMEOUT = 120
+STAGE_2_TIMEOUT = 300
+WRAP_UP_TIMEOUT = 300
+COOLDOWN_TIME = 60
+
 DEBUGGER_INTEGRATIONS = {"debugpy", "ptvsd"}
 CORE_INTEGRATIONS = ("homeassistant", "persistent_notification")
 LOGGING_INTEGRATIONS = {
@@ -503,7 +508,9 @@ async def _async_set_up_integrations(
     if stage_1_domains:
         _LOGGER.info("Setting up stage 1: %s", stage_1_domains)
         try:
-            async with hass.timeout.async_timeout(120, cool_down=60):
+            async with hass.timeout.async_timeout(
+                STAGE_1_TIMEOUT, cool_down=COOLDOWN_TIME
+            ):
                 await async_setup_multi_components(
                     hass, stage_1_domains, config, setup_started
                 )
@@ -516,7 +523,9 @@ async def _async_set_up_integrations(
     if stage_2_domains:
         _LOGGER.info("Setting up stage 2: %s", stage_2_domains)
         try:
-            async with hass.timeout.async_timeout(300, cool_down=60):
+            async with hass.timeout.async_timeout(
+                STAGE_2_TIMEOUT, cool_down=COOLDOWN_TIME
+            ):
                 await async_setup_multi_components(
                     hass, stage_2_domains, config, setup_started
                 )
@@ -526,7 +535,7 @@ async def _async_set_up_integrations(
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
     try:
-        async with hass.timeout.async_timeout(300, cool_down=60):
+        async with hass.timeout.async_timeout(WRAP_UP_TIMEOUT, cool_down=COOLDOWN_TIME):
             await hass.async_block_till_done()
     except asyncio.TimeoutError:
         _LOGGER.warning("Setup timeout on bootstrap - moving forward")

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -35,13 +35,11 @@ from homeassistant.helpers.typing import ConfigType
 import homeassistant.util.dt as dt_util
 
 from . import migration, purge
-from .const import DATA_INSTANCE, SQLITE_URL_PREFIX
+from .const import DATA_INSTANCE, DOMAIN, SQLITE_URL_PREFIX
 from .models import Base, Events, RecorderRuns, States
 from .util import session_scope, validate_or_move_away_sqlite_database
 
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "recorder"
 
 SERVICE_PURGE = "purge"
 

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -2,3 +2,4 @@
 
 DATA_INSTANCE = "recorder_instance"
 SQLITE_URL_PREFIX = "sqlite://"
+DOMAIN = "recorder"

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1,6 +1,5 @@
 """Schema migration helpers."""
 import logging
-import os
 
 from sqlalchemy import Table, text
 from sqlalchemy.engine import reflection
@@ -36,7 +35,7 @@ def migrate_schema(instance):
             "Database is about to upgrade. Schema version: %s", current_version
         )
 
-        with instance.hass.timeout.freeze(zone_name=DOMAIN):
+        with instance.hass.timeout.freeze(DOMAIN):
             for version in range(current_version, SCHEMA_VERSION):
                 new_version = version + 1
                 _LOGGER.info("Upgrading recorder db schema to version %s", new_version)

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -8,15 +8,13 @@ from sqlalchemy.exc import InternalError, OperationalError, SQLAlchemyError
 
 from .models import SCHEMA_VERSION, Base, SchemaChanges
 from .util import session_scope
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-PROGRESS_FILE = ".migration_progress"
 
 
 def migrate_schema(instance):
     """Check if the schema needs to be upgraded."""
-    progress_path = instance.hass.config.path(PROGRESS_FILE)
-
     with session_scope(session=instance.get_session()) as session:
         res = (
             session.query(SchemaChanges)
@@ -32,20 +30,13 @@ def migrate_schema(instance):
             )
 
         if current_version == SCHEMA_VERSION:
-            # Clean up if old migration left file
-            if os.path.isfile(progress_path):
-                _LOGGER.warning("Found existing migration file, cleaning up")
-                os.remove(instance.hass.config.path(PROGRESS_FILE))
             return
-
-        with open(progress_path, "w"):
-            pass
 
         _LOGGER.warning(
             "Database is about to upgrade. Schema version: %s", current_version
         )
 
-        try:
+        with instance.hass.timeout.freeze(zone_name=DOMAIN):
             for version in range(current_version, SCHEMA_VERSION):
                 new_version = version + 1
                 _LOGGER.info("Upgrading recorder db schema to version %s", new_version)
@@ -53,8 +44,6 @@ def migrate_schema(instance):
                 session.add(SchemaChanges(schema_version=new_version))
 
                 _LOGGER.info("Upgrade to version %s done", new_version)
-        finally:
-            os.remove(instance.hass.config.path(PROGRESS_FILE))
 
 
 def _create_index(engine, table_name, index_name):

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -5,9 +5,9 @@ from sqlalchemy import Table, text
 from sqlalchemy.engine import reflection
 from sqlalchemy.exc import InternalError, OperationalError, SQLAlchemyError
 
+from .const import DOMAIN
 from .models import SCHEMA_VERSION, Base, SchemaChanges
 from .util import session_scope
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -450,7 +450,7 @@ class HomeAssistant:
             async with self.timeout.async_timeout(120):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
-            _LOGGER.warning("Move hard forward after stage 1 shutodwn")
+            _LOGGER.warning("Timed out waiting for shutdown stage 1 to complete, the shutdown will continue")
 
         # stage 2
         self.state = CoreState.final_write

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -35,7 +35,6 @@ from typing import (
 )
 import uuid
 
-from async_timeout import timeout
 import attr
 import voluptuous as vol
 import yarl

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -185,12 +185,12 @@ class HomeAssistant:
         self.helpers = loader.Helpers(self)
         # This is a dictionary that any component can store any data on.
         self.data: dict = {}
-        self.state = CoreState.not_running
-        self.exit_code = 0
+        self.state: CoreState = CoreState.not_running
+        self.exit_code: int = 0
         # If not None, use to signal end-of-loop
         self._stopped: Optional[asyncio.Event] = None
         # Timeout handler for Core/Helper namespace
-        self.timeout = ZoneTimeout()
+        self.timeout: ZoneTimeout = ZoneTimeout()
 
     @property
     def is_running(self) -> bool:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -450,7 +450,9 @@ class HomeAssistant:
             async with self.timeout.async_timeout(120):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
-            _LOGGER.warning("Timed out waiting for shutdown stage 1 to complete, the shutdown will continue")
+            _LOGGER.warning(
+                "Timed out waiting for shutdown stage 1 to complete, the shutdown will continue"
+            )
 
         # stage 2
         self.state = CoreState.final_write
@@ -459,7 +461,9 @@ class HomeAssistant:
             async with self.timeout.async_timeout(60):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
-            _LOGGER.warning("Timed out waiting for shutdown stage 2 to complete, the shutdown will continue")
+            _LOGGER.warning(
+                "Timed out waiting for shutdown stage 2 to complete, the shutdown will continue"
+            )
 
         # stage 3
         self.state = CoreState.not_running
@@ -468,7 +472,9 @@ class HomeAssistant:
             async with self.timeout.async_timeout(30):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
-            _LOGGER.warning("Timed out waiting for shutdown stage 3 to complete, the shutdown will continue")
+            _LOGGER.warning(
+                "Timed out waiting for shutdown stage 3 to complete, the shutdown will continue"
+            )
 
         # Python 3.9+ and backported in runner.py
         await self.loop.shutdown_default_executor()  # type: ignore

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -76,6 +76,7 @@ from homeassistant.util import location, network
 from homeassistant.util.async_ import fire_coroutine_threadsafe, run_callback_threadsafe
 import homeassistant.util.dt as dt_util
 from homeassistant.util.thread import fix_threading_exception_logging
+from homeassistant.util.timeout import ZoneTimeout
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 # Typing imports that create a circular dependency
@@ -188,6 +189,8 @@ class HomeAssistant:
         self.exit_code = 0
         # If not None, use to signal end-of-loop
         self._stopped: Optional[asyncio.Event] = None
+        # Timeout handler for Core/Helper namespace
+        self.timeout = ZoneTimeout()
 
     @property
     def is_running(self) -> bool:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -459,7 +459,7 @@ class HomeAssistant:
             async with self.timeout.async_timeout(60):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
-            _LOGGER.warning("Move hard forward after stage 2 shutodwn")
+            _LOGGER.warning("Timed out waiting for shutdown stage 2 to complete, the shutdown will continue")
 
         # stage 3
         self.state = CoreState.not_running

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -468,7 +468,7 @@ class HomeAssistant:
             async with self.timeout.async_timeout(30):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
-            _LOGGER.warning("Move hard forward after stage 3 shutodwn")
+            _LOGGER.warning("Timed out waiting for shutdown stage 3 to complete, the shutdown will continue")
 
         # Python 3.9+ and backported in runner.py
         await self.loop.shutdown_default_executor()  # type: ignore

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -75,7 +75,7 @@ from homeassistant.util import location, network
 from homeassistant.util.async_ import fire_coroutine_threadsafe, run_callback_threadsafe
 import homeassistant.util.dt as dt_util
 from homeassistant.util.thread import fix_threading_exception_logging
-from homeassistant.util.timeout import ZoneTimeout
+from homeassistant.util.timeout import TimeoutManager
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 # Typing imports that create a circular dependency
@@ -189,7 +189,7 @@ class HomeAssistant:
         # If not None, use to signal end-of-loop
         self._stopped: Optional[asyncio.Event] = None
         # Timeout handler for Core/Helper namespace
-        self.timeout: ZoneTimeout = ZoneTimeout()
+        self.timeout: TimeoutManager = TimeoutManager()
 
     @property
     def is_running(self) -> bool:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -448,7 +448,7 @@ class HomeAssistant:
         self.async_track_tasks()
         self.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         try:
-            async with self.timeout.asnyc_timeout(120):
+            async with self.timeout.async_timeout(120):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
             _LOGGER.warning("Move hard forward after stage 1 shutodwn")
@@ -457,7 +457,7 @@ class HomeAssistant:
         self.state = CoreState.final_write
         self.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
         try:
-            async with self.timeout.asnyc_timeout(60):
+            async with self.timeout.async_timeout(60):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
             _LOGGER.warning("Move hard forward after stage 2 shutodwn")
@@ -466,7 +466,7 @@ class HomeAssistant:
         self.state = CoreState.not_running
         self.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
         try:
-            async with self.timeout.asnyc_timeout(30):
+            async with self.timeout.async_timeout(30):
                 await self.async_block_till_done()
         except asyncio.TimeoutError:
             _LOGGER.warning("Move hard forward after stage 3 shutodwn")

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -177,7 +177,8 @@ class EntityPlatform:
         try:
             task = async_create_setup_task()
 
-            await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)
+            async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, self.domain):
+                await asyncio.shield(task)
 
             # Block till all entities are done
             if self._tasks:

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -122,11 +122,11 @@ async def async_process_requirements(
             if pkg_util.is_installed(req):
                 continue
 
-            def _install(hass: HomeAssistant, req: str, kwargs: Dict) -> bool:
+            def _install(req: str, kwargs: Dict) -> bool:
                 """Install requirement."""
                 return pkg_util.install_package(req, **kwargs)
 
-            ret = await hass.async_add_executor_job(_install, hass, req, kwargs)
+            ret = await hass.async_add_executor_job(_install, req, kwargs)
 
             if not ret:
                 raise RequirementsNotFound(name, [req])

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -2,7 +2,6 @@
 import asyncio
 import logging
 import os
-from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
 
 from homeassistant.core import HomeAssistant
@@ -14,7 +13,6 @@ DATA_PIP_LOCK = "pip_lock"
 DATA_PKG_CACHE = "pkg_cache"
 DATA_INTEGRATIONS_WITH_REQS = "integrations_with_reqs"
 CONSTRAINT_FILE = "package_constraints.txt"
-PROGRESS_FILE = ".pip_progress"
 _LOGGER = logging.getLogger(__name__)
 DISCOVERY_INTEGRATIONS: Dict[str, Iterable[str]] = {
     "ssdp": ("ssdp",),
@@ -124,20 +122,14 @@ async def async_process_requirements(
             if pkg_util.is_installed(req):
                 continue
 
+            def _install(hass: HomeAssistant, req: str, kwargs: Dict) -> bool:
+                """Install requirement."""
+                return pkg_util.install_package(req, **kwargs)
+
             ret = await hass.async_add_executor_job(_install, hass, req, kwargs)
 
             if not ret:
                 raise RequirementsNotFound(name, [req])
-
-
-def _install(hass: HomeAssistant, req: str, kwargs: Dict) -> bool:
-    """Install requirement."""
-    progress_path = Path(hass.config.path(PROGRESS_FILE))
-    progress_path.touch()
-    try:
-        return pkg_util.install_package(req, **kwargs)
-    finally:
-        progress_path.unlink()
 
 
 def pip_kwargs(config_dir: Optional[str]) -> Dict[str, Any]:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -191,9 +191,7 @@ async def _async_setup_component(
             return False
 
         async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, zone_name=domain):
-            # TODO: swap this back out when we figure out
-            # why changing it to await is breaking lots of tests
-            result = await asyncio.wait_for(task, SLOW_SETUP_MAX_WAIT)
+            result = await task
     except asyncio.TimeoutError:
         _LOGGER.error(
             "Setup of %s is taking longer than %s seconds."

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -22,11 +22,7 @@ DATA_SETUP = "setup_tasks"
 DATA_DEPS_REQS = "deps_reqs_processed"
 
 SLOW_SETUP_WARNING = 10
-
-# Since its possible for databases to be
-# upwards of 36GiB (or larger) in the wild
-# we wait up to 3 hours for startup
-SLOW_SETUP_MAX_WAIT = 10800
+SLOW_SETUP_MAX_WAIT = 180
 
 
 @core.callback

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -190,7 +190,7 @@ async def _async_setup_component(
             hass.data[DATA_SETUP_STARTED].pop(domain)
             return False
 
-        async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, zone_name=domain):
+        async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, domain):
             result = await task
     except asyncio.TimeoutError:
         _LOGGER.error(

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -191,7 +191,7 @@ async def _async_setup_component(
             hass.data[DATA_SETUP_STARTED].pop(domain)
             return False
 
-        async with hass.timeout.asnyc_timeout(SLOW_SETUP_MAX_WAIT, zone_name=domain):
+        async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, zone_name=domain):
             result = await task
     except asyncio.TimeoutError:
         _LOGGER.error(

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -191,7 +191,9 @@ async def _async_setup_component(
             return False
 
         async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, zone_name=domain):
-            result = await task
+            # TODO: swap this back out when we figure out
+            # why changing it to await is breaking lots of tests
+            result = await asyncio.wait_for(task, SLOW_SETUP_MAX_WAIT)
     except asyncio.TimeoutError:
         _LOGGER.error(
             "Setup of %s is taking longer than %s seconds."

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -321,9 +321,10 @@ async def async_process_deps_reqs(
         raise HomeAssistantError("Could not set up all dependencies.")
 
     if not hass.config.skip_pip and integration.requirements:
-        await requirements.async_get_integration_with_requirements(
-            hass, integration.domain
-        )
+        async with hass.timeout.freeze(zone_name=integration.domain):
+            await requirements.async_get_integration_with_requirements(
+                hass, integration.domain
+            )
 
     processed.add(integration.domain)
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -85,10 +85,7 @@ async def _async_process_dependencies(
         return True
 
     _LOGGER.debug("Dependency %s will wait for %s", integration.domain, list(tasks))
-    if integration.domain in hass.timeout.zones:
-        async with hass.timeout.freeze(integration.domain):
-            results = await asyncio.gather(*tasks.values())
-    else:
+    async with hass.timeout.freeze(integration.domain):
         results = await asyncio.gather(*tasks.values())
 
     failed = [

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -85,7 +85,10 @@ async def _async_process_dependencies(
         return True
 
     _LOGGER.debug("Dependency %s will wait for %s", integration.domain, list(tasks))
-    async with hass.timeout.freeze(integration.domain):
+    if integration.domain in hass.timeout.zones:
+        async with hass.timeout.freeze(integration.domain):
+            results = await asyncio.gather(*tasks.values())
+    else:
         results = await asyncio.gather(*tasks.values())
 
     failed = [

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -317,12 +317,7 @@ async def async_process_deps_reqs(
         raise HomeAssistantError("Could not set up all dependencies.")
 
     if not hass.config.skip_pip and integration.requirements:
-        if integration.domain in hass.timeout.zones:
-            async with hass.timeout.async_freeze(integration.domain):
-                await requirements.async_get_integration_with_requirements(
-                    hass, integration.domain
-                )
-        else:
+        async with hass.timeout.async_freeze(integration.domain):
             await requirements.async_get_integration_with_requirements(
                 hass, integration.domain
             )

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -190,7 +190,8 @@ async def _async_setup_component(
             hass.data[DATA_SETUP_STARTED].pop(domain)
             return False
 
-        result = await asyncio.wait_for(task, SLOW_SETUP_MAX_WAIT)
+        async with hass.timeout.asnyc_timeout(SLOW_SETUP_MAX_WAIT, zone_name=domain):
+            result = await task
     except asyncio.TimeoutError:
         _LOGGER.error(
             "Setup of %s is taking longer than %s seconds."

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -85,7 +85,7 @@ async def _async_process_dependencies(
         return True
 
     _LOGGER.debug("Dependency %s will wait for %s", integration.domain, list(tasks))
-    async with hass.timeout.freeze(integration.domain):
+    async with hass.timeout.async_freeze(integration.domain):
         results = await asyncio.gather(*tasks.values())
 
     failed = [
@@ -318,7 +318,7 @@ async def async_process_deps_reqs(
 
     if not hass.config.skip_pip and integration.requirements:
         if integration.domain in hass.timeout.zones:
-            async with hass.timeout.freeze(integration.domain):
+            async with hass.timeout.async_freeze(integration.domain):
                 await requirements.async_get_integration_with_requirements(
                     hass, integration.domain
                 )

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -89,7 +89,8 @@ async def _async_process_dependencies(
         return True
 
     _LOGGER.debug("Dependency %s will wait for %s", integration.domain, list(tasks))
-    results = await asyncio.gather(*tasks.values())
+    async with hass.timeout.freeze(zone_name=integration.domain):
+        results = await asyncio.gather(*tasks.values())
 
     failed = [
         domain

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -89,7 +89,7 @@ async def _async_process_dependencies(
         return True
 
     _LOGGER.debug("Dependency %s will wait for %s", integration.domain, list(tasks))
-    async with hass.timeout.freeze(zone_name=integration.domain):
+    async with hass.timeout.freeze(integration.domain):
         results = await asyncio.gather(*tasks.values())
 
     failed = [
@@ -321,7 +321,7 @@ async def async_process_deps_reqs(
         raise HomeAssistantError("Could not set up all dependencies.")
 
     if not hass.config.skip_pip and integration.requirements:
-        async with hass.timeout.freeze(zone_name=integration.domain):
+        async with hass.timeout.freeze(integration.domain):
             await requirements.async_get_integration_with_requirements(
                 hass, integration.domain
             )

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -22,7 +22,7 @@ DATA_SETUP = "setup_tasks"
 DATA_DEPS_REQS = "deps_reqs_processed"
 
 SLOW_SETUP_WARNING = 10
-SLOW_SETUP_MAX_WAIT = 180
+SLOW_SETUP_MAX_WAIT = 300
 
 
 @core.callback

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -320,7 +320,12 @@ async def async_process_deps_reqs(
         raise HomeAssistantError("Could not set up all dependencies.")
 
     if not hass.config.skip_pip and integration.requirements:
-        async with hass.timeout.freeze(integration.domain):
+        if integration.domain in hass.timeout.zones:
+            async with hass.timeout.freeze(integration.domain):
+                await requirements.async_get_integration_with_requirements(
+                    hass, integration.domain
+                )
+        else:
             await requirements.async_get_integration_with_requirements(
                 hass, integration.domain
             )

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -20,6 +20,21 @@ class _State(str, enum.Enum):
     FREEZE = "FREEZE"
 
 
+class _FreezeNull:
+    """An empty freeze for when no timeout is set for a zone and we request a freeze.
+    
+     This should only happen in tests.
+     """
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> Optional[bool]:
+        return None
+
+    async def __aenter__(self) -> _FreezeNull:
+        return self
 class _FreezeGlobal:
     """Internal Freeze Context Manager object for Global."""
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -168,7 +168,7 @@ class _TaskGlobal:
         if exc_type is asyncio.CancelledError and self.state == _State.TIMEOUT:
             raise asyncio.TimeoutError
 
-        self._state == _State.EXIT
+        self._state = _State.EXIT
         self._wait_zone.set()
         return None
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -106,7 +106,7 @@ class _FreezeZone:
     """Internal Freeze Context Manager object for Zone."""
 
     def __init__(self, zone: _Zone, loop: asyncio.AbstractEventLoop) -> None:
-        """Initalize internal timeout context manager."""
+        """Initialize internal timeout context manager."""
         self._loop: asyncio.AbstractEventLoop = loop
         self._zone: _Zone = zone
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -388,7 +388,7 @@ class ZoneTimeout:
     @property
     def freezes_done(self) -> bool:
         """Return True if all freezes are finish."""
-        return not bool(self._freezes)
+        return not self._freezes
 
     @property
     def zones(self) -> Dict[str, _Zone]:

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -12,7 +12,7 @@ class _State(str, enum.Enum):
     """States of a Zone."""
 
     INIT = "INIT"
-    ENTER = "ENTER"
+    ACTIVE = "ACTIVE"
     TIMEOUT = "TIMEOUT"
     EXIT = "EXIT"
     FREEZE = "FREEZE"
@@ -156,7 +156,7 @@ class _TaskGlobal:
     async def __aenter__(self) -> _TaskGlobal:
         self._manager.global_tasks.append(self)
         self._start_timer()
-        self._state = _State.ENTER
+        self._state = _State.ACTIVE
         return self
 
     async def __aexit__(
@@ -304,7 +304,7 @@ class _Zone:
         """Start into new Task."""
         if self.state == _State.TIMEOUT:
             raise asyncio.TimeoutError
-        elif self.state != _State.ENTER:
+        elif self.state != _State.ACTIVE:
             self._start_timer()
 
         self._count += 1
@@ -330,7 +330,7 @@ class _Zone:
 
     def _start_timer(self) -> None:
         """Start timeout handler."""
-        self._state = _State.ENTER
+        self._state = _State.ACTIVE
         self._time = self._loop.time() + self._timeout
         self._timeout_handler = self._loop.call_at(self._time, self._on_timeout)
 
@@ -357,7 +357,7 @@ class _Zone:
 
     def pause(self) -> None:
         """Stop timers while it freeze."""
-        if self._state != _State.ENTER:
+        if self._state != _State.ACTIVE:
             return
         self._state = _State.FREEZE
         self._stop_timer()
@@ -366,7 +366,7 @@ class _Zone:
         """Reset timer after freeze."""
         if self._state != _State.FREEZE:
             return
-        self._state = _State.ENTER
+        self._state = _State.ACTIVE
         self._start_timer()
 
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -159,7 +159,7 @@ class _TaskGlobal:
         timeout: float,
         cool_down: float,
     ) -> None:
-        """Initalize internal timeout context manager."""
+        """Initialize internal timeout context manager."""
         self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         self._manager: ZoneTimeout = manager
         self._task: asyncio.Task[Any] = task

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Union, Type, Optional
 from types import TracebackType
 
 ZONE_GLOBAL = "global"
+COOL_DOWN = 1
 
 
 class _State(str, enum.Enum):
@@ -223,7 +224,7 @@ class _TaskGlobal:
     async def _on_wait(self) -> None:
         """Wait until zones are done."""
         await self._wait_zone.wait()
-        await asyncio.sleep(0)  # Allow context switch
+        await asyncio.sleep(COOL_DOWN)  # Allow context switch
         if not self.state == _State.TIMEOUT:
             return
         self._cancel_task()

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -1,0 +1,313 @@
+"""Zone based timeout handling."""
+from __future__ import annotations
+import asyncio
+import enum
+from typing import Any, Dict, List, Union, Type, TracebackType, Optional
+
+ZONE_ALL = "all"
+
+
+class _StateZone(enum.Enum, str):
+    INIT = "INIT"
+    ENTER = "ENTER"
+    TIMEOUT = "TIMEOUT"
+    EXIT = "EXIT"
+
+
+class _Freeze:
+    """Internal Freeze Context Manager object."""
+
+    def __init__(self, manager: ZoneTimeout, loop: asyncio.AbstractEventLoop) -> None:
+        """Initalize internal timeout context manager."""
+        self._loop: asyncio.AbstractEventLoop = loop
+        self._manager: ZoneTimeout = manager
+
+    async def __aenter__(self) -> _Freeze:
+        self._enter()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> Optional[bool]:
+        self._exit()
+        return None
+
+    def __enter__(self) -> _Freeze:
+        self._loop.call_soon_threadsafe(self._enter)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> Optional[bool]:
+        self._loop.call_soon_threadsafe(self._exit)
+
+    def _enter(self) -> None:
+        """Run freeze."""
+        if self._manager.freezes_done:
+            # Zones & Global reset
+            for zone in self._manager.zones:
+                zone.stop()
+            for task in self._manager.global_tasks:
+                task.stop()
+
+        self._manager.freezes.append(self)
+
+    def _exit(self) -> None:
+        """Finish freeze."""
+        self._manager.freezes.pop(self, None)
+        if not self._manager.freezes_done:
+            return
+
+        # Zones & Global reset
+        for zone in self._manager.zones:
+            zone.reset()
+        for task in self._manager.global_tasks:
+            task.reset()
+
+
+class _TaskGlobal:
+    """Internal Timeout Context Manager object for ALL Zones."""
+
+    def __init__(
+        self, manager: ZoneTimeout, task: asyncio.Task[Any], timeout: float
+    ) -> None:
+        """Initalize internal timeout context manager."""
+        self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        self._manager: ZoneTimeout = manager
+        self._task: asyncio.Task[Any] = task
+        self._timeout: float = timeout
+        self._timeout_handler: Optional[asyncio.Handle] = None
+
+    async def __aenter__(self) -> _TaskGlobal:
+        self._manager.global_tasks.append(self)
+        self._start_timer()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> Optional[bool]:
+        self._stop_timer()
+        self._manager.global_tasks.pop(self, None)
+        if exc_type is asyncio.CancelledError:
+            raise asyncio.TimeoutError
+
+        return None
+
+    def _start_timer(self, timeout: Optional[float] = None) -> None:
+        """Start timeout handler."""
+        timeout = timeout or self._timeout
+        self._timeout_handler = self._loop.call_at(
+            self._loop.time() + timeout, self._on_timeout
+        )
+
+    def _stop_timer(self) -> None:
+        """Stop zone timer."""
+        if self._timeout_handler is None:
+            return
+        self._timeout_handler.cancel()
+        self._timeout_handler = None
+
+    def _on_timeout(self) -> None:
+        """Process timeout."""
+        self._timeout_handler = None
+
+        # Reset timer if zones are running
+        if not self._manager.zones_done:
+            self._start_timer(30)
+
+        # Cancel task
+        if self._task.done():
+            return
+        self._task.cancel()
+
+    def stop(self) -> None:
+        """Stop timers while it freeze."""
+        self._stop_timer()
+
+    def reset(self) -> None:
+        """Reset timer after freeze."""
+        self._start_timer()
+
+
+class _TaskZone:
+    """Internal Timeout Context Manager object for Task."""
+
+    def __init__(self, zone: _Zone, task: asyncio.Task[Any]) -> None:
+        """Initalize internal timeout context manager."""
+        self._zone: _Zone = zone
+        self._task: asyncio.Task[Any] = task
+
+    def done(self) -> bool:
+        """Return True if the task is done."""
+        return self._task.done()
+
+    def cancel(self) -> None:
+        """Cancel a running task."""
+        self._task.canel()
+
+    async def __aenter__(self) -> _TaskZone:
+        self._zone.enter_task(self)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> Optional[bool]:
+        self._zone.exit_task(self, exc_type)
+        return None
+
+
+class _Zone:
+    """Internal Timeout Context Manager object."""
+
+    def __init__(self, manager: ZoneTimeout, zone: str, timeout: float) -> None:
+        """Initalize internal timeout context manager."""
+        self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        self._manager: ZoneTimeout = manager
+        self._zone: str = zone
+        self._tasks: List[_TaskZone] = []
+        self._timeout: float = timeout
+        self._state: _StateZone = _StateZone.INIT
+        self._count: int = 0
+        self._timeout_handler: Optional[asyncio.Handle] = None
+
+    @property
+    def name(self) -> str:
+        """Return Zone name."""
+        return self._zone
+
+    @property
+    def state(self) -> _StateZone:
+        """Return state of the Zone."""
+
+    def enter_task(self, task: _TaskZone) -> None:
+        """Start into new Task."""
+        if self.state == _StateZone.TIMEOUT:
+            raise asyncio.TimeoutError
+        elif self.state != _StateZone.ENTER:
+            self._start_timer()
+
+        self._count += 1
+        self._tasks.append(task)
+
+    def exit_task(self, task: _TaskZone, exc_type: Type[BaseException]) -> None:
+        """Exit a running Task."""
+        self._count -= 1
+
+        if exc_type is asyncio.CancelledError and self.state == _StateZone.TIMEOUT:
+            if self._count == 0:
+                self._manager.zones.pop(self.name, None)
+            raise asyncio.TimeoutError
+
+        # On latest listener
+        if self._count == 0 and self.state != _StateZone.EXIT:
+            self._state = _StateZone.EXIT
+            self._stop_timer()
+            self._manager.zones.pop(self.name, None)
+
+        self._tasks.pop(task)
+
+    def _start_timer(self) -> None:
+        """Start timeout handler."""
+        self._state = _StateZone.ENTER
+        self._timeout_handler = self._loop.call_at(
+            self._loop.timer() + self._timeout, self._on_timeout
+        )
+
+    def _stop_timer(self) -> None:
+        """Stop zone timer."""
+        if self._timeout_handler is None:
+            return
+        self._timeout_handler.cancel()
+        self._timeout_handler = None
+
+    def _on_timeout(self) -> None:
+        """Process timeout."""
+        self._state = _StateZone.TIMEOUT
+
+        # Cancel all running tasks
+        for task in self._tasks:
+            if task.done():
+                continue
+            task.cancel()
+
+    def stop(self) -> None:
+        """Stop timers while it freeze."""
+        self._stop_timer()
+
+    def reset(self) -> None:
+        """Reset timer after freeze."""
+        self._start_timer()
+
+
+class ZoneTimeout:
+    """Async zone based timeout handler."""
+
+    def __init__(self):
+        """Initalize ZoneTimeout handler."""
+        self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        self._zones: Dict[str, _Zone] = {}
+        self._globals: List[_TaskGlobal] = []
+        self._freezes: List[_Freeze] = []
+
+    @property
+    def zones_done(self) -> bool:
+        """Return True if all zones are finish."""
+        return not bool(self._zones)
+
+    @property
+    def freezes_done(self) -> bool:
+        """Return True if all freezes are finish."""
+        return not bool(self._freezes)
+
+    @property
+    def zones(self) -> Dict[str, _Zone]:
+        """Return all Zones."""
+        return self._zones
+
+    @property
+    def global_tasks(self) -> List[_TaskGlobal]:
+        """Return all Zones."""
+        return self._globals
+
+    @property
+    def freezes(self) -> List[_Freeze]:
+        """Return all freezes."""
+        return self._freezes
+
+    def asnyc_timeout(
+        self, timeout: float, zone_name: str = ZONE_ALL
+    ) -> Union[_TaskZone, _TaskGlobal]:
+        """Timeout based on a zone."""
+        current_task: asyncio.Task[Any] = asyncio.current_task()
+
+        # Zone all
+        if zone_name == ZONE_ALL:
+            task = _TaskGlobal(self, current_task, timeout)
+            return task
+
+        # Zone Handling
+        if zone_name in self.zones:
+            zone: _Zone = self.zones[zone_name]
+        else:
+            self.zones[zone_name] = zone = _Zone(self, zone_name, timeout)
+
+        # Create Task
+        task = _TaskZone(zone, current_task)
+        return task
+
+    def freeze(self) -> _Freeze:
+        """Freeze all timer until job is done."""
+        freeze = _Freeze(self, self._loop)
+        return freeze

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -391,7 +391,7 @@ class ZoneTimeout:
     """Async zone based timeout handler."""
 
     def __init__(self):
-        """Initalize ZoneTimeout handler."""
+        """Initialize ZoneTimeout handler."""
         self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         self._zones: Dict[str, _Zone] = {}
         self._globals: List[_TaskGlobal] = []

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -225,6 +225,7 @@ class _TaskGlobal:
         await self._wait_zone.wait()
         if not self.state == _State.TIMEOUT:
             return
+        await asyncio.sleep(0)  # Allow context switch
         self._cancel_task()
 
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -169,7 +169,7 @@ class _TaskZone:
 
 
 class _Zone:
-    """Internal Timeout Context Manager object."""
+    """Internal Zone Timeout Manager."""
 
     def __init__(self, manager: ZoneTimeout, zone: str, timeout: float) -> None:
         """Initalize internal timeout context manager."""

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -223,9 +223,9 @@ class _TaskGlobal:
     async def _on_wait(self) -> None:
         """Wait until zones are done."""
         await self._wait_zone.wait()
+        await asyncio.sleep(0)  # Allow context switch
         if not self.state == _State.TIMEOUT:
             return
-        await asyncio.sleep(0)  # Allow context switch
         self._cancel_task()
 
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -61,7 +61,7 @@ class _FreezeGlobal:
             task.pause()
 
         # Zones reset
-        for zone in self._manager.zones:
+        for zone in self._manager.zones.values():
             if not zone.freezes_done:
                 continue
             zone.pause()
@@ -79,7 +79,7 @@ class _FreezeGlobal:
             task.reset()
 
         # Zones reset
-        for zone in self._manager.zones:
+        for zone in self._manager.zones.values():
             if not zone.freezes_done:
                 continue
             zone.reset()

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -255,7 +255,7 @@ class _TaskZone:
     """Internal Timeout Context Manager object for Task."""
 
     def __init__(self, zone: _Zone, task: asyncio.Task[Any]) -> None:
-        """Initalize internal timeout context manager."""
+        """Initialize internal timeout context manager."""
         self._zone: _Zone = zone
         self._task: asyncio.Task[Any] = task
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -313,7 +313,7 @@ class _Zone:
         """Start into new Task."""
         if self.state == _State.TIMEOUT:
             raise asyncio.TimeoutError
-        elif self.state != _State.ACTIVE:
+        if self.state != _State.ACTIVE:
             self._start_timer()
 
         self._count += 1

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -471,4 +471,6 @@ class ZoneTimeout:
             return _FreezeZone(zone, self._loop)
 
         # Should not happens...
-        return _FreezeGlobal(self, self._loop)
+        # Should only happen in tests.
+        _LOGGER.debug("Cannot freeze zone: %s because no timeout is set.")
+        return _FreezeNull()

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -416,7 +416,7 @@ class ZoneTimeout:
         for task in self._globals:
             task.zones_done_signal()
 
-    def asnyc_timeout(
+    def async_timeout(
         self, timeout: float, zone_name: str = ZONE_GLOBAL, cool_down: float = 0
     ) -> Union[_TaskZone, _TaskGlobal]:
         """Timeout based on a zone.

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -39,7 +39,7 @@ class _FreezeGlobal:
     """Internal Freeze Context Manager object for Global."""
 
     def __init__(self, manager: ZoneTimeout, loop: asyncio.AbstractEventLoop) -> None:
-        """Initalize internal timeout context manager."""
+        """Initialize internal timeout context manager."""
         self._loop: asyncio.AbstractEventLoop = loop
         self._manager: ZoneTimeout = manager
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -1,9 +1,10 @@
 """Zone based timeout handling."""
 from __future__ import annotations
+
 import asyncio
 import enum
-from typing import Any, Dict, List, Union, Type, Optional
 from types import TracebackType
+from typing import Any, Dict, List, Optional, Type, Union
 
 ZONE_GLOBAL = "global"
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -289,7 +289,10 @@ class ZoneTimeout:
     def asnyc_timeout(
         self, timeout: float, zone_name: str = ZONE_ALL
     ) -> Union[_TaskZone, _TaskGlobal]:
-        """Timeout based on a zone."""
+        """Timeout based on a zone.
+
+        For using as Async Context Manager.
+        """
         current_task: asyncio.Task[Any] = asyncio.current_task()
 
         # Zone all
@@ -308,6 +311,9 @@ class ZoneTimeout:
         return task
 
     def freeze(self) -> _Freeze:
-        """Freeze all timer until job is done."""
+        """Freeze all timer until job is done.
+
+        For using as (Async) Context Manager.
+        """
         freeze = _Freeze(self, self._loop)
         return freeze

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -66,11 +66,11 @@ class _FreezeGlobal:
                 continue
             zone.pause()
 
-        self._manager.freezes.append(self)
+        self._manager.global_freezes.append(self)
 
     def _exit(self) -> None:
         """Finish freeze."""
-        self._manager.freezes.remove(self)
+        self._manager.global_freezes.remove(self)
         if not self._manager.freezes_done:
             return
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -483,5 +483,5 @@ class ZoneTimeout:
 
         # Should not happens...
         # Should only happen in tests.
-        _LOGGER.debug("Cannot freeze zone: %s because no timeout is set.")
+        _LOGGER.debug("Cannot freeze zone: %s because no timeout is set.", zone_name)
         return _FreezeNull()

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -355,7 +355,7 @@ class _Zone:
     @property
     def active(self) -> bool:
         """Return True if zone is active."""
-        return self._tasks or self._freezes
+        return len(self._tasks) > 0 or len(self._freezes) > 0
 
     @property
     def freezes_done(self) -> bool:

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -483,5 +483,9 @@ class ZoneTimeout:
 
         # Should not happens...
         # Should only happen in tests.
-        _LOGGER.debug("Cannot freeze zone: %s because no timeout is set.", zone_name)
+        _LOGGER.debug(
+            "Cannot freeze zone: %s because no timeout is set.",
+            zone_name,
+            stack_info=True,
+        )
         return _FreezeNull()

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 ZONE_GLOBAL = "global"
 
+_LOGGER = logging.getLogger(__name__)
 
 class _State(str, enum.Enum):
     """States of a Zone."""

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 import asyncio
 import enum
-from typing import Any, Dict, List, Union, Type, TracebackType, Optional
+from typing import Any, Dict, List, Union, Type, Optional
+from types import TracebackType
 
 ZONE_GLOBAL = "global"
 

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -199,7 +199,7 @@ class _TaskGlobal:
 
         # Reset timer if zones are running
         if not self._manager.zones_done:
-            asyncio.create_task(self._on_wait)
+            asyncio.create_task(self._on_wait())
         else:
             self._cancel_task()
 
@@ -396,7 +396,7 @@ class ZoneTimeout:
     def drop_zone(self, zone_name: str) -> None:
         """Drop a zone out of scope."""
         self._zones.pop(zone_name, None)
-        if not self._zones:
+        if self._zones:
             return
 
         # Signal Global task, all zones are done

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -285,7 +285,7 @@ class _Zone:
     """Internal Zone Timeout Manager."""
 
     def __init__(self, manager: ZoneTimeout, zone: str, timeout: float) -> None:
-        """Initalize internal timeout context manager."""
+        """Initialize internal timeout context manager."""
         self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         self._manager: ZoneTimeout = manager
         self._zone: str = zone

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -133,6 +133,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
         device_id=device_entry.id,
     )
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_capabilities = {
         "arm_away": {"extra_fields": []},
@@ -170,6 +171,7 @@ async def test_get_action_capabilities_arm_code(hass, device_reg, entity_reg):
         device_id=device_entry.id,
     )
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_capabilities = {
         "arm_away": {
@@ -267,6 +269,8 @@ async def test_action(hass):
         },
     )
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
     assert (
         hass.states.get("alarm_control_panel.alarm_no_arm_code").state == STATE_UNKNOWN
     )

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -60,6 +60,7 @@ async def test_get_conditions(hass, device_reg, entity_reg):
         )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_conditions = [
         {

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -60,6 +60,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_triggers = [
         {

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -46,6 +46,7 @@ async def test_get_actions(hass, device_reg, entity_reg):
         DOMAIN, "test", ent.unique_id, device_id=device_entry.id
     )
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_actions = [
         {
@@ -81,6 +82,7 @@ async def test_get_actions_tilt(hass, device_reg, entity_reg):
         DOMAIN, "test", ent.unique_id, device_id=device_entry.id
     )
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_actions = [
         {
@@ -128,6 +130,7 @@ async def test_get_actions_set_pos(hass, device_reg, entity_reg):
         DOMAIN, "test", ent.unique_id, device_id=device_entry.id
     )
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_actions = [
         {
@@ -157,6 +160,7 @@ async def test_get_actions_set_tilt_pos(hass, device_reg, entity_reg):
         DOMAIN, "test", ent.unique_id, device_id=device_entry.id
     )
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_actions = [
         {
@@ -199,6 +203,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     actions = await async_get_device_automations(hass, "action", device_entry.id)
     assert len(actions) == 2  # open, close
@@ -226,6 +231,7 @@ async def test_get_action_capabilities_set_pos(hass, device_reg, entity_reg):
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_capabilities = {
         "extra_fields": [
@@ -268,6 +274,7 @@ async def test_get_action_capabilities_set_tilt_pos(hass, device_reg, entity_reg
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     expected_capabilities = {
         "extra_fields": [
@@ -325,6 +332,7 @@ async def test_action(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     open_calls = async_mock_service(hass, "cover", "open_cover")
     close_calls = async_mock_service(hass, "cover", "close_cover")
@@ -377,6 +385,7 @@ async def test_action_tilt(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     open_calls = async_mock_service(hass, "cover", "open_cover_tilt")
     close_calls = async_mock_service(hass, "cover", "close_cover_tilt")
@@ -437,6 +446,7 @@ async def test_action_set_position(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     cover_pos_calls = async_mock_service(hass, "cover", "set_cover_position")
     tilt_pos_calls = async_mock_service(hass, "cover", "set_cover_tilt_position")

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -366,6 +366,7 @@ async def test_reconnect(hass, monkeypatch, mock_connection_factory):
     protocol.wait_closed = wait_closed
 
     await async_setup_component(hass, "sensor", {"sensor": config})
+    await hass.async_block_till_done()
 
     assert connection_factory.call_count == 1
 

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -104,6 +104,7 @@ async def test_valid_config_with_info(hass):
             }
         },
     )
+    await hass.async_block_till_done()
 
 
 async def test_valid_config_no_name(hass):
@@ -114,6 +115,7 @@ async def test_valid_config_no_name(hass):
             "switch",
             {"switch": {"platform": "flux", "lights": ["light.desk", "light.lamp"]}},
         )
+        await hass.async_block_till_done()
 
 
 async def test_invalid_config_no_lights(hass):
@@ -122,6 +124,7 @@ async def test_invalid_config_no_lights(hass):
         assert await async_setup_component(
             hass, "switch", {"switch": {"platform": "flux", "name": "flux"}}
         )
+        await hass.async_block_till_done()
 
 
 async def test_flux_when_switch_is_off(hass, legacy_patchable_time):
@@ -168,6 +171,7 @@ async def test_flux_when_switch_is_off(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
 
@@ -218,6 +222,7 @@ async def test_flux_before_sunrise(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         await common.async_turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -271,6 +276,7 @@ async def test_flux_before_sunrise_known_location(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         await common.async_turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -325,6 +331,7 @@ async def test_flux_after_sunrise_before_sunset(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         await common.async_turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -380,6 +387,7 @@ async def test_flux_after_sunset_before_stop(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -434,6 +442,7 @@ async def test_flux_after_stop_before_sunrise(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -490,6 +499,7 @@ async def test_flux_with_custom_start_stop_times(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -547,6 +557,7 @@ async def test_flux_before_sunrise_stop_next_day(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -608,6 +619,7 @@ async def test_flux_after_sunrise_before_sunset_stop_next_day(
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -669,6 +681,7 @@ async def test_flux_after_sunset_before_midnight_stop_next_day(
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -729,6 +742,7 @@ async def test_flux_after_sunset_after_midnight_stop_next_day(
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -789,6 +803,7 @@ async def test_flux_after_stop_before_sunrise_stop_next_day(
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -846,6 +861,7 @@ async def test_flux_with_custom_colortemps(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -902,6 +918,7 @@ async def test_flux_with_custom_brightness(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -974,6 +991,7 @@ async def test_flux_with_multiple_lights(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -1033,6 +1051,7 @@ async def test_flux_with_mired(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         common.turn_on(hass, "switch.flux")
         await hass.async_block_till_done()
@@ -1085,6 +1104,7 @@ async def test_flux_with_rgb(hass, legacy_patchable_time):
                 }
             },
         )
+        await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
         await common.async_turn_on(hass, "switch.flux")
         await hass.async_block_till_done()

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -34,6 +34,7 @@ async def test_get_actions_support_open(hass, device_reg, entity_reg):
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -77,6 +78,7 @@ async def test_get_actions_not_support_open(hass, device_reg, entity_reg):
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -146,6 +148,7 @@ async def test_action(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
 
     lock_calls = async_mock_service(hass, "lock", "lock")
     unlock_calls = async_mock_service(hass, "lock", "unlock")

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -188,8 +188,8 @@ async def test_platform_warn_slow_setup(hass):
         assert mock_call.called
 
         # mock_calls[0] is the warning message for component setup
-        # mock_calls[6] is the warning message for platform setup
-        timeout, logger_method = mock_call.mock_calls[6][1][:2]
+        # mock_calls[4] is the warning message for platform setup
+        timeout, logger_method = mock_call.mock_calls[4][1][:2]
 
         assert timeout == entity_platform.SLOW_SETUP_WARNING
         assert logger_method == _LOGGER.warning

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1140,8 +1140,8 @@ async def test_start_taking_too_long(loop, caplog):
     caplog.set_level(logging.WARNING)
 
     try:
-        with patch(
-            "homeassistant.core.timeout", side_effect=asyncio.TimeoutError
+        with patch.object(
+            hass, "async_block_till_done", side_effect=asyncio.TimeoutError
         ), patch("homeassistant.core._async_create_timer") as mock_timer:
             await hass.async_start()
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,15 +1,12 @@
 """Test requirements module."""
 import os
-from pathlib import Path
 
 import pytest
 
 from homeassistant import loader, setup
 from homeassistant.requirements import (
     CONSTRAINT_FILE,
-    PROGRESS_FILE,
     RequirementsNotFound,
-    _install,
     async_get_integration_with_requirements,
     async_process_requirements,
 )
@@ -188,24 +185,6 @@ async def test_install_on_docker(hass):
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
             no_cache_dir=True,
         )
-
-
-async def test_progress_lock(hass):
-    """Test an install attempt on an existing package."""
-    progress_path = Path(hass.config.path(PROGRESS_FILE))
-    kwargs = {"hello": "world"}
-
-    def assert_env(req, **passed_kwargs):
-        """Assert the env."""
-        assert progress_path.exists()
-        assert req == "hello"
-        assert passed_kwargs == kwargs
-        return True
-
-    with patch("homeassistant.util.package.install_package", side_effect=assert_env):
-        _install(hass, "hello", kwargs)
-
-    assert not progress_path.exists()
 
 
 async def test_discovery_requirements_ssdp(hass):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -483,12 +483,14 @@ class TestSetup:
 async def test_component_warn_slow_setup(hass):
     """Warn we log when a component setup takes a long time."""
     mock_integration(hass, MockModule("test_component1"))
-    with patch.object(hass.loop, "call_later") as mock_call:
+    with patch.object(hass.loop, "call_later") as mock_call, patch.object(
+        setup, "SLOW_SETUP_MAX_WAIT", 0
+    ):
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert result
         assert mock_call.called
 
-        assert len(mock_call.mock_calls) == 5
+        assert len(mock_call.mock_calls) == 3
         timeout, logger_method = mock_call.mock_calls[0][1][:2]
 
         assert timeout == setup.SLOW_SETUP_WARNING

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -483,9 +483,7 @@ class TestSetup:
 async def test_component_warn_slow_setup(hass):
     """Warn we log when a component setup takes a long time."""
     mock_integration(hass, MockModule("test_component1"))
-    with patch.object(hass.loop, "call_later") as mock_call, patch.object(
-        setup, "SLOW_SETUP_MAX_WAIT", 0
-    ):
+    with patch.object(hass.loop, "call_later") as mock_call:
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert result
         assert mock_call.called
@@ -495,9 +493,6 @@ async def test_component_warn_slow_setup(hass):
 
         assert timeout == setup.SLOW_SETUP_WARNING
         assert logger_method == setup._LOGGER.warning
-
-        timeout, function = mock_call.mock_calls[1][1][:2]
-        assert timeout == setup.SLOW_SETUP_MAX_WAIT
 
         assert mock_call().cancel.called
 
@@ -510,8 +505,7 @@ async def test_platform_no_warn_slow(hass):
     with patch.object(hass.loop, "call_later") as mock_call:
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert result
-        timeout, function = mock_call.mock_calls[0][1][:2]
-        assert timeout == setup.SLOW_SETUP_MAX_WAIT
+        assert len(mock_call.mock_calls) == 0
 
 
 async def test_platform_error_slow_setup(hass, caplog):

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from homeassistant.util.timeout import FreezeError, ZoneTimeout
+from homeassistant.util.timeout import ZoneTimeout
 
 
 @pytest.fixture(autouse=True)
@@ -172,13 +172,13 @@ async def test_simple_zone_timeout_freeze():
             await asyncio.sleep(0.3)
 
 
-async def test_simple_zone_timeout_freeze_without_timeout_throws():
+async def test_simple_zone_timeout_freeze_without_timeout():
     """Test a simple zone timeout freeze on a zone that does not have a timeout set."""
     timeout = ZoneTimeout()
 
-    with pytest.raises(FreezeError):
+    async with timeout.async_timeout(0.1, "test"):
         async with timeout.freeze("test"):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.3)
 
 
 async def test_simple_zone_timeout_freeze_reset():

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -1,5 +1,6 @@
 """Test Home Assistant timeout handler."""
 import asyncio
+import time
 
 import pytest
 
@@ -23,6 +24,15 @@ async def test_simple_global_timeout():
             await asyncio.sleep(0.3)
 
 
+async def test_simple_global_timeout_with_executor_job(hass):
+    """Test a simple global timeout with executor job."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.async_timeout(0.1):
+            await hass.async_add_executor_job(lambda: time.sleep(0.2))
+
+
 async def test_simple_global_timeout_freeze():
     """Test a simple global timeout freeze."""
     timeout = ZoneTimeout()
@@ -30,6 +40,15 @@ async def test_simple_global_timeout_freeze():
     async with timeout.async_timeout(0.2):
         async with timeout.freeze():
             await asyncio.sleep(0.3)
+
+
+async def test_simple_global_timeout_freeze_with_executor_job(hass):
+    """Test a simple global timeout freeze with executor job."""
+    timeout = ZoneTimeout()
+
+    async with timeout.async_timeout(0.2):
+        async with timeout.freeze():
+            await hass.async_add_executor_job(lambda: time.sleep(0.3))
 
 
 async def test_simple_global_timeout_freeze_reset():

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -15,10 +15,28 @@ async def test_simple_global_timeout():
             await asyncio.sleep(0.5)
 
 
+async def test_simple_global_timeout_freeze():
+    """Test a simple global timeout freeze."""
+    timeout = ZoneTimeout()
+
+    async with timeout.asnyc_timeout(0.2):
+        async with timeout.freeze():
+            await asyncio.sleep(0.5)
+
+
 async def test_simple_zone_timeout():
     """Test a simple zone timeout."""
     timeout = ZoneTimeout()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.asnyc_timeout(0.1, "test"):
+            await asyncio.sleep(0.5)
+
+
+async def test_simple_zone_timeout_freeze():
+    """Test a simple zone timeout freeze."""
+    timeout = ZoneTimeout()
+
+    async with timeout.asnyc_timeout(0.2, "test"):
+        async with timeout.freeze("test"):
             await asyncio.sleep(0.5)

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -101,6 +101,26 @@ async def test_simple_zone_timeout_freeze_reset():
             await asyncio.sleep(0.2, "test")
 
 
+async def test_mix_zone_timeout_freeze_and_global_freeze():
+    """Test a mix zone timeout freeze and global freeze."""
+    timeout = ZoneTimeout()
+
+    async with timeout.async_timeout(0.2, "test"):
+        async with timeout.freeze("test"):
+            async with timeout.freeze():
+                await asyncio.sleep(0.3)
+
+
+async def test_mix_global_and_zone_timeout_freeze_():
+    """Test a mix zone timeout freeze and global freeze."""
+    timeout = ZoneTimeout()
+
+    async with timeout.async_timeout(0.2, "test"):
+        async with timeout.freeze():
+            async with timeout.freeze("test"):
+                await asyncio.sleep(0.3)
+
+
 async def test_mix_zone_timeout_freeze():
     """Test a mix zone timeout global freeze."""
     timeout = ZoneTimeout()

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -49,3 +49,15 @@ async def test_mix_zone_timeout_freeze():
     async with timeout.asnyc_timeout(0.2, "test"):
         async with timeout.freeze():
             await asyncio.sleep(0.3)
+
+
+async def test_mix_zone_timeout():
+    """Test a mix zone timeout global."""
+    timeout = ZoneTimeout()
+
+    async with timeout.asnyc_timeout(0.1):
+        try:
+            async with timeout.asnyc_timeout(0.2, "test"):
+                await asyncio.sleep(0.4)
+        except asyncio.TimeoutError:
+            pass

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -6,6 +6,14 @@ import pytest
 from homeassistant.util.timeout import ZoneTimeout
 
 
+@pytest.fixture(autouse=True)
+def fix_cool_down():
+    """Patch cool down of the module."""
+    from homeassistant.util import timeout
+
+    timeout.COOL_DOWN = 0
+
+
 async def test_simple_global_timeout():
     """Test a simple global timeout."""
     timeout = ZoneTimeout()

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -4,12 +4,12 @@ import time
 
 import pytest
 
-from homeassistant.util.timeout import ZoneTimeout
+from homeassistant.util.timeout import TimeoutManager
 
 
 async def test_simple_global_timeout():
     """Test a simple global timeout."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.1):
@@ -18,7 +18,7 @@ async def test_simple_global_timeout():
 
 async def test_simple_global_timeout_with_executor_job(hass):
     """Test a simple global timeout with executor job."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.1):
@@ -27,7 +27,7 @@ async def test_simple_global_timeout_with_executor_job(hass):
 
 async def test_simple_global_timeout_freeze():
     """Test a simple global timeout freeze."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.2):
         async with timeout.async_freeze():
@@ -36,7 +36,7 @@ async def test_simple_global_timeout_freeze():
 
 async def test_simple_zone_timeout_freeze_inside_executor_job(hass):
     """Test a simple zone timeout freeze inside an executor job."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     def _some_sync_work():
         with timeout.freeze("recorder"):
@@ -49,7 +49,7 @@ async def test_simple_zone_timeout_freeze_inside_executor_job(hass):
 
 async def test_simple_global_timeout_freeze_inside_executor_job(hass):
     """Test a simple global timeout freeze inside an executor job."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     def _some_sync_work():
         with timeout.freeze():
@@ -61,7 +61,7 @@ async def test_simple_global_timeout_freeze_inside_executor_job(hass):
 
 async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job(hass):
     """Test a simple global timeout freeze inside an executor job."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     def _some_sync_work():
         with timeout.freeze("recorder"):
@@ -74,7 +74,7 @@ async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job(has
 
 async def test_mix_global_timeout_freeze_and_zone_freeze_different_order(hass):
     """Test a simple global timeout freeze inside an executor job before timeout was set."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     def _some_sync_work():
         with timeout.freeze("recorder"):
@@ -90,7 +90,7 @@ async def test_mix_global_timeout_freeze_and_zone_freeze_other_zone_inside_execu
     hass,
 ):
     """Test a simple global timeout freeze other zone inside an executor job."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     def _some_sync_work():
         with timeout.freeze("not_recorder"):
@@ -107,7 +107,7 @@ async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job_sec
     hass,
 ):
     """Test a simple global timeout freeze inside an executor job with second job outside of zone context."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     def _some_sync_work():
         with timeout.freeze("recorder"):
@@ -122,7 +122,7 @@ async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job_sec
 
 async def test_simple_global_timeout_freeze_with_executor_job(hass):
     """Test a simple global timeout freeze with executor job."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.2):
         async with timeout.async_freeze():
@@ -131,7 +131,7 @@ async def test_simple_global_timeout_freeze_with_executor_job(hass):
 
 async def test_simple_global_timeout_freeze_reset():
     """Test a simple global timeout freeze reset."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.2):
@@ -142,7 +142,7 @@ async def test_simple_global_timeout_freeze_reset():
 
 async def test_simple_zone_timeout():
     """Test a simple zone timeout."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.1, "test"):
@@ -151,7 +151,7 @@ async def test_simple_zone_timeout():
 
 async def test_multiple_zone_timeout():
     """Test a simple zone timeout."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.1, "test"):
@@ -161,7 +161,7 @@ async def test_multiple_zone_timeout():
 
 async def test_different_zone_timeout():
     """Test a simple zone timeout."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.1, "test"):
@@ -171,7 +171,7 @@ async def test_different_zone_timeout():
 
 async def test_simple_zone_timeout_freeze():
     """Test a simple zone timeout freeze."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.2, "test"):
         async with timeout.async_freeze("test"):
@@ -180,7 +180,7 @@ async def test_simple_zone_timeout_freeze():
 
 async def test_simple_zone_timeout_freeze_without_timeout():
     """Test a simple zone timeout freeze on a zone that does not have a timeout set."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.1, "test"):
         async with timeout.async_freeze("test"):
@@ -189,7 +189,7 @@ async def test_simple_zone_timeout_freeze_without_timeout():
 
 async def test_simple_zone_timeout_freeze_reset():
     """Test a simple zone timeout freeze reset."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.2, "test"):
@@ -200,7 +200,7 @@ async def test_simple_zone_timeout_freeze_reset():
 
 async def test_mix_zone_timeout_freeze_and_global_freeze():
     """Test a mix zone timeout freeze and global freeze."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.2, "test"):
         async with timeout.async_freeze("test"):
@@ -210,7 +210,7 @@ async def test_mix_zone_timeout_freeze_and_global_freeze():
 
 async def test_mix_global_and_zone_timeout_freeze_():
     """Test a mix zone timeout freeze and global freeze."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.2, "test"):
         async with timeout.async_freeze():
@@ -220,7 +220,7 @@ async def test_mix_global_and_zone_timeout_freeze_():
 
 async def test_mix_zone_timeout_freeze():
     """Test a mix zone timeout global freeze."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.2, "test"):
         async with timeout.async_freeze():
@@ -229,7 +229,7 @@ async def test_mix_zone_timeout_freeze():
 
 async def test_mix_zone_timeout():
     """Test a mix zone timeout global."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.1):
         try:
@@ -241,7 +241,7 @@ async def test_mix_zone_timeout():
 
 async def test_mix_zone_timeout_trigger_global():
     """Test a mix zone timeout global with trigger it."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.1):
@@ -256,7 +256,7 @@ async def test_mix_zone_timeout_trigger_global():
 
 async def test_mix_zone_timeout_trigger_global_cool_down():
     """Test a mix zone timeout global with trigger it with cool_down."""
-    timeout = ZoneTimeout()
+    timeout = TimeoutManager()
 
     async with timeout.async_timeout(0.1, cool_down=0.3):
         try:

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -12,7 +12,7 @@ async def test_simple_global_timeout():
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.asnyc_timeout(0.1):
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.3)
 
 
 async def test_simple_global_timeout_freeze():
@@ -30,7 +30,7 @@ async def test_simple_zone_timeout():
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.asnyc_timeout(0.1, "test"):
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.3)
 
 
 async def test_simple_zone_timeout_freeze():

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -24,6 +24,17 @@ async def test_simple_global_timeout_freeze():
             await asyncio.sleep(0.3)
 
 
+async def test_simple_global_timeout_freeze_reset():
+    """Test a simple global timeout freeze reset."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.asnyc_timeout(0.2):
+            async with timeout.freeze():
+                await asyncio.sleep(0.1)
+            await asyncio.sleep(0.2)
+
+
 async def test_simple_zone_timeout():
     """Test a simple zone timeout."""
     timeout = ZoneTimeout()
@@ -40,6 +51,17 @@ async def test_simple_zone_timeout_freeze():
     async with timeout.asnyc_timeout(0.2, "test"):
         async with timeout.freeze("test"):
             await asyncio.sleep(0.3)
+
+
+async def test_simple_zone_timeout_freeze_reset():
+    """Test a simple zone timeout freeze reset."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.asnyc_timeout(0.2, "test"):
+            async with timeout.freeze("test"):
+                await asyncio.sleep(0.1)
+            await asyncio.sleep(0.2, "test")
 
 
 async def test_mix_zone_timeout_freeze():

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -1,0 +1,24 @@
+"""Test Home Assistant timeout handler."""
+import asyncio
+
+import pytest
+
+from homeassistant.util.timeout import ZoneTimeout
+
+
+async def test_simple_global_timeout():
+    """Test a simple global timeout."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.asnyc_timeout(0.1):
+            await asyncio.sleep(0.5)
+
+
+async def test_simple_zone_timeout():
+    """Test a simple zone timeout."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.asnyc_timeout(0.1, "test"):
+            await asyncio.sleep(0.5)

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -21,7 +21,7 @@ async def test_simple_global_timeout_freeze():
 
     async with timeout.asnyc_timeout(0.2):
         async with timeout.freeze():
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.3)
 
 
 async def test_simple_zone_timeout():
@@ -39,4 +39,13 @@ async def test_simple_zone_timeout_freeze():
 
     async with timeout.asnyc_timeout(0.2, "test"):
         async with timeout.freeze("test"):
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.3)
+
+
+async def test_mix_zone_timeout_freeze():
+    """Test a mix zone timeout global freeze."""
+    timeout = ZoneTimeout()
+
+    async with timeout.asnyc_timeout(0.2, "test"):
+        async with timeout.freeze():
+            await asyncio.sleep(0.3)

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -106,3 +106,17 @@ async def test_mix_zone_timeout_trigger_global():
                 pass
 
             await asyncio.sleep(0.3)
+
+
+async def test_mix_zone_timeout_trigger_global_cool_down():
+    """Test a mix zone timeout global with trigger it with cool_down."""
+    timeout = ZoneTimeout()
+
+    async with timeout.asnyc_timeout(0.1, cool_down=0.3):
+        try:
+            async with timeout.asnyc_timeout(0.1, "test"):
+                await asyncio.sleep(0.3)
+        except asyncio.TimeoutError:
+            pass
+
+        await asyncio.sleep(0.2)

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -42,6 +42,78 @@ async def test_simple_global_timeout_freeze():
             await asyncio.sleep(0.3)
 
 
+async def test_simple_zone_timeout_freeze_inside_executor_job(hass):
+    """Test a simple zone timeout freeze inside an executor job."""
+    timeout = ZoneTimeout()
+
+    def _some_sync_work():
+        with timeout.freeze("recorder"):
+            time.sleep(0.3)
+
+    async with timeout.async_timeout(1.0):
+        async with timeout.async_timeout(0.2, zone_name="recorder"):
+            await hass.async_add_executor_job(_some_sync_work)
+
+
+async def test_simple_global_timeout_freeze_inside_executor_job(hass):
+    """Test a simple global timeout freeze inside an executor job."""
+    timeout = ZoneTimeout()
+
+    def _some_sync_work():
+        with timeout.freeze():
+            time.sleep(0.3)
+
+    async with timeout.async_timeout(0.2):
+        await hass.async_add_executor_job(_some_sync_work)
+
+
+async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job(hass):
+    """Test a simple global timeout freeze inside an executor job."""
+    timeout = ZoneTimeout()
+
+    def _some_sync_work():
+        with timeout.freeze("recorder"):
+            time.sleep(0.3)
+
+    async with timeout.async_timeout(0.1):
+        async with timeout.async_timeout(0.2, zone_name="recorder"):
+            await hass.async_add_executor_job(_some_sync_work)
+
+
+async def test_mix_global_timeout_freeze_and_zone_freeze_other_zone_inside_executor_job(
+    hass,
+):
+    """Test a simple global timeout freeze other zone inside an executor job."""
+    timeout = ZoneTimeout()
+
+    def _some_sync_work():
+        with timeout.freeze("not_recorder"):
+            time.sleep(0.3)
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.async_timeout(0.1):
+            async with timeout.async_timeout(0.2, zone_name="recorder"):
+                async with timeout.async_timeout(0.2, zone_name="not_recorder"):
+                    await hass.async_add_executor_job(_some_sync_work)
+
+
+async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job_second_job_outside_zone_context(
+    hass,
+):
+    """Test a simple global timeout freeze inside an executor job with second job outside of zone context."""
+    timeout = ZoneTimeout()
+
+    def _some_sync_work():
+        with timeout.freeze("recorder"):
+            time.sleep(0.3)
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.async_timeout(0.1):
+            async with timeout.async_timeout(0.2, zone_name="recorder"):
+                await hass.async_add_executor_job(_some_sync_work)
+            await hass.async_add_executor_job(lambda: time.sleep(0.2))
+
+
 async def test_simple_global_timeout_freeze_with_executor_job(hass):
     """Test a simple global timeout freeze with executor job."""
     timeout = ZoneTimeout()

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -7,14 +7,6 @@ import pytest
 from homeassistant.util.timeout import ZoneTimeout
 
 
-@pytest.fixture(autouse=True)
-def fix_cool_down():
-    """Patch cool down of the module."""
-    from homeassistant.util import timeout
-
-    timeout.COOL_DOWN = 0
-
-
 async def test_simple_global_timeout():
     """Test a simple global timeout."""
     timeout = ZoneTimeout()

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -3,7 +3,7 @@ import asyncio
 
 import pytest
 
-from homeassistant.util.timeout import ZoneTimeout
+from homeassistant.util.timeout import FreezeError, ZoneTimeout
 
 
 @pytest.fixture(autouse=True)
@@ -59,6 +59,15 @@ async def test_simple_zone_timeout_freeze():
     async with timeout.async_timeout(0.2, "test"):
         async with timeout.freeze("test"):
             await asyncio.sleep(0.3)
+
+
+async def test_simple_zone_timeout_freeze_without_timeout_throws():
+    """Test a simple zone timeout freeze on a zone that does not have a timeout set."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(FreezeError):
+        async with timeout.freeze("test"):
+            await asyncio.sleep(0.1)
 
 
 async def test_simple_zone_timeout_freeze_reset():

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -19,7 +19,7 @@ async def test_simple_global_timeout():
     timeout = ZoneTimeout()
 
     with pytest.raises(asyncio.TimeoutError):
-        async with timeout.asnyc_timeout(0.1):
+        async with timeout.async_timeout(0.1):
             await asyncio.sleep(0.3)
 
 
@@ -27,7 +27,7 @@ async def test_simple_global_timeout_freeze():
     """Test a simple global timeout freeze."""
     timeout = ZoneTimeout()
 
-    async with timeout.asnyc_timeout(0.2):
+    async with timeout.async_timeout(0.2):
         async with timeout.freeze():
             await asyncio.sleep(0.3)
 
@@ -37,7 +37,7 @@ async def test_simple_global_timeout_freeze_reset():
     timeout = ZoneTimeout()
 
     with pytest.raises(asyncio.TimeoutError):
-        async with timeout.asnyc_timeout(0.2):
+        async with timeout.async_timeout(0.2):
             async with timeout.freeze():
                 await asyncio.sleep(0.1)
             await asyncio.sleep(0.2)
@@ -48,7 +48,7 @@ async def test_simple_zone_timeout():
     timeout = ZoneTimeout()
 
     with pytest.raises(asyncio.TimeoutError):
-        async with timeout.asnyc_timeout(0.1, "test"):
+        async with timeout.async_timeout(0.1, "test"):
             await asyncio.sleep(0.3)
 
 
@@ -56,7 +56,7 @@ async def test_simple_zone_timeout_freeze():
     """Test a simple zone timeout freeze."""
     timeout = ZoneTimeout()
 
-    async with timeout.asnyc_timeout(0.2, "test"):
+    async with timeout.async_timeout(0.2, "test"):
         async with timeout.freeze("test"):
             await asyncio.sleep(0.3)
 
@@ -66,7 +66,7 @@ async def test_simple_zone_timeout_freeze_reset():
     timeout = ZoneTimeout()
 
     with pytest.raises(asyncio.TimeoutError):
-        async with timeout.asnyc_timeout(0.2, "test"):
+        async with timeout.async_timeout(0.2, "test"):
             async with timeout.freeze("test"):
                 await asyncio.sleep(0.1)
             await asyncio.sleep(0.2, "test")
@@ -76,7 +76,7 @@ async def test_mix_zone_timeout_freeze():
     """Test a mix zone timeout global freeze."""
     timeout = ZoneTimeout()
 
-    async with timeout.asnyc_timeout(0.2, "test"):
+    async with timeout.async_timeout(0.2, "test"):
         async with timeout.freeze():
             await asyncio.sleep(0.3)
 
@@ -85,9 +85,9 @@ async def test_mix_zone_timeout():
     """Test a mix zone timeout global."""
     timeout = ZoneTimeout()
 
-    async with timeout.asnyc_timeout(0.1):
+    async with timeout.async_timeout(0.1):
         try:
-            async with timeout.asnyc_timeout(0.2, "test"):
+            async with timeout.async_timeout(0.2, "test"):
                 await asyncio.sleep(0.4)
         except asyncio.TimeoutError:
             pass
@@ -98,9 +98,9 @@ async def test_mix_zone_timeout_trigger_global():
     timeout = ZoneTimeout()
 
     with pytest.raises(asyncio.TimeoutError):
-        async with timeout.asnyc_timeout(0.1):
+        async with timeout.async_timeout(0.1):
             try:
-                async with timeout.asnyc_timeout(0.1, "test"):
+                async with timeout.async_timeout(0.1, "test"):
                     await asyncio.sleep(0.3)
             except asyncio.TimeoutError:
                 pass
@@ -112,9 +112,9 @@ async def test_mix_zone_timeout_trigger_global_cool_down():
     """Test a mix zone timeout global with trigger it with cool_down."""
     timeout = ZoneTimeout()
 
-    async with timeout.asnyc_timeout(0.1, cool_down=0.3):
+    async with timeout.async_timeout(0.1, cool_down=0.3):
         try:
-            async with timeout.asnyc_timeout(0.1, "test"):
+            async with timeout.async_timeout(0.1, "test"):
                 await asyncio.sleep(0.3)
         except asyncio.TimeoutError:
             pass

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -38,7 +38,7 @@ async def test_simple_global_timeout_freeze():
     timeout = ZoneTimeout()
 
     async with timeout.async_timeout(0.2):
-        async with timeout.freeze():
+        async with timeout.async_freeze():
             await asyncio.sleep(0.3)
 
 
@@ -80,6 +80,20 @@ async def test_mix_global_timeout_freeze_and_zone_freeze_inside_executor_job(has
             await hass.async_add_executor_job(_some_sync_work)
 
 
+async def test_mix_global_timeout_freeze_and_zone_freeze_different_order(hass):
+    """Test a simple global timeout freeze inside an executor job before timeout was set."""
+    timeout = ZoneTimeout()
+
+    def _some_sync_work():
+        with timeout.freeze("recorder"):
+            time.sleep(0.4)
+
+    async with timeout.async_timeout(0.1):
+        hass.async_add_executor_job(_some_sync_work)
+        async with timeout.async_timeout(0.2, zone_name="recorder"):
+            await asyncio.sleep(0.3)
+
+
 async def test_mix_global_timeout_freeze_and_zone_freeze_other_zone_inside_executor_job(
     hass,
 ):
@@ -119,7 +133,7 @@ async def test_simple_global_timeout_freeze_with_executor_job(hass):
     timeout = ZoneTimeout()
 
     async with timeout.async_timeout(0.2):
-        async with timeout.freeze():
+        async with timeout.async_freeze():
             await hass.async_add_executor_job(lambda: time.sleep(0.3))
 
 
@@ -129,7 +143,7 @@ async def test_simple_global_timeout_freeze_reset():
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.2):
-            async with timeout.freeze():
+            async with timeout.async_freeze():
                 await asyncio.sleep(0.1)
             await asyncio.sleep(0.2)
 
@@ -168,7 +182,7 @@ async def test_simple_zone_timeout_freeze():
     timeout = ZoneTimeout()
 
     async with timeout.async_timeout(0.2, "test"):
-        async with timeout.freeze("test"):
+        async with timeout.async_freeze("test"):
             await asyncio.sleep(0.3)
 
 
@@ -177,7 +191,7 @@ async def test_simple_zone_timeout_freeze_without_timeout():
     timeout = ZoneTimeout()
 
     async with timeout.async_timeout(0.1, "test"):
-        async with timeout.freeze("test"):
+        async with timeout.async_freeze("test"):
             await asyncio.sleep(0.3)
 
 
@@ -187,7 +201,7 @@ async def test_simple_zone_timeout_freeze_reset():
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout.async_timeout(0.2, "test"):
-            async with timeout.freeze("test"):
+            async with timeout.async_freeze("test"):
                 await asyncio.sleep(0.1)
             await asyncio.sleep(0.2, "test")
 
@@ -197,8 +211,8 @@ async def test_mix_zone_timeout_freeze_and_global_freeze():
     timeout = ZoneTimeout()
 
     async with timeout.async_timeout(0.2, "test"):
-        async with timeout.freeze("test"):
-            async with timeout.freeze():
+        async with timeout.async_freeze("test"):
+            async with timeout.async_freeze():
                 await asyncio.sleep(0.3)
 
 
@@ -207,8 +221,8 @@ async def test_mix_global_and_zone_timeout_freeze_():
     timeout = ZoneTimeout()
 
     async with timeout.async_timeout(0.2, "test"):
-        async with timeout.freeze():
-            async with timeout.freeze("test"):
+        async with timeout.async_freeze():
+            async with timeout.async_freeze("test"):
                 await asyncio.sleep(0.3)
 
 
@@ -217,7 +231,7 @@ async def test_mix_zone_timeout_freeze():
     timeout = ZoneTimeout()
 
     async with timeout.async_timeout(0.2, "test"):
-        async with timeout.freeze():
+        async with timeout.async_freeze():
             await asyncio.sleep(0.3)
 
 

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -52,6 +52,26 @@ async def test_simple_zone_timeout():
             await asyncio.sleep(0.3)
 
 
+async def test_multiple_zone_timeout():
+    """Test a simple zone timeout."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.async_timeout(0.1, "test"):
+            async with timeout.async_timeout(0.5, "test"):
+                await asyncio.sleep(0.3)
+
+
+async def test_different_zone_timeout():
+    """Test a simple zone timeout."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.async_timeout(0.1, "test"):
+            async with timeout.async_timeout(0.5, "other"):
+                await asyncio.sleep(0.3)
+
+
 async def test_simple_zone_timeout_freeze():
     """Test a simple zone timeout freeze."""
     timeout = ZoneTimeout()

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -61,3 +61,18 @@ async def test_mix_zone_timeout():
                 await asyncio.sleep(0.4)
         except asyncio.TimeoutError:
             pass
+
+
+async def test_mix_zone_timeout_trigger_global():
+    """Test a mix zone timeout global with trigger it."""
+    timeout = ZoneTimeout()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.asnyc_timeout(0.1):
+            try:
+                async with timeout.asnyc_timeout(0.1, "test"):
+                    await asyncio.sleep(0.3)
+            except asyncio.TimeoutError:
+                pass
+
+            await asyncio.sleep(0.3)


### PR DESCRIPTION
## Proposed change

This timeout handler solve forever all issues with blocking startup setups without a hack or workaround. It's a zone/global-based timeout handler.

ToDo:
- Init in early-stage and share it over `hass.data`
- Wrap every boot stage with a global timeout - 5min
- On component/integration setup, use a zone (domain) based timeout of 2min (or 1min?)
- Wrap pip install with a freeze
- Wrap database migration with a freeze

This domain allows a clean setup and respect all kind of timeouts and raise only a timeout if a component make issues.
This needs some tweaks and optimization, all help is welcome.

```python
async with hass.data["timeout"].async_timeout(300):
    await hass.async_block_till_done()

async with hass.data["timeout"].async_timeout(300, cool_down=60):
    await hass.async_block_till_done()  # give 1min time to finish after zones are done


# Or zone-based

async with hass.data["timeout"].async_timeout(120, "domain"):
    await integration.async_setup_component()
```

```python
async with hass.data["timeout"].freeze():
    await pip.install(...)

with hass.data["timeout"].freeze():
    migrate_database()

# Or zone-based

with hass.data["timeout"].freeze("recorder"):
    migrate_database()

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
