### PR TITLE
Allow to set default dark theme and persist frontend default themes

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -368,21 +368,6 @@ async def _async_setup_themes(hass, themes):
         hass.bus.async_fire(EVENT_THEMES_UPDATED)
 
     @callback
-    def save_theme_store():
-        """Update store with new theme data."""
-        store = hass.data[DATA_THEMES_STORE]
-
-        @callback
-        def _data_to_save():
-            """Return data to save."""
-            return {
-                DATA_DEFAULT_THEME: hass.data[DATA_DEFAULT_THEME],
-                DATA_DEFAULT_DARK_THEME: hass.data.get(DATA_DEFAULT_DARK_THEME),
-            }
-
-        store.async_delay_save(_data_to_save, THEMES_SAVE_DELAY)
-
-    @callback
     def set_theme(call):
         """Set backend-preferred theme."""
         name = call.data[CONF_NAME]
@@ -406,7 +391,13 @@ async def _async_setup_themes(hass, themes):
             to_set = name
 
         hass.data[theme_key] = to_set
-        save_theme_store()
+        store.async_delay_save(
+            lambda: {
+                DATA_DEFAULT_THEME: hass.data[DATA_DEFAULT_THEME],
+                DATA_DEFAULT_DARK_THEME: hass.data.get(DATA_DEFAULT_DARK_THEME),
+            },
+            THEMES_SAVE_DELAY,
+        )
         update_theme_and_fire_event()
 
     async def reload_themes(_):

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -402,6 +402,7 @@ async def _async_setup_themes(hass, themes):
             else:
                 hass.data[DATA_DEFAULT_DARK_THEME] = None
             save_theme_store()
+            update_theme_and_fire_event()
         else:
             _LOGGER.warning("Theme %s is not defined", name)
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -78,6 +78,7 @@ DATA_THEMES = "frontend_themes"
 DATA_DEFAULT_THEME = "frontend_default_theme"
 DATA_DEFAULT_DARK_THEME = "frontend_default_dark_theme"
 DEFAULT_THEME = "default"
+VALUE_NO_THEME = "none"
 
 PRIMARY_COLOR = "primary-color"
 
@@ -367,6 +368,9 @@ def _async_setup_themes(hass, themes):
         if name == DEFAULT_THEME or name in hass.data[DATA_THEMES]:
             _LOGGER.info("Theme %s set as default dark", name)
             hass.data[DATA_DEFAULT_DARK_THEME] = name
+            update_theme_and_fire_event()
+        elif name == VALUE_NO_THEME:
+            hass.data[DATA_DEFAULT_DARK_THEME] = None
             update_theme_and_fire_event()
         else:
             _LOGGER.warning("Theme %s is not defined", name)

--- a/homeassistant/components/frontend/services.yaml
+++ b/homeassistant/components/frontend/services.yaml
@@ -4,8 +4,11 @@ set_theme:
   description: Set a theme unless the client selected per-device theme.
   fields:
     name:
-      description: Name of a predefined theme or 'default'.
+      description: Name of a predefined theme, 'default' or 'none'.
       example: "light"
+    mode:
+      description: The mode the theme is for, either 'dark' or 'light' (default).
+      example: "dark"
 
 reload_themes:
   description: Reload themes from yaml configuration.

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1,4 +1,5 @@
 """The tests for Home Assistant frontend."""
+from datetime import timedelta
 import re
 
 import pytest
@@ -10,16 +11,25 @@ from homeassistant.components.frontend import (
     CONF_THEMES,
     DOMAIN,
     EVENT_PANELS_UPDATED,
+    THEMES_STORAGE_KEY,
 )
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import HTTP_NOT_FOUND
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt
 
 from tests.async_mock import patch
-from tests.common import async_capture_events
+from tests.common import async_capture_events, async_fire_time_changed
 
-CONFIG_THEMES = {DOMAIN: {CONF_THEMES: {"happy": {"primary-color": "red"}}}}
+CONFIG_THEMES = {
+    DOMAIN: {
+        CONF_THEMES: {
+            "happy": {"primary-color": "red"},
+            "dark": {"primary-color": "black"},
+        }
+    }
+}
 
 
 @pytest.fixture
@@ -118,7 +128,10 @@ async def test_themes_api(hass, hass_ws_client):
 
     assert msg["result"]["default_theme"] == "default"
     assert msg["result"]["default_dark_theme"] is None
-    assert msg["result"]["themes"] == {"happy": {"primary-color": "red"}}
+    assert msg["result"]["themes"] == {
+        "happy": {"primary-color": "red"},
+        "dark": {"primary-color": "black"},
+    }
 
     # safe mode
     hass.config.safe_mode = True
@@ -128,6 +141,58 @@ async def test_themes_api(hass, hass_ws_client):
     assert msg["result"]["default_theme"] == "safe_mode"
     assert msg["result"]["themes"] == {
         "safe_mode": {"primary-color": "#db4437", "accent-color": "#eeee02"}
+    }
+
+
+async def test_themes_persist(hass, hass_ws_client, hass_storage):
+    """Test that theme settings are restores after restart."""
+
+    hass_storage[THEMES_STORAGE_KEY] = {
+        "key": THEMES_STORAGE_KEY,
+        "version": 1,
+        "data": {
+            "frontend_default_theme": "happy",
+            "frontend_default_dark_theme": "dark",
+        },
+    }
+
+    assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 5, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_theme"] == "happy"
+    assert msg["result"]["default_dark_theme"] == "dark"
+
+
+async def test_themes_save_storage(hass, hass_storage):
+    """Test that theme settings are restores after restart."""
+
+    hass_storage[THEMES_STORAGE_KEY] = {
+        "key": THEMES_STORAGE_KEY,
+        "version": 1,
+        "data": {},
+    }
+
+    assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
+
+    await hass.services.async_call(
+        DOMAIN, "set_theme", {"name": "happy"}, blocking=True
+    )
+
+    await hass.services.async_call(
+        DOMAIN, "set_theme", {"name": "dark", "mode": "dark"}, blocking=True
+    )
+
+    # To trigger the call_later
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=60))
+    # To execute the save
+    await hass.async_block_till_done()
+
+    assert hass_storage[THEMES_STORAGE_KEY]["data"] == {
+        "frontend_default_theme": "happy",
+        "frontend_default_dark_theme": "dark",
     }
 
 
@@ -150,6 +215,17 @@ async def test_themes_set_theme(hass, hass_ws_client):
     )
 
     await client.send_json({"id": 6, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_theme"] == "default"
+
+    await hass.services.async_call(
+        DOMAIN, "set_theme", {"name": "happy"}, blocking=True
+    )
+
+    await hass.services.async_call(DOMAIN, "set_theme", {"name": "none"}, blocking=True)
+
+    await client.send_json({"id": 7, "type": "frontend/get_themes"})
     msg = await client.receive_json()
 
     assert msg["result"]["default_theme"] == "default"
@@ -177,13 +253,13 @@ async def test_themes_set_dark_theme(hass, hass_ws_client):
     client = await hass_ws_client(hass)
 
     await hass.services.async_call(
-        DOMAIN, "set_theme", {"name": "happy", "mode": "dark"}, blocking=True
+        DOMAIN, "set_theme", {"name": "dark", "mode": "dark"}, blocking=True
     )
 
     await client.send_json({"id": 5, "type": "frontend/get_themes"})
     msg = await client.receive_json()
 
-    assert msg["result"]["default_dark_theme"] == "happy"
+    assert msg["result"]["default_dark_theme"] == "dark"
 
     await hass.services.async_call(
         DOMAIN, "set_theme", {"name": "default", "mode": "dark"}, blocking=True

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -117,6 +117,7 @@ async def test_themes_api(hass, hass_ws_client):
     msg = await client.receive_json()
 
     assert msg["result"]["default_theme"] == "default"
+    assert msg["result"]["default_dark_theme"] is None
     assert msg["result"]["themes"] == {"happy": {"primary-color": "red"}}
 
     # safe mode
@@ -168,6 +169,55 @@ async def test_themes_set_theme_wrong_name(hass, hass_ws_client):
     msg = await client.receive_json()
 
     assert msg["result"]["default_theme"] == "default"
+
+
+async def test_themes_set_dark_theme(hass, hass_ws_client):
+    """Test frontend.set_dark_theme service."""
+    assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
+    client = await hass_ws_client(hass)
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "happy"}, blocking=True
+    )
+
+    await client.send_json({"id": 5, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] == "happy"
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "default"}, blocking=True
+    )
+
+    await client.send_json({"id": 6, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] == "default"
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "none"}, blocking=True
+    )
+
+    await client.send_json({"id": 7, "type": "frontend/get_themes"})
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] is None
+
+
+async def test_themes_set_dark_theme_wrong_name(hass, hass_ws_client):
+    """Test frontend.set_dark_theme service called with wrong name."""
+    assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
+    client = await hass_ws_client(hass)
+
+    await hass.services.async_call(
+        DOMAIN, "set_dark_theme", {"name": "wrong"}, blocking=True
+    )
+
+    await client.send_json({"id": 5, "type": "frontend/get_themes"})
+
+    msg = await client.receive_json()
+
+    assert msg["result"]["default_dark_theme"] is None
 
 
 async def test_themes_reload_themes(hass, hass_ws_client):

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -172,12 +172,12 @@ async def test_themes_set_theme_wrong_name(hass, hass_ws_client):
 
 
 async def test_themes_set_dark_theme(hass, hass_ws_client):
-    """Test frontend.set_dark_theme service."""
+    """Test frontend.set_theme service called with dark mode."""
     assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
     client = await hass_ws_client(hass)
 
     await hass.services.async_call(
-        DOMAIN, "set_dark_theme", {"name": "happy"}, blocking=True
+        DOMAIN, "set_theme", {"name": "happy", "mode": "dark"}, blocking=True
     )
 
     await client.send_json({"id": 5, "type": "frontend/get_themes"})
@@ -186,7 +186,7 @@ async def test_themes_set_dark_theme(hass, hass_ws_client):
     assert msg["result"]["default_dark_theme"] == "happy"
 
     await hass.services.async_call(
-        DOMAIN, "set_dark_theme", {"name": "default"}, blocking=True
+        DOMAIN, "set_theme", {"name": "default", "mode": "dark"}, blocking=True
     )
 
     await client.send_json({"id": 6, "type": "frontend/get_themes"})
@@ -195,7 +195,7 @@ async def test_themes_set_dark_theme(hass, hass_ws_client):
     assert msg["result"]["default_dark_theme"] == "default"
 
     await hass.services.async_call(
-        DOMAIN, "set_dark_theme", {"name": "none"}, blocking=True
+        DOMAIN, "set_theme", {"name": "none", "mode": "dark"}, blocking=True
     )
 
     await client.send_json({"id": 7, "type": "frontend/get_themes"})
@@ -205,12 +205,12 @@ async def test_themes_set_dark_theme(hass, hass_ws_client):
 
 
 async def test_themes_set_dark_theme_wrong_name(hass, hass_ws_client):
-    """Test frontend.set_dark_theme service called with wrong name."""
+    """Test frontend.set_theme service called with mode dark and wrong name."""
     assert await async_setup_component(hass, "frontend", CONFIG_THEMES)
     client = await hass_ws_client(hass)
 
     await hass.services.async_call(
-        DOMAIN, "set_dark_theme", {"name": "wrong"}, blocking=True
+        DOMAIN, "set_theme", {"name": "wrong", "mode": "dark"}, blocking=True
     )
 
     await client.send_json({"id": 5, "type": "frontend/get_themes"})


### PR DESCRIPTION
## Proposed change
Setting a default theme on the backend doesn't survive restarts of hass now and require automations.

This persists the default and default dark theme

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
