### PR TITLE
Add support for reload_on_update to _abort_if_unique_id_configured

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -198,7 +198,9 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         bridge = self._async_get_bridge(host, discovery_info[ssdp.ATTR_UPNP_SERIAL])
 
         await self.async_set_unique_id(bridge.id)
-        self._abort_if_unique_id_configured(updates={CONF_HOST: bridge.host})
+        self._abort_if_unique_id_configured(
+            updates={CONF_HOST: bridge.host}, reload_on_update=False
+        )
 
         self.bridge = bridge
         return await self.async_step_link()

--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -329,7 +329,9 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             # abort and update an existing config entry if host info changes
             await self.async_set_unique_id(self.data[CONF_ID])
-            self._abort_if_unique_id_configured(updates=self.data)
+            self._abort_if_unique_id_configured(
+                updates=self.data, reload_on_update=False
+            )
             return self.async_show_form(
                 step_id="confirm",
                 description_placeholders={

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -885,7 +885,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
                         entry, data={**entry.data, **updates}
                     )
                     if changed and reload_on_update:
-                        asyncio.create_task(
+                        self.hass.async_create_task(
                             self.hass.config_entries.async_reload(entry.entry_id)
                         )
                 raise data_entry_flow.AbortFlow("already_configured")

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -769,16 +769,17 @@ class ConfigEntries:
             changed = True
             entry.title = cast(str, title)
 
-        if data is not _UNDEF and dict(entry.data) != dict(data):
+        if data is not _UNDEF and entry.data != data:  # type: ignore
             changed = True
             entry.data = MappingProxyType(data)
 
-        if options is not _UNDEF and entry.options != options:
+        if options is not _UNDEF and entry.options != options:  # type: ignore
             changed = True
             entry.options = MappingProxyType(options)
 
-        if system_options is not _UNDEF and entry.system_options.as_dict() != dict(
-            system_options
+        if (
+            system_options is not _UNDEF
+            and entry.system_options.as_dict() != system_options
         ):
             changed = True
             entry.system_options.update(**system_options)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -871,7 +871,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     @callback
     def _abort_if_unique_id_configured(
-        self, updates: Optional[Dict[Any, Any]] = None, reload_on_update: bool = False,
+        self, updates: Optional[Dict[Any, Any]] = None, reload_on_update: bool = True,
     ) -> None:
         """Abort if the unique ID is already configured."""
         assert self.hass

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -773,7 +773,7 @@ class ConfigEntries:
             changed = True
             entry.data = MappingProxyType(data)
 
-        if options is not _UNDEF and dict(entry.options) != dict(options):
+        if options is not _UNDEF and entry.options != options:
             changed = True
             entry.options = MappingProxyType(options)
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -728,23 +728,6 @@ class ConfigEntries:
 
         return await entry.async_unload(self.hass)
 
-    async def async_reload_if_supported(self, entry_id: str) -> bool:
-        """Reload an entry if the integrations supports reload.
-
-        If an entry was not loaded, will just load.
-
-        Returns False if the reload fails or is unsupported.
-        """
-        entry = self.async_get_entry(entry_id)
-
-        if entry is None:
-            raise UnknownEntry
-
-        if not support_entry_unload(self.hass, entry.domain):
-            return False
-
-        return await self.async_reload(entry_id)
-
     async def async_reload(self, entry_id: str) -> bool:
         """Reload an entry.
 
@@ -903,9 +886,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
                     )
                     if changed and reload_on_update:
                         asyncio.create_task(
-                            self.hass.config_entries.async_reload_if_supported(
-                                entry.entry_id
-                            )
+                            self.hass.config_entries.async_reload(entry.entry_id)
                         )
                 raise data_entry_flow.AbortFlow("already_configured")
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -750,22 +750,44 @@ class ConfigEntries:
         data: dict = _UNDEF,
         options: dict = _UNDEF,
         system_options: dict = _UNDEF,
-    ) -> None:
-        """Update a config entry."""
+    ) -> bool:
+        """Update a config entry.
+
+        If the entry was changed, the update_listeners are
+        fired and this function returns True
+
+        If the entry was not changed, the update_listeners are
+        not fired and this function returns False
+        """
+        changed = False
+
         if unique_id is not _UNDEF:
+            if entry.unique_id != unique_id:
+                changed = True
             entry.unique_id = cast(Optional[str], unique_id)
 
         if title is not _UNDEF:
+            if entry.title != title:
+                changed = True
             entry.title = cast(str, title)
 
         if data is not _UNDEF:
+            if dict(entry.data) != dict(data):
+                changed = True
             entry.data = MappingProxyType(data)
 
         if options is not _UNDEF:
+            if dict(entry.options) != dict(options):
+                changed = True
             entry.options = MappingProxyType(options)
 
         if system_options is not _UNDEF:
+            if entry.system_options.as_dict() != dict(system_options):
+                changed = True
             entry.system_options.update(**system_options)
+
+        if not changed:
+            return False
 
         for listener_ref in entry.update_listeners:
             listener = listener_ref()
@@ -773,6 +795,8 @@ class ConfigEntries:
                 self.hass.async_create_task(listener(self.hass, entry))
 
         self._async_schedule_save()
+
+        return True
 
     async def async_forward_entry_setup(self, entry: ConfigEntry, domain: str) -> bool:
         """Forward the setup of an entry to a different component.
@@ -850,7 +874,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     @callback
     def _abort_if_unique_id_configured(
-        self, updates: Optional[Dict[Any, Any]] = None
+        self, updates: Optional[Dict[Any, Any]] = None, reload_on_update: bool = False,
     ) -> None:
         """Abort if the unique ID is already configured."""
         assert self.hass
@@ -859,10 +883,14 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
         for entry in self._async_current_entries():
             if entry.unique_id == self.unique_id:
-                if updates is not None and not updates.items() <= entry.data.items():
-                    self.hass.config_entries.async_update_entry(
+                if updates is not None:
+                    changed = self.hass.config_entries.async_update_entry(
                         entry, data={**entry.data, **updates}
                     )
+                    if changed and reload_on_update:
+                        asyncio.create_task(
+                            self.hass.config_entries.async_reload(entry.entry_id)
+                        )
                 raise data_entry_flow.AbortFlow("already_configured")
 
     async def async_set_unique_id(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -761,29 +761,26 @@ class ConfigEntries:
         """
         changed = False
 
-        if unique_id is not _UNDEF:
-            if entry.unique_id != unique_id:
-                changed = True
+        if unique_id is not _UNDEF and entry.unique_id != unique_id:
+            changed = True
             entry.unique_id = cast(Optional[str], unique_id)
 
-        if title is not _UNDEF:
-            if entry.title != title:
-                changed = True
+        if title is not _UNDEF and entry.title != title:
+            changed = True
             entry.title = cast(str, title)
 
-        if data is not _UNDEF:
-            if dict(entry.data) != dict(data):
-                changed = True
+        if data is not _UNDEF and dict(entry.data) != dict(data):
+            changed = True
             entry.data = MappingProxyType(data)
 
-        if options is not _UNDEF:
-            if dict(entry.options) != dict(options):
-                changed = True
+        if options is not _UNDEF and dict(entry.options) != dict(options):
+            changed = True
             entry.options = MappingProxyType(options)
 
-        if system_options is not _UNDEF:
-            if entry.system_options.as_dict() != dict(system_options):
-                changed = True
+        if system_options is not _UNDEF and entry.system_options.as_dict() != dict(
+            system_options
+        ):
+            changed = True
             entry.system_options.update(**system_options)
 
         if not changed:

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -290,9 +290,7 @@ async def test_update_address(hass):
     device = await setup_axis_integration(hass)
     assert device.api.config.host == "1.2.3.4"
 
-    with patch(
-        "homeassistant.components.axis.async_setup", return_value=True
-    ) as mock_setup, patch(
+    with patch("axis.vapix.session_request", new=vapix_session_request), patch(
         "homeassistant.components.axis.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
         await hass.config_entries.flow.async_init(
@@ -308,7 +306,6 @@ async def test_update_address(hass):
         await hass.async_block_till_done()
 
     assert device.api.config.host == "2.3.4.5"
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -290,19 +290,26 @@ async def test_update_address(hass):
     device = await setup_axis_integration(hass)
     assert device.api.config.host == "1.2.3.4"
 
-    await hass.config_entries.flow.async_init(
-        AXIS_DOMAIN,
-        data={
-            "host": "2.3.4.5",
-            "port": 80,
-            "hostname": "name",
-            "properties": {"macaddress": MAC},
-        },
-        context={"source": "zeroconf"},
-    )
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.axis.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.axis.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        await hass.config_entries.flow.async_init(
+            AXIS_DOMAIN,
+            data={
+                "host": "2.3.4.5",
+                "port": 80,
+                "hostname": "name",
+                "properties": {"macaddress": MAC},
+            },
+            context={"source": "zeroconf"},
+        )
+        await hass.async_block_till_done()
 
     assert device.api.config.host == "2.3.4.5"
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_device_unavailable(hass):

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -135,19 +135,26 @@ async def test_update_address(hass):
     gateway = await setup_deconz_integration(hass)
     assert gateway.api.host == "1.2.3.4"
 
-    await hass.config_entries.flow.async_init(
-        deconz.config_flow.DOMAIN,
-        data={
-            ssdp.ATTR_SSDP_LOCATION: "http://2.3.4.5:80/",
-            ssdp.ATTR_UPNP_MANUFACTURER_URL: deconz.config_flow.DECONZ_MANUFACTURERURL,
-            ssdp.ATTR_UPNP_SERIAL: BRIDGEID,
-            ssdp.ATTR_UPNP_UDN: "uuid:456DEF",
-        },
-        context={"source": "ssdp"},
-    )
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.deconz.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.deconz.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        await hass.config_entries.flow.async_init(
+            deconz.config_flow.DOMAIN,
+            data={
+                ssdp.ATTR_SSDP_LOCATION: "http://2.3.4.5:80/",
+                ssdp.ATTR_UPNP_MANUFACTURER_URL: deconz.config_flow.DECONZ_MANUFACTURERURL,
+                ssdp.ATTR_UPNP_SERIAL: BRIDGEID,
+                ssdp.ATTR_UPNP_UDN: "uuid:456DEF",
+            },
+            context={"source": "ssdp"},
+        )
+        await hass.async_block_till_done()
 
     assert gateway.api.host == "2.3.4.5"
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_reset_after_successful_setup(hass):

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -136,8 +136,6 @@ async def test_update_address(hass):
     assert gateway.api.host == "1.2.3.4"
 
     with patch(
-        "homeassistant.components.deconz.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.deconz.async_setup_entry", return_value=True,
     ) as mock_setup_entry:
         await hass.config_entries.flow.async_init(
@@ -153,7 +151,6 @@ async def test_update_address(hass):
         await hass.async_block_till_done()
 
     assert gateway.api.host == "2.3.4.5"
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -48,9 +48,16 @@ async def test_flow_works(hass, mock_panel):
         "port": 1234,
     }
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
+
     assert result["type"] == "create_entry"
     assert result["data"]["host"] == "1.2.3.4"
     assert result["data"]["port"] == 1234
@@ -59,6 +66,8 @@ async def test_flow_works(hass, mock_panel):
     assert result["data"]["default_options"] == config_flow.OPTIONS_SCHEMA(
         {config_flow.CONF_IO: {}}
     )
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_pro_flow_works(hass, mock_panel):
@@ -87,9 +96,15 @@ async def test_pro_flow_works(hass, mock_panel):
         "port": 1234,
     }
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["data"]["host"] == "1.2.3.4"
     assert result["data"]["port"] == 1234
@@ -98,6 +113,8 @@ async def test_pro_flow_works(hass, mock_panel):
     assert result["data"]["default_options"] == config_flow.OPTIONS_SCHEMA(
         {config_flow.CONF_IO: {}}
     )
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_ssdp(hass, mock_panel):
@@ -187,10 +204,18 @@ async def test_import_no_host_user_finish(hass, mock_panel):
     }
 
     # final confirmation
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
     assert result["type"] == "create_entry"
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_ssdp_host_user_finish(hass, mock_panel):
@@ -260,10 +285,18 @@ async def test_import_ssdp_host_user_finish(hass, mock_panel):
     }
 
     # final confirmation
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
     assert result["type"] == "create_entry"
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_ssdp_already_configured(hass, mock_panel):
@@ -354,15 +387,21 @@ async def test_ssdp_host_update(hass, mock_panel):
         "model": "Konnected Pro",
     }
 
-    result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
-        context={"source": "ssdp"},
-        data={
-            "ssdp_location": "http://1.1.1.1:1234/Device.xml",
-            "manufacturer": config_flow.KONN_MANUFACTURER,
-            "modelName": config_flow.KONN_MODEL_PRO,
-        },
-    )
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            config_flow.DOMAIN,
+            context={"source": "ssdp"},
+            data={
+                "ssdp_location": "http://1.1.1.1:1234/Device.xml",
+                "manufacturer": config_flow.KONN_MANUFACTURER,
+                "modelName": config_flow.KONN_MODEL_PRO,
+            },
+        )
+        await hass.async_block_till_done()
     assert result["type"] == "abort"
 
     # confirm the host value was updated, access_token was not
@@ -370,6 +409,8 @@ async def test_ssdp_host_update(hass, mock_panel):
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["port"] == 1234
     assert entry.data["access_token"] == "11223344556677889900"
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_existing_config(hass, mock_panel):
@@ -424,9 +465,15 @@ async def test_import_existing_config(hass, mock_panel):
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["data"] == {
         "host": "1.2.3.4",
@@ -489,6 +536,8 @@ async def test_import_existing_config(hass, mock_panel):
             ],
         },
     }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_existing_config_entry(hass, mock_panel):
@@ -512,42 +561,54 @@ async def test_import_existing_config_entry(hass, mock_panel):
 
     # utilize a global access token this time
     hass.data[config_flow.DOMAIN] = {"access_token": "SUPERSECRETTOKEN"}
-    result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
-        context={"source": "import"},
-        data={
-            "host": "1.2.3.4",
-            "port": 1234,
-            "id": "112233445566",
-            "default_options": {
-                "blink": True,
-                "discovery": True,
-                "io": {
-                    "1": "Disabled",
-                    "10": "Binary Sensor",
-                    "11": "Disabled",
-                    "12": "Disabled",
-                    "2": "Binary Sensor",
-                    "3": "Disabled",
-                    "4": "Disabled",
-                    "5": "Disabled",
-                    "6": "Binary Sensor",
-                    "7": "Disabled",
-                    "8": "Disabled",
-                    "9": "Disabled",
-                    "alarm1": "Disabled",
-                    "alarm2_out2": "Disabled",
-                    "out": "Disabled",
-                    "out1": "Disabled",
+
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            config_flow.DOMAIN,
+            context={"source": "import"},
+            data={
+                "host": "1.2.3.4",
+                "port": 1234,
+                "id": "112233445566",
+                "default_options": {
+                    "blink": True,
+                    "discovery": True,
+                    "io": {
+                        "1": "Disabled",
+                        "10": "Binary Sensor",
+                        "11": "Disabled",
+                        "12": "Disabled",
+                        "2": "Binary Sensor",
+                        "3": "Disabled",
+                        "4": "Disabled",
+                        "5": "Disabled",
+                        "6": "Binary Sensor",
+                        "7": "Disabled",
+                        "8": "Disabled",
+                        "9": "Disabled",
+                        "alarm1": "Disabled",
+                        "alarm2_out2": "Disabled",
+                        "out": "Disabled",
+                        "out1": "Disabled",
+                    },
+                    "binary_sensors": [
+                        {"inverse": False, "type": "door", "zone": "2"},
+                        {
+                            "inverse": True,
+                            "type": "Window",
+                            "name": "winder",
+                            "zone": "6",
+                        },
+                        {"inverse": False, "type": "door", "zone": "10"},
+                    ],
                 },
-                "binary_sensors": [
-                    {"inverse": False, "type": "door", "zone": "2"},
-                    {"inverse": True, "type": "Window", "name": "winder", "zone": "6"},
-                    {"inverse": False, "type": "door", "zone": "10"},
-                ],
             },
-        },
-    )
+        )
+        await hass.async_block_till_done()
 
     assert result["type"] == "abort"
 
@@ -561,6 +622,8 @@ async def test_import_existing_config_entry(hass, mock_panel):
         "model": "Konnected Pro",
         "extra": "something",
     }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_pin_config(hass, mock_panel):
@@ -604,9 +667,15 @@ async def test_import_pin_config(hass, mock_panel):
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
+    with patch(
+        "homeassistant.components.konnected.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.konnected.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["data"] == {
         "host": "1.2.3.4",
@@ -658,6 +727,8 @@ async def test_import_pin_config(hass, mock_panel):
             ],
         },
     }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_option_flow(hass, mock_panel):

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -48,16 +48,9 @@ async def test_flow_works(hass, mock_panel):
         "port": 1234,
     }
 
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        await hass.async_block_till_done()
-
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] == "create_entry"
     assert result["data"]["host"] == "1.2.3.4"
     assert result["data"]["port"] == 1234
@@ -66,8 +59,6 @@ async def test_flow_works(hass, mock_panel):
     assert result["data"]["default_options"] == config_flow.OPTIONS_SCHEMA(
         {config_flow.CONF_IO: {}}
     )
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_pro_flow_works(hass, mock_panel):
@@ -96,15 +87,9 @@ async def test_pro_flow_works(hass, mock_panel):
         "port": 1234,
     }
 
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] == "create_entry"
     assert result["data"]["host"] == "1.2.3.4"
     assert result["data"]["port"] == 1234
@@ -113,8 +98,6 @@ async def test_pro_flow_works(hass, mock_panel):
     assert result["data"]["default_options"] == config_flow.OPTIONS_SCHEMA(
         {config_flow.CONF_IO: {}}
     )
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_ssdp(hass, mock_panel):
@@ -204,18 +187,10 @@ async def test_import_no_host_user_finish(hass, mock_panel):
     }
 
     # final confirmation
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] == "create_entry"
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_ssdp_host_user_finish(hass, mock_panel):
@@ -285,18 +260,10 @@ async def test_import_ssdp_host_user_finish(hass, mock_panel):
     }
 
     # final confirmation
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] == "create_entry"
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_ssdp_already_configured(hass, mock_panel):
@@ -387,21 +354,15 @@ async def test_ssdp_host_update(hass, mock_panel):
         "model": "Konnected Pro",
     }
 
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": "ssdp"},
-            data={
-                "ssdp_location": "http://1.1.1.1:1234/Device.xml",
-                "manufacturer": config_flow.KONN_MANUFACTURER,
-                "modelName": config_flow.KONN_MODEL_PRO,
-            },
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        context={"source": "ssdp"},
+        data={
+            "ssdp_location": "http://1.1.1.1:1234/Device.xml",
+            "manufacturer": config_flow.KONN_MANUFACTURER,
+            "modelName": config_flow.KONN_MODEL_PRO,
+        },
+    )
     assert result["type"] == "abort"
 
     # confirm the host value was updated, access_token was not
@@ -409,8 +370,6 @@ async def test_ssdp_host_update(hass, mock_panel):
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["port"] == 1234
     assert entry.data["access_token"] == "11223344556677889900"
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_existing_config(hass, mock_panel):
@@ -465,15 +424,9 @@ async def test_import_existing_config(hass, mock_panel):
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
 
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] == "create_entry"
     assert result["data"] == {
         "host": "1.2.3.4",
@@ -536,8 +489,6 @@ async def test_import_existing_config(hass, mock_panel):
             ],
         },
     }
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_existing_config_entry(hass, mock_panel):
@@ -561,54 +512,42 @@ async def test_import_existing_config_entry(hass, mock_panel):
 
     # utilize a global access token this time
     hass.data[config_flow.DOMAIN] = {"access_token": "SUPERSECRETTOKEN"}
-
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": "import"},
-            data={
-                "host": "1.2.3.4",
-                "port": 1234,
-                "id": "112233445566",
-                "default_options": {
-                    "blink": True,
-                    "discovery": True,
-                    "io": {
-                        "1": "Disabled",
-                        "10": "Binary Sensor",
-                        "11": "Disabled",
-                        "12": "Disabled",
-                        "2": "Binary Sensor",
-                        "3": "Disabled",
-                        "4": "Disabled",
-                        "5": "Disabled",
-                        "6": "Binary Sensor",
-                        "7": "Disabled",
-                        "8": "Disabled",
-                        "9": "Disabled",
-                        "alarm1": "Disabled",
-                        "alarm2_out2": "Disabled",
-                        "out": "Disabled",
-                        "out1": "Disabled",
-                    },
-                    "binary_sensors": [
-                        {"inverse": False, "type": "door", "zone": "2"},
-                        {
-                            "inverse": True,
-                            "type": "Window",
-                            "name": "winder",
-                            "zone": "6",
-                        },
-                        {"inverse": False, "type": "door", "zone": "10"},
-                    ],
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        context={"source": "import"},
+        data={
+            "host": "1.2.3.4",
+            "port": 1234,
+            "id": "112233445566",
+            "default_options": {
+                "blink": True,
+                "discovery": True,
+                "io": {
+                    "1": "Disabled",
+                    "10": "Binary Sensor",
+                    "11": "Disabled",
+                    "12": "Disabled",
+                    "2": "Binary Sensor",
+                    "3": "Disabled",
+                    "4": "Disabled",
+                    "5": "Disabled",
+                    "6": "Binary Sensor",
+                    "7": "Disabled",
+                    "8": "Disabled",
+                    "9": "Disabled",
+                    "alarm1": "Disabled",
+                    "alarm2_out2": "Disabled",
+                    "out": "Disabled",
+                    "out1": "Disabled",
                 },
+                "binary_sensors": [
+                    {"inverse": False, "type": "door", "zone": "2"},
+                    {"inverse": True, "type": "Window", "name": "winder", "zone": "6"},
+                    {"inverse": False, "type": "door", "zone": "10"},
+                ],
             },
-        )
-        await hass.async_block_till_done()
+        },
+    )
 
     assert result["type"] == "abort"
 
@@ -622,8 +561,6 @@ async def test_import_existing_config_entry(hass, mock_panel):
         "model": "Konnected Pro",
         "extra": "something",
     }
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_import_pin_config(hass, mock_panel):
@@ -667,15 +604,9 @@ async def test_import_pin_config(hass, mock_panel):
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
 
-    with patch(
-        "homeassistant.components.konnected.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.konnected.async_setup_entry", return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] == "create_entry"
     assert result["data"] == {
         "host": "1.2.3.4",
@@ -727,8 +658,6 @@ async def test_import_pin_config(hass, mock_panel):
             ],
         },
     }
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_option_flow(hass, mock_panel):

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1829,14 +1829,40 @@ async def test_updating_entry_with_and_without_changes(manager):
     assert manager.async_update_entry(entry) is False
     assert manager.async_update_entry(entry, data={"second": True}) is True
     assert manager.async_update_entry(entry, data={"second": True}) is False
+    assert (
+        manager.async_update_entry(entry, data={"second": True, "third": 456}) is True
+    )
+    assert (
+        manager.async_update_entry(entry, data={"second": True, "third": 456}) is False
+    )
     assert manager.async_update_entry(entry, options={"second": True}) is True
     assert manager.async_update_entry(entry, options={"second": True}) is False
+    assert (
+        manager.async_update_entry(entry, options={"second": True, "third": "123"})
+        is True
+    )
+    assert (
+        manager.async_update_entry(entry, options={"second": True, "third": "123"})
+        is False
+    )
     assert (
         manager.async_update_entry(entry, system_options={"disable_new_entities": True})
         is True
     )
     assert (
         manager.async_update_entry(entry, system_options={"disable_new_entities": True})
+        is False
+    )
+    assert (
+        manager.async_update_entry(
+            entry, system_options={"disable_new_entities": False}
+        )
+        is True
+    )
+    assert (
+        manager.async_update_entry(
+            entry, system_options={"disable_new_entities": False}
+        )
         is False
     )
     assert manager.async_update_entry(entry, title="thetitle") is False

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -805,6 +805,31 @@ async def test_entry_unload_succeed(hass, manager):
     assert entry.state == config_entries.ENTRY_STATE_NOT_LOADED
 
 
+async def test_entry_unload_if_supported_succeed(hass, manager):
+    """Test that we can unload an entry."""
+    entry = MockConfigEntry(domain="comp", state=config_entries.ENTRY_STATE_LOADED)
+    entry.add_to_hass(hass)
+
+    async_unload_entry = AsyncMock(return_value=True)
+
+    mock_integration(hass, MockModule("comp", async_unload_entry=async_unload_entry))
+
+    assert await manager.async_unload_if_supported(entry.entry_id) is True
+    assert len(async_unload_entry.mock_calls) == 1
+    assert entry.state == config_entries.ENTRY_STATE_NOT_LOADED
+
+
+async def test_entry_unload_if_supported_not_supproted(hass, manager):
+    """Test that we handle entries that cannot reload."""
+    entry = MockConfigEntry(domain="comp", state=config_entries.ENTRY_STATE_LOADED)
+    entry.add_to_hass(hass)
+
+    mock_integration(hass, MockModule("comp"))
+
+    assert await manager.async_unload_if_supported(entry.entry_id) is False
+    assert entry.state == config_entries.ENTRY_STATE_LOADED
+
+
 @pytest.mark.parametrize(
     "state",
     (


### PR DESCRIPTION
## Breaking change

`_abort_if_unique_id_configured` will now automatically reload the config entry when passing `updates`.  If the desired behavior is to not reload, pass `reload_on_update=False`

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implement suggestion here https://github.com/home-assistant/core/pull/38559#issuecomment-670241739

Previously we checked to see if new data was added to the config entry data and avoided calling `async_update_entry`.  This change expands that protection so that `async_update_entry` itself now avoids firing update listeners and writing
the storage if there are no actual changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
