### PR TITLE
Allow automation to be turned off without stopping actions

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -394,7 +394,10 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self.async_disable(kwargs[CONF_STOP_ACTIONS])
+        if CONF_STOP_ACTIONS in kwargs:
+            await self.async_disable(kwargs[CONF_STOP_ACTIONS])
+        else:
+            await self.async_disable()
 
     async def async_trigger(self, variables, skip_condition=False, context=None):
         """Trigger automation.

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -67,6 +67,7 @@ CONF_TRIGGER = "trigger"
 CONF_CONDITION_TYPE = "condition_type"
 CONF_INITIAL_STATE = "initial_state"
 CONF_SKIP_CONDITION = "skip_condition"
+CONF_STOP_ACTIONS = "stop_actions"
 
 CONDITION_USE_TRIGGER_VALUES = "use_trigger_values"
 CONDITION_TYPE_AND = "and"
@@ -75,6 +76,7 @@ CONDITION_TYPE_OR = "or"
 
 DEFAULT_CONDITION_TYPE = CONDITION_TYPE_AND
 DEFAULT_INITIAL_STATE = True
+DEFAULT_STOP_ACTIONS = True
 
 EVENT_AUTOMATION_RELOADED = "automation_reloaded"
 EVENT_AUTOMATION_TRIGGERED = "automation_triggered"
@@ -225,7 +227,11 @@ async def async_setup(hass, config):
     )
     component.async_register_entity_service(SERVICE_TOGGLE, {}, "async_toggle")
     component.async_register_entity_service(SERVICE_TURN_ON, {}, "async_turn_on")
-    component.async_register_entity_service(SERVICE_TURN_OFF, {}, "async_turn_off")
+    component.async_register_entity_service(
+        SERVICE_TURN_OFF,
+        {vol.Optional(CONF_STOP_ACTIONS, default=DEFAULT_STOP_ACTIONS): cv.boolean},
+        "async_turn_off",
+    )
 
     async def reload_service_handler(service_call):
         """Remove all automations and load new ones from config."""
@@ -261,6 +267,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         self._async_detach_triggers = None
         self._cond_func = cond_func
         self.action_script = action_script
+        self.action_script.change_listener = self.async_write_ha_state
         self._last_triggered = None
         self._initial_state = initial_state
         self._is_enabled = False
@@ -289,11 +296,10 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         attrs = {
             ATTR_LAST_TRIGGERED: self._last_triggered,
             ATTR_MODE: self.action_script.script_mode,
+            ATTR_CUR: self.action_script.runs,
         }
         if self.action_script.supports_max:
             attrs[ATTR_MAX] = self.action_script.max_runs
-            if self.is_on:
-                attrs[ATTR_CUR] = self.action_script.runs
         return attrs
 
     @property
@@ -388,7 +394,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self.async_disable()
+        await self.async_disable(kwargs[CONF_STOP_ACTIONS])
 
     async def async_trigger(self, variables, skip_condition=False, context=None):
         """Trigger automation.
@@ -456,9 +462,9 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         )
         self.async_write_ha_state()
 
-    async def async_disable(self):
+    async def async_disable(self, stop_actions=DEFAULT_STOP_ACTIONS):
         """Disable the automation entity."""
-        if not self._is_enabled:
+        if not self._is_enabled and not self.action_script.runs:
             return
 
         self._is_enabled = False
@@ -467,7 +473,8 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             self._async_detach_triggers()
             self._async_detach_triggers = None
 
-        await self.action_script.async_stop()
+        if stop_actions:
+            await self.action_script.async_stop()
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/automation/services.yaml
+++ b/homeassistant/components/automation/services.yaml
@@ -12,6 +12,9 @@ turn_off:
     entity_id:
       description: Name of the automation to turn off.
       example: "automation.notify_home"
+    stop_actions:
+      description: Stop currently running actions (defaults to true).
+      example: false
 
 toggle:
   description: Toggle an automation.
@@ -27,7 +30,7 @@ trigger:
       description: Name of the automation to trigger.
       example: "automation.notify_home"
     skip_condition:
-      description: Whether or not the condition will be skipped (defaults to True).
+      description: Whether or not the condition will be skipped (defaults to true).
       example: true
 
 reload:

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -278,11 +278,10 @@ class ScriptEntity(ToggleEntity):
         attrs = {
             ATTR_LAST_TRIGGERED: self.script.last_triggered,
             ATTR_MODE: self.script.script_mode,
+            ATTR_CUR: self.script.runs,
         }
         if self.script.supports_max:
             attrs[ATTR_MAX] = self.script.max_runs
-            if self.is_on:
-                attrs[ATTR_CUR] = self.script.runs
         if self.script.last_action:
             attrs[ATTR_LAST_ACTION] = self.script.last_action
         return attrs

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -390,6 +390,17 @@ async def test_services(hass, calls):
     await hass.async_block_till_done()
     assert len(calls) == 2
 
+    await common.async_toggle(hass, entity_id)
+    await hass.async_block_till_done()
+
+    assert not automation.is_on(hass, entity_id)
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    await common.async_toggle(hass, entity_id)
+    await hass.async_block_till_done()
+
     await common.async_trigger(hass, entity_id)
     await hass.async_block_till_done()
     assert len(calls) == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This change is actually not a breaking change, but it is making up for the fact that a previous change was that was not marked as such. Specifically I'm referring to #38348.

It turns out there are valid use cases where an automation needs to be turned off, so that it will not trigger, but where previous runs may still be active that should be allowed to complete. E.g., an automation that performs a reasonably lengthy procedure that should not be aborted midstream, otherwise it would leave the system in an undesirable state. Or a queued automation that needs to handle all previous events, some of which may not be complete when the automation is turned off.

The work around for the previous breakage is to use the new service parameter described below.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds an optional parameter to the `automation.turn_off` service, namely `stop_actions`, which defaults to `true`, that controls whether or not active runs should be stopped when the automation is turned off.

Also the automation's `current` attribute was not being updated properly. This is also fixed. And, to make its usage easier, it will be present for all modes and at all times. (Same is being done for scripts.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
This is being considered a bug fix since it is allowing the old behavior that was effectively broken by the PR noted above.

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
# Turn off automation so that it will not trigger again,
# but let any currently active runs finish.
- service: automation.turn_off
  entity_id: automation.AUTOMATION
  data:
    stop_actions: false
# Maybe do some other things
- ...
# Now wait for any previously active runs to finish.
- wait_template: "{{ is_state_attr('automation.AUTOMATION', 'current', 0) }}"
- ...
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#14134

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
