### PR TITLE
Cache emulated hue states attributes between get and put calls to avoid unexpected alexa errors

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -72,6 +72,8 @@ from homeassistant.util.network import is_local
 
 _LOGGER = logging.getLogger(__name__)
 
+# How long to wait for a state change to happen
+STATE_CHANGE_WAIT_TIMEOUT = 2.0
 # How long an entry state's cache will be valid for in seconds.
 STATE_CACHED_TIMEOUT = 2.0
 
@@ -833,7 +835,7 @@ async def wait_for_state_change_or_timeout(hass, entity_id, timeout):
     unsub = async_track_state_change_event(hass, [entity_id], _async_event_changed)
 
     try:
-        await asyncio.wait_for(ev.wait(), timeout=STATE_CACHED_TIMEOUT)
+        await asyncio.wait_for(ev.wait(), timeout=STATE_CHANGE_WAIT_TIMEOUT)
     except asyncio.TimeoutError:
         pass
     finally:

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -2,6 +2,7 @@
 import asyncio
 import hashlib
 import logging
+import time
 
 from homeassistant import core
 from homeassistant.components import (
@@ -66,9 +67,16 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util.network import is_local
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long an entry state's cache will be valid for in seconds.
+STATE_CACHED_TIMEOUT = 2.0
+# Index value when accessing a cached state.
+STATE_CACHE_STATE = 0
+STATE_CACHE_TIME = 1
 
 STATE_BRIGHTNESS = "bri"
 STATE_COLORMODE = "colormode"
@@ -520,7 +528,9 @@ class HueOneLightChangeView(HomeAssistantView):
             # they'll map to "on". Thus, instead of reporting its actual
             # status, we report what Alexa will want to see, which is the same
             # as the actual requested command.
-            config.cached_states[entity_id] = parsed
+            config.cached_states[entity_id] = [parsed, None]
+        else:
+            config.cached_states[entity_id] = [parsed, time.time()]
 
         # Separate call to turn on needed
         if turn_on_needed:
@@ -534,9 +544,17 @@ class HueOneLightChangeView(HomeAssistantView):
             )
 
         if service is not None:
+            state_will_change = parsed[STATE_ON] != (entity.state != STATE_OFF)
+
             hass.async_create_task(
                 hass.services.async_call(domain, service, data, blocking=True)
             )
+
+            if state_will_change:
+                # Wait for the state to change.
+                await wait_for_state_change_or_timeout(
+                    hass, entity_id, STATE_CACHED_TIMEOUT
+                )
 
         # Create success responses for all received keys
         json_response = [
@@ -556,16 +574,30 @@ class HueOneLightChangeView(HomeAssistantView):
                     create_hue_success_response(entity_number, val, parsed[key])
                 )
 
-        # Echo fetches the state immediately after the PUT method returns.
-        # Waiting for a short time allows the changes to propagate.
-        await asyncio.sleep(0.25)
-
         return self.json(json_response)
 
 
 def get_entity_state(config, entity):
     """Retrieve and convert state and brightness values for an entity."""
-    cached_state = config.cached_states.get(entity.entity_id, None)
+    cached_state_entry = config.cached_states.get(entity.entity_id, None)
+    cached_state = None
+
+    # Check if we have a cached entry, and if so if it hasn't expired.
+    if cached_state_entry is not None:
+        entry_state, entry_time = cached_state_entry
+        if entry_time is None:
+            # Handle the case where the entity is listed in config.off_maps_to_on_domains.
+            cached_state = entry_state
+        elif time.time() - entry_time < STATE_CACHED_TIMEOUT and entry_state[
+            STATE_ON
+        ] == (entity.state != STATE_OFF):
+            # We only want to use the cache if the actual state of the entity
+            # is in sync so that it can be detected as an error by Alexa.
+            cached_state = entry_state
+        else:
+            # Remove the now stale cached entry.
+            config.cached_states.pop(entity.entity_id)
+
     data = {
         STATE_ON: False,
         STATE_BRIGHTNESS: None,
@@ -791,3 +823,21 @@ def hue_brightness_to_hass(value):
 def hass_to_hue_brightness(value):
     """Convert hass brightness 0..255 to hue 1..254 scale."""
     return max(1, round((value / 255) * HUE_API_STATE_BRI_MAX))
+
+
+async def wait_for_state_change_or_timeout(hass, entity_id, timeout):
+    """Wait for an entity to change state."""
+    ev = asyncio.Event()
+
+    @core.callback
+    def _async_event_changed(_):
+        ev.set()
+
+    unsub = async_track_state_change_event(hass, [entity_id], _async_event_changed)
+
+    try:
+        await asyncio.wait_for(ev.wait(), timeout=STATE_CACHED_TIMEOUT)
+    except asyncio.TimeoutError:
+        pass
+    finally:
+        unsub()

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -74,9 +74,6 @@ _LOGGER = logging.getLogger(__name__)
 
 # How long an entry state's cache will be valid for in seconds.
 STATE_CACHED_TIMEOUT = 2.0
-# Index value when accessing a cached state.
-STATE_CACHE_STATE = 0
-STATE_CACHE_TIME = 1
 
 STATE_BRIGHTNESS = "bri"
 STATE_COLORMODE = "colormode"

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1,4 +1,5 @@
 """The tests for the emulated Hue component."""
+import asyncio
 from datetime import timedelta
 from ipaddress import ip_address
 import json
@@ -18,7 +19,7 @@ from homeassistant.components import (
     media_player,
     script,
 )
-from homeassistant.components.emulated_hue import Config
+from homeassistant.components.emulated_hue import Config, hue_api
 from homeassistant.components.emulated_hue.hue_api import (
     HUE_API_STATE_BRI,
     HUE_API_STATE_HUE,
@@ -1058,3 +1059,126 @@ async def test_unauthorized_user_blocked(hue_client):
 
         result_json = await result.json()
         assert result_json[0]["error"]["description"] == "unauthorized user"
+
+
+async def test_put_then_get_cached_properly(hass, hass_hue, hue_client):
+    """Test the setting of light states and an immediate readback reads the same values."""
+
+    # Turn the bedroom light on first
+    await hass_hue.services.async_call(
+        light.DOMAIN,
+        const.SERVICE_TURN_ON,
+        {const.ATTR_ENTITY_ID: "light.ceiling_lights", light.ATTR_BRIGHTNESS: 153},
+        blocking=True,
+    )
+
+    ceiling_lights = hass_hue.states.get("light.ceiling_lights")
+    assert ceiling_lights.state == STATE_ON
+    assert ceiling_lights.attributes[light.ATTR_BRIGHTNESS] == 153
+
+    # update light state through api
+    await perform_put_light_state(
+        hass_hue,
+        hue_client,
+        "light.ceiling_lights",
+        True,
+        hue=4369,
+        saturation=127,
+        brightness=254,
+    )
+
+    # Check that a Hue brightness level of 254 becomes 255 in HA realm.
+    assert (
+        hass.states.get("light.ceiling_lights").attributes[light.ATTR_BRIGHTNESS] == 255
+    )
+
+    # Make sure that the GET response is the same as the PUT response within 2 seconds if the service call is successful and the state doesn't change.
+    # We simulate a long latence for the actual setting of the entity by forcibly sitting different values directly.
+    await hass_hue.services.async_call(
+        light.DOMAIN,
+        const.SERVICE_TURN_ON,
+        {const.ATTR_ENTITY_ID: "light.ceiling_lights", light.ATTR_BRIGHTNESS: 153},
+        blocking=True,
+    )
+
+    # go through api to get the state back, the value returned should match those set in the last PUT request.
+    ceiling_json = await perform_get_light_state(
+        hue_client, "light.ceiling_lights", HTTP_OK
+    )
+
+    assert ceiling_json["state"][HUE_API_STATE_HUE] == 4369
+    assert ceiling_json["state"][HUE_API_STATE_SAT] == 127
+    assert ceiling_json["state"][HUE_API_STATE_BRI] == 254
+
+    # Make sure that the GET response does not use the cache if PUT response within 2 seconds if the service call is Unsuccessful and the state does not change.
+    await hass_hue.services.async_call(
+        light.DOMAIN,
+        const.SERVICE_TURN_OFF,
+        {const.ATTR_ENTITY_ID: "light.ceiling_lights"},
+        blocking=True,
+    )
+
+    # go through api to get the state back
+    ceiling_json = await perform_get_light_state(
+        hue_client, "light.ceiling_lights", HTTP_OK
+    )
+
+    # Now it should be the real value as the state of the entity has changed to OFF.
+    assert ceiling_json["state"][HUE_API_STATE_HUE] == 0
+    assert ceiling_json["state"][HUE_API_STATE_SAT] == 0
+    assert ceiling_json["state"][HUE_API_STATE_BRI] == 1
+
+    # Ensure we read the actual value after exceeding the timeout time.
+
+    # Turn the bedroom light back on first
+    await hass_hue.services.async_call(
+        light.DOMAIN,
+        const.SERVICE_TURN_ON,
+        {const.ATTR_ENTITY_ID: "light.ceiling_lights"},
+        blocking=True,
+    )
+
+    # update light state through api
+    await perform_put_light_state(
+        hass_hue,
+        hue_client,
+        "light.ceiling_lights",
+        True,
+        hue=4369,
+        saturation=127,
+        brightness=254,
+    )
+
+    await hass_hue.services.async_call(
+        light.DOMAIN,
+        const.SERVICE_TURN_ON,
+        {
+            const.ATTR_ENTITY_ID: "light.ceiling_lights",
+            light.ATTR_BRIGHTNESS: 127,
+            light.ATTR_RGB_COLOR: (1, 2, 7),
+        },
+        blocking=True,
+    )
+
+    # go through api to get the state back, the value returned should match those set in the last PUT request.
+    ceiling_json = await perform_get_light_state(
+        hue_client, "light.ceiling_lights", HTTP_OK
+    )
+
+    # With no wait, we must be reading what we set via the PUT call.
+    assert ceiling_json["state"][HUE_API_STATE_HUE] == 4369
+    assert ceiling_json["state"][HUE_API_STATE_SAT] == 127
+    assert ceiling_json["state"][HUE_API_STATE_BRI] == 254
+
+    with patch.object(hue_api, "STATE_CACHED_TIMEOUT", 0.000001):
+        await asyncio.sleep(0.000001)
+
+        # go through api to get the state back, the value returned should now match the actual values.
+        ceiling_json = await perform_get_light_state(
+            hue_client, "light.ceiling_lights", HTTP_OK
+        )
+
+        # Once we're after the cached duration, we should see the real value.
+        assert ceiling_json["state"][HUE_API_STATE_HUE] == 41869
+        assert ceiling_json["state"][HUE_API_STATE_SAT] == 217
+        assert ceiling_json["state"][HUE_API_STATE_BRI] == 127

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1337,7 +1337,6 @@ async def test_put_than_get_when_service_call_fails(hass, hass_hue, hue_client):
     assert ceiling_lights.state == STATE_OFF
 
     with patch.object(hue_api, "STATE_CHANGE_WAIT_TIMEOUT", 0.000001):
-        await asyncio.sleep(0.000001)
         # update light state through api
         await perform_put_light_state(
             hass_hue,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When Alexa issues a command to a Hue hub; it immediately queries the hub for the entity's state.to confirm if the command was successful.
It expects the state to be effective immediately.
There may be a delay for the new state to actually be active, this is particularly obvious when using group lights.

This leads Alexa to report that the light had an error.

We now cache the state sets by Alexa and return those cached values for up to two seconds.

Fixes #38446


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
No changes required anywhere.

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38446
- This PR is related to issue: #35307
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
