### PR TITLE
Cleanup Netatmo sensors

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -150,20 +150,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
             _LOGGER.debug(
                 "Adding module %s %s", module.get("module_name"), module.get("_id"),
             )
-            conditions = data_class.get_monitored_conditions(module_id=module["_id"])
+            conditions = [
+                c.lower()
+                for c in data_class.get_monitored_conditions(module_id=module["_id"])
+            ]
             for condition in conditions:
-                if f"{condition.lower()}_value" in SENSOR_TYPES:
+                if f"{condition}_value" in SENSOR_TYPES:
                     conditions.append(f"{condition}_value")
-                elif f"{condition.lower()}_lvl" in SENSOR_TYPES:
+                elif f"{condition}_lvl" in SENSOR_TYPES:
                     conditions.append(f"{condition}_lvl")
-                elif condition.lower() == "battery_vp":
+                elif condition == "battery_vp":
                     conditions.append("battery_lvl")
 
             for condition in conditions:
                 entities.append(
-                    NetatmoSensor(
-                        data_handler, data_class_name, module, condition.lower()
-                    )
+                    NetatmoSensor(data_handler, data_class_name, module, condition)
                 )
 
         return entities

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -315,8 +315,8 @@ class NetatmoSensor(NetatmoBase):
         if data is None:
             if self._state:
                 _LOGGER.debug(
-                    "No data (%s) found for %s (%s)",
-                    self._data,
+                    "No data found for %s - %s (%s)",
+                    self.name,
                     self._device_name,
                     self._id,
                 )

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -121,7 +121,6 @@ PUBLIC = "public"
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the Netatmo weather and homecoach platform."""
-    device_registry = await hass.helpers.device_registry.async_get_registry()
     data_handler = hass.data[DOMAIN][entry.entry_id][DATA_HANDLER]
 
     async def find_entities(data_class_name):
@@ -174,6 +173,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
         HOMECOACH_DATA_CLASS_NAME,
     ]:
         async_add_entities(await find_entities(data_class_name), True)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
 
     @callback
     async def add_public_entities(update=True):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The sensor for wind and gust angle is split up into two entities so that it now returns the direction (e.g. `NE`) and the actual value (e.g. `178°`) rather than a string containing both (e.g. `NE (123°)`). 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The sensor for wind and gust angle is split up into two entities so that it now returns the direction (e.g. `NE`) and the actual value (e.g. `178°`) rather than a string containing both (e.g. `NE (123°)`). 
Further now the correct device classes are used where available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
