### PR TITLE
Bump codespell from v1.16.0 to v1.17.1 and fix new spelling errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing
+          - --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,iam,incomfort
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
           - --quiet
         files: ^((homeassistant|script|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v1.16.0
+    rev: v1.17.1
     hooks:
       - id: codespell
         args:

--- a/homeassistant/components/august/exceptions.py
+++ b/homeassistant/components/august/exceptions.py
@@ -1,4 +1,4 @@
-"""Shared excecption for the august integration."""
+"""Shared exceptions for the august integration."""
 
 from homeassistant import exceptions
 

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -259,7 +259,7 @@ class AlexaConfig(alexa_config.AbstractConfig):
             return True
 
         except asyncio.TimeoutError:
-            _LOGGER.warning("Timeout trying to sync entitites to Alexa")
+            _LOGGER.warning("Timeout trying to sync entities to Alexa")
             return False
 
         except aiohttp.ClientError as err:

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -66,7 +66,7 @@ class HassIODiscovery(HomeAssistantView):
         try:
             data = await self.hassio.get_discovery_message(uuid)
         except HassioAPIError as err:
-            _LOGGER.error("Can't read discovey data: %s", err)
+            _LOGGER.error("Can't read discovery data: %s", err)
             raise HTTPServiceUnavailable() from None
 
         await self.async_process_new(data)

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -104,7 +104,7 @@ class SamsungTVDevice(MediaPlayerEntity):
         self._bridge.register_reauth_callback(self.access_denied)
 
     def access_denied(self):
-        """Access denied callbck."""
+        """Access denied callback."""
         LOGGER.debug("Access denied in getting remote object")
         self.hass.add_job(
             self.hass.config_entries.flow.async_init(

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -29,7 +29,7 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
 
     def _create_device(self, name: str, prt: str):
-        """Create an antry async."""
+        """Create an entry async."""
         return self.async_create_entry(title=name, data={CONF_PORT: prt})
 
     def _test_connection(self, prt):

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -2,7 +2,7 @@
 
 bandit==1.6.2
 black==19.10b0
-codespell==1.16.0
+codespell==1.17.1
 flake8-docstrings==1.5.0
 flake8==3.8.3
 isort==4.3.21

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -764,7 +764,7 @@ async def test_automation_with_bad_trigger(hass, caplog):
 
 
 async def test_websocket_device_not_found(hass, hass_ws_client):
-    """Test caling command with unknown device."""
+    """Test calling command with unknown device."""
     await async_setup_component(hass, "device_automation", {})
     client = await hass_ws_client(hass)
     await client.send_json(

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -694,7 +694,7 @@ async def test_play_media_playlist(
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
     playlist = playlists[0]
-    # Play without enqueing
+    # Play without enqueuing
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_PLAY_MEDIA,
@@ -708,7 +708,7 @@ async def test_play_media_playlist(
     player.add_to_queue.assert_called_once_with(
         playlist, const.ADD_QUEUE_REPLACE_AND_PLAY
     )
-    # Play with enqueing
+    # Play with enqueuing
     player.add_to_queue.reset_mock()
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -50,7 +50,7 @@ def test_recorder_bad_execute(hass_recorder):
     hass_recorder()
 
     def to_native(validate_entity_id=True):
-        """Rasie exception."""
+        """Raise exception."""
         raise SQLAlchemyError()
 
     mck1 = MagicMock()

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -180,8 +180,8 @@ def log_msg(nr=2):
     _LOGGER.error("error message %s", nr)
 
 
-async def test_dedup_logs(hass, simple_queue, hass_client):
-    """Test that duplicate log entries are dedup."""
+async def test_dedupe_logs(hass, simple_queue, hass_client):
+    """Test that duplicate log entries are dedupe."""
     await async_setup_component(hass, system_log.DOMAIN, {})
     _LOGGER.error("error message 1")
     log_msg()

--- a/tests/components/tplink/test_common.py
+++ b/tests/components/tplink/test_common.py
@@ -17,7 +17,7 @@ async def test_async_add_entities_retry(hass: HomeAssistantType):
     objects = ["Object 1", "Object 2", "Object 3", "Object 4"]
 
     # For each call to async_add_entities_callback, the following side effects
-    # will be triggered in order. This set of side effects accuratley simulates
+    # will be triggered in order. This set of side effects accurateley simulates
     # 3 attempts to add all entities while also handling several return types.
     # To help understand what's going on, a comment exists describing what the
     # object list looks like throughout the iterations.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -944,14 +944,14 @@ class TestConfig(unittest.TestCase):
 
             self.config.allowlist_external_dirs = {"/home", "/var"}
 
-            unvalid = [
+            invalid = [
                 "/hass/config/secure",
                 "/etc/passwd",
                 "/root/secure_file",
                 "/var/../etc/passwd",
                 test_file,
             ]
-            for path in unvalid:
+            for path in invalid:
                 assert not self.config.is_allowed_path(path)
 
             with pytest.raises(AssertionError):

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -354,7 +354,7 @@ class TestSecrets(unittest.TestCase):
         assert expected == self._yaml["component"]
 
     def test_secrets_from_parent_folder(self):
-        """Test loading secrets from parent foler."""
+        """Test loading secrets from parent folder."""
         expected = {"api_password": "pwhttp"}
         self._yaml = load_yaml(
             os.path.join(self._sub_folder_path, "sub.yaml"),


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps codespell from v1.16.0 to v1.17.1.

See the differences from the previous version [here](https://github.com/codespell-project/codespell/compare/v1.16.0...v1.17.1).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
