### PR TITLE
Add events to Dynalite platform

### DIFF
--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -86,7 +86,7 @@ class DynaliteBridge:
                     ATTR_PRESET: notification.data[dyn_CONF_PRESET],
                 },
             )
-            self.hass.bus.fire(
+            self.hass.bus.async_fire(
                 f"dynalite_{self.host}_selected_area_{notification.data[dyn_CONF_AREA]}_preset_{notification.data[dyn_CONF_PRESET]}"
             )
 

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -75,19 +75,20 @@ class DynaliteBridge:
         """Handle a notification from the platform and issue events."""
         if notification.notification == NOTIFICATION_PACKET:
             self.hass.bus.fire(
-                f"dynalite_{self.host}_packet",
-                {ATTR_PACKET: notification.data[NOTIFICATION_PACKET]},
+                "dynalite_packet",
+                {
+                    CONF_HOST: self.host,
+                    ATTR_PACKET: notification.data[NOTIFICATION_PACKET],
+                },
             )
         if notification.notification == NOTIFICATION_PRESET:
             self.hass.bus.fire(
-                f"dynalite_{self.host}_preset",
+                "dynalite_preset",
                 {
+                    CONF_HOST: self.host,
                     ATTR_AREA: notification.data[dyn_CONF_AREA],
                     ATTR_PRESET: notification.data[dyn_CONF_PRESET],
                 },
-            )
-            self.hass.bus.fire(
-                f"dynalite_{self.host}_selected_area_{notification.data[dyn_CONF_AREA]}_preset_{notification.data[dyn_CONF_PRESET]}"
             )
 
     @callback

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -16,7 +16,14 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import ATTR_AREA, ATTR_PACKET, ATTR_PRESET, ENTITY_PLATFORMS, LOGGER
+from .const import (
+    ATTR_AREA,
+    ATTR_HOST,
+    ATTR_PACKET,
+    ATTR_PRESET,
+    ENTITY_PLATFORMS,
+    LOGGER,
+)
 from .convert_config import convert_config
 
 
@@ -77,7 +84,7 @@ class DynaliteBridge:
             self.hass.bus.async_fire(
                 "dynalite_packet",
                 {
-                    CONF_HOST: self.host,
+                    ATTR_HOST: self.host,
                     ATTR_PACKET: notification.data[NOTIFICATION_PACKET],
                 },
             )
@@ -85,7 +92,7 @@ class DynaliteBridge:
             self.hass.bus.async_fire(
                 "dynalite_preset",
                 {
-                    CONF_HOST: self.host,
+                    ATTR_HOST: self.host,
                     ATTR_AREA: notification.data[dyn_CONF_AREA],
                     ATTR_PRESET: notification.data[dyn_CONF_PRESET],
                 },

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -79,7 +79,7 @@ class DynaliteBridge:
                 {ATTR_PACKET: notification.data[NOTIFICATION_PACKET]},
             )
         if notification.notification == NOTIFICATION_PRESET:
-            self.hass.bus.fire(
+            self.hass.bus.async_fire(
                 f"dynalite_{self.host}_preset",
                 {
                     ATTR_AREA: notification.data[dyn_CONF_AREA],

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -76,12 +76,12 @@ class DynaliteBridge:
         LOGGER.error("XXX handle_notification %s", notification)  # XXX
         if notification.notification == NOTIFICATION_PACKET:
             self.hass.bus.fire(
-                f"dynalite_{self.host}",
+                f"dynalite_{self.host}_packet",
                 {ATTR_PACKET: notification.data[NOTIFICATION_PACKET]},
             )
         if notification.notification == NOTIFICATION_PRESET:
             self.hass.bus.fire(
-                f"dynalite_{self.host}_packet",
+                f"dynalite_{self.host}_preset",
                 {
                     ATTR_AREA: notification.data[dyn_CONF_AREA],
                     ATTR_PRESET: notification.data[dyn_CONF_PRESET],

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -74,7 +74,7 @@ class DynaliteBridge:
     def handle_notification(self, notification: DynaliteNotification) -> None:
         """Handle a notification from the platform and issue events."""
         if notification.notification == NOTIFICATION_PACKET:
-            self.hass.bus.fire(
+            self.hass.bus.async_fire(
                 f"dynalite_{self.host}_packet",
                 {ATTR_PACKET: notification.data[NOTIFICATION_PACKET]},
             )

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -2,13 +2,21 @@
 
 from typing import Any, Callable, Dict, List, Optional
 
-from dynalite_devices_lib.dynalite_devices import DynaliteBaseDevice, DynaliteDevices
+from dynalite_devices_lib.dynalite_devices import (
+    CONF_AREA as dyn_CONF_AREA,
+    CONF_PRESET as dyn_CONF_PRESET,
+    NOTIFICATION_PACKET,
+    NOTIFICATION_PRESET,
+    DynaliteBaseDevice,
+    DynaliteDevices,
+    DynaliteNotification,
+)
 
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import ENTITY_PLATFORMS, LOGGER
+from .const import ATTR_AREA, ATTR_PACKET, ATTR_PRESET, ENTITY_PLATFORMS, LOGGER
 from .convert_config import convert_config
 
 
@@ -26,6 +34,7 @@ class DynaliteBridge:
         self.dynalite_devices = DynaliteDevices(
             new_device_func=self.add_devices_when_registered,
             update_device_func=self.update_device,
+            notification_func=self.handle_notification,
         )
         self.dynalite_devices.configure(convert_config(config))
 
@@ -60,6 +69,27 @@ class DynaliteBridge:
             async_dispatcher_send(self.hass, self.update_signal())
         else:
             async_dispatcher_send(self.hass, self.update_signal(device))
+
+    @callback
+    def handle_notification(self, notification: DynaliteNotification) -> None:
+        """Handle a notification from the platform and issue events."""
+        LOGGER.error("XXX handle_notification %s", notification)  # XXX
+        if notification.notification == NOTIFICATION_PACKET:
+            self.hass.bus.fire(
+                f"dynalite_{self.host}",
+                {ATTR_PACKET: notification.data[NOTIFICATION_PACKET]},
+            )
+        if notification.notification == NOTIFICATION_PRESET:
+            self.hass.bus.fire(
+                f"dynalite_{self.host}_packet",
+                {
+                    ATTR_AREA: notification.data[dyn_CONF_AREA],
+                    ATTR_PRESET: notification.data[dyn_CONF_PRESET],
+                },
+            )
+            self.hass.bus.fire(
+                f"dynalite_{self.host}_selected_area_{notification.data[dyn_CONF_AREA]}_preset_{notification.data[dyn_CONF_PRESET]}"
+            )
 
     @callback
     def register_add_devices(self, platform: str, async_add_devices: Callable) -> None:

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -73,7 +73,6 @@ class DynaliteBridge:
     @callback
     def handle_notification(self, notification: DynaliteNotification) -> None:
         """Handle a notification from the platform and issue events."""
-        LOGGER.error("XXX handle_notification %s", notification)  # XXX
         if notification.notification == NOTIFICATION_PACKET:
             self.hass.bus.fire(
                 f"dynalite_{self.host}_packet",

--- a/homeassistant/components/dynalite/const.py
+++ b/homeassistant/components/dynalite/const.py
@@ -50,6 +50,7 @@ DEFAULT_TEMPLATES = {
     ],
 }
 
+ATTR_AREA = "area"
+ATTR_HOST = "host"
 ATTR_PACKET = "packet"
 ATTR_PRESET = "preset"
-ATTR_AREA = "area"

--- a/homeassistant/components/dynalite/const.py
+++ b/homeassistant/components/dynalite/const.py
@@ -49,3 +49,7 @@ DEFAULT_TEMPLATES = {
         CONF_TILT_TIME,
     ],
 }
+
+ATTR_PACKET = "packet"
+ATTR_PRESET = "preset"
+ATTR_AREA = "area"

--- a/homeassistant/components/dynalite/manifest.json
+++ b/homeassistant/components/dynalite/manifest.json
@@ -4,5 +4,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dynalite",
   "codeowners": ["@ziv1234"],
-  "requirements": ["dynalite_devices==0.1.41"]
+  "requirements": ["dynalite_devices==0.1.44"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -503,7 +503,7 @@ dsmr_parser==0.18
 dweepy==0.3.0
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.41
+dynalite_devices==0.1.44
 
 # homeassistant.components.rainforest_eagle
 eagle200_reader==0.2.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ doorbirdpy==2.0.8
 dsmr_parser==0.18
 
 # homeassistant.components.dynalite
-dynalite_devices==0.1.41
+dynalite_devices==0.1.44
 
 # homeassistant.components.ee_brightbox
 eebrightbox==0.0.4

--- a/tests/components/dynalite/test_bridge.py
+++ b/tests/components/dynalite/test_bridge.py
@@ -10,8 +10,12 @@ from dynalite_devices_lib.dynalite_devices import (
 )
 
 from homeassistant.components import dynalite
-from homeassistant.components.dynalite.const import ATTR_AREA, ATTR_PACKET, ATTR_PRESET
-from homeassistant.const import CONF_HOST
+from homeassistant.components.dynalite.const import (
+    ATTR_AREA,
+    ATTR_HOST,
+    ATTR_PACKET,
+    ATTR_PRESET,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from tests.async_mock import AsyncMock, Mock, patch
@@ -129,7 +133,7 @@ async def test_notifications(hass):
     await hass.async_block_till_done()
     event_listener1.assert_called_once()
     my_event = event_listener1.mock_calls[0][1][0]
-    assert my_event.data[CONF_HOST] == host
+    assert my_event.data[ATTR_HOST] == host
     assert my_event.data[ATTR_PACKET] == packet
     event_listener2 = Mock()
     hass.bus.async_listen("dynalite_preset", event_listener2)
@@ -141,6 +145,6 @@ async def test_notifications(hass):
     await hass.async_block_till_done()
     event_listener2.assert_called_once()
     my_event = event_listener2.mock_calls[0][1][0]
-    assert my_event.data[CONF_HOST] == host
+    assert my_event.data[ATTR_HOST] == host
     assert my_event.data[ATTR_AREA] == 7
     assert my_event.data[ATTR_PRESET] == 2

--- a/tests/components/dynalite/test_bridge.py
+++ b/tests/components/dynalite/test_bridge.py
@@ -1,6 +1,16 @@
 """Test Dynalite bridge."""
 
+
+from dynalite_devices_lib.dynalite_devices import (
+    CONF_AREA as dyn_CONF_AREA,
+    CONF_PRESET as dyn_CONF_PRESET,
+    NOTIFICATION_PACKET,
+    NOTIFICATION_PRESET,
+    DynaliteNotification,
+)
+
 from homeassistant.components import dynalite
+from homeassistant.components.dynalite.const import ATTR_AREA, ATTR_PACKET, ATTR_PRESET
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from tests.async_mock import AsyncMock, Mock, patch
@@ -95,3 +105,44 @@ async def test_register_then_add_devices(hass):
     await hass.async_block_till_done()
     assert hass.states.get("light.name")
     assert hass.states.get("switch.name2")
+
+
+async def test_notifications(hass):
+    """Test that update works."""
+    host = "1.2.3.4"
+    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.dynalite.bridge.DynaliteDevices"
+    ) as mock_dyn_dev:
+        mock_dyn_dev().async_setup = AsyncMock(return_value=True)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        notification_func = mock_dyn_dev.mock_calls[1][2]["notification_func"]
+    event_listener1 = Mock()
+    hass.bus.async_listen(f"dynalite_{host}_packet", event_listener1)
+    packet = [5, 4, 3, 2]
+    notification_func(
+        DynaliteNotification(NOTIFICATION_PACKET, {NOTIFICATION_PACKET: packet})
+    )
+    await hass.async_block_till_done()
+    event_listener1.assert_called_once()
+    my_event = event_listener1.mock_calls[0][1][0]
+    assert my_event.data[ATTR_PACKET] == packet
+    event_listener2 = Mock()
+    hass.bus.async_listen(f"dynalite_{host}_preset", event_listener2)
+    event_listener3 = Mock()
+    hass.bus.async_listen(f"dynalite_{host}_selected_area_7_preset_2", event_listener3)
+    notification_func(
+        DynaliteNotification(
+            NOTIFICATION_PRESET, {dyn_CONF_AREA: 7, dyn_CONF_PRESET: 2}
+        )
+    )
+    await hass.async_block_till_done()
+    event_listener2.assert_called_once()
+    my_event = event_listener2.mock_calls[0][1][0]
+    assert my_event.data[ATTR_AREA] == 7
+    assert my_event.data[ATTR_PRESET] == 2
+    event_listener3.assert_called_once()
+    my_event = event_listener3.mock_calls[0][1][0]
+    assert not my_event.data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change. Only additional events

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added events when things happen on the network:
1. Any time there is a Dynet network packet (usually when a switch is pushed). This was asked by a couple of people who wanted to configure additional dynalite opcodes
2. Any time there is a preset selected in an area. This is useful as sometimes these presets are logical and only create a sequence of commands in Dynalite (e.g. turn a full floor off), so they may not have a good on/off triggers to create automations.

done with a new version of the library, v0.44: https://github.com/ziv1234/python-dynalite-devices/releases/tag/v0.44
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14189

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
