### PR TITLE
Add node firmware to ozw device registry

### DIFF
--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -114,7 +114,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         # Filter out CommandClasses we're definitely not interested in.
         if value.command_class in [
-            CommandClass.VERSION,
             CommandClass.MANUFACTURER_SPECIFIC,
         ]:
             return

--- a/homeassistant/components/ozw/entity.py
+++ b/homeassistant/components/ozw/entity.py
@@ -192,8 +192,10 @@ class ZWaveDeviceEntity(Entity):
             "name": create_device_name(node),
             "manufacturer": node.node_manufacturer_name,
             "model": node.node_product_name,
-            "sw_version": node_firmware.value,
         }
+        if node_firmware is not None:
+            device_info["sw_version"] = node_firmware.value
+
         # device with multiple instances is split up into virtual devices for each instance
         if node_instance > 1:
             parent_dev_id = create_device_id(node)

--- a/homeassistant/components/ozw/entity.py
+++ b/homeassistant/components/ozw/entity.py
@@ -7,6 +7,8 @@ from openzwavemqtt.const import (
     EVENT_INSTANCE_STATUS_CHANGED,
     EVENT_VALUE_CHANGED,
     OZW_READY_STATES,
+    CommandClass,
+    ValueIndex,
 )
 from openzwavemqtt.models.node import OZWNode
 from openzwavemqtt.models.value import OZWValue
@@ -182,11 +184,15 @@ class ZWaveDeviceEntity(Entity):
         node = self.values.primary.node
         node_instance = self.values.primary.instance
         dev_id = create_device_id(node, self.values.primary.instance)
+        node_firmware = node.get_value(
+            CommandClass.VERSION, ValueIndex.VERSION_APPLICATION
+        )
         device_info = {
             "identifiers": {(DOMAIN, dev_id)},
             "name": create_device_name(node),
             "manufacturer": node.node_manufacturer_name,
             "model": node.node_product_name,
+            "sw_version": node_firmware.value,
         }
         # device with multiple instances is split up into virtual devices for each instance
         if node_instance > 1:

--- a/homeassistant/components/ozw/manifest.json
+++ b/homeassistant/components/ozw/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ozw",
   "requirements": [
-    "python-openzwave-mqtt==1.0.2"
+    "python-openzwave-mqtt==1.0.4"
   ],
   "after_dependencies": [
     "mqtt"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1734,7 +1734,7 @@ python-nest==4.1.0
 python-nmap==0.6.1
 
 # homeassistant.components.ozw
-python-openzwave-mqtt==1.0.2
+python-openzwave-mqtt==1.0.4
 
 # homeassistant.components.qbittorrent
 python-qbittorrent==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -791,7 +791,7 @@ python-miio==0.5.3
 python-nest==4.1.0
 
 # homeassistant.components.ozw
-python-openzwave-mqtt==1.0.2
+python-openzwave-mqtt==1.0.4
 
 # homeassistant.components.songpal
 python-songpal==0.12


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the firmware of the node to the device registry for zwave devices using the ozw integration. Some zwave devices have different parameters based on firmware version, so it is useful to have it listed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

NOTE: Due to a bug in python-openzwavemqtt, this requires python-openzwavemqtt > 1.0.3, which is not yet released.  

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
