### PR TITLE
Reduce opensky network traffic, add attributes to events, use aiohttp

### DIFF
--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -49,15 +49,19 @@ OPENSKY_API_FIELDS = [
     ATTR_CALLSIGN,
     "origin_country",
     "time_position",
-    "time_velocity",
+    "last_contact",
     ATTR_LONGITUDE,
     ATTR_LATITUDE,
     ATTR_ALTITUDE,
     ATTR_ON_GROUND,
     "velocity",
-    "heading",
+    "true_track",
     "vertical_rate",
     "sensors",
+    "geo_altitude",
+    "squawk",
+    "spi",
+    "position_source",
 ]
 
 

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -40,6 +40,11 @@ EVENT_OPENSKY_ENTRY = f"{DOMAIN}_entry"
 EVENT_OPENSKY_EXIT = f"{DOMAIN}_exit"
 SCAN_INTERVAL = timedelta(seconds=12)  # opensky public limit is 10 seconds
 
+MIN_LAT = math.radians(-90)
+MAX_LAT = math.radians(90)
+MIN_LON = math.radians(-180)
+MAX_LON = math.radians(180)
+
 OPENSKY_ATTRIBUTION = (
     "Information provided by the OpenSky Network (https://opensky-network.org)"
 )
@@ -135,11 +140,6 @@ class OpenSkySensor(Entity):
         License: https://creativecommons.org/licenses/by/3.0/
         Changes: Adapted for Home Assistant's opensky sensor
         """
-        MIN_LAT = math.radians(-90)
-        MAX_LAT = math.radians(90)
-        MIN_LON = math.radians(-180)
-        MAX_LON = math.radians(180)
-
         rad_lat = math.radians(self._latitude)
         rad_lon = math.radians(self._longitude)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `callsign` attribute for `opensky` events now gets forwarded as received from the OpenSky Network, so it may contain leading or trailing whitespace characters. White-space can be stripped within a template: `{{ trigger.event.data.callsign.strip() }}`

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `opensky` integration used to pull states of all airplanes worldwide every 12 seconds, causing high load on already saturated servers and forward only very few attributes per plane to its events (i.e. callsign and altitude).

With this PR, only the states of flights within the configured area of interest get fetched, and all available attributes included in the response from the OpenSky Network API get forwarded to `opensky` events, so we can handle other important data like ICAO24 ID, location, velocity etc.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14155

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
