### PR TITLE
Add Influxdb precision option

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -57,6 +57,7 @@ from .const import (
     CONF_PASSWORD,
     CONF_PATH,
     CONF_PORT,
+    CONF_PRECISION,
     CONF_RETRY_COUNT,
     CONF_SSL,
     CONF_TAGS,
@@ -307,13 +308,13 @@ def get_influx_connection(conf, test_write=False, test_read=False):
     kwargs = {
         CONF_TIMEOUT: TIMEOUT,
     }
+    precision = conf.get(CONF_PRECISION)
 
     if conf[CONF_API_VERSION] == API_VERSION_2:
         kwargs[CONF_URL] = conf[CONF_URL]
         kwargs[CONF_TOKEN] = conf[CONF_TOKEN]
         kwargs[INFLUX_CONF_ORG] = conf[CONF_ORG]
         bucket = conf.get(CONF_BUCKET)
-
         influx = InfluxDBClientV2(**kwargs)
         query_api = influx.query_api()
         initial_write_mode = SYNCHRONOUS if test_write else ASYNCHRONOUS
@@ -322,7 +323,7 @@ def get_influx_connection(conf, test_write=False, test_read=False):
         def write_v2(json):
             """Write data to V2 influx."""
             try:
-                write_api.write(bucket=bucket, record=json)
+                write_api.write(bucket=bucket, record=json, write_precision=precision)
             except (urllib3.exceptions.HTTPError, OSError) as exc:
                 raise ConnectionError(CONNECTION_ERROR % exc) from exc
             except ApiException as exc:
@@ -393,7 +394,7 @@ def get_influx_connection(conf, test_write=False, test_read=False):
     def write_v1(json):
         """Write data to V1 influx."""
         try:
-            influx.write_points(json)
+            influx.write_points(json, time_precision=precision)
         except (
             requests.exceptions.RequestException,
             exceptions.InfluxDBServerError,

--- a/homeassistant/components/influxdb/const.py
+++ b/homeassistant/components/influxdb/const.py
@@ -29,6 +29,7 @@ CONF_COMPONENT_CONFIG_GLOB = "component_config_glob"
 CONF_COMPONENT_CONFIG_DOMAIN = "component_config_domain"
 CONF_RETRY_COUNT = "max_retries"
 CONF_IGNORE_ATTRIBUTES = "ignore_attributes"
+CONF_PRECISION = "precision"
 
 CONF_LANGUAGE = "language"
 CONF_QUERIES = "queries"
@@ -136,6 +137,7 @@ COMPONENT_CONFIG_SCHEMA_CONNECTION = {
     vol.Optional(CONF_PATH): cv.string,
     vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_SSL): cv.boolean,
+    vol.Optional(CONF_PRECISION): vol.In(["ms", "s", "us", "ns"]),
     # Connection config for V1 API only.
     vol.Inclusive(CONF_USERNAME, "authentication"): cv.string,
     vol.Inclusive(CONF_PASSWORD, "authentication"): cv.string,


### PR DESCRIPTION
## Proposed change
Add 1 feature to influxdb component:
- allow configuration of precision. Using a larger precision allows influxdb to compress the data better.

## Docs PR
https://github.com/home-assistant/home-assistant.io/pull/14130

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
precision: "ms"
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/14130


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
