### PR TITLE
Reload volumio config entry on update

### DIFF
--- a/homeassistant/components/volumio/manifest.json
+++ b/homeassistant/components/volumio/manifest.json
@@ -5,5 +5,5 @@
   "codeowners": ["@OnFreund"],
   "config_flow": true,
   "zeroconf": ["_Volumio._tcp.local."],
-  "requirements": ["pyvolumio==0.1"]
+  "requirements": ["pyvolumio==0.1.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1831,7 +1831,7 @@ pyvizio==0.1.49
 pyvlx==0.2.16
 
 # homeassistant.components.volumio
-pyvolumio==0.1
+pyvolumio==0.1.1
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -833,7 +833,7 @@ pyvesync==1.1.0
 pyvizio==0.1.49
 
 # homeassistant.components.volumio
-pyvolumio==0.1
+pyvolumio==0.1.1
 
 # homeassistant.components.html5
 pywebpush==1.9.2


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the Volumio config flow discovers an existing config entry for an instance, it updates the information and aborts. This PR adds a listener to the update and reloads the config entry so the changes are picked up.
This means that if the Volumio ip changes while HA is up and running, Volumio will pick up on those changes automatically.

Also bumps the Volumio dependency, to fix the wrong error being displayed when can't connect.
See code changes here: https://github.com/OnFreund/PyVolumio/compare/v0.1.0...v0.1.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
