### PR TITLE
Fix ads integration after 0.113 

### DIFF
--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -230,7 +230,13 @@ class AdsHub:
 
         hnotify = int(contents.hNotification)
         _LOGGER.debug("Received notification %d", hnotify)
-        data = contents.data
+
+        # get dynamically sized data array
+        data_size = contents.cbSampleSize
+        data = (ctypes.c_ubyte * data_size).from_address(
+            ctypes.addressof(contents)
+            + pyads.structs.SAdsNotificationHeader.data.offset
+        )
 
         try:
             with self._lock:
@@ -241,17 +247,17 @@ class AdsHub:
 
         # Parse data to desired datatype
         if notification_item.plc_datatype == self.PLCTYPE_BOOL:
-            value = bool(struct.unpack("<?", bytearray(data)[:1])[0])
+            value = bool(struct.unpack("<?", bytearray(data))[0])
         elif notification_item.plc_datatype == self.PLCTYPE_INT:
-            value = struct.unpack("<h", bytearray(data)[:2])[0]
+            value = struct.unpack("<h", bytearray(data))[0]
         elif notification_item.plc_datatype == self.PLCTYPE_BYTE:
-            value = struct.unpack("<B", bytearray(data)[:1])[0]
+            value = struct.unpack("<B", bytearray(data))[0]
         elif notification_item.plc_datatype == self.PLCTYPE_UINT:
-            value = struct.unpack("<H", bytearray(data)[:2])[0]
+            value = struct.unpack("<H", bytearray(data))[0]
         elif notification_item.plc_datatype == self.PLCTYPE_DINT:
-            value = struct.unpack("<i", bytearray(data)[:4])[0]
+            value = struct.unpack("<i", bytearray(data))[0]
         elif notification_item.plc_datatype == self.PLCTYPE_UDINT:
-            value = struct.unpack("<I", bytearray(data)[:4])[0]
+            value = struct.unpack("<I", bytearray(data))[0]
         else:
             value = bytearray(data)
             _LOGGER.warning("No callback available for this datatype")

--- a/homeassistant/components/ads/manifest.json
+++ b/homeassistant/components/ads/manifest.json
@@ -2,6 +2,6 @@
   "domain": "ads",
   "name": "ADS",
   "documentation": "https://www.home-assistant.io/integrations/ads",
-  "requirements": ["pyads==3.1.3"],
+  "requirements": ["pyads==3.2.1"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1202,7 +1202,7 @@ py_nextbusnext==0.1.4
 # py_noaa==0.3.0
 
 # homeassistant.components.ads
-pyads==3.1.3
+pyads==3.2.1
 
 # homeassistant.components.hisense_aehw4a1
 pyaehw4a1==0.3.5


### PR DESCRIPTION
## Breaking change

## Proposed change
This PR fixes issues (#38151, #38150) with the ads component. The issue was introduced with the update of pyads from 
version 3.0.7 to 3.1.3. It resulted in a timeout error when trying to initialize ads entities.

https://github.com/stlehmann/pyads/compare/3.1.3...3.2.1

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml
# Configure a default setup of Home Assistant (frontend, api, etc)
default_config:

# Text to speech
tts:
  - platform: google_translate
ads:
  device: '172.18.3.25.1.1'
  port: 851

switch:
  - platform: ads
    adsvar: GVL.b1

binary_sensor:
  - platform: ads
    adsvar: GVL.b2

sensor:
  - platform: ads
    adsvar: GVL.b
    unit_of_measurement: '°C'
    adstype: int

group: !include groups.yaml
automation: !include automations.yaml
script: !include scripts.yaml
scene: !include scenes.yaml
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38151, fixes #38150 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [-] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
