### PR TITLE
Revert "Add a timeout for async_add_entities"

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -1,6 +1,5 @@
 """Class to manage the entities for a single platform."""
 import asyncio
-from contextlib import suppress
 from contextvars import ContextVar
 from datetime import datetime, timedelta
 from logging import Logger
@@ -24,8 +23,6 @@ if TYPE_CHECKING:
 
 SLOW_SETUP_WARNING = 10
 SLOW_SETUP_MAX_WAIT = 60
-SLOW_ADD_ENTITIES_MAX_WAIT = 60
-
 PLATFORM_NOT_READY_RETRIES = 10
 DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
@@ -285,10 +282,8 @@ class EntityPlatform:
         device_registry = await hass.helpers.device_registry.async_get_registry()
         entity_registry = await hass.helpers.entity_registry.async_get_registry()
         tasks = [
-            asyncio.create_task(
-                self._async_add_entity(  # type: ignore
-                    entity, update_before_add, entity_registry, device_registry
-                )
+            self._async_add_entity(  # type: ignore
+                entity, update_before_add, entity_registry, device_registry
             )
             for entity in new_entities
         ]
@@ -297,24 +292,7 @@ class EntityPlatform:
         if not tasks:
             return
 
-        await asyncio.wait(tasks, timeout=SLOW_ADD_ENTITIES_MAX_WAIT)
-
-        for idx, entity in enumerate(new_entities):
-            task = tasks[idx]
-            if task.done():
-                await task
-                continue
-
-            self.logger.warning(
-                "Timed out adding entity %s for domain %s with platform %s after %ds.",
-                entity.entity_id,
-                self.domain,
-                self.platform_name,
-                SLOW_ADD_ENTITIES_MAX_WAIT,
-            )
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
+        await asyncio.gather(*tasks)
 
         if self._async_unsub_polling is not None or not any(
             entity.should_poll for entity in self.entities.values()


### PR DESCRIPTION
Reverts home-assistant/core#38474

Generates issues on beta which are not a bug. Look like we need to reinvest more time how that will be fixed without timeout working things or need to make a border that you can not add more as x entities at the same time.

Side note: Maybe a bad idea to add 2 different timeout logic into the new version. Let's first fix the timeout manager and if they work well, we can move forward. Otherwise, we need to first discover where the problem is.