### PR TITLE
Fix homekit_controller pairing retry when the first attempt is busy

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -277,7 +277,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except aiohomekit.exceptions.MalformedPinError:
                 # Library claimed pin was invalid before even making an API call
                 errors["pairing_code"] = "authentication_error"
-                self.finish_pairing = None
             except aiohomekit.AuthenticationError:
                 # PairSetup M4 - SRP proof failed
                 # PairSetup M6 - Ed25519 signature verification failed

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -257,7 +257,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except aiohomekit.MaxTriesError:
                 # The accessory has received more than 100 unsuccessful auth
                 # attempts.
-                errors["pairing_code"] = "max_tries_error"
+                return self.async_abort(reason="max_tries_error")
             except aiohomekit.UnavailableError:
                 # The accessory is already paired - cannot try to pair again.
                 return self.async_abort(reason="already_paired")

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -254,10 +254,12 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
                 # Already performing a pair setup operation with a different
                 # controller
                 errors["pairing_code"] = "busy_error"
+                self.finish_pairing = None
             except aiohomekit.MaxTriesError:
                 # The accessory has received more than 100 unsuccessful auth
                 # attempts.
                 errors["pairing_code"] = "max_tries_error"
+                self.finish_pairing = None
             except aiohomekit.UnavailableError:
                 # The accessory is already paired - cannot try to pair again.
                 return self.async_abort(reason="already_paired")
@@ -267,6 +269,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Pairing attempt failed with an unhandled exception")
                 errors["pairing_code"] = "pairing_failed"
+                self.finish_pairing = None
 
         if pair_info:
             code = pair_info["pairing_code"]

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -253,7 +253,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except aiohomekit.BusyError:
                 # Already performing a pair setup operation with a different
                 # controller
-                errors["pairing_code"] = "busy_error"
+                return self.async_abort(reason="busy_error")
             except aiohomekit.MaxTriesError:
                 # The accessory has received more than 100 unsuccessful auth
                 # attempts.

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -268,7 +268,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except IndexError:
                 # TLV error, usually not in pairing mode
                 _LOGGER.exception("Pairing communication failed")
-                errors["base"] = "tlv_error"
+                errors["base"] = "protocol_error"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Pairing attempt failed with an unhandled exception")
                 errors["pairing_code"] = "pairing_failed"

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -25,6 +25,7 @@
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
+      "tlv_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
       "busy_error": "Device refused to add pairing as it is already pairing with another controller.",

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -23,11 +23,11 @@
       "unknown_error": "Device reported an unknown error. Pairing failed.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {
       "no_devices": "No unpaired devices could be found",
+      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
       "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
       "already_configured": "Accessory is already configured with this controller.",

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -25,7 +25,7 @@
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "tlv_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
+      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
       "busy_error": "Device refused to add pairing as it is already pairing with another controller.",

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -19,7 +19,7 @@
       },
       "try_pair_later": {
         "title": "Pairing Unavailable",
-        "description": "Ensure the device is in pairing mode or try restarting the device"
+        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
       }      
     },
     "error": {

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -23,7 +23,6 @@
       "unknown_error": "Device reported an unknown error. Pairing failed.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
       "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
@@ -32,6 +31,7 @@
       "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
       "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
       "already_configured": "Accessory is already configured with this controller.",
+      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
       "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting configuration entry for it in Home Assistant that must first be removed.",
       "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
       "already_in_progress": "Config flow for device is already in progress."

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -16,22 +16,26 @@
         "data": {
           "pairing_code": "Pairing Code"
         }
-      }
+      },
+      "try_pair_later": {
+        "title": "Pairing Unavailable",
+        "description": "Ensure the device is in pairing mode or try restarting the device"
+      }      
     },
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
+      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
+      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {
       "no_devices": "No unpaired devices could be found",
-      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
       "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
       "already_configured": "Accessory is already configured with this controller.",
-      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
       "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting configuration entry for it in Home Assistant that must first be removed.",
       "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
       "already_in_progress": "Config flow for device is already in progress."

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -25,6 +25,7 @@
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
+      "tlv_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
       "busy_error": "Device refused to add pairing as it is already pairing with another controller.",

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -1,40 +1,44 @@
 {
-    "config": {
-        "abort": {
-            "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
-            "already_configured": "Accessory is already configured with this controller.",
-            "already_in_progress": "Config flow for device is already in progress.",
-            "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
-            "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
-            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting configuration entry for it in Home Assistant that must first be removed.",
-            "no_devices": "No unpaired devices could be found"
-        },
-        "error": {
-            "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
-            "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
-            "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-            "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
-            "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently.",
-            "unable_to_pair": "Unable to pair, please try again.",
-            "unknown_error": "Device reported an unknown error. Pairing failed."
-        },
-        "flow_title": "HomeKit Accessory: {name}",
-        "step": {
-            "pair": {
-                "data": {
-                    "pairing_code": "Pairing Code"
-                },
-                "description": "Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory",
-                "title": "Pair with HomeKit Accessory"
-            },
-            "user": {
-                "data": {
-                    "device": "Device"
-                },
-                "description": "Select the device you want to pair with",
-                "title": "Pair with HomeKit Accessory"
-            }
+  "title": "HomeKit Controller",
+  "config": {
+    "flow_title": "HomeKit Accessory: {name}",
+    "step": {
+      "user": {
+        "title": "Pair with HomeKit Accessory",
+        "description": "Select the device you want to pair with",
+        "data": {
+          "device": "Device"
         }
+      },
+      "pair": {
+        "title": "Pair with HomeKit Accessory",
+        "description": "Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory",
+        "data": {
+          "pairing_code": "Pairing Code"
+        }
+      },
+      "try_pair_later": {
+        "title": "Pairing Unavailable",
+        "description": "Ensure the device is in pairing mode or try restarting the device"
+      }      
     },
-    "title": "HomeKit Controller"
+    "error": {
+      "unable_to_pair": "Unable to pair, please try again.",
+      "unknown_error": "Device reported an unknown error. Pairing failed.",
+      "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
+      "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
+      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
+      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
+      "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
+    },
+    "abort": {
+      "no_devices": "No unpaired devices could be found",
+      "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
+      "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
+      "already_configured": "Accessory is already configured with this controller.",
+      "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting configuration entry for it in Home Assistant that must first be removed.",
+      "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
+      "already_in_progress": "Config flow for device is already in progress."
+    }
+  }
 }

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -25,7 +25,7 @@
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "tlv_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
+      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
       "busy_error": "Device refused to add pairing as it is already pairing with another controller.",

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -19,7 +19,7 @@
       },
       "try_pair_later": {
         "title": "Pairing Unavailable",
-        "description": "Ensure the device is in pairing mode or try restarting the device"
+        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
       }      
     },
     "error": {

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -347,6 +347,13 @@ async def test_pair_form_errors_on_start(hass, controller, exception, expected):
         "source": "zeroconf",
     }
 
+    # User re-tries entering pairing code
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"pairing_code": "111-22-333"}
+    )
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Koogeek-LS1-20833F"
+
 
 @pytest.mark.parametrize("exception,expected", PAIRING_FINISH_ABORT_ERRORS)
 async def test_pair_abort_errors_on_finish(hass, controller, exception, expected):

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -25,7 +25,7 @@ PAIRING_START_ABORT_ERRORS = [
 PAIRING_TRY_LATER_ERRORS = [
     (aiohomekit.BusyError, "busy_error"),
     (aiohomekit.MaxTriesError, "max_tries_error"),
-    (IndexError, "tlv_error"),
+    (IndexError, "protocol_error"),
 ]
 
 PAIRING_FINISH_FORM_ERRORS = [

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -14,11 +14,12 @@ from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 PAIRING_START_FORM_ERRORS = [
-    (aiohomekit.MaxTriesError, "max_tries_error"),
     (KeyError, "pairing_failed"),
 ]
 
 PAIRING_START_ABORT_ERRORS = [
+    (aiohomekit.BusyError, "busy_error"),
+    (aiohomekit.MaxTriesError, "max_tries_error"),
     (aiohomekit.AccessoryNotFoundError, "accessory_not_found_error"),
     (aiohomekit.UnavailableError, "already_paired"),
 ]
@@ -545,28 +546,3 @@ async def test_unignore_ignores_missing_devices(hass, controller):
 
     assert result["type"] == "abort"
     assert result["reason"] == "no_devices"
-
-
-async def test_pair_busy_first_attempt(hass, controller):
-    """Test various pairing errors."""
-
-    device = setup_mock_accessory(controller)
-    discovery_info = get_device_discovery_info(device)
-
-    # Device is discovered
-    result = await hass.config_entries.flow.async_init(
-        "homekit_controller", context={"source": "zeroconf"}, data=discovery_info
-    )
-
-    assert get_flow_context(hass, result) == {
-        "hkid": "00:00:00:00:00:00",
-        "title_placeholders": {"name": "TestDevice"},
-        "unique_id": "00:00:00:00:00:00",
-        "source": "zeroconf",
-    }
-
-    # User initiates pairing - device is busy
-    with patch.object(device, "start_pairing", side_effect=aiohomekit.BusyError("1")):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result["type"] == "abort"
-    assert result["reason"] == "busy_error"


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix homekit_controller pairing retry

If the device was busy on the first pairing attempt, it
was not possible to retry due to the below exception:

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/config_flow.py", line 248, in async_step_pair
    pairing = await self.finish_pairing(code)
TypeError: 'NoneType' object is not callable
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
