### PR TITLE
Standardize Vizio update service schema

### DIFF
--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -34,9 +34,9 @@ ATTR_SETTING_NAME = "setting_name"
 ATTR_NEW_VALUE = "new_value"
 
 UPDATE_SETTING_SCHEMA = {
-    vol.Required(ATTR_SETTING_TYPE): cv.string,
-    vol.Required(ATTR_SETTING_NAME): cv.string,
-    vol.Required(ATTR_NEW_VALUE): vol.Or(vol.Coerce(int), cv.string),
+    vol.Required(ATTR_SETTING_TYPE): vol.All(cv.string, vol.Lower, cv.slugify),
+    vol.Required(ATTR_SETTING_NAME): vol.All(cv.string, vol.Lower, cv.slugify),
+    vol.Required(ATTR_NEW_VALUE): vol.Any(vol.Coerce(int), cv.string),
 }
 
 CONF_ADDITIONAL_CONFIGS = "additional_configs"

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -291,9 +291,7 @@ class VizioDevice(MediaPlayerEntity):
     ) -> None:
         """Update a setting when update_setting service is called."""
         await self._device.set_setting(
-            setting_type.lower().replace(" ", "_"),
-            setting_name.lower().replace(" ", "_"),
-            new_value,
+            setting_type, setting_name, new_value,
         )
 
     async def async_added_to_hass(self):

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -392,7 +392,10 @@ async def test_services(
         DOMAIN,
         "set_setting",
         SERVICE_UPDATE_SETTING,
-        {"setting_type": "Audio", "setting_name": "EQ", "new_value": "Music"},
+        {"setting_type": "Audio", "setting_name": "AV Delay", "new_value": 0},
+        "audio",
+        "av_delay",
+        0,
     )
 
 

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -387,15 +387,26 @@ async def test_services(
         SERVICE_SELECT_SOUND_MODE,
         {ATTR_SOUND_MODE: "Music"},
     )
+    # Test that the update_setting service does config validation/transformation correctly
     await _test_service(
         hass,
         DOMAIN,
         "set_setting",
         SERVICE_UPDATE_SETTING,
-        {"setting_type": "Audio", "setting_name": "AV Delay", "new_value": 0},
+        {"setting_type": "Audio", "setting_name": "AV Delay", "new_value": "0"},
         "audio",
         "av_delay",
         0,
+    )
+    await _test_service(
+        hass,
+        DOMAIN,
+        "set_setting",
+        SERVICE_UPDATE_SETTING,
+        {"setting_type": "Audio", "setting_name": "EQ", "new_value": "Music"},
+        "audio",
+        "eq",
+        "Music",
     )
 
 


### PR DESCRIPTION
## Proposed change
This is a follow up to comments @MartinHjelmare made on #36739. `vol.Or` was updated to `vol.Any`, the data transformations that were being performed in the service function are now being done in the service schema, and tests have been updated to ensure that the transformation occurs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR relates to #36739

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
