### PR TITLE
Remove unneeded noqa statements using yesqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,10 @@ repos:
           - flake8-docstrings==1.5.0
           - pydocstyle==5.0.2
         files: ^(homeassistant|script|tests)/.+\.py$
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.2.1
+    hooks:
+      - id: yesqa
   - repo: https://github.com/PyCQA/bandit
     rev: 1.6.2
     hooks:

--- a/homeassistant/auth/permissions/models.py
+++ b/homeassistant/auth/permissions/models.py
@@ -5,8 +5,8 @@ import attr
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from homeassistant.helpers import entity_registry as ent_reg  # noqa: F401
-    from homeassistant.helpers import device_registry as dev_reg  # noqa: F401
+    from homeassistant.helpers import entity_registry as ent_reg
+    from homeassistant.helpers import device_registry as dev_reg
 
 
 @attr.s(slots=True)

--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -33,7 +33,7 @@ class HomeAssistantTCPSite(web.BaseSite):
         backlog: int = 128,
         reuse_address: Optional[bool] = None,
         reuse_port: Optional[bool] = None,
-    ) -> None:  # noqa: D107
+    ) -> None:
         super().__init__(
             runner,
             shutdown_timeout=shutdown_timeout,
@@ -46,12 +46,12 @@ class HomeAssistantTCPSite(web.BaseSite):
         self._reuse_port = reuse_port
 
     @property
-    def name(self) -> str:  # noqa: D102
+    def name(self) -> str:
         scheme = "https" if self._ssl_context else "http"
         host = self._host[0] if isinstance(self._host, list) else "0.0.0.0"
         return str(URL.build(scheme=scheme, host=host, port=self._port))
 
-    async def start(self) -> None:  # noqa: D102
+    async def start(self) -> None:
         await super().start()
         loop = asyncio.get_running_loop()
         server = self._runner.server

--- a/homeassistant/components/juicenet/device.py
+++ b/homeassistant/components/juicenet/device.py
@@ -14,7 +14,7 @@ class JuiceNetApi:
         self._devices = []
 
     async def setup(self):
-        """JuiceNet device setup."""  # noqa: D403
+        """JuiceNet device setup."""
         self._devices = await self.api.get_devices()
 
     @property

--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -4,7 +4,7 @@ import secrets
 from homeassistant import config_entries
 from homeassistant.const import CONF_WEBHOOK_ID
 
-from .const import DOMAIN  # noqa pylint: disable=unused-import
+from .const import DOMAIN  # pylint: disable=unused-import
 from .helper import supports_encryption
 
 CONF_SECRET = "secret"

--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSONEncoder
 
 if TYPE_CHECKING:
-    from .connection import ActiveConnection  # noqa
+    from .connection import ActiveConnection
 
 
 WebSocketCommandHandler = Callable[[HomeAssistant, "ActiveConnection", dict], None]

--- a/homeassistant/components/zone/config_flow.py
+++ b/homeassistant/components/zone/config_flow.py
@@ -6,7 +6,7 @@ migrated to the storage collection.
 """
 from homeassistant import config_entries
 
-from .const import DOMAIN  # noqa  # pylint:disable=unused-import
+from .const import DOMAIN  # pylint:disable=unused-import
 
 
 class ZoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional
 import jinja2
 
 if TYPE_CHECKING:
-    from .core import Context  # noqa: F401 pylint: disable=unused-import
+    from .core import Context  # pylint: disable=unused-import
 
 
 class HomeAssistantError(Exception):

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -41,7 +41,7 @@ from .singleton import singleton
 from .typing import HomeAssistantType
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry  # noqa: F401
+    from homeassistant.config_entries import ConfigEntry
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -40,7 +40,7 @@ from homeassistant.util.yaml import load_yaml
 from homeassistant.util.yaml.loader import JSON_TYPE
 
 if TYPE_CHECKING:
-    from homeassistant.helpers.entity import Entity  # noqa
+    from homeassistant.helpers.entity import Entity
 
 
 # mypy: allow-untyped-defs, no-check-untyped-defs

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -9,3 +9,4 @@ isort==4.3.21
 pydocstyle==5.0.2
 pyupgrade==2.7.2
 yamllint==1.24.2
+yesqa==1.2.1

--- a/tests/common.py
+++ b/tests/common.py
@@ -1063,37 +1063,37 @@ class hashdict(dict):
     def __key(self):
         return tuple(sorted(self.items()))
 
-    def __repr__(self):  # noqa: D105 no docstring
+    def __repr__(self):
         return ", ".join(f"{i[0]!s}={i[1]!r}" for i in self.__key())
 
-    def __hash__(self):  # noqa: D105 no docstring
+    def __hash__(self):
         return hash(self.__key())
 
-    def __setitem__(self, key, value):  # noqa: D105 no docstring
+    def __setitem__(self, key, value):
         raise TypeError(f"{self.__class__.__name__} does not support item assignment")
 
-    def __delitem__(self, key):  # noqa: D105 no docstring
+    def __delitem__(self, key):
         raise TypeError(f"{self.__class__.__name__} does not support item assignment")
 
-    def clear(self):  # noqa: D102 no docstring
+    def clear(self):
         raise TypeError(f"{self.__class__.__name__} does not support item assignment")
 
-    def pop(self, *args, **kwargs):  # noqa: D102 no docstring
+    def pop(self, *args, **kwargs):
         raise TypeError(f"{self.__class__.__name__} does not support item assignment")
 
-    def popitem(self, *args, **kwargs):  # noqa: D102 no docstring
+    def popitem(self, *args, **kwargs):
         raise TypeError(f"{self.__class__.__name__} does not support item assignment")
 
-    def setdefault(self, *args, **kwargs):  # noqa: D102 no docstring
+    def setdefault(self, *args, **kwargs):
         raise TypeError(f"{self.__class__.__name__} does not support item assignment")
 
-    def update(self, *args, **kwargs):  # noqa: D102 no docstring
+    def update(self, *args, **kwargs):
         raise TypeError(f"{self.__class__.__name__} does not support item assignment")
 
     # update is not ok because it mutates the object
     # __add__ is ok because it creates a new object
     # while the new object is under construction, it's ok to mutate it
-    def __add__(self, right):  # noqa: D105 no docstring
+    def __add__(self, right):
         result = hashdict(self)
         dict.update(result, right)
         return result

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 
 from homeassistant.components.google_assistant import helpers
-from homeassistant.components.google_assistant.const import (  # noqa: F401
+from homeassistant.components.google_assistant.const import (
     EVENT_COMMAND_RECEIVED,
     NOT_EXPOSE_LOCAL,
 )


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I found unnecessary `# noqa` statements using `yesqa`.

There are two options:
1. Merge only the fixes
2. Merge including yesqa in pre-commit
   - [ ] Need to add it to CI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
