### PR TITLE
Improve tests for Airly integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -31,10 +31,6 @@ omit =
     homeassistant/components/agent_dvr/camera.py
     homeassistant/components/agent_dvr/const.py
     homeassistant/components/agent_dvr/helpers.py
-    homeassistant/components/airly/__init__.py
-    homeassistant/components/airly/air_quality.py
-    homeassistant/components/airly/sensor.py
-    homeassistant/components/airly/const.py
     homeassistant/components/airvisual/__init__.py
     homeassistant/components/airvisual/air_quality.py
     homeassistant/components/airvisual/sensor.py

--- a/homeassistant/components/airly/air_quality.py
+++ b/homeassistant/components/airly/air_quality.py
@@ -31,6 +31,10 @@ LABEL_PM_2_5_PERCENT = f"{ATTR_PM_2_5}_percent_of_limit"
 LABEL_PM_10_LIMIT = f"{ATTR_PM_10}_limit"
 LABEL_PM_10_PERCENT = f"{ATTR_PM_10}_percent_of_limit"
 
+# An update of this entity is not making a web request, but uses internal data only to
+# not exceed allowed numbers of requests.
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Airly air_quality entity based on a config entry."""

--- a/homeassistant/components/airly/air_quality.py
+++ b/homeassistant/components/airly/air_quality.py
@@ -31,9 +31,7 @@ LABEL_PM_2_5_PERCENT = f"{ATTR_PM_2_5}_percent_of_limit"
 LABEL_PM_10_LIMIT = f"{ATTR_PM_10}_limit"
 LABEL_PM_10_PERCENT = f"{ATTR_PM_10}_percent_of_limit"
 
-# An update of this entity is not making a web request, but uses internal data only to
-# not exceed allowed numbers of requests.
-PARALLEL_UPDATES = 0
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/airly/manifest.json
+++ b/homeassistant/components/airly/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/airly",
   "codeowners": ["@bieniu"],
   "requirements": ["airly==0.0.2"],
-  "config_flow": true
+  "config_flow": true,
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -27,6 +27,10 @@ ATTR_ICON = "icon"
 ATTR_LABEL = "label"
 ATTR_UNIT = "unit"
 
+# An update of this entity is not making a web request, but uses internal data only to
+# not exceed allowed numbers of requests.
+PARALLEL_UPDATES = 0
+
 SENSOR_TYPES = {
     ATTR_API_PM1: {
         ATTR_DEVICE_CLASS: None,

--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -27,9 +27,7 @@ ATTR_ICON = "icon"
 ATTR_LABEL = "label"
 ATTR_UNIT = "unit"
 
-# An update of this entity is not making a web request, but uses internal data only to
-# not exceed allowed numbers of requests.
-PARALLEL_UPDATES = 0
+PARALLEL_UPDATES = 1
 
 SENSOR_TYPES = {
     ATTR_API_PM1: {

--- a/tests/components/airly/__init__.py
+++ b/tests/components/airly/__init__.py
@@ -1,1 +1,32 @@
 """Tests for Airly."""
+import json
+
+from homeassistant.components.airly.const import DOMAIN
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry, load_fixture
+
+
+async def init_integration(hass, forecast=False) -> MockConfigEntry:
+    """Set up the Airly integration in Home Assistant."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id="55.55-122.12",
+        data={
+            "api_key": "foo",
+            "latitude": 55.55,
+            "longitude": 122.12,
+            "name": "Home",
+        },
+    )
+
+    with patch(
+        "airly._private._RequestsHandler.get",
+        return_value=json.loads(load_fixture("airly_valid_station.json")),
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry

--- a/tests/components/airly/test_air_quality.py
+++ b/tests/components/airly/test_air_quality.py
@@ -1,0 +1,113 @@
+"""Test air_quality of Airly integration."""
+from datetime import timedelta
+import json
+
+from airly.exceptions import AirlyError
+
+from homeassistant.components.air_quality import ATTR_AQI, ATTR_PM_2_5, ATTR_PM_10
+from homeassistant.components.airly.air_quality import (
+    ATTRIBUTION,
+    LABEL_ADVICE,
+    LABEL_AQI_DESCRIPTION,
+    LABEL_AQI_LEVEL,
+    LABEL_PM_2_5_LIMIT,
+    LABEL_PM_2_5_PERCENT,
+    LABEL_PM_10_LIMIT,
+    LABEL_PM_10_PERCENT,
+)
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_ENTITY_ID,
+    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
+
+from tests.async_mock import patch
+from tests.common import async_fire_time_changed, load_fixture
+from tests.components.airly import init_integration
+
+
+async def test_air_quality(hass):
+    """Test states of the air_quality."""
+    await init_integration(hass)
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    state = hass.states.get("air_quality.home")
+    assert state
+    assert state.state == "14"
+    assert state.attributes.get(ATTR_AQI) == 23
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(LABEL_ADVICE) == "Great air!"
+    assert state.attributes.get(ATTR_PM_10) == 19
+    assert state.attributes.get(ATTR_PM_2_5) == 14
+    assert state.attributes.get(LABEL_AQI_DESCRIPTION) == "Great air here today!"
+    assert state.attributes.get(LABEL_AQI_LEVEL) == "very low"
+    assert state.attributes.get(LABEL_PM_2_5_LIMIT) == 25.0
+    assert state.attributes.get(LABEL_PM_2_5_PERCENT) == 55
+    assert state.attributes.get(LABEL_PM_10_LIMIT) == 50.0
+    assert state.attributes.get(LABEL_PM_10_PERCENT) == 37
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    )
+    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
+
+    entry = registry.async_get("air_quality.home")
+    assert entry
+    assert entry.unique_id == "55.55-122.12"
+
+
+async def test_availability(hass):
+    """Ensure that we mark the entities unavailable correctly when service causes an error."""
+    await init_integration(hass)
+
+    state = hass.states.get("air_quality.home")
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "14"
+
+    future = utcnow() + timedelta(minutes=60)
+    with patch(
+        "airly._private._RequestsHandler.get",
+        side_effect=AirlyError(500, "Unexpected error"),
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("air_quality.home")
+        assert state
+        assert state.state == STATE_UNAVAILABLE
+
+    future = utcnow() + timedelta(minutes=120)
+    with patch(
+        "airly._private._RequestsHandler.get",
+        return_value=json.loads(load_fixture("airly_valid_station.json")),
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("air_quality.home")
+        assert state
+        assert state.state != STATE_UNAVAILABLE
+        assert state.state == "14"
+
+
+async def test_manual_update_entity(hass):
+    """Test manual update entity via service homeasasistant/update_entity."""
+    await init_integration(hass)
+
+    await async_setup_component(hass, "homeassistant", {})
+    with patch(
+        "homeassistant.components.airly.AirlyDataUpdateCoordinator._async_update_data"
+    ) as mock_update:
+        await hass.services.async_call(
+            "homeassistant",
+            "update_entity",
+            {ATTR_ENTITY_ID: ["air_quality.home"]},
+            blocking=True,
+        )
+        assert mock_update.call_count == 1

--- a/tests/components/airly/test_init.py
+++ b/tests/components/airly/test_init.py
@@ -1,0 +1,104 @@
+"""Test init of Airly integration."""
+import json
+
+from homeassistant.components.airly.const import DOMAIN
+from homeassistant.config_entries import (
+    ENTRY_STATE_LOADED,
+    ENTRY_STATE_NOT_LOADED,
+    ENTRY_STATE_SETUP_RETRY,
+)
+from homeassistant.const import STATE_UNAVAILABLE
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry, load_fixture
+from tests.components.airly import init_integration
+
+
+async def test_async_setup_entry(hass):
+    """Test a successful setup entry."""
+    await init_integration(hass)
+
+    state = hass.states.get("air_quality.home")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "14"
+
+
+async def test_config_not_ready(hass):
+    """Test for setup failure if connection to Airly is missing."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id="55.55-122.12",
+        data={
+            "api_key": "foo",
+            "latitude": 55.55,
+            "longitude": 122.12,
+            "name": "Home",
+        },
+    )
+
+    with patch("airly._private._RequestsHandler.get", side_effect=ConnectionError()):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.state == ENTRY_STATE_SETUP_RETRY
+
+
+async def test_config_without_unique_id(hass):
+    """Test for setup entry without unique_id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        data={
+            "api_key": "foo",
+            "latitude": 55.55,
+            "longitude": 122.12,
+            "name": "Home",
+        },
+    )
+
+    with patch(
+        "airly._private._RequestsHandler.get",
+        return_value=json.loads(load_fixture("airly_valid_station.json")),
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.state == ENTRY_STATE_LOADED
+        assert entry.unique_id == "55.55-122.12"
+
+
+async def test_config_with_turned_off_station(hass):
+    """Test for setup entry for a turned off measuring station."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id="55.55-122.12",
+        data={
+            "api_key": "foo",
+            "latitude": 55.55,
+            "longitude": 122.12,
+            "name": "Home",
+        },
+    )
+
+    with patch(
+        "airly._private._RequestsHandler.get",
+        return_value=json.loads(load_fixture("airly_no_station.json")),
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.state == ENTRY_STATE_SETUP_RETRY
+
+
+async def test_unload_entry(hass):
+    """Test successful unload of entry."""
+    entry = await init_integration(hass)
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.state == ENTRY_STATE_LOADED
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state == ENTRY_STATE_NOT_LOADED
+    assert not hass.data.get(DOMAIN)

--- a/tests/components/airly/test_sensor.py
+++ b/tests/components/airly/test_sensor.py
@@ -1,0 +1,128 @@
+"""Test sensor of Airly integration."""
+from datetime import timedelta
+import json
+
+from homeassistant.components.airly.sensor import ATTRIBUTION
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    PRESSURE_HPA,
+    STATE_UNAVAILABLE,
+    TEMP_CELSIUS,
+    UNIT_PERCENTAGE,
+)
+from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
+
+from tests.async_mock import patch
+from tests.common import async_fire_time_changed, load_fixture
+from tests.components.airly import init_integration
+
+
+async def test_sensor(hass):
+    """Test states of the sensor."""
+    await init_integration(hass)
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    state = hass.states.get("sensor.home_humidity")
+    assert state
+    assert state.state == "92.8"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_PERCENTAGE
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_HUMIDITY
+
+    entry = registry.async_get("sensor.home_humidity")
+    assert entry
+    assert entry.unique_id == "55.55-122.12-humidity"
+
+    state = hass.states.get("sensor.home_pm1")
+    assert state
+    assert state.state == "9"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    )
+    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
+
+    entry = registry.async_get("sensor.home_pm1")
+    assert entry
+    assert entry.unique_id == "55.55-122.12-pm1"
+
+    state = hass.states.get("sensor.home_pressure")
+    assert state
+    assert state.state == "1001"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_HPA
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_PRESSURE
+
+    entry = registry.async_get("sensor.home_pressure")
+    assert entry
+    assert entry.unique_id == "55.55-122.12-pressure"
+
+    state = hass.states.get("sensor.home_temperature")
+    assert state
+    assert state.state == "14.2"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+
+    entry = registry.async_get("sensor.home_temperature")
+    assert entry
+    assert entry.unique_id == "55.55-122.12-temperature"
+
+
+async def test_availability(hass):
+    """Ensure that we mark the entities unavailable correctly when service is offline."""
+    await init_integration(hass)
+
+    state = hass.states.get("sensor.home_humidity")
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "92.8"
+
+    future = utcnow() + timedelta(minutes=60)
+    with patch("airly._private._RequestsHandler.get", side_effect=ConnectionError()):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.home_humidity")
+        assert state
+        assert state.state == STATE_UNAVAILABLE
+
+    future = utcnow() + timedelta(minutes=120)
+    with patch(
+        "airly._private._RequestsHandler.get",
+        return_value=json.loads(load_fixture("airly_valid_station.json")),
+    ):
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.home_humidity")
+        assert state
+        assert state.state != STATE_UNAVAILABLE
+        assert state.state == "92.8"
+
+
+async def test_manual_update_entity(hass):
+    """Test manual update entity via service homeasasistant/update_entity."""
+    await init_integration(hass)
+
+    await async_setup_component(hass, "homeassistant", {})
+    with patch(
+        "homeassistant.components.airly.AirlyDataUpdateCoordinator._async_update_data"
+    ) as mock_update:
+        await hass.services.async_call(
+            "homeassistant",
+            "update_entity",
+            {ATTR_ENTITY_ID: ["sensor.home_humidity"]},
+            blocking=True,
+        )
+        assert mock_update.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds 100% test coverage and `PARALLEL_UPDATES` to achieve platinum score in the Integration Quality Scale.

```
----------- coverage: platform linux, python 3.8.3-final-0 -----------
Name                                            Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------
homeassistant/components/airly/__init__.py         76      0   100%
homeassistant/components/airly/air_quality.py      66      0   100%
homeassistant/components/airly/config_flow.py      49      0   100%
homeassistant/components/airly/const.py            18      0   100%
homeassistant/components/airly/sensor.py           65      0   100%
-----------------------------------------------------------------------------
TOTAL                                             274      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
