### PR TITLE
Ensure bond unique ids are unique across hubs

### DIFF
--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -27,7 +27,9 @@ class BondEntity(Entity):
     @property
     def unique_id(self) -> Optional[str]:
         """Get unique ID for the entity."""
-        return self._device.device_id
+        hub_id = self._hub.bond_id
+        device_id = self._device.device_id
+        return f"{hub_id}_{device_id}"
 
     @property
     def name(self) -> Optional[str]:

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -58,7 +58,7 @@ async def setup_platform(
     """Set up the specified Bond platform."""
     mock_entry = MockConfigEntry(
         domain=BOND_DOMAIN,
-        data={CONF_HOST: "1.1.1.1", CONF_ACCESS_TOKEN: "test-token"},
+        data={CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
     )
     mock_entry.add_to_hass(hass)
 

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -34,10 +34,17 @@ def shades(name: str):
 
 async def test_entity_registry(hass: core.HomeAssistant):
     """Tests that the devices are registered in the entity registry."""
-    await setup_platform(hass, COVER_DOMAIN, shades("name-1"))
+    await setup_platform(
+        hass,
+        COVER_DOMAIN,
+        shades("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_device_id="test-device-id",
+    )
 
     registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
-    assert [key for key in registry.entities] == ["cover.name_1"]
+    entity = registry.entities["cover.name_1"]
+    assert entity.unique_id == "test-hub-id_test-device-id"
 
 
 async def test_open_cover(hass: core.HomeAssistant):

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -52,10 +52,17 @@ async def turn_fan_on(
 
 async def test_entity_registry(hass: core.HomeAssistant):
     """Tests that the devices are registered in the entity registry."""
-    await setup_platform(hass, FAN_DOMAIN, ceiling_fan("name-1"))
+    await setup_platform(
+        hass,
+        FAN_DOMAIN,
+        ceiling_fan("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_device_id="test-device-id",
+    )
 
     registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
-    assert [key for key in registry.entities] == ["fan.name_1"]
+    entity = registry.entities["fan.name_1"]
+    assert entity.unique_id == "test-hub-id_test-device-id"
 
 
 async def test_non_standard_speed_list(hass: core.HomeAssistant):

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -57,10 +57,17 @@ def fireplace(name: str):
 
 async def test_entity_registry(hass: core.HomeAssistant):
     """Tests that the devices are registered in the entity registry."""
-    await setup_platform(hass, LIGHT_DOMAIN, ceiling_fan("name-1"))
+    await setup_platform(
+        hass,
+        LIGHT_DOMAIN,
+        ceiling_fan("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_device_id="test-device-id",
+    )
 
     registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
-    assert [key for key in registry.entities] == ["light.name_1"]
+    entity = registry.entities["light.name_1"]
+    assert entity.unique_id == "test-hub-id_test-device-id"
 
 
 async def test_sbb_trust_state(hass: core.HomeAssistant):

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -29,10 +29,17 @@ def generic_device(name: str):
 
 async def test_entity_registry(hass: core.HomeAssistant):
     """Tests that the devices are registered in the entity registry."""
-    await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
+    await setup_platform(
+        hass,
+        SWITCH_DOMAIN,
+        generic_device("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_device_id="test-device-id",
+    )
 
     registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
-    assert [key for key in registry.entities] == ["switch.name_1"]
+    entity = registry.entities["switch.name_1"]
+    assert entity.unique_id == "test-hub-id_test-device-id"
 
 
 async def test_turn_on_switch(hass: core.HomeAssistant):


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

When you have multiple Bond hubs, each with its own set of devices, those devices has IDs that bond integration uses to generate unique entity IDs in HA. Unfortunately, those IDs are only unique within the hub. So it is possible that unique IDs generated for entities from different hubs will not be unique and collide.

This PR fixes this bug by prefixing device ID with a hub ID - resulting ID is now truly unique.
Breaking change - after restarting you will see each bond entity twice. One - live - with new unique ID. Second - disabled - with old unique ID.
How to make it work:
1. Remove the disabled entity (note its friendly ID, e.g. "cover.shades"
2. Optionally rename the generated friendly ID on the live entity, so that your automations continue to work. For example, your live entity will have ID "cover.shades_2". Rename it to "cover.shades"

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes potential non-unique entity ID generation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38493
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
