### PR TITLE
Add identifiers to device registry api output

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -73,6 +73,7 @@ def _entry_dict(entry):
         "sw_version": entry.sw_version,
         "entry_type": entry.entry_type,
         "id": entry.id,
+        "identifiers": list(entry.identifiers),
         "via_device_id": entry.via_device_id,
         "area_id": entry.area_id,
         "name_by_user": entry.name_by_user,

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -46,6 +46,7 @@ async def test_list_devices(hass, client, registry):
         {
             "config_entries": ["1234"],
             "connections": [["ethernet", "12:34:56:78:90:AB:CD:EF"]],
+            "identifiers": [["bridgeid", "0123"]],
             "manufacturer": "manufacturer",
             "model": "model",
             "name": None,
@@ -58,6 +59,7 @@ async def test_list_devices(hass, client, registry):
         {
             "config_entries": ["1234"],
             "connections": [],
+            "identifiers": [["bridgeid", "1234"]],
             "manufacturer": "manufacturer",
             "model": "model",
             "name": None,


### PR DESCRIPTION
## Proposed change
Currently the device registry websocket API returns all of the device data except the `identifiers`. This adds `identifiers` to the returned output.

I plan to use this in the frontend to extract node and instance ids for the ozw config panel. Should be useful for config panels for other integrations in the future. 

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.