### PR TITLE
Add device_info property and simplify generation of unique_id for Airly integration

### DIFF
--- a/homeassistant/components/airly/air_quality.py
+++ b/homeassistant/components/airly/air_quality.py
@@ -18,6 +18,7 @@ from .const import (
     ATTR_API_PM25,
     ATTR_API_PM25_LIMIT,
     ATTR_API_PM25_PERCENT,
+    DEFAULT_NAME,
     DOMAIN,
 )
 
@@ -40,9 +41,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    async_add_entities(
-        [AirlyAirQuality(coordinator, name, config_entry.unique_id)], False
-    )
+    async_add_entities([AirlyAirQuality(coordinator, name)], False)
 
 
 def round_state(func):
@@ -60,11 +59,10 @@ def round_state(func):
 class AirlyAirQuality(AirQualityEntity):
     """Define an Airly air quality."""
 
-    def __init__(self, coordinator, name, unique_id):
+    def __init__(self, coordinator, name):
         """Initialize."""
         self.coordinator = coordinator
         self._name = name
-        self._unique_id = unique_id
         self._icon = "mdi:blur"
 
     @property
@@ -108,7 +106,18 @@ class AirlyAirQuality(AirQualityEntity):
     @property
     def unique_id(self):
         """Return a unique_id for this entity."""
-        return self._unique_id
+        return f"{self.coordinator.latitude}-{self.coordinator.longitude}"
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "identifiers": {
+                (DOMAIN, self.coordinator.latitude, self.coordinator.longitude)
+            },
+            "name": DEFAULT_NAME,
+            "entry_type": "service",
+        }
 
     @property
     def available(self):

--- a/homeassistant/components/airly/air_quality.py
+++ b/homeassistant/components/airly/air_quality.py
@@ -20,6 +20,7 @@ from .const import (
     ATTR_API_PM25_PERCENT,
     DEFAULT_NAME,
     DOMAIN,
+    MANUFACTURER,
 )
 
 ATTRIBUTION = "Data provided by Airly"
@@ -116,6 +117,7 @@ class AirlyAirQuality(AirQualityEntity):
                 (DOMAIN, self.coordinator.latitude, self.coordinator.longitude)
             },
             "name": DEFAULT_NAME,
+            "manufacturer": MANUFACTURER,
             "entry_type": "service",
         }
 

--- a/homeassistant/components/airly/const.py
+++ b/homeassistant/components/airly/const.py
@@ -15,5 +15,6 @@ ATTR_API_PRESSURE = "PRESSURE"
 ATTR_API_TEMPERATURE = "TEMPERATURE"
 DEFAULT_NAME = "Airly"
 DOMAIN = "airly"
+MANUFACTURER = "Airly sp. z o.o."
 MAX_REQUESTS_PER_DAY = 100
 NO_AIRLY_SENSORS = "There are no Airly sensors in this area yet."

--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -20,6 +20,7 @@ from .const import (
     ATTR_API_TEMPERATURE,
     DEFAULT_NAME,
     DOMAIN,
+    MANUFACTURER,
 )
 
 ATTRIBUTION = "Data provided by Airly"
@@ -134,7 +135,7 @@ class AirlySensor(Entity):
                 (DOMAIN, self.coordinator.latitude, self.coordinator.longitude)
             },
             "name": DEFAULT_NAME,
-            "manufacturer": "Airly sp. z o.o.",
+            "manufacturer": MANUFACTURER,
             "entry_type": "service",
         }
 

--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -18,6 +18,7 @@ from .const import (
     ATTR_API_PM1,
     ATTR_API_PRESSURE,
     ATTR_API_TEMPERATURE,
+    DEFAULT_NAME,
     DOMAIN,
 )
 
@@ -65,8 +66,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     sensors = []
     for sensor in SENSOR_TYPES:
-        unique_id = f"{config_entry.unique_id}-{sensor.lower()}"
-        sensors.append(AirlySensor(coordinator, name, sensor, unique_id))
+        sensors.append(AirlySensor(coordinator, name, sensor))
 
     async_add_entities(sensors, False)
 
@@ -74,11 +74,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AirlySensor(Entity):
     """Define an Airly sensor."""
 
-    def __init__(self, coordinator, name, kind, unique_id):
+    def __init__(self, coordinator, name, kind):
         """Initialize."""
         self.coordinator = coordinator
         self._name = name
-        self._unique_id = unique_id
         self.kind = kind
         self._device_class = None
         self._state = None
@@ -125,7 +124,19 @@ class AirlySensor(Entity):
     @property
     def unique_id(self):
         """Return a unique_id for this entity."""
-        return self._unique_id
+        return f"{self.coordinator.latitude}-{self.coordinator.longitude}-{self.kind.lower()}"
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            "identifiers": {
+                (DOMAIN, self.coordinator.latitude, self.coordinator.longitude)
+            },
+            "name": DEFAULT_NAME,
+            "manufacturer": "Airly sp. z o.o.",
+            "entry_type": "service",
+        }
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- adds the `device_info` property with `entry_type: service`
- simplifies generation `unique_id` of the entities


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
