### PR TITLE
Move system log processing out of the event loop

### DIFF
--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -1,5 +1,9 @@
 """Test system log component."""
+import asyncio
 import logging
+import queue
+
+import pytest
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import system_log
@@ -11,13 +15,34 @@ _LOGGER = logging.getLogger("test_logger")
 BASIC_CONFIG = {"system_log": {"max_entries": 2}}
 
 
+@pytest.fixture
+def simple_queue():
+    """Fixture that get the queue."""
+    simple_queue_fixed = queue.SimpleQueue()
+    with patch(
+        "homeassistant.components.system_log.queue.SimpleQueue",
+        return_value=simple_queue_fixed,
+    ):
+        yield simple_queue_fixed
+
+
+async def _async_block_until_queue_empty(hass, sq):
+    # Unfortunately we are stuck with polling
+    await hass.async_block_till_done()
+    while not sq.empty():
+        await asyncio.sleep(0.01)
+    await hass.async_block_till_done()
+
+
 async def get_error_log(hass, hass_client, expected_count):
     """Fetch all entries from system_log via the API."""
+
     client = await hass_client()
     resp = await client.get("/api/error/all")
     assert resp.status == 200
 
     data = await resp.json()
+
     assert len(data) == expected_count
     return data
 
@@ -46,41 +71,49 @@ def get_frame(name):
     return (name, 5, None, None)
 
 
-async def test_normal_logs(hass, hass_client):
+async def test_normal_logs(hass, simple_queue, hass_client):
     """Test that debug and info are not logged."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
+
     _LOGGER.debug("debug")
     _LOGGER.info("info")
+    await _async_block_until_queue_empty(hass, simple_queue)
 
     # Assert done by get_error_log
     await get_error_log(hass, hass_client, 0)
 
 
-async def test_exception(hass, hass_client):
+async def test_exception(hass, simple_queue, hass_client):
     """Test that exceptions are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _generate_and_log_exception("exception message", "log message")
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = (await get_error_log(hass, hass_client, 1))[0]
     assert_log(log, "exception message", "log message", "ERROR")
 
 
-async def test_warning(hass, hass_client):
+async def test_warning(hass, simple_queue, hass_client):
     """Test that warning are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.warning("warning message")
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = (await get_error_log(hass, hass_client, 1))[0]
     assert_log(log, "", "warning message", "WARNING")
 
 
-async def test_error(hass, hass_client):
+async def test_error(hass, simple_queue, hass_client):
     """Test that errors are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.error("error message")
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = (await get_error_log(hass, hass_client, 1))[0]
     assert_log(log, "", "error message", "ERROR")
 
 
-async def test_config_not_fire_event(hass):
+async def test_config_not_fire_event(hass, simple_queue):
     """Test that errors are not posted as events with default config."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     events = []
@@ -93,12 +126,12 @@ async def test_config_not_fire_event(hass):
     hass.bus.async_listen(system_log.EVENT_SYSTEM_LOG, event_listener)
 
     _LOGGER.error("error message")
-    await hass.async_block_till_done()
+    await _async_block_until_queue_empty(hass, simple_queue)
 
     assert len(events) == 0
 
 
-async def test_error_posted_as_event(hass):
+async def test_error_posted_as_event(hass, simple_queue):
     """Test that error are posted as events."""
     await async_setup_component(
         hass, system_log.DOMAIN, {"system_log": {"max_entries": 2, "fire_event": True}}
@@ -113,26 +146,30 @@ async def test_error_posted_as_event(hass):
     hass.bus.async_listen(system_log.EVENT_SYSTEM_LOG, event_listener)
 
     _LOGGER.error("error message")
-    await hass.async_block_till_done()
+    await _async_block_until_queue_empty(hass, simple_queue)
 
     assert len(events) == 1
     assert_log(events[0].data, "", "error message", "ERROR")
 
 
-async def test_critical(hass, hass_client):
+async def test_critical(hass, simple_queue, hass_client):
     """Test that critical are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.critical("critical message")
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = (await get_error_log(hass, hass_client, 1))[0]
     assert_log(log, "", "critical message", "CRITICAL")
 
 
-async def test_remove_older_logs(hass, hass_client):
+async def test_remove_older_logs(hass, simple_queue, hass_client):
     """Test that older logs are rotated out."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.error("error message 1")
     _LOGGER.error("error message 2")
     _LOGGER.error("error message 3")
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = await get_error_log(hass, hass_client, 2)
     assert_log(log[0], "", "error message 3", "ERROR")
     assert_log(log[1], "", "error message 2", "ERROR")
@@ -143,19 +180,23 @@ def log_msg(nr=2):
     _LOGGER.error("error message %s", nr)
 
 
-async def test_dedup_logs(hass, hass_client):
+async def test_dedup_logs(hass, simple_queue, hass_client):
     """Test that duplicate log entries are dedup."""
     await async_setup_component(hass, system_log.DOMAIN, {})
     _LOGGER.error("error message 1")
     log_msg()
     log_msg("2-2")
     _LOGGER.error("error message 3")
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = await get_error_log(hass, hass_client, 3)
     assert_log(log[0], "", "error message 3", "ERROR")
     assert log[1]["count"] == 2
     assert_log(log[1], "", ["error message 2", "error message 2-2"], "ERROR")
 
     log_msg()
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = await get_error_log(hass, hass_client, 3)
     assert_log(log[0], "", ["error message 2", "error message 2-2"], "ERROR")
     assert log[0]["timestamp"] > log[0]["first_occurred"]
@@ -164,6 +205,8 @@ async def test_dedup_logs(hass, hass_client):
     log_msg("2-4")
     log_msg("2-5")
     log_msg("2-6")
+    await _async_block_until_queue_empty(hass, simple_queue)
+
     log = await get_error_log(hass, hass_client, 3)
     assert_log(
         log[0],
@@ -179,15 +222,16 @@ async def test_dedup_logs(hass, hass_client):
     )
 
 
-async def test_clear_logs(hass, hass_client):
+async def test_clear_logs(hass, simple_queue, hass_client):
     """Test that the log can be cleared via a service call."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.error("error message")
+    await _async_block_until_queue_empty(hass, simple_queue)
 
     hass.async_add_job(
         hass.services.async_call(system_log.DOMAIN, system_log.SERVICE_CLEAR, {})
     )
-    await hass.async_block_till_done()
+    await _async_block_until_queue_empty(hass, simple_queue)
 
     # Assert done by get_error_log
     await get_error_log(hass, hass_client, 0)
@@ -239,16 +283,17 @@ async def test_write_choose_level(hass):
     assert logger.method_calls[0] == ("debug", ("test_message",))
 
 
-async def test_unknown_path(hass, hass_client):
+async def test_unknown_path(hass, simple_queue, hass_client):
     """Test error logged from unknown path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.findCaller = MagicMock(return_value=("unknown_path", 0, None, None))
     _LOGGER.error("error message")
+    await _async_block_until_queue_empty(hass, simple_queue)
     log = (await get_error_log(hass, hass_client, 1))[0]
     assert log["source"] == ["unknown_path", 0]
 
 
-def log_error_from_test_path(path):
+async def async_log_error_from_test_path(hass, path, sq):
     """Log error while mocking the path."""
     call_path = "internal_path.py"
     with patch.object(
@@ -266,24 +311,29 @@ def log_error_from_test_path(path):
             ),
         ):
             _LOGGER.error("error message")
+            await _async_block_until_queue_empty(hass, sq)
 
 
-async def test_homeassistant_path(hass, hass_client):
+async def test_homeassistant_path(hass, simple_queue, hass_client):
     """Test error logged from Home Assistant path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     with patch(
         "homeassistant.components.system_log.HOMEASSISTANT_PATH",
         new=["venv_path/homeassistant"],
     ):
-        log_error_from_test_path("venv_path/homeassistant/component/component.py")
+        await async_log_error_from_test_path(
+            hass, "venv_path/homeassistant/component/component.py", simple_queue
+        )
         log = (await get_error_log(hass, hass_client, 1))[0]
     assert log["source"] == ["component/component.py", 5]
 
 
-async def test_config_path(hass, hass_client):
+async def test_config_path(hass, simple_queue, hass_client):
     """Test error logged from config path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     with patch.object(hass.config, "config_dir", new="config"):
-        log_error_from_test_path("config/custom_component/test.py")
+        await async_log_error_from_test_path(
+            hass, "config/custom_component/test.py", simple_queue
+        )
         log = (await get_error_log(hass, hass_client, 1))[0]
     assert log["source"] == ["custom_component/test.py", 5]


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move system log processing out of the event loop.   Same change as https://github.com/home-assistant/core/pull/35633 but for system_log.   
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `automations.yaml` to generate a lot of log messages for testing:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example automations.yaml
- id: '1596237944175'
  alias: Spam the log
  description: ''
  trigger:
  - platform: time_pattern
    seconds: /1
  condition: []
  action:
  - data_template:
      level: warning
      logger: mycomponent.myplatform
      message: '{{ now() }} Something went wrong'
    service: system_log.write
  mode: single
- id: '15962379441765'
  alias: Spam the log2
  description: ''
  trigger:
  - platform: time_pattern
    seconds: /1
  condition: []
  action:
  - data_template:
      level: warning
      logger: mycomponent.myplatform
      message: Something went wrong2
    service: system_log.write
  mode: single
- id: '15962379441767'
  alias: Spam the log3
  trigger:
  - platform: time_pattern
    seconds: /1
  condition: []
  action:
  - data_template:
      level: warning
      logger: mycomponent.myplatform
      message: Something went wrong3
    service: system_log.write
  mode: single

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38375
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
