### PR TITLE
Allow disabling integrations in manifest, block uuid package being installed and disable ezviz

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          pip install -U pip==20.1.1 setuptools
+          pip install -U pip setuptools
           pip install -r requirements.txt -r requirements_test.txt
           # Uninstalling typing as a workaround. Eventually we should make sure
           # all our dependencies drop typing.
@@ -603,7 +603,7 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          pip install -U pip==20.1.1 setuptools wheel
+          pip install -U pip setuptools wheel
           pip install -r requirements_all.txt
           pip install -r requirements_test.txt
           # Uninstalling typing as a workaround. Eventually we should make sure

--- a/homeassistant/components/ezviz/camera.py
+++ b/homeassistant/components/ezviz/camera.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 
+# pylint: disable=import-error
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
 from pyezviz.camera import EzvizCamera
 from pyezviz.client import EzvizClient, PyEzvizError

--- a/homeassistant/components/ezviz/manifest.json
+++ b/homeassistant/components/ezviz/manifest.json
@@ -1,4 +1,5 @@
 {
+  "disabled": "Dependency contains code that breaks Home Assistant.",
   "domain": "ezviz",
   "name": "Ezviz",
   "documentation": "https://www.home-assistant.io/integrations/ezviz",

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -272,6 +272,11 @@ class Integration:
         return cast(str, self.manifest["name"])
 
     @property
+    def disabled(self) -> Optional[str]:
+        """Return reason integration is disabled."""
+        return cast(Optional[str], self.manifest.get("disabled"))
+
+    @property
     def domain(self) -> str:
         """Return domain."""
         return cast(str, self.manifest["domain"])

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -44,3 +44,6 @@ enum34==1000000000.0.0
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
+
+# This is built-in and breaks pip if installed
+uuid==1000000000.0.0

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -124,6 +124,10 @@ async def _async_setup_component(
         log_error("Integration not found.")
         return False
 
+    if integration.disabled:
+        log_error(f"dependency is disabled - {integration.disabled}")
+        return False
+
     # Validate all dependencies exist and there are no circular dependencies
     if not await integration.resolve_dependencies():
         return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1334,9 +1334,6 @@ pyephember==0.3.1
 # homeassistant.components.everlights
 pyeverlights==0.1.0
 
-# homeassistant.components.ezviz
-pyezviz==0.1.5
-
 # homeassistant.components.fido
 pyfido==2.1.1
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -71,6 +71,9 @@ enum34==1000000000.0.0
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
+
+# This is built-in and breaks pip if installed
+uuid==1000000000.0.0
 """
 
 IGNORE_PRE_COMMIT_HOOK_ID = (

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -181,6 +181,9 @@ def gather_requirements_from_manifests(errors, reqs):
             errors.append(f"The manifest for integration {domain} is invalid.")
             continue
 
+        if integration.disabled:
+            continue
+
         process_requirements(
             errors, integration.requirements, f"homeassistant.components.{domain}", reqs
         )

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -54,6 +54,7 @@ MANIFEST_SCHEMA = vol.Schema(
         vol.Optional("dependencies"): [str],
         vol.Optional("after_dependencies"): [str],
         vol.Required("codeowners"): [str],
+        vol.Optional("disabled"): str,
     }
 )
 

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -74,6 +74,11 @@ class Integration:
         return self.path.name
 
     @property
+    def disabled(self) -> str:
+        """List of disabled."""
+        return self.manifest.get("disabled", None)
+
+    @property
     def requirements(self) -> List[str]:
         """List of requirements."""
         return self.manifest.get("requirements", [])

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -74,9 +74,9 @@ class Integration:
         return self.path.name
 
     @property
-    def disabled(self) -> str:
+    def disabled(self) -> Optional[str]:
         """List of disabled."""
-        return self.manifest.get("disabled", None)
+        return self.manifest.get("disabled")
 
     @property
     def requirements(self) -> List[str]:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -583,3 +583,15 @@ async def test_parallel_entry_setup(hass):
     await setup.async_setup_component(hass, "comp", {})
 
     assert calls == [1, 2, 1, 2]
+
+
+async def test_integration_disabled(hass, caplog):
+    """Test we can disable an integration."""
+    disabled_reason = "Dependency contains code that breaks Home Assistant"
+    mock_integration(
+        hass,
+        MockModule("test_component1", partial_manifest={"disabled": disabled_reason}),
+    )
+    result = await setup.async_setup_component(hass, "test_component1", {})
+    assert not result
+    assert disabled_reason in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The ezviz integration has been disabled, as its dependencies contain code that breaks Home Assistant.


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
CI for the 113.3 release is breaking ([logs](https://github.com/home-assistant/core/pull/38443/checks?check_run_id=934299008)) because an old `uuid` package is installed. Not sure how that happened. Blocking it in this PR to see what package shows up . 

Found culprit. It's the ezviz integration. This PR will disable that integration so we don't block Python environments. I had a PR open for a month but no action was taken.

- pyEzviz https://github.com/BaQs/pyEzviz/pull/10

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
