### PR TITLE
Time trigger can also accept an input_datetime Entity ID

### DIFF
--- a/homeassistant/components/automation/time.py
+++ b/homeassistant/components/automation/time.py
@@ -1,4 +1,5 @@
 """Offer time listening automation rules."""
+from datetime import datetime
 import logging
 
 import voluptuous as vol
@@ -6,39 +7,112 @@ import voluptuous as vol
 from homeassistant.const import CONF_AT, CONF_PLATFORM
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.event import async_track_time_change
+from homeassistant.helpers.event import (
+    async_track_point_in_time,
+    async_track_state_change,
+    async_track_time_change,
+)
+import homeassistant.util.dt as dt_util
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)
 
+_TIME_TRIGGER_SCHEMA = vol.Any(
+    cv.time,
+    vol.All(str, cv.entity_domain("input_datetime")),
+    msg="Expected HH:MM, HH:MM:SS or Entity ID from domain 'input_datetime'",
+)
+
 TRIGGER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_PLATFORM): "time",
-        vol.Required(CONF_AT): vol.All(cv.ensure_list, [cv.time]),
+        vol.Required(CONF_AT): vol.All(cv.ensure_list, [_TIME_TRIGGER_SCHEMA]),
     }
 )
 
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
-    at_times = config[CONF_AT]
+    entities = {}
+    removes = []
 
     @callback
     def time_automation_listener(now):
         """Listen for time changes and calls action."""
         hass.async_run_job(action, {"trigger": {"platform": "time", "now": now}})
 
-    removes = [
-        async_track_time_change(
-            hass,
-            time_automation_listener,
-            hour=at_time.hour,
-            minute=at_time.minute,
-            second=at_time.second,
-        )
-        for at_time in at_times
-    ]
+    @callback
+    def update_entity_trigger(entity_id, old_state=None, new_state=None):
+        # If a listener was already set up for entity, remove it.
+        remove = entities.get(entity_id)
+        if remove:
+            remove()
+            removes.remove(remove)
+            remove = None
+
+        # Check state of entity. If valid, set up a listener.
+        if new_state:
+            has_date = new_state.attributes["has_date"]
+            if has_date:
+                year = new_state.attributes["year"]
+                month = new_state.attributes["month"]
+                day = new_state.attributes["day"]
+            has_time = new_state.attributes["has_time"]
+            if has_time:
+                hour = new_state.attributes["hour"]
+                minute = new_state.attributes["minute"]
+                second = new_state.attributes["second"]
+            else:
+                # If no time then use midnight.
+                hour = minute = second = 0
+
+            if has_date:
+                # If input_datetime has date, then track point in time.
+                trigger_dt = dt_util.DEFAULT_TIME_ZONE.localize(
+                    datetime(year, month, day, hour, minute, second)
+                )
+                # Only set up listener if time is now or in the future.
+                if trigger_dt >= dt_util.now():
+                    remove = async_track_point_in_time(
+                        hass, time_automation_listener, trigger_dt
+                    )
+            elif has_time:
+                # Else if it has time, then track time change.
+                remove = async_track_time_change(
+                    hass,
+                    time_automation_listener,
+                    hour=hour,
+                    minute=minute,
+                    second=second,
+                )
+
+        # Was a listener set up?
+        if remove:
+            removes.append(remove)
+
+        entities[entity_id] = remove
+
+    for at_time in config[CONF_AT]:
+        if isinstance(at_time, str):
+            # input_datetime entity
+            update_entity_trigger(at_time, new_state=hass.states.get(at_time))
+        else:
+            # datetime.time
+            removes.append(
+                async_track_time_change(
+                    hass,
+                    time_automation_listener,
+                    hour=at_time.hour,
+                    minute=at_time.minute,
+                    second=at_time.second,
+                )
+            )
+
+    # Track state changes of any entities.
+    removes.append(
+        async_track_state_change(hass, list(entities), update_entity_trigger)
+    )
 
     @callback
     def remove_track_time_changes():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A common scenario is triggering an automation from an `input_datetime`. This generally requires a template trigger with a less than obvious, and non-trivial, template that also generally requires configuring `sensor.time` (or similar) in the system. E.g., the following was taken straight from the `input_datetime` doc page:
```yaml
trigger:
  platform: template
  value_template: "{{ states('sensor.time') == (state_attr('input_datetime.bedroom_alarm_clock_time', 'timestamp') | int | timestamp_custom('%H:%M', False)) }}"
```
This change allows the `time` trigger to accept an `input_datetime` Entity ID directly. It can also handle all useful combinations of `has_date` & `has_time`. The above would now be as simple as:
```yaml
trigger:
  platform: time
  at: input_datetime.bedroom_alarm_clock_time
```

This will make it much simpler to trigger an automation based on an `input_datetime`. It will also make it easy to trigger on a specific date (which previously would also require a template condition.)

Lastly, this will make it much easier to have long delayed actions that can survive a restart. (See doc PR for example.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#14207

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
