### PR TITLE
Suppress MQTT discovery updates without changes

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -169,7 +169,8 @@ class MqttBinarySensor(
 
             if expire_after is not None and expire_after > 0:
 
-                # When expire_after is set, and we receive a message, assume device is not expired since it has to be to receive the message
+                # When expire_after is set, and we receive a message, assume device is
+                # not expired since it has to be to receive the message
                 self._expired = False
 
                 # Reset old trigger

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -101,10 +101,10 @@ async def async_setup_entity_template(
     config, async_add_entities, config_entry, discovery_data
 ):
     """Set up a MQTT Template light."""
-    async_add_entities([MqttTemplate(config, config_entry, discovery_data)])
+    async_add_entities([MqttLightTemplate(config, config_entry, discovery_data)])
 
 
-class MqttTemplate(
+class MqttLightTemplate(
     MqttAttributes,
     MqttAvailability,
     MqttDiscoveryUpdate,

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -28,6 +28,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -42,6 +43,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
+from tests.async_mock import patch
 from tests.common import assert_setup_component, async_fire_mqtt_message
 from tests.components.alarm_control_panel import common
 
@@ -573,6 +575,20 @@ async def test_discovery_update_alarm(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, alarm_control_panel.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_alarm(hass, mqtt_mock, caplog):
+    """Test update of discovered alarm_control_panel."""
+    config1 = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
+    config1["name"] = "Beer"
+
+    data1 = json.dumps(config1)
+    with patch(
+        "homeassistant.components.mqtt.alarm_control_panel.MqttAlarm.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, alarm_control_panel.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -26,6 +26,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -591,6 +592,20 @@ async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, binary_sensor.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_binary_sensor(hass, mqtt_mock, caplog):
+    """Test update of discovered binary_sensor."""
+    config1 = copy.deepcopy(DEFAULT_CONFIG[binary_sensor.DOMAIN])
+    config1["name"] = "Beer"
+
+    data1 = json.dumps(config1)
+    with patch(
+        "homeassistant.components.mqtt.binary_sensor.MqttBinarySensor.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, binary_sensor.DOMAIN, data1, discovery_update
+        )
 
 
 async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -16,6 +16,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -30,6 +31,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
+from tests.async_mock import patch
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
@@ -153,12 +155,23 @@ async def test_discovery_update_camera(hass, mqtt_mock, caplog):
     entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     await async_start(hass, "homeassistant", entry)
 
-    data1 = '{ "name": "Beer",' '  "topic": "test_topic"}'
-    data2 = '{ "name": "Milk",' '  "topic": "test_topic"}'
+    data1 = '{ "name": "Beer", "topic": "test_topic"}'
+    data2 = '{ "name": "Milk", "topic": "test_topic"}'
 
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, camera.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_camera(hass, mqtt_mock, caplog):
+    """Test update of discovered camera."""
+    data1 = '{ "name": "Beer", "topic": "test_topic"}'
+    with patch(
+        "homeassistant.components.mqtt.camera.MqttCamera.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, camera.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception
@@ -168,7 +181,7 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
     await async_start(hass, "homeassistant", entry)
 
     data1 = '{ "name": "Beer" }'
-    data2 = '{ "name": "Milk",' '  "topic": "test_topic"}'
+    data2 = '{ "name": "Milk", "topic": "test_topic"}'
 
     await help_test_discovery_broken(
         hass, mqtt_mock, caplog, camera.DOMAIN, data1, data2

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -34,6 +34,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -48,7 +49,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-from tests.async_mock import call
+from tests.async_mock import call, patch
 from tests.common import async_fire_mqtt_message
 from tests.components.climate import common
 
@@ -909,11 +910,22 @@ async def test_discovery_update_climate(hass, mqtt_mock, caplog):
     )
 
 
+async def test_discovery_update_unchanged_climate(hass, mqtt_mock, caplog):
+    """Test update of discovered climate."""
+    data1 = '{ "name": "Beer" }'
+    with patch(
+        "homeassistant.components.mqtt.climate.MqttClimate.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, CLIMATE_DOMAIN, data1, discovery_update
+        )
+
+
 @pytest.mark.no_fail_on_log_exception
 async def test_discovery_broken(hass, mqtt_mock, caplog):
     """Test handling of bad discovery message."""
-    data1 = '{ "name": "Beer",' '  "power_command_topic": "test_topic#" }'
-    data2 = '{ "name": "Milk", ' '  "power_command_topic": "test_topic" }'
+    data1 = '{ "name": "Beer", "power_command_topic": "test_topic#" }'
+    data2 = '{ "name": "Milk", "power_command_topic": "test_topic" }'
     await help_test_discovery_broken(
         hass, mqtt_mock, caplog, CLIMATE_DOMAIN, data1, data2
     )

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -497,6 +497,29 @@ async def help_test_discovery_update(hass, mqtt_mock, caplog, domain, data1, dat
     assert state is None
 
 
+async def help_test_discovery_update_unchanged(
+    hass, mqtt_mock, caplog, domain, data1, discovery_update
+):
+    """Test update of discovered component without changes.
+
+    This is a test helper for the MqttDiscoveryUpdate mixin.
+    """
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    await async_start(hass, "homeassistant", entry)
+
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data1)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{domain}.beer")
+    assert state is not None
+    assert state.name == "Beer"
+
+    async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data1)
+    await hass.async_block_till_done()
+
+    assert not discovery_update.called
+
+
 async def help_test_discovery_broken(hass, mqtt_mock, caplog, domain, data1, data2):
     """Test handling of bad discovery message."""
     entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -38,6 +38,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -52,6 +53,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
+from tests.async_mock import patch
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
@@ -1862,24 +1864,35 @@ async def test_unique_id(hass, mqtt_mock):
 
 async def test_discovery_removal_cover(hass, mqtt_mock, caplog):
     """Test removal of discovered cover."""
-    data = '{ "name": "test",' '  "command_topic": "test_topic" }'
+    data = '{ "name": "test", "command_topic": "test_topic" }'
     await help_test_discovery_removal(hass, mqtt_mock, caplog, cover.DOMAIN, data)
 
 
 async def test_discovery_update_cover(hass, mqtt_mock, caplog):
     """Test update of discovered cover."""
-    data1 = '{ "name": "Beer",' '  "command_topic": "test_topic" }'
-    data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
+    data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
+    data2 = '{ "name": "Milk", "command_topic": "test_topic" }'
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, cover.DOMAIN, data1, data2
     )
 
 
+async def test_discovery_update_unchanged_cover(hass, mqtt_mock, caplog):
+    """Test update of discovered cover."""
+    data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
+    with patch(
+        "homeassistant.components.mqtt.cover.MqttCover.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, cover.DOMAIN, data1, discovery_update
+        )
+
+
 @pytest.mark.no_fail_on_log_exception
 async def test_discovery_broken(hass, mqtt_mock, caplog):
     """Test handling of bad discovery message."""
-    data1 = '{ "name": "Beer",' '  "command_topic": "test_topic#" }'
-    data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
+    data1 = '{ "name": "Beer", "command_topic": "test_topic#" }'
+    data2 = '{ "name": "Milk", "command_topic": "test_topic" }'
     await help_test_discovery_broken(
         hass, mqtt_mock, caplog, cover.DOMAIN, data1, data2
     )

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -19,6 +19,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -33,6 +34,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
+from tests.async_mock import patch
 from tests.common import async_fire_mqtt_message
 from tests.components.fan import common
 
@@ -689,22 +691,33 @@ async def test_unique_id(hass, mqtt_mock):
 
 async def test_discovery_removal_fan(hass, mqtt_mock, caplog):
     """Test removal of discovered fan."""
-    data = '{ "name": "test",' '  "command_topic": "test_topic" }'
+    data = '{ "name": "test", "command_topic": "test_topic" }'
     await help_test_discovery_removal(hass, mqtt_mock, caplog, fan.DOMAIN, data)
 
 
 async def test_discovery_update_fan(hass, mqtt_mock, caplog):
     """Test update of discovered fan."""
-    data1 = '{ "name": "Beer",' '  "command_topic": "test_topic" }'
-    data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
+    data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
+    data2 = '{ "name": "Milk", "command_topic": "test_topic" }'
     await help_test_discovery_update(hass, mqtt_mock, caplog, fan.DOMAIN, data1, data2)
+
+
+async def test_discovery_update_unchanged_fan(hass, mqtt_mock, caplog):
+    """Test update of discovered fan."""
+    data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
+    with patch(
+        "homeassistant.components.mqtt.fan.MqttFan.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, fan.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception
 async def test_discovery_broken(hass, mqtt_mock, caplog):
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
-    data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
+    data2 = '{ "name": "Milk", "command_topic": "test_topic" }'
     await help_test_discovery_broken(hass, mqtt_mock, caplog, fan.DOMAIN, data1, data2)
 
 

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -31,6 +31,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -45,6 +46,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
+from tests.async_mock import patch
 from tests.common import async_fire_mqtt_message
 from tests.components.vacuum import common
 
@@ -641,6 +643,17 @@ async def test_discovery_update_vacuum(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, vacuum.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_vacuum(hass, mqtt_mock, caplog):
+    """Test update of discovered vacuum."""
+    data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
+    with patch(
+        "homeassistant.components.mqtt.vacuum.schema_legacy.MqttVacuum.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, vacuum.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -170,6 +170,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -1448,6 +1449,21 @@ async def test_discovery_update_light(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, light.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_light(hass, mqtt_mock, caplog):
+    """Test update of discovered light."""
+    data1 = (
+        '{ "name": "Beer",'
+        '  "state_topic": "test_topic",'
+        '  "command_topic": "test_topic" }'
+    )
+    with patch(
+        "homeassistant.components.mqtt.light.schema_basic.MqttLight.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, light.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -110,6 +110,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -1177,6 +1178,22 @@ async def test_discovery_update_light(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, light.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_light(hass, mqtt_mock, caplog):
+    """Test update of discovered light."""
+    data1 = (
+        '{ "name": "Beer",'
+        '  "schema": "json",'
+        '  "state_topic": "test_topic",'
+        '  "command_topic": "test_topic" }'
+    )
+    with patch(
+        "homeassistant.components.mqtt.light.schema_json.MqttLightJson.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, light.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -47,6 +47,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -921,6 +922,24 @@ async def test_discovery_update_light(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, light.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_light(hass, mqtt_mock, caplog):
+    """Test update of discovered light."""
+    data1 = (
+        '{ "name": "Beer",'
+        '  "schema": "template",'
+        '  "state_topic": "test_topic",'
+        '  "command_topic": "test_topic",'
+        '  "command_on_template": "on",'
+        '  "command_off_template": "off"}'
+    )
+    with patch(
+        "homeassistant.components.mqtt.light.schema_template.MqttLightTemplate.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, light.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -20,6 +20,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -34,6 +35,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
+from tests.async_mock import patch
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
@@ -380,6 +382,21 @@ async def test_discovery_update_lock(hass, mqtt_mock, caplog):
         '  "availability_topic": "availability_topic2" }'
     )
     await help_test_discovery_update(hass, mqtt_mock, caplog, LOCK_DOMAIN, data1, data2)
+
+
+async def test_discovery_update_unchanged_lock(hass, mqtt_mock, caplog):
+    """Test update of discovered lock."""
+    data1 = (
+        '{ "name": "Beer",'
+        '  "state_topic": "test_topic",'
+        '  "command_topic": "command_topic" }'
+    )
+    with patch(
+        "homeassistant.components.mqtt.lock.MqttLock.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, LOCK_DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -24,6 +24,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_availability,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info,
     help_test_entity_debug_info_max_messages,
     help_test_entity_debug_info_message,
@@ -425,24 +426,35 @@ async def test_unique_id(hass, mqtt_mock):
 
 async def test_discovery_removal_sensor(hass, mqtt_mock, caplog):
     """Test removal of discovered sensor."""
-    data = '{ "name": "test",' '  "state_topic": "test_topic" }'
+    data = '{ "name": "test", "state_topic": "test_topic" }'
     await help_test_discovery_removal(hass, mqtt_mock, caplog, sensor.DOMAIN, data)
 
 
 async def test_discovery_update_sensor(hass, mqtt_mock, caplog):
     """Test update of discovered sensor."""
-    data1 = '{ "name": "Beer",' '  "state_topic": "test_topic" }'
-    data2 = '{ "name": "Milk",' '  "state_topic": "test_topic" }'
+    data1 = '{ "name": "Beer", "state_topic": "test_topic" }'
+    data2 = '{ "name": "Milk", "state_topic": "test_topic" }'
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, sensor.DOMAIN, data1, data2
     )
 
 
+async def test_discovery_update_unchanged_sensor(hass, mqtt_mock, caplog):
+    """Test update of discovered sensor."""
+    data1 = '{ "name": "Beer", "state_topic": "test_topic" }'
+    with patch(
+        "homeassistant.components.mqtt.sensor.MqttSensor.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, sensor.DOMAIN, data1, discovery_update
+        )
+
+
 @pytest.mark.no_fail_on_log_exception
 async def test_discovery_broken(hass, mqtt_mock, caplog):
     """Test handling of bad discovery message."""
-    data1 = '{ "name": "Beer",' '  "state_topic": "test_topic#" }'
-    data2 = '{ "name": "Milk",' '  "state_topic": "test_topic" }'
+    data1 = '{ "name": "Beer", "state_topic": "test_topic#" }'
+    data2 = '{ "name": "Milk", "state_topic": "test_topic" }'
     await help_test_discovery_broken(
         hass, mqtt_mock, caplog, sensor.DOMAIN, data1, data2
     )

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -41,6 +41,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -55,6 +56,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
+from tests.async_mock import patch
 from tests.common import async_fire_mqtt_message
 from tests.components.vacuum import common
 
@@ -410,24 +412,35 @@ async def test_unique_id(hass, mqtt_mock):
 
 async def test_discovery_removal_vacuum(hass, mqtt_mock, caplog):
     """Test removal of discovered vacuum."""
-    data = '{ "schema": "state", "name": "test",' '  "command_topic": "test_topic"}'
+    data = '{ "schema": "state", "name": "test", "command_topic": "test_topic"}'
     await help_test_discovery_removal(hass, mqtt_mock, caplog, vacuum.DOMAIN, data)
 
 
 async def test_discovery_update_vacuum(hass, mqtt_mock, caplog):
     """Test update of discovered vacuum."""
-    data1 = '{ "schema": "state", "name": "Beer",' '  "command_topic": "test_topic"}'
-    data2 = '{ "schema": "state", "name": "Milk",' '  "command_topic": "test_topic"}'
+    data1 = '{ "schema": "state", "name": "Beer", "command_topic": "test_topic"}'
+    data2 = '{ "schema": "state", "name": "Milk", "command_topic": "test_topic"}'
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, vacuum.DOMAIN, data1, data2
     )
 
 
+async def test_discovery_update_unchanged_vacuum(hass, mqtt_mock, caplog):
+    """Test update of discovered vacuum."""
+    data1 = '{ "schema": "state", "name": "Beer", "command_topic": "test_topic"}'
+    with patch(
+        "homeassistant.components.mqtt.vacuum.schema_state.MqttStateVacuum.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, vacuum.DOMAIN, data1, discovery_update
+        )
+
+
 @pytest.mark.no_fail_on_log_exception
 async def test_discovery_broken(hass, mqtt_mock, caplog):
     """Test handling of bad discovery message."""
-    data1 = '{ "schema": "state", "name": "Beer",' '  "command_topic": "test_topic#"}'
-    data2 = '{ "schema": "state", "name": "Milk",' '  "command_topic": "test_topic"}'
+    data1 = '{ "schema": "state", "name": "Beer", "command_topic": "test_topic#"}'
+    data2 = '{ "schema": "state", "name": "Milk", "command_topic": "test_topic"}'
     await help_test_discovery_broken(
         hass, mqtt_mock, caplog, vacuum.DOMAIN, data1, data2
     )

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -15,6 +15,7 @@ from .test_common import (
     help_test_discovery_removal,
     help_test_discovery_update,
     help_test_discovery_update_attr,
+    help_test_discovery_update_unchanged,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -318,6 +319,21 @@ async def test_discovery_update_switch(hass, mqtt_mock, caplog):
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, switch.DOMAIN, data1, data2
     )
+
+
+async def test_discovery_update_unchanged_switch(hass, mqtt_mock, caplog):
+    """Test update of discovered switch."""
+    data1 = (
+        '{ "name": "Beer",'
+        '  "state_topic": "test_topic",'
+        '  "command_topic": "test_topic" }'
+    )
+    with patch(
+        "homeassistant.components.mqtt.switch.MqttSwitch.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass, mqtt_mock, caplog, switch.DOMAIN, data1, discovery_update
+        )
 
 
 @pytest.mark.no_fail_on_log_exception


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When reconnecting to MQTT broker, retained MQTT discovery messages may be received again.
For some components, e.g. MQTT Climate, this causes the state to be reset.
This PR suppresses MQTT discovery updates without changes to avoid resetting entity states.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31759 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
