### PR TITLE
Fix rmvtransport breaking when destinations don't match

### DIFF
--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -235,7 +235,7 @@ class RMVDepartureData:
                 self._station_id,
                 products=self._products,
                 direction_id=self._direction,
-                max_journeys=150,
+                max_journeys=50,
             )
 
         except RMVtransportApiConnectionError:

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -100,7 +100,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     tasks = [sensor.async_update() for sensor in sensors]
     if tasks:
         await asyncio.wait(tasks)
-    if not all(sensor.data.departures for sensor in sensors):
+
+    if not any(sensor.data for sensor in sensors):
         raise PlatformNotReady
 
     async_add_entities(sensors)
@@ -165,6 +166,7 @@ class RMVDepartureSensor(Entity):
                 "minutes": self.data.departures[0].get("minutes"),
                 "departure_time": self.data.departures[0].get("departure_time"),
                 "product": self.data.departures[0].get("product"),
+                ATTR_ATTRIBUTION: ATTRIBUTION,
             }
         except IndexError:
             return {}
@@ -183,13 +185,16 @@ class RMVDepartureSensor(Entity):
         """Get the latest data and update the state."""
         await self.data.async_update()
 
+        if self._name == DEFAULT_NAME:
+            self._name = self.data.station
+
+        self._station = self.data.station
+
         if not self.data.departures:
             self._state = None
             self._icon = ICONS[None]
             return
-        if self._name == DEFAULT_NAME:
-            self._name = self.data.station
-        self._station = self.data.station
+
         self._state = self.data.departures[0].get("minutes")
         self._icon = ICONS[self.data.departures[0].get("product")]
 
@@ -220,6 +225,7 @@ class RMVDepartureData:
         self._max_journeys = max_journeys
         self.rmv = RMVtransport(session, timeout)
         self.departures = []
+        self._error_notification = False
 
     @Throttle(SCAN_INTERVAL)
     async def async_update(self):
@@ -229,33 +235,51 @@ class RMVDepartureData:
                 self._station_id,
                 products=self._products,
                 direction_id=self._direction,
-                max_journeys=50,
+                max_journeys=150,
             )
+
         except RMVtransportApiConnectionError:
             self.departures = []
             _LOGGER.warning("Could not retrieve data from rmv.de")
             return
+
         self.station = _data.get("station")
+
         _deps = []
+        _deps_not_found = set(self._destinations)
+
         for journey in _data["journeys"]:
             # find the first departure meeting the criteria
-            _nextdep = {ATTR_ATTRIBUTION: ATTRIBUTION}
+            _nextdep = {}
             if self._destinations:
                 dest_found = False
                 for dest in self._destinations:
                     if dest in journey["stops"]:
                         dest_found = True
+                        if dest in _deps_not_found:
+                            _deps_not_found.remove(dest)
                         _nextdep["destination"] = dest
+
                 if not dest_found:
                     continue
+
             elif self._lines and journey["number"] not in self._lines:
                 continue
+
             elif journey["minutes"] < self._time_offset:
                 continue
+
             for attr in ["direction", "departure_time", "product", "minutes"]:
                 _nextdep[attr] = journey.get(attr, "")
+
             _nextdep["line"] = journey.get("number", "")
             _deps.append(_nextdep)
+
             if len(_deps) > self._max_journeys:
                 break
+
+        if not self._error_notification and _deps_not_found:
+            self._error_notification = True
+            _LOGGER.info("Destination(s) %s not found", ", ".join(_deps_not_found))
+
         self.departures = _deps

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -48,7 +48,7 @@ VALID_CONFIG_DEST = {
 
 def get_departures_mock():
     """Mock rmvtransport departures loading."""
-    data = {
+    return {
         "station": "Frankfurt (Main) Hauptbahnhof",
         "stationId": "3000010",
         "filter": "11111111111",
@@ -145,18 +145,16 @@ def get_departures_mock():
             },
         ],
     }
-    return data
 
 
 def get_no_departures_mock():
     """Mock no departures in results."""
-    data = {
+    return {
         "station": "Frankfurt (Main) Hauptbahnhof",
         "stationId": "3000010",
         "filter": "11111111111",
         "journeys": [],
     }
-    return data
 
 
 async def test_rmvtransport_min_config(hass):
@@ -232,4 +230,4 @@ async def test_rmvtransport_no_departures(hass):
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
-    assert not state
+    assert state.state == "unavailable"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes an issue where the sensor breaks badly when the it is given a station that is not on the list of stops. This also caused other configured journeys to break and is now fixed. The user now will be given information in the logs about the station that causes the sensor to be `unavailable`. Further correct the place of the attribution information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
  - platform: rmvtransport
    timeout: 120
    next_departure:
      - station: 3001992
        name: ignore
        destinations:
          - Frankfurt (Main) Südbahnhof
        max_journeys: 5
        time_offset: 10
      - station: 3000903
        destinations:
          - Frankfurt (Main) Hauptbahnhof
          - Frankfurt (Main) Hauptbahnhof tief
        max_journeys: 5
        time_offset: 10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38356 and #25717
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
