### PR TITLE
Support extracting entities by domain from templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -46,8 +46,7 @@ _ENVIRONMENT = "template.environment"
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
-    r"(?:(?:states\.|(?P<func>is_state|is_state_attr|state_attr|states|expand)"
-    r"\((?:[\ \'\"]?))(?P<entity_id>[\w]+\.[\w]+)|(?P<variable>[\w]+))",
+    r"(?:(?:(?:states\.|(?P<func>is_state|is_state_attr|state_attr|states|expand)\((?:[\ \'\"]?))(?P<entity_id>[\w]+\.[\w]+)|states\.(?P<domain_outer>[a-z]+)|states\[(?:[\'\"]?)(?P<domain_inner>[\w]+))|(?P<variable>[\w]+))",
     re.I | re.M,
 )
 _RE_JINJA_DELIMITERS = re.compile(r"\{%|\{\{")
@@ -105,6 +104,12 @@ def extract_entities(
                     extraction_final.append(entity.entity_id)
 
             extraction_final.append(result.group("entity_id"))
+        elif result.group("domain_inner") or result.group("domain_outer"):
+            extraction_final.extend(
+                hass.states.async_entity_ids(
+                    result.group("domain_inner") or result.group("domain_outer")
+                )
+            )
 
         if (
             variables

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1842,6 +1842,23 @@ def test_extract_entities_domain_states_outer(hass):
     ) == {"light.switch", "light.switch2", "light.switch3"}
 
 
+def test_extract_entities_domain_states_outer_with_group(hass):
+    """Test extract entities function by domain."""
+    hass.states.async_set("light.switch", "on")
+    hass.states.async_set("light.switch2", "on")
+    hass.states.async_set("light.switch3", "off")
+    hass.states.async_set("switch.pool_light", "off")
+    hass.states.async_set("group.lights", "off", {"entity_id": ["switch.pool_light"]})
+
+    assert set(
+        template.extract_entities(
+            hass,
+            "{{ states.light | selectattr('entity_id', 'in', state_attr('group.lights', 'entity_id')) }}",
+            {},
+        )
+    ) == {"light.switch", "light.switch2", "light.switch3", "group.lights"}
+
+
 def test_jinja_namespace(hass):
     """Test Jinja's namespace command can be used."""
     test_template = template.Template(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1812,6 +1812,36 @@ def test_extract_entities_with_variables(hass):
     )
 
 
+def test_extract_entities_domain_states_inner(hass):
+    """Test extract entities function by domain."""
+    hass.states.async_set("light.switch", "on")
+    hass.states.async_set("light.switch2", "on")
+    hass.states.async_set("light.switch3", "off")
+
+    assert set(
+        template.extract_entities(
+            hass,
+            "{{ states['light'] | selectattr('state','eq','on') | list | count > 0 }}",
+            {},
+        )
+    ) == {"light.switch", "light.switch2", "light.switch3"}
+
+
+def test_extract_entities_domain_states_outer(hass):
+    """Test extract entities function by domain."""
+    hass.states.async_set("light.switch", "on")
+    hass.states.async_set("light.switch2", "on")
+    hass.states.async_set("light.switch3", "off")
+
+    assert set(
+        template.extract_entities(
+            hass,
+            "{{ states.light | selectattr('state','eq','off') | list | count > 0 }}",
+            {},
+        )
+    ) == {"light.switch", "light.switch2", "light.switch3"}
+
+
 def test_jinja_namespace(hass):
     """Test Jinja's namespace command can be used."""
     test_template = template.Template(


### PR DESCRIPTION
##  Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Support extracting entities by domain from templates
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38224
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
