### PR TITLE
Add event and device trigger that fire when devices drop from the ZHA Zigbee network

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -51,7 +51,8 @@
       "device_tilted": "Device tilted",
       "device_knocked": "Device knocked \"{subtype}\"",
       "device_dropped": "Device dropped",
-      "device_flipped": "Device flipped \"{subtype}\""
+      "device_flipped": "Device flipped \"{subtype}\"",
+      "device_offline": "Device offline"
     },
     "trigger_subtype": {
       "turn_on": "Turn on",

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -1,12 +1,23 @@
 """ZHA device automation trigger tests."""
+from datetime import timedelta
+import time
+
 import pytest
 import zigpy.zcl.clusters.general as general
 
 import homeassistant.components.automation as automation
+import homeassistant.components.zha.core.device as zha_core_device
 from homeassistant.helpers.device_registry import async_get_registry
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import async_get_device_automations, async_mock_service
+from .common import async_enable_traffic
+
+from tests.common import (
+    async_fire_time_changed,
+    async_get_device_automations,
+    async_mock_service,
+)
 
 ON = 1
 OFF = 0
@@ -49,7 +60,7 @@ async def mock_devices(hass, zigpy_device_mock, zha_device_joined_restored):
                 "out_clusters": [general.OnOff.cluster_id],
                 "device_type": 0,
             }
-        },
+        }
     )
 
     zha_device = await zha_device_joined_restored(zigpy_device)
@@ -79,6 +90,13 @@ async def test_triggers(hass, mock_devices):
     triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
 
     expected_triggers = [
+        {
+            "device_id": reg_device.id,
+            "domain": "zha",
+            "platform": "device",
+            "type": "device_offline",
+            "subtype": "device_offline",
+        },
         {
             "device_id": reg_device.id,
             "domain": "zha",
@@ -128,7 +146,15 @@ async def test_no_triggers(hass, mock_devices):
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
 
     triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
-    assert triggers == []
+    assert triggers == [
+        {
+            "device_id": reg_device.id,
+            "domain": "zha",
+            "platform": "device",
+            "type": "device_offline",
+            "subtype": "device_offline",
+        }
+    ]
 
 
 async def test_if_fires_on_event(hass, mock_devices, calls):
@@ -176,6 +202,74 @@ async def test_if_fires_on_event(hass, mock_devices, calls):
     channel.zha_send_event(COMMAND_SINGLE, [])
     await hass.async_block_till_done()
 
+    assert len(calls) == 1
+    assert calls[0].data["message"] == "service called"
+
+
+async def test_device_offline_fires(
+    hass, zigpy_device_mock, zha_device_restored, calls
+):
+    """Test for device offline triggers firing."""
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                "in_clusters": [general.Basic.cluster_id],
+                "out_clusters": [general.OnOff.cluster_id],
+                "device_type": 0,
+            }
+        }
+    )
+
+    zha_device = await zha_device_restored(zigpy_device, last_seen=time.time())
+    await async_enable_traffic(hass, [zha_device])
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "device_id": zha_device.device_id,
+                        "domain": "zha",
+                        "platform": "device",
+                        "type": "device_offline",
+                        "subtype": "device_offline",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {"message": "service called"},
+                    },
+                }
+            ]
+        },
+    )
+
+    await hass.async_block_till_done()
+    assert zha_device.available is True
+
+    zigpy_device.last_seen = (
+        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2
+    )
+
+    # there are 3 checkins to perform before marking the device unavailable
+    future = dt_util.utcnow() + timedelta(seconds=90)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    future = dt_util.utcnow() + timedelta(seconds=90)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    future = dt_util.utcnow() + timedelta(
+        seconds=zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 100
+    )
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    assert zha_device.available is False
     assert len(calls) == 1
     assert calls[0].data["message"] == "service called"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a device trigger and an event that can be used to determine when devices may have dropped from the ZHA Zigbee network. These can easily be used in automations that notify the user when devices fall off the network.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
