### PR TITLE
Migrate rtorrent component to own domain and add services

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -764,6 +764,7 @@ omit =
     homeassistant/components/rpi_gpio_pwm/light.py
     homeassistant/components/rpi_pfio/*
     homeassistant/components/rpi_rf/switch.py
+    homeassistant/components/rtorrent/__init__.py
     homeassistant/components/rtorrent/sensor.py
     homeassistant/components/russound_rio/media_player.py
     homeassistant/components/russound_rnet/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -379,6 +379,7 @@ homeassistant/components/roomba/* @pschmitt @cyr-ius @shenxn
 homeassistant/components/roon/* @pavoni
 homeassistant/components/rpi_gpio_pwm/* @soldag
 homeassistant/components/rpi_power/* @shenxn @swetoast
+homeassistant/components/rtorrent/* @disrupted
 homeassistant/components/ruckus_unleashed/* @gabe565
 homeassistant/components/safe_mode/* @home-assistant/core
 homeassistant/components/saj/* @fredericvl

--- a/homeassistant/components/rtorrent/__init__.py
+++ b/homeassistant/components/rtorrent/__init__.py
@@ -142,7 +142,6 @@ class RTorrentData:
 
     def update(self):
         """Get the latest data from rTorrent instance."""
-
         multicall = xmlrpc.client.MultiCall(self._api)
         multicall.throttle.global_up.rate()
         multicall.throttle.global_down.rate()

--- a/homeassistant/components/rtorrent/__init__.py
+++ b/homeassistant/components/rtorrent/__init__.py
@@ -1,1 +1,183 @@
 """The rtorrent component."""
+from datetime import timedelta
+import logging
+import xmlrpc.client
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_MONITORED_VARIABLES,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+    CONF_URL,
+    DATA_RATE_KILOBYTES_PER_SECOND,
+    DATA_RATE_MEGABYTES_PER_SECOND,
+    STATE_IDLE,
+)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import track_time_interval
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_SPEED = "speed"
+
+DOMAIN = "rtorrent"
+DATA_RTORRENT = "data_rtorrent"
+DATA_UPDATED = "rtorrent_data_updated"
+
+DEFAULT_NAME = "rTorrent"
+DEFAULT_SPEED_LIMIT = 1000  # 1 MB/s
+
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=5)
+
+SENSOR_TYPES = {
+    "current_status": ["Status", None, "mdi:server-network"],
+    "upload_speed": ["Up Speed", DATA_RATE_MEGABYTES_PER_SECOND, "mdi:upload"],
+    "download_speed": ["Down Speed", DATA_RATE_MEGABYTES_PER_SECOND, "mdi:download"],
+    "upload_limit": ["Up Limit", DATA_RATE_KILOBYTES_PER_SECOND, "mdi:upload"],
+    "download_limit": ["Down Limit", DATA_RATE_KILOBYTES_PER_SECOND, "mdi:download"],
+    "all_torrents": ["All Torrents", None, "mdi:view-list-outline"],
+    "stopped_torrents": ["Stopped Torrents", None, "mdi:stop"],
+    "complete_torrents": ["Complete Torrents", None, "mdi:playlist_check"],
+    "uploading_torrents": ["Uploading Torrents", None, "mdi:upload-multiple"],
+    "downloading_torrents": ["Downloading Torrents", None, "mdi:download-multiple"],
+    "active_torrents": ["Active Torrents", None, "mdi:playlist-play"],
+}
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_URL): cv.url,
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(
+                    CONF_MONITORED_VARIABLES, default=list(SENSOR_TYPES)
+                ): vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                ): cv.time_period,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+SERVICE_SET_DOWNLOAD_SPEED = "set_download_speed"
+SERVICE_SET_UPLOAD_SPEED = "set_upload_speed"
+SPEED_LIMIT_SCHEMA = vol.Schema(
+    {vol.Optional(ATTR_SPEED, default=DEFAULT_SPEED_LIMIT): cv.positive_int}
+)
+
+
+def setup(hass, config):
+    """Set up is called when Home Assistant is loading our component."""
+    url = config[DOMAIN][CONF_URL]
+    name = config[DOMAIN][CONF_NAME]
+    scan_interval = config[DOMAIN][CONF_SCAN_INTERVAL]
+
+    try:
+        rtorrent = xmlrpc.client.ServerProxy(url)
+    except (xmlrpc.client.ProtocolError, ConnectionRefusedError) as ex:
+        _LOGGER.error("Connection to rtorrent daemon failed")
+        raise PlatformNotReady from ex
+
+    rtorrent_data = hass.data[DATA_RTORRENT] = RTorrentData(hass, rtorrent)
+    rtorrent_data.update()
+
+    def service_handler(call):
+        """Handle service calls."""
+        if call.service == SERVICE_SET_DOWNLOAD_SPEED:
+            limit = call.data.get(ATTR_SPEED, DEFAULT_SPEED_LIMIT)
+            rtorrent.set_download_rate(f"{limit}k")
+        elif call.service == SERVICE_SET_UPLOAD_SPEED:
+            limit = call.data.get(ATTR_SPEED, DEFAULT_SPEED_LIMIT)
+            rtorrent.set_upload_rate(f"{limit}k")
+
+    hass.services.register(
+        DOMAIN, SERVICE_SET_DOWNLOAD_SPEED, service_handler, schema=SPEED_LIMIT_SCHEMA
+    )
+
+    hass.services.register(
+        DOMAIN, SERVICE_SET_UPLOAD_SPEED, service_handler, schema=SPEED_LIMIT_SCHEMA
+    )
+
+    def refresh(event_time):
+        """Get the latest data from rTorrent."""
+        rtorrent_data.update()
+
+    track_time_interval(hass, refresh, scan_interval)
+
+    sensorconfig = {
+        "client_name": name,
+        "monitored_variables": config[DOMAIN][CONF_MONITORED_VARIABLES],
+    }
+
+    hass.helpers.discovery.load_platform("sensor", DOMAIN, sensorconfig, config)
+
+    # Return boolean to indicate that initialization was successfully.
+    return True
+
+
+class RTorrentData:
+    """Get the latest data and update the states."""
+
+    def __init__(self, hass, api):
+        """Initialize the rTorrent XMLRPC API."""
+        self.hass = hass
+        self.available = True
+        self._api = api
+        self.data = None
+        self.upload = None
+        self.download = None
+        self.upload_limit = None
+        self.download_limit = None
+        self.all_torrents = None
+        self.stopped_torrents = None
+        self.complete_torrents = None
+        self.seeding = None
+        self.downloading = None
+        self.status = None
+
+    def update(self):
+        """Get the latest data from rTorrent instance."""
+
+        multicall = xmlrpc.client.MultiCall(self._api)
+        multicall.throttle.global_up.rate()
+        multicall.throttle.global_down.rate()
+        multicall.throttle.global_up.max_rate()
+        multicall.throttle.global_down.max_rate()
+        multicall.d.multicall2("", "main")
+        multicall.d.multicall2("", "stopped")
+        multicall.d.multicall2("", "complete")
+        multicall.d.multicall2("", "seeding", "d.up.rate=")
+        multicall.d.multicall2("", "leeching", "d.down.rate=")
+
+        try:
+            self.data = multicall()
+            self.available = True
+            dispatcher_send(self.hass, DATA_UPDATED)
+        except (xmlrpc.client.ProtocolError, ConnectionRefusedError, OSError) as err:
+            self.available = False
+            _LOGGER.error("Unable to refresh rTorrent data: %s", err)
+            return
+        self.upload = self.data[0]
+        self.download = self.data[1]
+        self.upload_limit = self.data[2]
+        self.download_limit = self.data[3]
+        self.all_torrents = self.data[4]
+        self.stopped_torrents = self.data[5]
+        self.complete_torrents = self.data[6]
+        self.seeding = len([t for t in self.data[7] if t[0]])
+        self.downloading = len([t for t in self.data[8] if t[0]])
+        if self.seeding > 0:
+            if self.downloading > 0:
+                self.status = "up_down"
+            else:
+                self.status = "seeding"
+        else:
+            if self.downloading > 0:
+                self.status = "downloading"
+            else:
+                self.status = STATE_IDLE

--- a/homeassistant/components/rtorrent/manifest.json
+++ b/homeassistant/components/rtorrent/manifest.json
@@ -2,5 +2,5 @@
   "domain": "rtorrent",
   "name": "rTorrent",
   "documentation": "https://www.home-assistant.io/integrations/rtorrent",
-  "codeowners": []
+  "codeowners": ["@disrupted"]
 }

--- a/homeassistant/components/rtorrent/sensor.py
+++ b/homeassistant/components/rtorrent/sensor.py
@@ -1,98 +1,70 @@
 """Support for monitoring the rtorrent BitTorrent client API."""
 import logging
-import xmlrpc.client
 
-import voluptuous as vol
-
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_MONITORED_VARIABLES,
-    CONF_NAME,
-    CONF_URL,
-    DATA_RATE_KILOBYTES_PER_SECOND,
-    STATE_IDLE,
-)
-from homeassistant.exceptions import PlatformNotReady
-import homeassistant.helpers.config_validation as cv
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
+from . import DATA_RTORRENT, DATA_UPDATED, SENSOR_TYPES
+
 _LOGGER = logging.getLogger(__name__)
-
-SENSOR_TYPE_CURRENT_STATUS = "current_status"
-SENSOR_TYPE_DOWNLOAD_SPEED = "download_speed"
-SENSOR_TYPE_UPLOAD_SPEED = "upload_speed"
-SENSOR_TYPE_ALL_TORRENTS = "all_torrents"
-SENSOR_TYPE_STOPPED_TORRENTS = "stopped_torrents"
-SENSOR_TYPE_COMPLETE_TORRENTS = "complete_torrents"
-SENSOR_TYPE_UPLOADING_TORRENTS = "uploading_torrents"
-SENSOR_TYPE_DOWNLOADING_TORRENTS = "downloading_torrents"
-SENSOR_TYPE_ACTIVE_TORRENTS = "active_torrents"
-
-DEFAULT_NAME = "rtorrent"
-SENSOR_TYPES = {
-    SENSOR_TYPE_CURRENT_STATUS: ["Status", None],
-    SENSOR_TYPE_DOWNLOAD_SPEED: ["Down Speed", DATA_RATE_KILOBYTES_PER_SECOND],
-    SENSOR_TYPE_UPLOAD_SPEED: ["Up Speed", DATA_RATE_KILOBYTES_PER_SECOND],
-    SENSOR_TYPE_ALL_TORRENTS: ["All Torrents", None],
-    SENSOR_TYPE_STOPPED_TORRENTS: ["Stopped Torrents", None],
-    SENSOR_TYPE_COMPLETE_TORRENTS: ["Complete Torrents", None],
-    SENSOR_TYPE_UPLOADING_TORRENTS: ["Uploading Torrents", None],
-    SENSOR_TYPE_DOWNLOADING_TORRENTS: ["Downloading Torrents", None],
-    SENSOR_TYPE_ACTIVE_TORRENTS: ["Active Torrents", None],
-}
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_URL): cv.url,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_MONITORED_VARIABLES, default=list(SENSOR_TYPES)): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES)]
-        ),
-    }
-)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the rtorrent sensors."""
-    url = config[CONF_URL]
-    name = config[CONF_NAME]
+    if discovery_info is None:
+        return
 
-    try:
-        rtorrent = xmlrpc.client.ServerProxy(url)
-    except (xmlrpc.client.ProtocolError, ConnectionRefusedError) as ex:
-        _LOGGER.error("Connection to rtorrent daemon failed")
-        raise PlatformNotReady from ex
-    dev = []
-    for variable in config[CONF_MONITORED_VARIABLES]:
-        dev.append(RTorrentSensor(variable, rtorrent, name))
+    rtorrent_data = hass.data[DATA_RTORRENT]
+    name = discovery_info["client_name"]
 
-    add_entities(dev)
+    devices = []
+    for sensor_type in discovery_info["monitored_variables"]:
+        devices.append(
+            RTorrentSensor(
+                rtorrent_data,
+                sensor_type,
+                name,
+                SENSOR_TYPES[sensor_type][0],
+                SENSOR_TYPES[sensor_type][1],
+                SENSOR_TYPES[sensor_type][2],
+            )
+        )
+
+    add_entities(devices, True)
 
 
-def format_speed(speed):
+def format_speed(speed, unit=2):
     """Return a bytes/s measurement as a human readable string."""
-    kb_spd = float(speed) / 1024
-    return round(kb_spd, 2 if kb_spd < 0.1 else 1)
+    speed_fmt = float(speed) / (1024 ** unit)
+    return round(speed_fmt, 2 if speed_fmt < 0.1 else 1)
 
 
 class RTorrentSensor(Entity):
     """Representation of an rtorrent sensor."""
 
-    def __init__(self, sensor_type, rtorrent_client, client_name):
+    def __init__(
+        self,
+        rtorrent_data,
+        sensor_type,
+        client_name,
+        sensor_name,
+        unit_of_measurement,
+        icon,
+    ):
         """Initialize the sensor."""
-        self._name = SENSOR_TYPES[sensor_type][0]
-        self.client = rtorrent_client
+        self._name = f"{client_name} {sensor_name}"
+        self.rtorrent_data = rtorrent_data
         self.type = sensor_type
         self.client_name = client_name
         self._state = None
-        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
-        self.data = None
-        self._available = False
+        self._unit_of_measurement = unit_of_measurement
+        self._icon = icon
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{self.client_name} {self._name}"
+        return self._name
 
     @property
     def state(self):
@@ -100,79 +72,48 @@ class RTorrentSensor(Entity):
         return self._state
 
     @property
-    def available(self):
-        """Return true if device is available."""
-        return self._available
-
-    @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return self._icon
+
+    @property
+    def available(self):
+        """Return true if device is available."""
+        return self.rtorrent_data.available
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, DATA_UPDATED, self._schedule_immediate_update
+            )
+        )
+
+    @callback
+    def _schedule_immediate_update(self):
+        self.async_schedule_update_ha_state(True)
+
     def update(self):
         """Get the latest data from rtorrent and updates the state."""
-        multicall = xmlrpc.client.MultiCall(self.client)
-        multicall.throttle.global_up.rate()
-        multicall.throttle.global_down.rate()
-        multicall.d.multicall2("", "main")
-        multicall.d.multicall2("", "stopped")
-        multicall.d.multicall2("", "complete")
-        multicall.d.multicall2("", "seeding", "d.up.rate=")
-        multicall.d.multicall2("", "leeching", "d.down.rate=")
+        states = {
+            "current_status": self.rtorrent_data.status,
+            "upload_speed": format_speed(self.rtorrent_data.upload),
+            "download_speed": format_speed(self.rtorrent_data.download),
+            "upload_limit": int(format_speed(self.rtorrent_data.upload_limit, 1)),
+            "download_limit": int(format_speed(self.rtorrent_data.download_limit, 1)),
+            "all_torrents": len(self.rtorrent_data.all_torrents),
+            "stopped_torrents": len(self.rtorrent_data.stopped_torrents),
+            "complete_torrents": len(self.rtorrent_data.complete_torrents),
+            "uploading_torrents": self.rtorrent_data.seeding,
+            "downloading_torrents": self.rtorrent_data.downloading,
+            "active_torrents": (
+                self.rtorrent_data.seeding + self.rtorrent_data.downloading
+            ),
+        }
 
-        try:
-            self.data = multicall()
-            self._available = True
-        except (xmlrpc.client.ProtocolError, ConnectionRefusedError, OSError) as ex:
-            _LOGGER.error("Connection to rtorrent failed (%s)", ex)
-            self._available = False
-            return
-
-        upload = self.data[0]
-        download = self.data[1]
-        all_torrents = self.data[2]
-        stopped_torrents = self.data[3]
-        complete_torrents = self.data[4]
-
-        uploading_torrents = 0
-        for up_torrent in self.data[5]:
-            if up_torrent[0]:
-                uploading_torrents += 1
-
-        downloading_torrents = 0
-        for down_torrent in self.data[6]:
-            if down_torrent[0]:
-                downloading_torrents += 1
-
-        active_torrents = uploading_torrents + downloading_torrents
-
-        if self.type == SENSOR_TYPE_CURRENT_STATUS:
-            if self.data:
-                if upload > 0 and download > 0:
-                    self._state = "up_down"
-                elif upload > 0 and download == 0:
-                    self._state = "seeding"
-                elif upload == 0 and download > 0:
-                    self._state = "downloading"
-                else:
-                    self._state = STATE_IDLE
-            else:
-                self._state = None
-
-        if self.data:
-            if self.type == SENSOR_TYPE_DOWNLOAD_SPEED:
-                self._state = format_speed(download)
-            elif self.type == SENSOR_TYPE_UPLOAD_SPEED:
-                self._state = format_speed(upload)
-            elif self.type == SENSOR_TYPE_ALL_TORRENTS:
-                self._state = len(all_torrents)
-            elif self.type == SENSOR_TYPE_STOPPED_TORRENTS:
-                self._state = len(stopped_torrents)
-            elif self.type == SENSOR_TYPE_COMPLETE_TORRENTS:
-                self._state = len(complete_torrents)
-            elif self.type == SENSOR_TYPE_UPLOADING_TORRENTS:
-                self._state = uploading_torrents
-            elif self.type == SENSOR_TYPE_DOWNLOADING_TORRENTS:
-                self._state = downloading_torrents
-            elif self.type == SENSOR_TYPE_ACTIVE_TORRENTS:
-                self._state = active_torrents
+        self._state = states.get(self.type, None)

--- a/homeassistant/components/rtorrent/services.yaml
+++ b/homeassistant/components/rtorrent/services.yaml
@@ -1,0 +1,15 @@
+# Describes the format for available rTorrent services
+
+set_download_speed:
+  description: Set download speed limit
+  fields:
+    speed:
+      description: Speed limit in kB/s. 0 is unlimited.
+      example: 1000
+
+set_upload_speed:
+  description: Set upload speed limit
+  fields:
+    speed:
+      description: Speed limit in kB/s. 0 is unlimited.
+      example: 1000


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

component has its own domain now.

that means you need to change your configuration from
```yaml
sensor:
  - platform: rtorrent
    url: !secret rt_url
    monitored_variables:
      - 'upload_speed'
      - 'download_speed'
```
to
```yaml
rtorrent:
  url: !secret rt_url
  monitored_variables:
    - 'upload_speed'
    - 'download_speed'
```

everything else remains the same


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I refactored parts of the code so that it would move to its own domain.
This enabled me to add services for setting download and upload speed limits on the rTorrent instance, so that it can be used in automations and for scheduling different speeds at different times of the day.
inspired by @chriscla who refactored the NZBGet component. https://github.com/home-assistant/core/pull/26462 https://github.com/home-assistant/core/pull/26900

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
rtorrent:
  url: 'http://<user>:<password>@<host>:<port>/RPC2'
  monitored_variables:
    - 'current_status'
    - 'download_speed'
    - 'upload_speed'
    - 'all_torrents'
    - 'stopped_torrents'
    - 'complete_torrents'
    - 'uploading_torrents'
    - 'downloading_torrents'
    - 'active_torrents'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14191

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
