### PR TITLE
Fix Kodi play_media media type casing

### DIFF
--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -774,7 +774,9 @@ class KodiDevice(MediaPlayerEntity):
     @cmd
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Send the play_media command to the media player."""
-        if media_type == MEDIA_TYPE_CHANNEL:
+        media_type_lower = media_type.lower()
+
+        if media_type_lower == MEDIA_TYPE_CHANNEL:
             await self.server.Player.Open({"item": {"channelid": int(media_id)}})
         elif media_type == MEDIA_TYPE_PLAYLIST:
             await self.server.Player.Open({"item": {"playlistid": int(media_id)}})

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -778,7 +778,7 @@ class KodiDevice(MediaPlayerEntity):
 
         if media_type_lower == MEDIA_TYPE_CHANNEL:
             await self.server.Player.Open({"item": {"channelid": int(media_id)}})
-        elif media_type == MEDIA_TYPE_PLAYLIST:
+        elif media_type_lower == MEDIA_TYPE_PLAYLIST:
             await self.server.Player.Open({"item": {"playlistid": int(media_id)}})
         elif media_type == "DIRECTORY":
             await self.server.Player.Open({"item": {"directory": str(media_id)}})

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -780,7 +780,7 @@ class KodiDevice(MediaPlayerEntity):
             await self.server.Player.Open({"item": {"channelid": int(media_id)}})
         elif media_type_lower == MEDIA_TYPE_PLAYLIST:
             await self.server.Player.Open({"item": {"playlistid": int(media_id)}})
-        elif media_type == "DIRECTORY":
+        elif media_type_lower == "directory":
             await self.server.Player.Open({"item": {"directory": str(media_id)}})
         elif media_type == "PLUGIN":
             await self.server.Player.Open({"item": {"file": str(media_id)}})

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -774,9 +774,9 @@ class KodiDevice(MediaPlayerEntity):
     @cmd
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Send the play_media command to the media player."""
-        if media_type == "CHANNEL":
+        if media_type == MEDIA_TYPE_CHANNEL:
             await self.server.Player.Open({"item": {"channelid": int(media_id)}})
-        elif media_type == "PLAYLIST":
+        elif media_type == MEDIA_TYPE_PLAYLIST:
             await self.server.Player.Open({"item": {"playlistid": int(media_id)}})
         elif media_type == "DIRECTORY":
             await self.server.Player.Open({"item": {"directory": str(media_id)}})

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -782,7 +782,7 @@ class KodiDevice(MediaPlayerEntity):
             await self.server.Player.Open({"item": {"playlistid": int(media_id)}})
         elif media_type_lower == "directory":
             await self.server.Player.Open({"item": {"directory": str(media_id)}})
-        elif media_type == "PLUGIN":
+        elif media_type_lower == "plugin":
             await self.server.Player.Open({"item": {"file": str(media_id)}})
         else:
             await self.server.Player.Open({"item": {"file": str(media_id)}})


### PR DESCRIPTION
## Proposed change

Alexa and the Services UI on HA feeds in a media type of "channel" for media type.
The Kodi code looks for a "CHANNEL" instead, as a result the functionality fails.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
