### PR TITLE
Add missing timeout to command_line platforms: cover, notify, switch

### DIFF
--- a/homeassistant/components/command_line/__init__.py
+++ b/homeassistant/components/command_line/__init__.py
@@ -1,1 +1,42 @@
 """The command_line component."""
+
+import logging
+import subprocess
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def call_shell_with_timeout(command, timeout):
+    """Run a shell command with a timeout."""
+    try:
+        _LOGGER.debug("Running command: %s", command)
+        subprocess.check_output(
+            command, shell=True, timeout=timeout  # nosec # shell by design
+        )
+        return 0
+    except subprocess.CalledProcessError as proc_exception:
+        _LOGGER.error("Command failed: %s", command)
+        return proc_exception.returncode
+    except subprocess.TimeoutExpired:
+        _LOGGER.error("Timeout for command: %s", command)
+        return -1
+    except subprocess.SubprocessError:
+        _LOGGER.error("Error trying to exec command: %s", command)
+        return -1
+
+
+def check_output_or_log(command, timeout):
+    """Run a shell command with a timeout and return the output."""
+    try:
+        return_value = subprocess.check_output(
+            command, shell=True, timeout=timeout  # nosec # shell by design
+        )
+        return return_value.strip().decode("utf-8")
+    except subprocess.CalledProcessError:
+        _LOGGER.error("Command failed: %s", command)
+    except subprocess.TimeoutExpired:
+        _LOGGER.error("Timeout for command: %s", command)
+    except subprocess.SubprocessError:
+        _LOGGER.error("Error trying to exec command: %s", command)
+
+    return None

--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
+from .const import CONF_COMMAND_TIMEOUT, DEFAULT_TIMEOUT
 from .sensor import CommandSensorData
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,8 +30,6 @@ DEFAULT_PAYLOAD_OFF = "OFF"
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
-CONF_COMMAND_TIMEOUT = "command_timeout"
-DEFAULT_TIMEOUT = 15
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/command_line/const.py
+++ b/homeassistant/components/command_line/const.py
@@ -1,0 +1,4 @@
+"""Allows to configure custom shell commands to turn a value for a sensor."""
+
+CONF_COMMAND_TIMEOUT = "command_timeout"
+DEFAULT_TIMEOUT = 15

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -8,26 +8,34 @@ from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationSer
 from homeassistant.const import CONF_COMMAND, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
+from .const import CONF_COMMAND_TIMEOUT, DEFAULT_TIMEOUT
+
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {vol.Required(CONF_COMMAND): cv.string, vol.Optional(CONF_NAME): cv.string}
+    {
+        vol.Required(CONF_COMMAND): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_COMMAND_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+    }
 )
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the Command Line notification service."""
     command = config[CONF_COMMAND]
+    timeout = config[CONF_COMMAND_TIMEOUT]
 
-    return CommandLineNotificationService(command)
+    return CommandLineNotificationService(command, timeout)
 
 
 class CommandLineNotificationService(BaseNotificationService):
     """Implement the notification service for the Command Line service."""
 
-    def __init__(self, command):
+    def __init__(self, command, timeout):
         """Initialize the service."""
         self.command = command
+        self._timeout = timeout
 
     def send_message(self, message="", **kwargs):
         """Send a message to a command line."""
@@ -38,8 +46,10 @@ class CommandLineNotificationService(BaseNotificationService):
                 stdin=subprocess.PIPE,
                 shell=True,  # nosec # shell by design
             )
-            proc.communicate(input=message)
+            proc.communicate(input=message, timeout=self._timeout)
             if proc.returncode != 0:
                 _LOGGER.error("Command failed: %s", self.command)
+        except subprocess.TimeoutExpired:
+            _LOGGER.error("Timeout for command: %s", self.command)
         except subprocess.SubprocessError:
-            _LOGGER.error("Error trying to exec Command: %s", self.command)
+            _LOGGER.error("Error trying to exec command: %s", self.command)

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -1,6 +1,5 @@
 """Support for custom shell commands to turn a switch on/off."""
 import logging
-import subprocess
 
 import voluptuous as vol
 
@@ -19,6 +18,9 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
+from . import call_shell_with_timeout, check_output_or_log
+from .const import CONF_COMMAND_TIMEOUT, DEFAULT_TIMEOUT
+
 _LOGGER = logging.getLogger(__name__)
 
 SWITCH_SCHEMA = vol.Schema(
@@ -28,6 +30,7 @@ SWITCH_SCHEMA = vol.Schema(
         vol.Optional(CONF_COMMAND_STATE): cv.string,
         vol.Optional(CONF_FRIENDLY_NAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_COMMAND_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     }
 )
 
@@ -52,10 +55,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 hass,
                 object_id,
                 device_config.get(CONF_FRIENDLY_NAME, object_id),
-                device_config.get(CONF_COMMAND_ON),
-                device_config.get(CONF_COMMAND_OFF),
+                device_config[CONF_COMMAND_ON],
+                device_config[CONF_COMMAND_OFF],
                 device_config.get(CONF_COMMAND_STATE),
                 value_template,
+                device_config[CONF_COMMAND_TIMEOUT],
             )
         )
 
@@ -78,6 +82,7 @@ class CommandSwitch(SwitchEntity):
         command_off,
         command_state,
         value_template,
+        timeout,
     ):
         """Initialize the switch."""
         self._hass = hass
@@ -88,37 +93,28 @@ class CommandSwitch(SwitchEntity):
         self._command_off = command_off
         self._command_state = command_state
         self._value_template = value_template
+        self._timeout = timeout
 
-    @staticmethod
-    def _switch(command):
+    def _switch(self, command):
         """Execute the actual commands."""
         _LOGGER.info("Running command: %s", command)
 
-        success = subprocess.call(command, shell=True) == 0  # nosec # shell by design
+        success = call_shell_with_timeout(command, self._timeout) == 0
 
         if not success:
             _LOGGER.error("Command failed: %s", command)
 
         return success
 
-    @staticmethod
-    def _query_state_value(command):
+    def _query_state_value(self, command):
         """Execute state command for return value."""
-        _LOGGER.info("Running state command: %s", command)
+        _LOGGER.info("Running state value command: %s", command)
+        return check_output_or_log(command, self._timeout)
 
-        try:
-            return_value = subprocess.check_output(
-                command, shell=True  # nosec # shell by design
-            )
-            return return_value.strip().decode("utf-8")
-        except subprocess.CalledProcessError:
-            _LOGGER.error("Command failed: %s", command)
-
-    @staticmethod
-    def _query_state_code(command):
+    def _query_state_code(self, command):
         """Execute state command for return code."""
-        _LOGGER.info("Running state command: %s", command)
-        return subprocess.call(command, shell=True) == 0  # nosec # shell by design
+        _LOGGER.info("Running state code command: %s", command)
+        return call_shell_with_timeout(command, self._timeout) == 0
 
     @property
     def should_poll(self):
@@ -146,8 +142,8 @@ class CommandSwitch(SwitchEntity):
             _LOGGER.error("No state command specified")
             return
         if self._value_template:
-            return CommandSwitch._query_state_value(self._command_state)
-        return CommandSwitch._query_state_code(self._command_state)
+            return self._query_state_value(self._command_state)
+        return self._query_state_code(self._command_state)
 
     def update(self):
         """Update device state."""
@@ -159,12 +155,12 @@ class CommandSwitch(SwitchEntity):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        if CommandSwitch._switch(self._command_on) and not self._command_state:
+        if self._switch(self._command_on) and not self._command_state:
             self._state = True
             self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        if CommandSwitch._switch(self._command_off) and not self._command_state:
+        if self._switch(self._command_off) and not self._command_state:
             self._state = False
             self.schedule_update_ha_state()

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -27,6 +27,7 @@ def rs(hass):
         "command_stop",
         "command_state",
         None,
+        15,
     )
 
 
@@ -45,7 +46,7 @@ def test_query_state_value(rs):
         assert "foo bar" == result
         assert mock_run.call_count == 1
         assert mock_run.call_args == mock.call(
-            "runme", shell=True,  # nosec # shell by design
+            "runme", shell=True, timeout=15  # nosec # shell by design
         )
 
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -74,7 +74,7 @@ class TestCommandSensorSensor(unittest.TestCase):
         """Ensure command with templates and quotes get rendered properly."""
         self.hass.states.set("sensor.test_state", "Works 2")
         with patch(
-            "homeassistant.components.command_line.sensor.subprocess.check_output",
+            "homeassistant.components.command_line.subprocess.check_output",
             return_value=b"Works\n",
         ) as check_output:
             data = command_line.CommandSensorData(

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -180,13 +180,14 @@ class TestCommandSwitch(unittest.TestCase):
             "echo 'off command'",
             None,
             None,
+            15,
         ]
 
         no_state_device = command_line.CommandSwitch(*init_args)
         assert no_state_device.assumed_state
 
         # Set state command
-        init_args[-2] = "cat {}"
+        init_args[-3] = "cat {}"
 
         state_device = command_line.CommandSwitch(*init_args)
         assert not state_device.assumed_state
@@ -201,6 +202,7 @@ class TestCommandSwitch(unittest.TestCase):
             "echo 'off command'",
             False,
             None,
+            15,
         ]
 
         test_switch = command_line.CommandSwitch(*init_args)


### PR DESCRIPTION
## Breaking change

The command_line cover, notify and switch platforms commands timeout after 15 seconds by default instead of blocking forever.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add missing timeout to command_line platforms: cover, notify, switch

These commands can block startup forever since they never timeout.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14141

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
