### PR TITLE
Reduce time to reload yaml and check configuration

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2,7 +2,7 @@
 import base64
 import collections.abc
 from datetime import datetime
-from functools import wraps
+from functools import lru_cache, wraps
 import json
 import logging
 import math
@@ -50,6 +50,7 @@ _RE_GET_ENTITIES = re.compile(
     re.I | re.M,
 )
 _RE_JINJA_DELIMITERS = re.compile(r"\{%|\{\{")
+_TEMPLATE_CACHE_SIZE_PER_ENV = 1024
 
 
 @bind_hass
@@ -1041,6 +1042,11 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
     def is_safe_attribute(self, obj, attr, value):
         """Test if attribute is safe."""
         return isinstance(obj, Namespace) or super().is_safe_attribute(obj, attr, value)
+
+    @lru_cache(maxsize=_TEMPLATE_CACHE_SIZE_PER_ENV)
+    def compile(self, value):
+        """Compile the template."""
+        return super().compile(value)
 
 
 _NO_HASS_ENV = TemplateEnvironment(None)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1044,9 +1044,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         return isinstance(obj, Namespace) or super().is_safe_attribute(obj, attr, value)
 
     @lru_cache(maxsize=_TEMPLATE_CACHE_SIZE_PER_ENV)
-    def compile(self, value):
+    def compile(self, source, name=None, filename=None, raw=False, defer_init=False):
         """Compile the template."""
-        return super().compile(value)
+        return super().compile(source, name, filename, raw, defer_init)
 
 
 _NO_HASS_ENV = TemplateEnvironment(None)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -51,7 +51,6 @@ _RE_GET_ENTITIES = re.compile(
     re.I | re.M,
 )
 _RE_JINJA_DELIMITERS = re.compile(r"\{%|\{\{")
-_TEMPLATE_CACHE_SIZE_PER_ENV = 1024
 
 
 @bind_hass

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1885,3 +1885,30 @@ def test_urlencode(hass):
         hass,
     )
     assert tpl.async_render() == "the%20quick%20brown%20fox%20%3D%20true"
+
+
+async def test_cache_garbage_collection():
+    """Test caching a template."""
+    template_string = (
+        "{% set dict = {'foo': 'x&y', 'bar': 42} %} {{ dict | urlencode }}"
+    )
+    tpl = template.Template((template_string),)
+    tpl.ensure_valid()
+    assert template._NO_HASS_ENV.template_cache.get(
+        template_string
+    )  # pylint: disable=protected-access
+
+    tpl2 = template.Template((template_string),)
+    tpl2.ensure_valid()
+    assert template._NO_HASS_ENV.template_cache.get(
+        template_string
+    )  # pylint: disable=protected-access
+
+    del tpl
+    assert template._NO_HASS_ENV.template_cache.get(
+        template_string
+    )  # pylint: disable=protected-access
+    del tpl2
+    assert not template._NO_HASS_ENV.template_cache.get(
+        template_string
+    )  # pylint: disable=protected-access


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We spend a significant amount of time compiling templates
that we have already compiled.

Use an WeakValueDictionary cache to avoid re-compiling templates when
reloading config/automations/scripts.

Cut my check config time from `3.78s` to `1.21s`

Should improve startup speed for those with lots of repeated templates

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
