### PR TITLE
Update pyhomematic to 0.1.68

### DIFF
--- a/homeassistant/components/homematic/const.py
+++ b/homeassistant/components/homematic/const.py
@@ -66,6 +66,7 @@ HM_DEVICE_TYPES = {
         "ColorEffectLight",
         "IPKeySwitchLevel",
         "ColdWarmDimmer",
+        "IPWDimmer",
     ],
     DISCOVER_SENSORS: [
         "SwitchPowermeter",
@@ -110,6 +111,7 @@ HM_DEVICE_TYPES = {
         "IPThermostatWall2",
         "IPRemoteMotionV2",
         "HBUNISenWEA",
+        "IPWMotionDection",
     ],
     DISCOVER_CLIMATE: [
         "Thermostat",
@@ -151,6 +153,7 @@ HM_DEVICE_TYPES = {
         "IPContact",
         "IPRemoteMotionV2",
         "IPWInputDevice",
+        "IPWMotionDection",
     ],
     DISCOVER_COVER: [
         "Blind",

--- a/homeassistant/components/homematic/manifest.json
+++ b/homeassistant/components/homematic/manifest.json
@@ -2,6 +2,6 @@
   "domain": "homematic",
   "name": "Homematic",
   "documentation": "https://www.home-assistant.io/integrations/homematic",
-  "requirements": ["pyhomematic==0.1.67"],
+  "requirements": ["pyhomematic==0.1.68"],
   "codeowners": ["@pvizeli", "@danielperna84"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1377,7 +1377,7 @@ pyhik==0.2.7
 pyhiveapi==0.2.20.1
 
 # homeassistant.components.homematic
-pyhomematic==0.1.67
+pyhomematic==0.1.68
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -647,7 +647,7 @@ pyhaversion==3.3.0
 pyheos==0.6.0
 
 # homeassistant.components.homematic
-pyhomematic==0.1.67
+pyhomematic==0.1.68
 
 # homeassistant.components.icloud
 pyicloud==0.9.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Changelog: <https://github.com/danielperna84/pyhomematic/releases/tag/0.1.67>

Upgrading the dependency. As a result the following will happen:
- Calling the `homematic.reconnect` service should work for setups with HomeMatic IP
- Passing the `rx_mode` argument while working with paramsets is now available
- Adds the Level-Status of HomeMatic IP covers devices as a sensor-entity (see #35774, doesn't fix the issue, but helps living with the bug the device has)
- Adds support for the following devices: HB-UNI-RGB-LED-CTR, HmIPW-DRD3, HmIPW-SPI, HmIPW-DRBL4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #35774
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
