### PR TITLE
Create variable with result of wait_template and accept template for timeout option

### DIFF
--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -137,18 +137,9 @@ async def async_attach_trigger(
                 }
 
                 try:
-                    if isinstance(time_delta, template.Template):
-                        period[entity] = cv.positive_time_period(
-                            time_delta.async_render(variables)
-                        )
-                    elif isinstance(time_delta, dict):
-                        time_delta_data = {}
-                        time_delta_data.update(
-                            template.render_complex(time_delta, variables)
-                        )
-                        period[entity] = cv.positive_time_period(time_delta_data)
-                    else:
-                        period[entity] = time_delta
+                    period[entity] = cv.positive_time_period(
+                        template.render_complex(time_delta, variables)
+                    )
                 except (exceptions.TemplateError, vol.Invalid) as ex:
                     _LOGGER.error(
                         "Error rendering '%s' for template: %s",

--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -47,11 +47,7 @@ TRIGGER_SCHEMA = vol.All(
             vol.Optional(CONF_BELOW): vol.Coerce(float),
             vol.Optional(CONF_ABOVE): vol.Coerce(float),
             vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-            vol.Optional(CONF_FOR): vol.Any(
-                vol.All(cv.time_period, cv.positive_timedelta),
-                cv.template,
-                cv.template_complex,
-            ),
+            vol.Optional(CONF_FOR): cv.positive_time_period_template,
         }
     ),
     cv.has_at_least_one_key(CONF_BELOW, CONF_ABOVE),
@@ -142,7 +138,7 @@ async def async_attach_trigger(
 
                 try:
                     if isinstance(time_delta, template.Template):
-                        period[entity] = vol.All(cv.time_period, cv.positive_timedelta)(
+                        period[entity] = cv.positive_time_period(
                             time_delta.async_render(variables)
                         )
                     elif isinstance(time_delta, dict):
@@ -150,9 +146,7 @@ async def async_attach_trigger(
                         time_delta_data.update(
                             template.render_complex(time_delta, variables)
                         )
-                        period[entity] = vol.All(cv.time_period, cv.positive_timedelta)(
-                            time_delta_data
-                        )
+                        period[entity] = cv.positive_time_period(time_delta_data)
                     else:
                         period[entity] = time_delta
                 except (exceptions.TemplateError, vol.Invalid) as ex:

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -111,16 +111,9 @@ async def async_attach_trigger(
         }
 
         try:
-            if isinstance(time_delta, template.Template):
-                period[entity] = cv.positive_time_period(
-                    time_delta.async_render(variables)
-                )
-            elif isinstance(time_delta, dict):
-                time_delta_data = {}
-                time_delta_data.update(template.render_complex(time_delta, variables))
-                period[entity] = cv.positive_time_period(time_delta_data)
-            else:
-                period[entity] = time_delta
+            period[entity] = cv.positive_time_period(
+                template.render_complex(time_delta, variables)
+            )
         except (exceptions.TemplateError, vol.Invalid) as ex:
             _LOGGER.error(
                 "Error rendering '%s' for template: %s", automation_info["name"], ex

--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -33,11 +33,7 @@ TRIGGER_SCHEMA = vol.All(
             # These are str on purpose. Want to catch YAML conversions
             vol.Optional(CONF_FROM): vol.Any(str, [str]),
             vol.Optional(CONF_TO): vol.Any(str, [str]),
-            vol.Optional(CONF_FOR): vol.Any(
-                vol.All(cv.time_period, cv.positive_timedelta),
-                cv.template,
-                cv.template_complex,
-            ),
+            vol.Optional(CONF_FOR): cv.positive_time_period_template,
         }
     ),
     cv.key_dependency(CONF_FOR, CONF_TO),
@@ -116,15 +112,13 @@ async def async_attach_trigger(
 
         try:
             if isinstance(time_delta, template.Template):
-                period[entity] = vol.All(cv.time_period, cv.positive_timedelta)(
+                period[entity] = cv.positive_time_period(
                     time_delta.async_render(variables)
                 )
             elif isinstance(time_delta, dict):
                 time_delta_data = {}
                 time_delta_data.update(template.render_complex(time_delta, variables))
-                period[entity] = vol.All(cv.time_period, cv.positive_timedelta)(
-                    time_delta_data
-                )
+                period[entity] = cv.positive_time_period(time_delta_data)
             else:
                 period[entity] = time_delta
         except (exceptions.TemplateError, vol.Invalid) as ex:

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -17,11 +17,7 @@ TRIGGER_SCHEMA = IF_ACTION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_PLATFORM): "template",
         vol.Required(CONF_VALUE_TEMPLATE): cv.template,
-        vol.Optional(CONF_FOR): vol.Any(
-            vol.All(cv.time_period, cv.positive_timedelta),
-            cv.template,
-            cv.template_complex,
-        ),
+        vol.Optional(CONF_FOR): cv.positive_time_period_template,
     }
 )
 
@@ -74,13 +70,11 @@ async def async_attach_trigger(
 
         try:
             if isinstance(time_delta, template.Template):
-                period = vol.All(cv.time_period, cv.positive_timedelta)(
-                    time_delta.async_render(variables)
-                )
+                period = cv.positive_time_period(time_delta.async_render(variables))
             elif isinstance(time_delta, dict):
                 time_delta_data = {}
                 time_delta_data.update(template.render_complex(time_delta, variables))
-                period = vol.All(cv.time_period, cv.positive_timedelta)(time_delta_data)
+                period = cv.positive_time_period(time_delta_data)
             else:
                 period = time_delta
         except (exceptions.TemplateError, vol.Invalid) as ex:

--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -69,14 +69,9 @@ async def async_attach_trigger(
         }
 
         try:
-            if isinstance(time_delta, template.Template):
-                period = cv.positive_time_period(time_delta.async_render(variables))
-            elif isinstance(time_delta, dict):
-                time_delta_data = {}
-                time_delta_data.update(template.render_complex(time_delta, variables))
-                period = cv.positive_time_period(time_delta_data)
-            else:
-                period = time_delta
+            period = cv.positive_time_period(
+                template.render_complex(time_delta, variables)
+            )
         except (exceptions.TemplateError, vol.Invalid) as ex:
             _LOGGER.error(
                 "Error rendering '%s' for template: %s", automation_info["name"], ex

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -68,13 +68,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_SENSOR): cv.entity_id,
         vol.Optional(CONF_AC_MODE): cv.boolean,
         vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
-        vol.Optional(CONF_MIN_DUR): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_MIN_DUR): cv.positive_time_period,
         vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_COLD_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
         vol.Optional(CONF_HOT_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
         vol.Optional(CONF_TARGET_TEMP): vol.Coerce(float),
-        vol.Optional(CONF_KEEP_ALIVE): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_KEEP_ALIVE): cv.positive_time_period,
         vol.Optional(CONF_INITIAL_HVAC_MODE): vol.In(
             [HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF]
         ),

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -56,7 +56,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_DEVICE_PORT): cv.port,
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-                ): vol.All(cv.time_period, cv.positive_timedelta),
+                ): cv.positive_time_period,
                 vol.Optional(CONF_ZONES, default=DEFAULT_ZONES): vol.All(
                     cv.ensure_list, [ZONE_SCHEMA]
                 ),

--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_SERVER_ID): cv.positive_int,
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=timedelta(minutes=DEFAULT_SCAN_INTERVAL)
-                ): vol.All(cv.time_period, cv.positive_timedelta),
+                ): cv.positive_time_period,
                 vol.Optional(CONF_MANUAL, default=False): cv.boolean,
                 vol.Optional(
                     CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -49,8 +49,8 @@ SENSOR_SCHEMA = vol.Schema(
         vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
         vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-        vol.Optional(CONF_DELAY_ON): vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_DELAY_OFF): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_DELAY_ON): cv.positive_time_period,
+        vol.Optional(CONF_DELAY_OFF): cv.positive_time_period,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )

--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -48,7 +48,7 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Required(CONF_CLIENT_SECRET): cv.string,
                     vol.Optional(
                         CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-                    ): vol.All(cv.time_period, cv.positive_timedelta),
+                    ): cv.positive_time_period,
                 }
             ),
         )

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -102,7 +102,7 @@ SERVICE_SCHEMA_SET_SCENE = XIAOMI_MIIO_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_SCHEMA_SET_DELAYED_TURN_OFF = XIAOMI_MIIO_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_TIME_PERIOD): vol.All(cv.time_period, cv.positive_timedelta)}
+    {vol.Required(ATTR_TIME_PERIOD): cv.positive_time_period}
 )
 
 SERVICE_TO_METHOD = {

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1006,7 +1006,7 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_WAIT_TEMPLATE): template,
-        vol.Optional(CONF_TIMEOUT): positive_time_period,
+        vol.Optional(CONF_TIMEOUT): positive_time_period_template,
         vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
     }
 )

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -402,6 +402,7 @@ def positive_timedelta(value: timedelta) -> timedelta:
 
 
 positive_time_period_dict = vol.All(time_period_dict, positive_timedelta)
+positive_time_period = vol.All(time_period, positive_timedelta)
 
 
 def remove_falsy(value: List[T]) -> List[T]:
@@ -528,6 +529,11 @@ def template_complex(value: Any) -> Any:
     if isinstance(value, str):
         return template(value)
     return value
+
+
+positive_time_period_template = vol.Any(
+    positive_time_period, template, template_complex
+)
 
 
 def datetime(value: Any) -> datetime_sys:
@@ -876,7 +882,7 @@ STATE_CONDITION_SCHEMA = vol.All(
             vol.Required(CONF_CONDITION): "state",
             vol.Required(CONF_ENTITY_ID): entity_ids,
             vol.Required(CONF_STATE): vol.Any(str, [str]),
-            vol.Optional(CONF_FOR): vol.All(time_period, positive_timedelta),
+            vol.Optional(CONF_FOR): positive_time_period,
             # To support use_trigger_value in automation
             # Deprecated 2016/04/25
             vol.Optional("from"): str,
@@ -992,9 +998,7 @@ CONDITION_SCHEMA: vol.Schema = key_value_schemas(
 _SCRIPT_DELAY_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_ALIAS): string,
-        vol.Required(CONF_DELAY): vol.Any(
-            vol.All(time_period, positive_timedelta), template, template_complex
-        ),
+        vol.Required(CONF_DELAY): positive_time_period_template,
     }
 )
 
@@ -1002,7 +1006,7 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_WAIT_TEMPLATE): template,
-        vol.Optional(CONF_TIMEOUT): vol.All(time_period, positive_timedelta),
+        vol.Optional(CONF_TIMEOUT): positive_time_period,
         vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
     }
 )

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,6 +1,6 @@
 """Helpers to execute scripts."""
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 import itertools
 import logging
@@ -241,20 +241,24 @@ class _ScriptRun:
             level=level,
         )
 
-    async def _async_delay_step(self):
-        """Handle delay."""
+    def _get_pos_time_period_template(self, key):
         try:
-            delay = cv.positive_time_period(
-                template.render_complex(self._action[CONF_DELAY], self._variables)
+            return cv.positive_time_period(
+                template.render_complex(self._action[key], self._variables)
             )
         except (exceptions.TemplateError, vol.Invalid) as ex:
             self._log(
-                "Error rendering %s delay template: %s",
+                "Error rendering %s %s template: %s",
                 self._script.name,
+                key,
                 ex,
                 level=logging.ERROR,
             )
             raise _StopScript
+
+    async def _async_delay_step(self):
+        """Handle delay."""
+        delay = self._get_pos_time_period_template(CONF_DELAY)
 
         self._script.last_action = self._action.get(CONF_ALIAS, f"delay {delay}")
         self._log("Executing step %s", self._script.last_action)
@@ -269,41 +273,55 @@ class _ScriptRun:
 
     async def _async_wait_template_step(self):
         """Handle a wait template."""
+        try:
+            delay = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
+        except KeyError:
+            delay = None
+
         self._script.last_action = self._action.get(CONF_ALIAS, "wait template")
-        self._log("Executing step %s", self._script.last_action)
+        self._log(
+            "Executing step %s%s",
+            self._script.last_action,
+            "" if delay is None else f" (timeout: {timedelta(seconds=delay)})",
+        )
+
+        self._variables["wait"] = {"remaining": delay, "completed": False}
 
         wait_template = self._action[CONF_WAIT_TEMPLATE]
         wait_template.hass = self._hass
 
         # check if condition already okay
         if condition.async_template(self._hass, wait_template, self._variables):
+            self._variables["wait"]["completed"] = True
             return
 
         @callback
         def async_script_wait(entity_id, from_s, to_s):
             """Handle script after template condition is true."""
+            self._variables["wait"] = {
+                "remaining": to_context.remaining if to_context else delay,
+                "completed": True,
+            }
             done.set()
 
+        to_context = None
         unsub = async_track_template(
             self._hass, wait_template, async_script_wait, self._variables
         )
 
         self._changed()
-        try:
-            delay = self._action[CONF_TIMEOUT].total_seconds()
-        except KeyError:
-            delay = None
         done = asyncio.Event()
         tasks = [
             self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
         ]
         try:
-            async with timeout(delay):
+            async with timeout(delay) as to_context:
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError:
             if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
                 self._log(_TIMEOUT_MSG)
                 raise _StopScript
+            self._variables["wait"]["remaining"] = 0.0
         finally:
             for task in tasks:
                 task.cancel()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -244,7 +244,7 @@ class _ScriptRun:
     async def _async_delay_step(self):
         """Handle delay."""
         try:
-            delay = vol.All(cv.time_period, cv.positive_timedelta)(
+            delay = cv.positive_time_period(
                 template.render_complex(self._action[CONF_DELAY], self._variables)
             )
         except (exceptions.TemplateError, vol.Invalid) as ex:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -273,9 +273,9 @@ class _ScriptRun:
 
     async def _async_wait_template_step(self):
         """Handle a wait template."""
-        try:
+        if CONF_TIMEOUT in self._action:
             delay = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
-        except KeyError:
+        else:
             delay = None
 
         self._script.last_action = self._action.get(CONF_ALIAS, "wait template")

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -620,7 +620,7 @@ async def test_wait_template_timeout(hass, caplog, timeout_param):
             {"event": event},
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
@@ -727,7 +727,7 @@ async def test_wait_template_variables_out(hass, mode):
         },
     ]
     sequence = cv.SCRIPT_SCHEMA(sequence)
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -604,10 +604,55 @@ async def test_wait_template_not_schedule(hass):
 
 
 @pytest.mark.parametrize(
+    "timeout_param", [5, "{{ 5 }}", {"seconds": 5}, {"seconds": "{{ 5 }}"}]
+)
+async def test_wait_template_timeout(hass, caplog, timeout_param):
+    """Test the wait timeout option."""
+    event = "test_event"
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {
+                "wait_template": "{{ states.switch.test.state == 'off' }}",
+                "timeout": timeout_param,
+                "continue_on_timeout": True,
+            },
+            {"event": event},
+        ]
+    )
+    script_obj = script.Script(hass, sequence)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
+
+    try:
+        hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 0
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        cur_time = dt_util.utcnow()
+        async_fire_time_changed(hass, cur_time + timedelta(seconds=4))
+        await asyncio.sleep(0)
+
+        assert len(events) == 0
+
+        async_fire_time_changed(hass, cur_time + timedelta(seconds=5))
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 1
+        assert "(timeout: 0:00:05)" in caplog.text
+
+
+@pytest.mark.parametrize(
     "continue_on_timeout,n_events", [(False, 0), (True, 1), (None, 1)]
 )
-async def test_wait_template_timeout(hass, continue_on_timeout, n_events):
-    """Test the wait template, halt on timeout."""
+async def test_wait_template_continue_on_timeout(hass, continue_on_timeout, n_events):
+    """Test the wait template continue_on_timeout option."""
     event = "test_event"
     events = async_capture_events(hass, event)
     sequence = [
@@ -638,8 +683,8 @@ async def test_wait_template_timeout(hass, continue_on_timeout, n_events):
         assert len(events) == n_events
 
 
-async def test_wait_template_variables(hass):
-    """Test the wait template with variables."""
+async def test_wait_template_variables_in(hass):
+    """Test the wait template with input variables."""
     sequence = cv.SCRIPT_SCHEMA({"wait_template": "{{ is_state(data, 'off') }}"})
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
@@ -660,6 +705,58 @@ async def test_wait_template_variables(hass):
         await hass.async_block_till_done()
 
         assert not script_obj.is_running
+
+
+@pytest.mark.parametrize("mode", ["no_timeout", "timeout_finish", "timeout_not_finish"])
+async def test_wait_template_variables_out(hass, mode):
+    """Test the wait template output variable."""
+    event = "test_event"
+    events = async_capture_events(hass, event)
+    action = {"wait_template": "{{ states.switch.test.state == 'off' }}"}
+    if mode != "no_timeout":
+        action["timeout"] = 5
+        action["continue_on_timeout"] = True
+    sequence = [
+        action,
+        {
+            "event": event,
+            "event_data_template": {
+                "completed": "{{ wait.completed }}",
+                "remaining": "{{ wait.remaining }}",
+            },
+        },
+    ]
+    sequence = cv.SCRIPT_SCHEMA(sequence)
+    script_obj = script.Script(hass, sequence)
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
+
+    try:
+        hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run())
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+        assert len(events) == 0
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        if mode == "timeout_not_finish":
+            async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+        else:
+            hass.states.async_set("switch.test", "off")
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 1
+        assert events[0].data["completed"] == str(mode != "timeout_not_finish")
+        remaining = events[0].data["remaining"]
+        if mode == "no_timeout":
+            assert remaining == "None"
+        elif mode == "timeout_finish":
+            assert 0.0 < float(remaining) < 5
+        else:
+            assert float(remaining) == 0.0
 
 
 async def test_condition_basic(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently it's not possible to know for sure if a `wait_template` with `continue_on_timeout` set to `true` completed because the template became true or the timeout expired. Also, if the timeout did not expire, there's no way to know how much of the timeout remains. This information is useful if wanting to take different actions based on whether or not the timeout was exceeded, and/or when implementing a multi-step wait where one timeout is desired for the complete sequence.

This change creates/updates a new variable for use within the current script/automation after each `wait_template` action, namely `wait`, with the following attributes:

- `completed`: indicates if the template evaluated to `true` before the timeout expired
- `remaining`: timeout remaining when template evaluated to `true`, or `none` if no timeout specified

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml
# Example configuration.yaml
script:
  blah:
    sequence:
      - wait_template: "{{ is_state('binary_sensor.abc', 'on') }}"
        timeout: 10
        continue_on_timeout: true
      - choose:
          - conditions:
              - condition: template
                value_template: "{{ not wait.completed }}"
            sequence:
              # Handle timeout case
        default:
          - wait_template: "{{ is_state('binary_sensor.xyz', 'off') }}"
            timeout: "{{ wait.remaining }}"
            continue_on_timeout: false
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#14196

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
