### PR TITLE
Bump pychromecast to 7.2.0

### DIFF
--- a/homeassistant/components/cast/config_flow.py
+++ b/homeassistant/components/cast/config_flow.py
@@ -1,16 +1,25 @@
 """Config flow for Cast."""
-from pychromecast.discovery import discover_chromecasts
+import functools
+
+from pychromecast.discovery import discover_chromecasts, stop_discovery
 
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
 
 from .const import DOMAIN
+from .helpers import ChromeCastZeroconf
 
 
 async def _async_has_devices(hass):
     """Return if there are devices that can be discovered."""
 
-    return await hass.async_add_executor_job(discover_chromecasts)
+    casts, browser = await hass.async_add_executor_job(
+        functools.partial(
+            discover_chromecasts, zeroconf_instance=ChromeCastZeroconf.get_zeroconf()
+        )
+    )
+    stop_discovery(browser)
+    return casts
 
 
 config_entry_flow.register_discovery_flow(

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==7.1.2"],
+  "requirements": ["pychromecast==7.2.0"],
   "after_dependencies": ["cloud","zeroconf"],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": ["@emontnemery"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1253,7 +1253,7 @@ pycfdns==0.0.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==7.1.2
+pychromecast==7.2.0
 
 # homeassistant.components.cmus
 pycmus==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -589,7 +589,7 @@ pyblackbird==0.5
 pybotvac==0.0.17
 
 # homeassistant.components.cast
-pychromecast==7.1.2
+pychromecast==7.2.0
 
 # homeassistant.components.coolmaster
 pycoolmasternet==0.0.4

--- a/tests/components/cast/test_init.py
+++ b/tests/components/cast/test_init.py
@@ -13,7 +13,9 @@ async def test_creating_entry_sets_up_media_player(hass):
         "homeassistant.components.cast.media_player.async_setup_entry",
         return_value=True,
     ) as mock_setup, patch(
-        "pychromecast.discovery.discover_chromecasts", return_value=True
+        "pychromecast.discovery.discover_chromecasts", return_value=(True, None)
+    ), patch(
+        "pychromecast.discovery.stop_discovery"
     ):
         result = await hass.config_entries.flow.async_init(
             cast.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -34,9 +36,7 @@ async def test_configuring_cast_creates_entry(hass):
     """Test that specifying config will create an entry."""
     with patch(
         "homeassistant.components.cast.async_setup_entry", return_value=True
-    ) as mock_setup, patch(
-        "pychromecast.discovery.discover_chromecasts", return_value=True
-    ):
+    ) as mock_setup:
         await async_setup_component(
             hass, cast.DOMAIN, {"cast": {"some_config": "to_trigger_import"}}
         )
@@ -49,9 +49,7 @@ async def test_not_configuring_cast_not_creates_entry(hass):
     """Test that no config will not create an entry."""
     with patch(
         "homeassistant.components.cast.async_setup_entry", return_value=True
-    ) as mock_setup, patch(
-        "pychromecast.discovery.discover_chromecasts", return_value=True
-    ):
+    ) as mock_setup:
         await async_setup_component(hass, cast.DOMAIN, {})
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pychromecast to 7.2.0 to fix one case where the shared zeroconf instance wasn't used (https://github.com/home-assistant/core/issues/35943#issuecomment-664058646)

pychromecast changelog: https://github.com/home-assistant-libs/pychromecast/compare/7.1.2...7.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
