### PR TITLE
Refactor ping integration to use icmplib to avoid startup being blocked

### DIFF
--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -1,10 +1,8 @@
 """Tracks the latency of a host by sending ICMP echo requests (ping)."""
 from datetime import timedelta
 import logging
-import re
-import subprocess
-import sys
 
+from icmplib import ping as icmp_ping
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
@@ -15,52 +13,46 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_ROUND_TRIP_TIME_AVG = "round_trip_time_avg"
 ATTR_ROUND_TRIP_TIME_MAX = "round_trip_time_max"
-ATTR_ROUND_TRIP_TIME_MDEV = "round_trip_time_mdev"
 ATTR_ROUND_TRIP_TIME_MIN = "round_trip_time_min"
+ATTR_PACKET_LOSS_PERCENT = "packet_loss_percent"
 
 CONF_PING_COUNT = "count"
 
-DEFAULT_NAME = "Ping Binary sensor"
+DEFAULT_NAME = "Ping"
 DEFAULT_PING_COUNT = 5
 DEFAULT_DEVICE_CLASS = "connectivity"
 
 SCAN_INTERVAL = timedelta(minutes=5)
 
-PING_MATCHER = re.compile(
-    r"(?P<min>\d+.\d+)\/(?P<avg>\d+.\d+)\/(?P<max>\d+.\d+)\/(?P<mdev>\d+.\d+)"
-)
-
-PING_MATCHER_BUSYBOX = re.compile(
-    r"(?P<min>\d+.\d+)\/(?P<avg>\d+.\d+)\/(?P<max>\d+.\d+)"
-)
-
-WIN32_PING_MATCHER = re.compile(r"(?P<min>\d+)ms.+(?P<max>\d+)ms.+(?P<avg>\d+)ms")
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PING_COUNT, default=DEFAULT_PING_COUNT): cv.positive_int,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_PING_COUNT, default=DEFAULT_PING_COUNT): vol.Range(
+            min=1, max=60
+        ),
     }
 )
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Ping Binary sensor."""
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    count = config.get(CONF_PING_COUNT)
+    host = config[CONF_HOST]
+    count = config[CONF_PING_COUNT]
+    name = config.get(CONF_NAME, f"{DEFAULT_NAME} {host}")
 
-    add_entities([PingBinarySensor(name, PingData(host, count))], True)
+    add_entities([PingBinarySensor(name, host, count)], True)
 
 
 class PingBinarySensor(BinarySensorEntity):
     """Representation of a Ping Binary sensor."""
 
-    def __init__(self, name, ping):
+    def __init__(self, name, host, count):
         """Initialize the Ping Binary sensor."""
+        self._ping = None
         self._name = name
-        self.ping = ping
+        self._host = host
+        self._count = count
 
     @property
     def name(self):
@@ -75,77 +67,21 @@ class PingBinarySensor(BinarySensorEntity):
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
-        return self.ping.available
+        return self._ping and self._ping.is_alive
 
     @property
     def device_state_attributes(self):
-        """Return the state attributes of the ICMP checo request."""
-        if self.ping.data is not False:
-            return {
-                ATTR_ROUND_TRIP_TIME_AVG: self.ping.data["avg"],
-                ATTR_ROUND_TRIP_TIME_MAX: self.ping.data["max"],
-                ATTR_ROUND_TRIP_TIME_MDEV: self.ping.data["mdev"],
-                ATTR_ROUND_TRIP_TIME_MIN: self.ping.data["min"],
-            }
+        """Return the state attributes of the ICMP echo request."""
+        if not self._ping:
+            return
+
+        return {
+            ATTR_ROUND_TRIP_TIME_AVG: self._ping.avg_rtt,
+            ATTR_ROUND_TRIP_TIME_MAX: self._ping.max_rtt,
+            ATTR_ROUND_TRIP_TIME_MIN: self._ping.min_rtt,
+            ATTR_PACKET_LOSS_PERCENT: self._ping.packet_loss * 100,
+        }
 
     def update(self):
         """Get the latest data."""
-        self.ping.update()
-
-
-class PingData:
-    """The Class for handling the data retrieval."""
-
-    def __init__(self, host, count):
-        """Initialize the data object."""
-        self._ip_address = host
-        self._count = count
-        self.data = {}
-        self.available = False
-
-        if sys.platform == "win32":
-            self._ping_cmd = [
-                "ping",
-                "-n",
-                str(self._count),
-                "-w",
-                "1000",
-                self._ip_address,
-            ]
-        else:
-            self._ping_cmd = [
-                "ping",
-                "-n",
-                "-q",
-                "-c",
-                str(self._count),
-                "-W1",
-                self._ip_address,
-            ]
-
-    def ping(self):
-        """Send ICMP echo request and return details if success."""
-        pinger = subprocess.Popen(
-            self._ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        try:
-            out = pinger.communicate()
-            _LOGGER.debug("Output is %s", str(out))
-            if sys.platform == "win32":
-                match = WIN32_PING_MATCHER.search(str(out).split("\n")[-1])
-                rtt_min, rtt_avg, rtt_max = match.groups()
-                return {"min": rtt_min, "avg": rtt_avg, "max": rtt_max, "mdev": ""}
-            if "max/" not in str(out):
-                match = PING_MATCHER_BUSYBOX.search(str(out).split("\n")[-1])
-                rtt_min, rtt_avg, rtt_max = match.groups()
-                return {"min": rtt_min, "avg": rtt_avg, "max": rtt_max, "mdev": ""}
-            match = PING_MATCHER.search(str(out).split("\n")[-1])
-            rtt_min, rtt_avg, rtt_max, rtt_mdev = match.groups()
-            return {"min": rtt_min, "avg": rtt_avg, "max": rtt_max, "mdev": rtt_mdev}
-        except (subprocess.CalledProcessError, AttributeError):
-            return False
-
-    def update(self):
-        """Retrieve the latest details from the host."""
-        self.data = self.ping()
-        self.available = bool(self.data)
+        self._ping = icmp_ping(self._host, count=self._count)

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -1,9 +1,8 @@
 """Tracks devices by sending a ICMP echo request (ping)."""
 from datetime import timedelta
 import logging
-import subprocess
-import sys
 
+from icmplib import ping as icmp_ping
 import voluptuous as vol
 
 from homeassistant import const, util
@@ -19,6 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_PING_COUNT = "count"
 
+PING_ATTEMPTS_COUNT = 3
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(const.CONF_HOSTS): {cv.slug: cv.string},
@@ -30,45 +31,34 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 class Host:
     """Host object with ping detection."""
 
-    def __init__(self, ip_address, dev_id, hass, config):
+    def __init__(self, ip_address, dev_id, config):
         """Initialize the Host pinger."""
-        self.hass = hass
         self.ip_address = ip_address
         self.dev_id = dev_id
         self._count = config[CONF_PING_COUNT]
-        if sys.platform == "win32":
-            self._ping_cmd = ["ping", "-n", "1", "-w", "1000", self.ip_address]
-        else:
-            self._ping_cmd = ["ping", "-n", "-q", "-c1", "-W1", self.ip_address]
 
     def ping(self):
         """Send an ICMP echo request and return True if success."""
-        pinger = subprocess.Popen(
-            self._ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
-        )
-        try:
-            pinger.communicate()
-            return pinger.returncode == 0
-        except subprocess.CalledProcessError:
-            return False
+        return icmp_ping(self.ip_address, count=PING_ATTEMPTS_COUNT).is_alive
 
     def update(self, see):
         """Update device state by sending one or more ping messages."""
-        failed = 0
-        while failed < self._count:  # check more times if host is unreachable
-            if self.ping():
-                see(dev_id=self.dev_id, source_type=SOURCE_TYPE_ROUTER)
-                return True
-            failed += 1
+        if self.ping():
+            see(dev_id=self.dev_id, source_type=SOURCE_TYPE_ROUTER)
+            return True
 
-        _LOGGER.debug("No response from %s failed=%d", self.ip_address, failed)
+        _LOGGER.debug(
+            "No response from %s (%s) failed=%d",
+            self.ip_address,
+            self.dev_id,
+            PING_ATTEMPTS_COUNT,
+        )
 
 
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Host objects and return the update function."""
     hosts = [
-        Host(ip, dev_id, hass, config)
-        for (dev_id, ip) in config[const.CONF_HOSTS].items()
+        Host(ip, dev_id, config) for (dev_id, ip) in config[const.CONF_HOSTS].items()
     ]
     interval = config.get(
         CONF_SCAN_INTERVAL,

--- a/homeassistant/components/ping/manifest.json
+++ b/homeassistant/components/ping/manifest.json
@@ -3,5 +3,6 @@
   "name": "Ping (ICMP)",
   "documentation": "https://www.home-assistant.io/integrations/ping",
   "codeowners": [],
+  "requirements": ["icmplib==1.1.1"],
   "quality_scale": "internal"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -774,6 +774,9 @@ ibm-watson==4.0.1
 # homeassistant.components.watson_iot
 ibmiotf==0.3.4
 
+# homeassistant.components.ping
+icmplib==1.1.1
+
 # homeassistant.components.iglo
 iglo==1.2.7
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The mdev attribute has been removed as the backend has been changed to `icmplib` to improve reliability.

**Root privileges or at least `CAP_NET_RAW` are required for the integration to work.**
**If that is going to be a problem, I can close this PR and modify the existing code to add timeouts instead.  Unfortunately the timeouts will have to be higher as there is no way to implement a replay timeout when calling a subprocess and the one inside the ping binaries are inconsistent across operating systems.**

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactor ping integration to use icmplib

Timeout is now enforced by icmplib which prevents startup
from ever being blocked.

* Added percent packet loss attribute

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38468
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14139

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
