### PR TITLE
Use current request context in OAuth redirect

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -118,7 +118,7 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
     @property
     def redirect_uri(self) -> str:
         """Return the redirect uri."""
-        return f"{get_url(self.hass)}{AUTH_CALLBACK_PATH}"
+        return f"{get_url(self.hass, require_current_request=True)}{AUTH_CALLBACK_PATH}"
 
     @property
     def extra_authorize_data(self) -> dict:

--- a/tests/components/almond/test_config_flow.py
+++ b/tests/components/almond/test_config_flow.py
@@ -1,17 +1,29 @@
 """Test the Almond config flow."""
 import asyncio
 
+import pytest
+
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.almond import config_flow
 from homeassistant.components.almond.const import DOMAIN
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import patch
+from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID_VALUE = "1234"
 CLIENT_SECRET_VALUE = "5678"
+
+
+@pytest.fixture
+def mock_current_request(hass):
+    """Mock current request."""
+    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.url = "https://example.com/some/request"
+        mock_request_context.get = Mock(return_value=mock_request)
+        yield mock_request_context
 
 
 async def test_import(hass):
@@ -87,7 +99,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["reason"] == "already_setup"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/almond/test_config_flow.py
+++ b/tests/components/almond/test_config_flow.py
@@ -1,29 +1,17 @@
 """Test the Almond config flow."""
 import asyncio
 
-import pytest
-
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.almond import config_flow
 from homeassistant.components.almond.const import DOMAIN
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID_VALUE = "1234"
 CLIENT_SECRET_VALUE = "5678"
-
-
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
 
 
 async def test_import(hass):
@@ -99,7 +87,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["reason"] == "already_setup"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -1,4 +1,6 @@
 """Test the Home Connect config flow."""
+import pytest
+
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.home_connect.const import (
     DOMAIN,
@@ -8,13 +10,23 @@ from homeassistant.components.home_connect.const import (
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import patch
+from tests.async_mock import Mock, patch
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock):
+@pytest.fixture
+def mock_current_request(hass):
+    """Mock current request."""
+    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.url = "https://example.com/some/request"
+        mock_request_context.get = Mock(return_value=mock_request)
+        yield mock_request_context
+
+
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -1,6 +1,4 @@
 """Test the Home Connect config flow."""
-import pytest
-
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.home_connect.const import (
     DOMAIN,
@@ -10,23 +8,13 @@ from homeassistant.components.home_connect.const import (
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
-
-
-async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -1,4 +1,6 @@
 """Test the Netatmo config flow."""
+import pytest
+
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.netatmo import config_flow
 from homeassistant.components.netatmo.const import (
@@ -11,13 +13,23 @@ from homeassistant.components.netatmo.const import (
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import patch
+from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 VALID_CONFIG = {}
+
+
+@pytest.fixture
+def mock_current_request(hass):
+    """Mock current request."""
+    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.url = "https://example.com/some/request"
+        mock_request_context.get = Mock(return_value=mock_request)
+        yield mock_request_context
 
 
 async def test_abort_if_existing_entry(hass):
@@ -42,7 +54,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -1,6 +1,4 @@
 """Test the Netatmo config flow."""
-import pytest
-
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.netatmo import config_flow
 from homeassistant.components.netatmo.const import (
@@ -13,23 +11,13 @@ from homeassistant.components.netatmo.const import (
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 VALID_CONFIG = {}
-
-
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
 
 
 async def test_abort_if_existing_entry(hass):
@@ -54,7 +42,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -1,6 +1,4 @@
 """Test the Smappee component config flow module."""
-import pytest
-
 from homeassistant import data_entry_flow, setup
 from homeassistant.components.smappee.const import (
     CONF_HOSTNAME,
@@ -14,21 +12,11 @@ from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
-
-
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
 
 
 async def test_show_user_form(hass):
@@ -332,9 +320,7 @@ async def test_abort_cloud_flow_if_local_device_exists(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_full_user_flow(
-    hass, aiohttp_client, aioclient_mock, mock_current_request
-):
+async def test_full_user_flow(hass, aiohttp_client, aioclient_mock, current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -1,4 +1,6 @@
 """Test the Smappee component config flow module."""
+import pytest
+
 from homeassistant import data_entry_flow, setup
 from homeassistant.components.smappee.const import (
     CONF_HOSTNAME,
@@ -12,11 +14,21 @@ from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import patch
+from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
+
+
+@pytest.fixture
+def mock_current_request(hass):
+    """Mock current request."""
+    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.url = "https://example.com/some/request"
+        mock_request_context.get = Mock(return_value=mock_request)
+        yield mock_request_context
 
 
 async def test_show_user_form(hass):
@@ -320,7 +332,9 @@ async def test_abort_cloud_flow_if_local_device_exists(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_full_user_flow(hass, aiohttp_client, aioclient_mock):
+async def test_full_user_flow(
+    hass, aiohttp_client, aioclient_mock, mock_current_request
+):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/somfy/test_config_flow.py
+++ b/tests/components/somfy/test_config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.components.somfy import DOMAIN, config_flow
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import patch
+from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID_VALUE = "1234"
@@ -32,6 +32,16 @@ async def mock_impl(hass):
     return impl
 
 
+@pytest.fixture
+def mock_current_request(hass):
+    """Mock current request."""
+    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.url = "https://example.com/some/request"
+        mock_request_context.get = Mock(return_value=mock_request)
+        yield mock_request_context
+
+
 async def test_abort_if_no_configuration(hass):
     """Check flow abort when no configuration."""
     flow = config_flow.SomfyFlowHandler()
@@ -52,7 +62,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["reason"] == "already_setup"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/somfy/test_config_flow.py
+++ b/tests/components/somfy/test_config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.components.somfy import DOMAIN, config_flow
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 CLIENT_ID_VALUE = "1234"
@@ -32,16 +32,6 @@ async def mock_impl(hass):
     return impl
 
 
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
-
-
 async def test_abort_if_no_configuration(hass):
     """Check flow abort when no configuration."""
     flow = config_flow.SomfyFlowHandler()
@@ -62,7 +52,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["reason"] == "already_setup"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the Spotify config flow."""
-import pytest
 from spotipy import SpotifyException
 
 from homeassistant import data_entry_flow, setup
@@ -8,18 +7,8 @@ from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
-
-
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
 
 
 async def test_abort_if_no_configuration(hass):
@@ -51,7 +40,7 @@ async def test_zeroconf_abort_if_existing_entry(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_request):
+async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     """Check a full flow."""
     assert await setup.async_setup_component(
         hass,
@@ -108,7 +97,7 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, mock_current_requ
 
 
 async def test_abort_if_spotify_error(
-    hass, aiohttp_client, aioclient_mock, mock_current_request
+    hass, aiohttp_client, aioclient_mock, current_request
 ):
     """Check Spotify errors causes flow to abort."""
     await setup.async_setup_component(

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -1,5 +1,5 @@
 """Tests for the Toon config flow."""
-
+import pytest
 from toonapi import Agreement, ToonError
 
 from homeassistant import data_entry_flow
@@ -10,7 +10,7 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import patch
+from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
 
 
@@ -29,6 +29,16 @@ async def setup_component(hass):
         await hass.async_block_till_done()
 
 
+@pytest.fixture
+def mock_current_request(hass):
+    """Mock current request."""
+    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.url = "https://example.com/some/request"
+        mock_request_context.get = Mock(return_value=mock_request)
+        yield mock_request_context
+
+
 async def test_abort_if_no_configuration(hass):
     """Test abort if no app is configured."""
     result = await hass.config_entries.flow.async_init(
@@ -39,7 +49,9 @@ async def test_abort_if_no_configuration(hass):
     assert result["reason"] == "missing_configuration"
 
 
-async def test_full_flow_implementation(hass, aiohttp_client, aioclient_mock):
+async def test_full_flow_implementation(
+    hass, aiohttp_client, aioclient_mock, mock_current_request
+):
     """Test registering an integration and finishing flow works."""
     await setup_component(hass)
 
@@ -95,7 +107,9 @@ async def test_full_flow_implementation(hass, aiohttp_client, aioclient_mock):
     }
 
 
-async def test_no_agreements(hass, aiohttp_client, aioclient_mock):
+async def test_no_agreements(
+    hass, aiohttp_client, aioclient_mock, mock_current_request
+):
     """Test abort when there are no displays."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -127,7 +141,9 @@ async def test_no_agreements(hass, aiohttp_client, aioclient_mock):
     assert result3["reason"] == "no_agreements"
 
 
-async def test_multiple_agreements(hass, aiohttp_client, aioclient_mock):
+async def test_multiple_agreements(
+    hass, aiohttp_client, aioclient_mock, mock_current_request
+):
     """Test abort when there are no displays."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -169,7 +185,9 @@ async def test_multiple_agreements(hass, aiohttp_client, aioclient_mock):
         assert result4["data"]["agreement_id"] == 1
 
 
-async def test_agreement_already_set_up(hass, aiohttp_client, aioclient_mock):
+async def test_agreement_already_set_up(
+    hass, aiohttp_client, aioclient_mock, mock_current_request
+):
     """Test showing display form again if display already exists."""
     await setup_component(hass)
     MockConfigEntry(domain=DOMAIN, unique_id=123).add_to_hass(hass)
@@ -202,7 +220,7 @@ async def test_agreement_already_set_up(hass, aiohttp_client, aioclient_mock):
         assert result3["reason"] == "already_configured"
 
 
-async def test_toon_abort(hass, aiohttp_client, aioclient_mock):
+async def test_toon_abort(hass, aiohttp_client, aioclient_mock, mock_current_request):
     """Test we abort on Toon error."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -247,7 +265,9 @@ async def test_import(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_import_migration(hass, aiohttp_client, aioclient_mock):
+async def test_import_migration(
+    hass, aiohttp_client, aioclient_mock, mock_current_request
+):
     """Test if importing step with migration works."""
     old_entry = MockConfigEntry(domain=DOMAIN, unique_id=123, version=1)
     old_entry.add_to_hass(hass)

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the Toon config flow."""
-import pytest
 from toonapi import Agreement, ToonError
 
 from homeassistant import data_entry_flow
@@ -10,7 +9,7 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 
@@ -29,16 +28,6 @@ async def setup_component(hass):
         await hass.async_block_till_done()
 
 
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
-
-
 async def test_abort_if_no_configuration(hass):
     """Test abort if no app is configured."""
     result = await hass.config_entries.flow.async_init(
@@ -50,7 +39,7 @@ async def test_abort_if_no_configuration(hass):
 
 
 async def test_full_flow_implementation(
-    hass, aiohttp_client, aioclient_mock, mock_current_request
+    hass, aiohttp_client, aioclient_mock, current_request
 ):
     """Test registering an integration and finishing flow works."""
     await setup_component(hass)
@@ -107,9 +96,7 @@ async def test_full_flow_implementation(
     }
 
 
-async def test_no_agreements(
-    hass, aiohttp_client, aioclient_mock, mock_current_request
-):
+async def test_no_agreements(hass, aiohttp_client, aioclient_mock, current_request):
     """Test abort when there are no displays."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -142,7 +129,7 @@ async def test_no_agreements(
 
 
 async def test_multiple_agreements(
-    hass, aiohttp_client, aioclient_mock, mock_current_request
+    hass, aiohttp_client, aioclient_mock, current_request
 ):
     """Test abort when there are no displays."""
     await setup_component(hass)
@@ -186,7 +173,7 @@ async def test_multiple_agreements(
 
 
 async def test_agreement_already_set_up(
-    hass, aiohttp_client, aioclient_mock, mock_current_request
+    hass, aiohttp_client, aioclient_mock, current_request
 ):
     """Test showing display form again if display already exists."""
     await setup_component(hass)
@@ -220,7 +207,7 @@ async def test_agreement_already_set_up(
         assert result3["reason"] == "already_configured"
 
 
-async def test_toon_abort(hass, aiohttp_client, aioclient_mock, mock_current_request):
+async def test_toon_abort(hass, aiohttp_client, aioclient_mock, current_request):
     """Test we abort on Toon error."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -265,9 +252,7 @@ async def test_import(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_import_migration(
-    hass, aiohttp_client, aioclient_mock, mock_current_request
-):
+async def test_import_migration(hass, aiohttp_client, aioclient_mock, current_request):
     """Test if importing step with migration works."""
     old_entry = MockConfigEntry(domain=DOMAIN, unique_id=123, version=1)
     old_entry.add_to_hass(hass)

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry, mock_platform
 
 TEST_DOMAIN = "oauth2_test"
@@ -54,16 +54,6 @@ def flow_handler(hass):
 
     with patch.dict(config_entries.HANDLERS, {TEST_DOMAIN: TestFlowHandler}):
         yield TestFlowHandler
-
-
-@pytest.fixture
-def mock_current_request(hass):
-    """Mock current request."""
-    with patch("homeassistant.helpers.network.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request.url = "https://example.com/some/request"
-        mock_request_context.get = Mock(return_value=mock_request)
-        yield mock_request_context
 
 
 class MockOAuth2Implementation(config_entry_oauth2_flow.AbstractOAuth2Implementation):
@@ -204,7 +194,7 @@ async def test_abort_discovered_existing_entries(hass, flow_handler, local_impl)
 
 
 async def test_full_flow(
-    hass, flow_handler, local_impl, aiohttp_client, aioclient_mock, mock_current_request
+    hass, flow_handler, local_impl, aiohttp_client, aioclient_mock, current_request
 ):
     """Check full flow."""
     await async_process_ha_core_config(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

OAuth authentication now uses the current request URL from the browser as the redirect target, instead of the internal URL setting. This matches the experience one would expect to happen and removes the need to fiddle around with the internal URL setting.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move OAuth flow to use the current request as the base for the URL to use as a redirect, instead of the internal URL helper.

The request context has been implemented in #38602.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35844, fixes #36133, fixes #36338, fixes #36422, fixes #38536
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
