### PR TITLE
Fix missing .name at entity_id in service example

### DIFF
--- a/homeassistant/components/camera/services.yaml
+++ b/homeassistant/components/camera/services.yaml
@@ -36,7 +36,7 @@ snapshot:
       example: "camera.living_room_camera"
     filename:
       description: Template of a Filename. Variable is entity_id.
-      example: "/tmp/snapshot_{{ entity_id }}"
+      example: "/tmp/snapshot_{{ entity_id.name }}.jpg"
 
 play_stream:
   description: Play camera stream on supported media player.
@@ -59,7 +59,7 @@ record:
       example: "camera.living_room_camera"
     filename:
       description: Template of a Filename. Variable is entity_id.  Must be mp4.
-      example: "/tmp/snapshot_{{ entity_id }}.mp4"
+      example: "/tmp/snapshot_{{ entity_id.name }}.mp4"
     duration:
       description: (Optional) Target recording length (in seconds).
       default: 30


### PR DESCRIPTION
for propper filename
same as https://github.com/home-assistant/home-assistant.io/pull/14145



## Proposed change
same thing as https://github.com/home-assistant/home-assistant.io/pull/14145
If it is only entity_id = /tmp/snapshot_<Entity m5_cam_i: idle> which is wrong, however entity_id.name is nice /tmp/snapshot_m5_cam_i


## Type of change

- [ ] Dependency upgrade
- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/14145
