### PR TITLE
Fix queued script not updating current attribute when queuing

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -539,23 +539,32 @@ class _QueuedScriptRun(_ScriptRun):
 
     async def async_run(self) -> None:
         """Run script."""
-        # Wait for previous run, if any, to finish by attempting to acquire the script's
-        # shared lock. At the same time monitor if we've been told to stop.
-        lock_task = self._hass.async_create_task(
-            self._script._queue_lck.acquire()  # pylint: disable=protected-access
-        )
-        stop_task = self._hass.async_create_task(self._stop.wait())
-        try:
-            await asyncio.wait(
-                {lock_task, stop_task}, return_when=asyncio.FIRST_COMPLETED
-            )
-        except asyncio.CancelledError:
-            lock_task.cancel()
-            self._finish()
-            raise
-        finally:
-            stop_task.cancel()
-        self.lock_acquired = lock_task.done() and not lock_task.cancelled()
+        queue_lock = self._script._queue_lck  # pylint: disable=protected-access
+        # Is there a previous run still active?
+        if queue_lock.locked():
+            # Yes: Wait for all previous runs to finish by attempting to acquire the
+            # script's shared lock. At the same time monitor if we've been told to stop.
+            # But first indicate state has changed since the number of active runs just
+            # increased.
+            self._changed()
+            lock_task = self._hass.async_create_task(queue_lock.acquire())
+            stop_task = self._hass.async_create_task(self._stop.wait())
+            try:
+                await asyncio.wait(
+                    {lock_task, stop_task}, return_when=asyncio.FIRST_COMPLETED
+                )
+            except asyncio.CancelledError:
+                lock_task.cancel()
+                self._finish()
+                raise
+            finally:
+                stop_task.cancel()
+            self.lock_acquired = lock_task.done() and not lock_task.cancelled()
+        else:
+            # No: We can just go ahead and grab the lock which will be immediately
+            # successful.
+            await queue_lock.acquire()
+            self.lock_acquired = True
 
         # If we've been told to stop, then just finish up. Otherwise, we've acquired the
         # lock so we can go ahead and start the run.

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -176,8 +176,6 @@ class _ScriptRun:
         try:
             if self._stop.is_set():
                 return
-            self._script.last_triggered = utcnow()
-            self._changed()
             self._log("Running script")
             for self._step, self._action in enumerate(self._script.sequence):
                 if self._stop.is_set():
@@ -797,6 +795,7 @@ class Script:
             self._hass, self, cast(dict, variables), context, self._log_exceptions
         )
         self._runs.append(run)
+        self.last_triggered = utcnow()
         self._changed()
 
         try:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1290,23 +1290,46 @@ async def test_script_mode_queued(hass):
     sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event, "event_data": {"value": 1}},
-            {"wait_template": "{{ states.switch.test.state == 'off' }}"},
+            {
+                "wait_template": "{{ states.switch.test.state == 'off' }}",
+                "alias": "wait_1",
+            },
             {"event": event, "event_data": {"value": 2}},
-            {"wait_template": "{{ states.switch.test.state == 'on' }}"},
+            {
+                "wait_template": "{{ states.switch.test.state == 'on' }}",
+                "alias": "wait_2",
+            },
         ]
     )
     logger = logging.getLogger("TEST")
     script_obj = script.Script(
         hass, sequence, script_mode="queued", max_runs=2, logger=logger
     )
-    wait_started_flag = async_watch_for_action(script_obj, "wait")
+
+    watch_messages = []
+
+    @callback
+    def check_action():
+        for message, flag in watch_messages:
+            if script_obj.last_action and message in script_obj.last_action:
+                flag.set()
+
+    script_obj.change_listener = check_action
+    wait_started_flag_1 = asyncio.Event()
+    watch_messages.append(("wait_1", wait_started_flag_1))
+    wait_started_flag_2 = asyncio.Event()
+    watch_messages.append(("wait_2", wait_started_flag_2))
 
     try:
+        assert not script_obj.is_running
+        assert script_obj.runs == 0
+
         hass.states.async_set("switch.test", "on")
         hass.async_create_task(script_obj.async_run())
-        await asyncio.wait_for(wait_started_flag.wait(), 1)
+        await asyncio.wait_for(wait_started_flag_1.wait(), 1)
 
         assert script_obj.is_running
+        assert script_obj.runs == 1
         assert len(events) == 1
         assert events[0].data["value"] == 1
 
@@ -1314,25 +1337,26 @@ async def test_script_mode_queued(hass):
         # This second run should not start until the first run has finished.
 
         hass.async_create_task(script_obj.async_run())
-
         await asyncio.sleep(0)
+
         assert script_obj.is_running
+        assert script_obj.runs == 2
         assert len(events) == 1
 
-        wait_started_flag.clear()
         hass.states.async_set("switch.test", "off")
-        await asyncio.wait_for(wait_started_flag.wait(), 1)
+        await asyncio.wait_for(wait_started_flag_2.wait(), 1)
 
         assert script_obj.is_running
+        assert script_obj.runs == 2
         assert len(events) == 2
         assert events[1].data["value"] == 2
 
-        wait_started_flag.clear()
+        wait_started_flag_1.clear()
         hass.states.async_set("switch.test", "on")
-        await asyncio.wait_for(wait_started_flag.wait(), 1)
+        await asyncio.wait_for(wait_started_flag_1.wait(), 1)
 
-        await asyncio.sleep(0)
         assert script_obj.is_running
+        assert script_obj.runs == 1
         assert len(events) == 3
         assert events[2].data["value"] == 1
     except (AssertionError, asyncio.TimeoutError):
@@ -1345,6 +1369,7 @@ async def test_script_mode_queued(hass):
         await hass.async_block_till_done()
 
         assert not script_obj.is_running
+        assert script_obj.runs == 0
         assert len(events) == 4
         assert events[3].data["value"] == 2
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a script configured in queued mode first queued a run it was not updating its `current` attribute (which is the current number of active runs.) This change fixes that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
