### PR TITLE
Add current request context to get_url helper

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -297,8 +297,8 @@ class HomeAssistantHTTP:
         app[KEY_HASS] = hass
 
         # This order matters
-        setup_real_ip(app, use_x_forwarded_for, trusted_proxies)
         setup_request_context(app, current_request)
+        setup_real_ip(app, use_x_forwarded_for, trusted_proxies)
 
         if is_ban_enabled:
             setup_bans(hass, app, login_threshold)

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -1,4 +1,5 @@
 """Support to serve the Home Assistant API as WSGI application."""
+from contextvars import ContextVar
 from ipaddress import ip_network
 import logging
 import os
@@ -28,6 +29,7 @@ from .ban import setup_bans
 from .const import KEY_AUTHENTICATED, KEY_HASS, KEY_HASS_USER, KEY_REAL_IP  # noqa: F401
 from .cors import setup_cors
 from .real_ip import setup_real_ip
+from .request_context import setup_request_context
 from .static import CACHE_HEADERS, CachingStaticResource
 from .view import HomeAssistantView  # noqa: F401
 from .web_runner import HomeAssistantTCPSite
@@ -296,6 +298,7 @@ class HomeAssistantHTTP:
 
         # This order matters
         setup_real_ip(app, use_x_forwarded_for, trusted_proxies)
+        setup_request_context(app, current_request)
 
         if is_ban_enabled:
             setup_bans(hass, app, login_threshold)
@@ -447,3 +450,8 @@ async def start_http_server_and_save_config(
         ]
 
     await store.async_save(conf)
+
+
+current_request: ContextVar[Optional[web.Request]] = ContextVar(
+    "current_request", default=None
+)

--- a/homeassistant/components/http/request_context.py
+++ b/homeassistant/components/http/request_context.py
@@ -1,0 +1,20 @@
+"""Middleware to set the request context."""
+
+from aiohttp.web import middleware
+
+from homeassistant.core import callback
+
+# mypy: allow-untyped-defs
+
+
+@callback
+def setup_request_context(app, context):
+    """Create request context middleware for the app."""
+
+    @middleware
+    async def request_context_middleware(request, handler):
+        """Request context middleware."""
+        context.set(request)
+        return await handler(request)
+
+    app.middlewares.append(request_context_middleware)

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -118,7 +118,7 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        return f"{get_url(self.hass)}{AUTH_CALLBACK_PATH}"
+        return f"{get_url(self.hass, require_current_request=True)}{AUTH_CALLBACK_PATH}"
 
     @property
     def extra_authorize_data(self) -> dict:

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -118,7 +118,7 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        return f"{get_url(self.hass, require_current_request=True)}{AUTH_CALLBACK_PATH}"
+        return f"{get_url(self.hass)}{AUTH_CALLBACK_PATH}"
 
     @property
     def extra_authorize_data(self) -> dict:

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -54,6 +54,7 @@ def get_url(
                 return _get_internal_url(
                     hass,
                     allow_ip=allow_ip,
+                    require_current_request=require_current_request,
                     require_ssl=require_ssl,
                     require_standard_port=require_standard_port,
                 )
@@ -67,6 +68,7 @@ def get_url(
                     allow_cloud=allow_cloud,
                     allow_ip=allow_ip,
                     prefer_cloud=prefer_cloud,
+                    require_current_request=require_current_request,
                     require_ssl=require_ssl,
                     require_standard_port=require_standard_port,
                 )

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -220,13 +220,9 @@ def _get_current_request_url(
         ):
             return normalize_url(str(ip_url))
 
-    try:
-        cloud_url = _get_cloud_url(hass)
-    except NoURLAvailableError:
-        pass
-    else:
-        if yarl.URL(cloud_url).host == request_host:
-            return normalize_url(cloud_url)
+    cloud_url = _get_cloud_url(hass)
+    if yarl.URL(cloud_url).host == request_host:
+        return normalize_url(cloud_url)
 
     raise NoURLAvailableError
 

--- a/tests/components/http/test_request_context.py
+++ b/tests/components/http/test_request_context.py
@@ -1,0 +1,30 @@
+"""Test request context middleware."""
+from contextvars import ContextVar
+
+from aiohttp import web
+
+from homeassistant.components.http.request_context import setup_request_context
+
+
+async def test_request_context_middleware(aiohttp_client):
+    """Test that request context is set from middleware."""
+    context = ContextVar("request", default=None)
+    app = web.Application()
+
+    async def mock_handler(request):
+        """Return the real IP as text."""
+        request_context = context.get()
+        assert request_context
+        assert request_context == request
+
+        return web.Response(text="hi!")
+
+    app.router.add_get("/", mock_handler)
+    setup_request_context(app, context)
+    mock_api_client = await aiohttp_client(app)
+
+    resp = await mock_api_client.get("/")
+    assert resp.status == 200
+
+    text = await resp.text()
+    assert text == "hi!"

--- a/tests/components/http/test_request_context.py
+++ b/tests/components/http/test_request_context.py
@@ -28,3 +28,6 @@ async def test_request_context_middleware(aiohttp_client):
 
     text = await resp.text()
     assert text == "hi!"
+
+    # We are outside of the context here, should be None
+    assert context.get() is None

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.network import (
     _get_deprecated_base_url,
     _get_external_url,
     _get_internal_url,
+    _get_request_host,
     get_url,
 )
 
@@ -371,6 +372,19 @@ async def test_get_url(hass: HomeAssistant):
 
     with pytest.raises(NoURLAvailableError):
         get_url(hass, allow_external=False, allow_internal=False)
+
+
+async def test_get_request_host(hass: HomeAssistant):
+    """Test getting the host of the current web request from the request context."""
+    with pytest.raises(NoURLAvailableError):
+        _get_request_host()
+
+    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.url = "http://example.com:8123/test/request"
+        mock_request_context.get = Mock(return_value=mock_request)
+
+        assert _get_request_host() == "example.com"
 
 
 async def test_get_deprecated_base_url_internal(hass: HomeAssistant):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds:

- Request context from the aiohttp server
- Extends `get_url` to allow to get the URL matching the current request context

Reason for adding this:

When using OAuth, currently we use the `internal_url` (forced), as this is the only one that should be able to work for everybody (to prevent NAT loopback issues).

The internal_url customization/override capability for the user, should generally not be used, only in rare cases. However, users seem to be confused they have to be visiting the `internal_url` actively in their browser in order to set up integration using an OAuth flow.

At this point, many start fiddling around with the internal URL, causing all new problems (like TTS issues with Google Cast).

The change in this PR allows for changing the `get_url` call used when doing OAuth to:

```py
get_url(require_current_request=True)
```

This will match up the actual used URL in the browser, with all the available URLs in Home Assistant and match those up. This way, the OAuth can be handled with the URL the user is using actively in its browser.

This means, OAuth doesn't have to depend on the `internal_url` anymore but will adjust to the user.

CC: @jjlawren 

## To do

- [x] Add tests to the `http` integration to verify the context var
- [x] Add tests to the `network` helper to verify the new option of `get_url`
- [x] Migrate OAuth handling to use this new helper method

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #38536 (closed), #37569 (closed), #34350, #26924 (closed), #35844,  #36133, #36338, #36422, #33634
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
