### PR TITLE
Convert extract_entities to use async_render_to_info

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -127,7 +127,7 @@ class BayesianBinarySensor(BinarySensorEntity):
 
         self.current_observations = OrderedDict({})
 
-        self.observations_by_entity = self._build_observations_by_entity()
+        self.observations_by_entity = None
 
         self.observation_handlers = {
             "numeric_state": self._process_numeric_state,
@@ -149,6 +149,7 @@ class BayesianBinarySensor(BinarySensorEntity):
         In addition, this method must register the state listener defined within, which
         will be called any time a relevant entity changes its state.
         """
+        self.observations_by_entity = self._build_observations_by_entity()
 
         @callback
         def async_threshold_sensor_state_listener(event):
@@ -235,8 +236,9 @@ class BayesianBinarySensor(BinarySensorEntity):
 
             if "entity_id" in obs:
                 entity_ids = [obs["entity_id"]]
-            elif "value_template" in obs:
-                entity_ids = obs.get(CONF_VALUE_TEMPLATE).extract_entities()
+            elif CONF_VALUE_TEMPLATE in obs:
+                obs[CONF_VALUE_TEMPLATE].hass = self.hass
+                entity_ids = obs[CONF_VALUE_TEMPLATE].extract_entities()
 
             for e_id in entity_ids:
                 obs_list = observations_by_entity.get(e_id, [])

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -19,7 +19,12 @@ def initialise_templates(hass, templates, attribute_templates=None):
 
 
 def extract_entities(
-    device_name, device_type, manual_entity_ids, templates, attribute_templates=None
+    hass,
+    device_name,
+    device_type,
+    manual_entity_ids,
+    templates,
+    attribute_templates=None,
 ):
     """Extract entity ids from templates and attribute templates."""
     if attribute_templates is None:
@@ -33,6 +38,7 @@ def extract_entities(
             if template is None:
                 continue
 
+            template.hass = hass
             template_entity_ids = template.extract_entities()
 
             if template_entity_ids != MATCH_ALL:

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -93,6 +93,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         template_entity_ids = set()
 
         if state_template is not None:
+            state_template.hass = hass
             temp_ids = state_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -86,6 +86,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         initialise_templates(hass, templates, attribute_templates)
         entity_ids = extract_entities(
+            hass,
             device,
             "binary sensor",
             device_config.get(ATTR_ENTITY_ID),

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -136,7 +136,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         initialise_templates(hass, templates)
         entity_ids = extract_entities(
-            device, "cover", device_config.get(CONF_ENTITY_ID), templates
+            hass, device, "cover", device_config.get(CONF_ENTITY_ID), templates
         )
 
         covers.append(

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -113,7 +113,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         }
 
         initialise_templates(hass, templates)
-        entity_ids = extract_entities(device, "fan", None, templates)
+        entity_ids = extract_entities(hass, device, "fan", None, templates)
 
         fans.append(
             TemplateFan(

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -121,7 +121,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         initialise_templates(hass, templates)
         entity_ids = extract_entities(
-            device, "light", device_config.get(CONF_ENTITY_ID), templates
+            hass, device, "light", device_config.get(CONF_ENTITY_ID), templates
         )
 
         lights.append(

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -56,7 +56,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     }
 
     initialise_templates(hass, templates)
-    entity_ids = extract_entities(device, "lock", None, templates)
+    entity_ids = extract_entities(hass, device, "lock", None, templates)
 
     async_add_devices(
         [

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -85,6 +85,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         initialise_templates(hass, templates, attribute_templates)
         entity_ids = extract_entities(
+            hass,
             device,
             "sensor",
             device_config.get(ATTR_ENTITY_ID),

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -80,7 +80,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         initialise_templates(hass, templates)
         entity_ids = extract_entities(
-            device, "switch", device_config.get(ATTR_ENTITY_ID), templates
+            hass, device, "switch", device_config.get(ATTR_ENTITY_ID), templates
         )
 
         switches.append(

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -127,7 +127,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         initialise_templates(hass, templates, attribute_templates)
         entity_ids = extract_entities(
-            device, "vacuum", None, templates, attribute_templates
+            hass, device, "vacuum", None, templates, attribute_templates
         )
 
         vacuums.append(

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -148,6 +148,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         for entity in self._attrs.values():
             depend.append(entity[0])
         if self._state_template is not None:
+            self._state_template.hass = self.hass
             for entity in self._state_template.extract_entities():
                 depend.append(entity)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -905,7 +905,9 @@ class StateMachine:
         return future.result()
 
     @callback
-    def async_entity_ids(self, domain_filter: Optional[str] = None) -> List[str]:
+    def async_entity_ids(
+        self, domain_filter: Optional[Union[str, Iterable]] = None
+    ) -> List[str]:
         """List of entity ids that are being tracked.
 
         This method must be run in the event loop.
@@ -913,12 +915,13 @@ class StateMachine:
         if domain_filter is None:
             return list(self._states.keys())
 
-        domain_filter = domain_filter.lower()
+        if isinstance(domain_filter, str):
+            domain_filter = [domain_filter.lower()]
 
         return [
             state.entity_id
             for state in self._states.values()
-            if state.domain == domain_filter
+            if state.domain in domain_filter
         ]
 
     def all(self) -> List[State]:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -46,6 +46,8 @@ _ENVIRONMENT = "template.environment"
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_JINJA_DELIMITERS = re.compile(r"\{%|\{\{")
+_RE_JINJA_IF_ELIF = re.compile("{[ \t]*%[ \t]+(?:if|elif)")
+_RE_JINJA_ELSE_ENDIF = re.compile("{[ \t]*%[ \t]+(?:else|endif)")
 
 _RESERVED_NAMES = {"contextfunction", "evalcontextfunction", "environmentfunction"}
 
@@ -176,12 +178,10 @@ class Template:
         # so we collect entities/domains that appear in code branches
         # that would not normally be transversed.
         template_without_conditionals = re.sub(
-            r"{[ \t]*%[ \t]+(?:if|elif)", "{% print", self.template
+            _RE_JINJA_IF_ELIF, "{% print", self.template
         )
         template_without_conditionals = re.sub(
-            r"{[ \t]*%[ \t]+(?:else|endif)",
-            '{% print ""',
-            template_without_conditionals,
+            _RE_JINJA_ELSE_ENDIF, '{% print ""', template_without_conditionals,
         )
 
         try:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -233,7 +233,7 @@ class Template:
 
         This method must be run in the event loop.
         """
-        return self._render_compiled(
+        return render_compiled(
             self._compiled or self._ensure_compiled(), variables, **kwargs
         )
 
@@ -245,28 +245,12 @@ class Template:
 
         This method must be run in the event loop.
         """
-        return self._render_compiled(
+        return render_compiled(
             self._compiled_without_conditionals
             or self._ensure_compiled_without_conditionals(),
             variables,
             **kwargs,
         )
-
-    @callback
-    def _render_compiled(
-        self, compiled: Any, variables: TemplateVarsType = None, **kwargs: Any,
-    ) -> str:
-        """Render given compiled template.
-
-        This method must be run in the event loop.
-        """
-        if variables is not None:
-            kwargs.update(variables)
-
-        try:
-            return compiled.render(kwargs).strip()
-        except jinja2.TemplateError as err:
-            raise TemplateError(err)
 
     @callback
     def async_render_to_info(
@@ -387,6 +371,23 @@ class Template:
     def __repr__(self) -> str:
         """Representation of Template."""
         return 'Template("' + self.template + '")'
+
+
+@callback
+def render_compiled(
+    compiled: Any, variables: TemplateVarsType = None, **kwargs: Any,
+) -> str:
+    """Render given compiled template.
+
+    This method must be run in the event loop.
+    """
+    if variables is not None:
+        kwargs.update(variables)
+
+    try:
+        return compiled.render(kwargs).strip()
+    except jinja2.TemplateError as err:
+        raise TemplateError(err)
 
 
 class AllStates:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -39,25 +39,22 @@ def render_to_info(hass, template_str, variables=None):
 def extract_entities(hass, template_str, variables=None):
     """Extract entities from a template."""
     info = render_to_info(hass, template_str, variables)
-    # pylint: disable=protected-access
-    assert not hasattr(info, "_domains")
-    return info._entities
+    return info.entities
 
 
 def assert_result_info(info, result, entities=None, domains=None, all_states=False):
     """Check result info."""
     assert info.result == result
-    # pylint: disable=protected-access
-    assert info._all_states == all_states
+    assert info.all_states == all_states
     assert info.filter_lifecycle("invalid_entity_name.somewhere") == all_states
     if entities is not None:
-        assert info._entities == frozenset(entities)
+        assert info.entities == frozenset(entities)
         assert all([info.filter(entity) for entity in entities])
         assert not info.filter("invalid_entity_name.somewhere")
     else:
-        assert not info._entities
+        assert not info.entities
     if domains is not None:
-        assert info._domains == frozenset(domains)
+        assert info.domains == frozenset(domains)
         assert all([info.filter_lifecycle(domain + ".entity") for domain in domains])
     else:
         assert not hasattr(info, "_domains")
@@ -1255,9 +1252,7 @@ async def test_closest_function_home_vs_group_entity_id(hass):
     await group.Group.async_create_group(hass, "location group", ["test_domain.object"])
 
     info = render_to_info(hass, '{{ closest("group.location_group").entity_id }}')
-    assert_result_info(
-        info, "test_domain.object", ["test_domain.object", "group.location_group"]
-    )
+    assert_result_info(info, "test_domain.object", ["test_domain.object"])
 
 
 async def test_closest_function_home_vs_group_state(hass):
@@ -1280,14 +1275,10 @@ async def test_closest_function_home_vs_group_state(hass):
     await group.Group.async_create_group(hass, "location group", ["test_domain.object"])
 
     info = render_to_info(hass, '{{ closest("group.location_group").entity_id }}')
-    assert_result_info(
-        info, "test_domain.object", ["test_domain.object", "group.location_group"]
-    )
+    assert_result_info(info, "test_domain.object", ["test_domain.object"])
 
     info = render_to_info(hass, "{{ closest(states.group.location_group).entity_id }}")
-    assert_result_info(
-        info, "test_domain.object", ["test_domain.object", "group.location_group"]
-    )
+    assert_result_info(info, "test_domain.object", ["test_domain.object"])
 
 
 async def test_expand(hass):
@@ -1303,7 +1294,7 @@ async def test_expand(hass):
     info = render_to_info(
         hass, "{{ expand('test.object') | map(attribute='entity_id') | join(', ') }}"
     )
-    assert_result_info(info, "test.object", [])
+    assert_result_info(info, "test.object", ["test.object"])
 
     info = render_to_info(
         hass,
@@ -1322,26 +1313,26 @@ async def test_expand(hass):
         hass,
         "{{ expand('group.new_group') | map(attribute='entity_id') | join(', ') }}",
     )
-    assert_result_info(info, "test.object", ["group.new_group"])
+    assert_result_info(info, "test.object", ["test.object"])
 
     info = render_to_info(
         hass, "{{ expand(states.group) | map(attribute='entity_id') | join(', ') }}"
     )
-    assert_result_info(info, "test.object", ["group.new_group"], ["group"])
+    assert_result_info(info, "test.object", ["test.object"], ["group"])
 
     info = render_to_info(
         hass,
         "{{ expand('group.new_group', 'test.object')"
         " | map(attribute='entity_id') | join(', ') }}",
     )
-    assert_result_info(info, "test.object", ["group.new_group"])
+    assert_result_info(info, "test.object", ["test.object"])
 
     info = render_to_info(
         hass,
         "{{ ['group.new_group', 'test.object'] | expand"
         " | map(attribute='entity_id') | join(', ') }}",
     )
-    assert_result_info(info, "test.object", ["group.new_group"])
+    assert_result_info(info, "test.object", ["test.object"])
 
 
 def test_closest_function_to_coord(hass):
@@ -1518,6 +1509,83 @@ def test_closest_function_state_with_invalid_location(hass):
     )
 
 
+def test_extract_entities_with_branching(hass):
+    """Test extract entities function by domain."""
+    hass.states.async_set("light.a", "off")
+    hass.states.async_set("light.b", "on")
+    hass.states.async_set("light.c", "off")
+
+    assert (
+        set(
+            template.extract_entities(
+                hass,
+                """
+{% if states.light.a == "on" %}
+  {{ states.light.b.state }}
+{% else %}
+  {{ states.light.c.state }}
+{% endif %}
+""",
+                {},
+            )
+        )
+        == {"light.a", "light.b", "light.c"}
+    )
+
+    assert (
+        set(
+            template.extract_entities(
+                hass,
+                """
+            {% if states.light.a.state == "A" %}
+            {% set domain = "light" %}
+            {{ states[domain].b.state }}
+            {% endif %}
+""",
+                {},
+            )
+        )
+        == {"light.a", "light.b"}
+    )
+
+
+def test_extract_entities_with_complex_branching(hass):
+    """Test extract entities function by domain."""
+    hass.states.async_set("light.a", "off")
+    hass.states.async_set("light.b", "on")
+    hass.states.async_set("light.c", "off")
+    hass.states.async_set("vacuum.a", "off")
+    hass.states.async_set("device_tracker.a", "off")
+    hass.states.async_set("device_tracker.b", "off")
+    hass.states.async_set("lock.a", "off")
+    hass.states.async_set("sensor.a", "off")
+    hass.states.async_set("binary_sensor.a", "off")
+
+    assert (
+        set(
+            template.extract_entities(
+                hass,
+                """
+{% set domain = "vacuum" %}
+{%      if                 states.light.a == "on" %}
+  {{ states.light.b.state }}
+{% elif  states.light.a == "on" %}
+  {{ states.device_tracker }}
+{%     elif     states.light.a == "on" %}
+  {{ states[domain] | list }}
+{%         elif     states.light.a == "on" %}
+  {{ states[otherdomain] | list }}
+{% elif states.light.a == "on" %}
+  {{ states["nonexist"] | list }}
+{% endif %}
+""",
+                {"otherdomain": "sensor"},
+            )
+        )
+        == {"light.a", "light.b", "sensor.a", "vacuum.a"}
+    )
+
+
 def test_closest_function_invalid_coordinates(hass):
     """Test closest function invalid coordinates."""
     hass.states.async_set(
@@ -1558,13 +1626,16 @@ def test_extract_entities_none_exclude_stuff(hass):
 
     assert (
         template.extract_entities(
-            hass, "{{ closest(states.zone.far_away, states.test_domain).entity_id }}"
+            hass,
+            "{{ closest(states.zone.far_away, states.test_domain.xxx).entity_id }}",
         )
         == MATCH_ALL
     )
 
     assert (
-        template.extract_entities(hass, '{{ distance("123", states.test_object_2) }}')
+        template.extract_entities(
+            hass, '{{ distance("123", states.test_object_2.user) }}'
+        )
         == MATCH_ALL
     )
 
@@ -1739,8 +1810,8 @@ Hercules you power goes done!.
             hass,
             """
 {{
-states.sensor.pick_temperature.state ~ „°C (“ ~
-states.sensor.pick_humidity.state ~ „ %“
+states.sensor.pick_temperature.state ~ "°C (" ~
+states.sensor.pick_humidity.state ~ " %"
 }}
         """,
         )
@@ -1759,22 +1830,27 @@ states.sensor.pick_humidity.state ~ „ %“
 
     await group.Group.async_create_group(hass, "empty group", [])
 
-    assert ["group.empty_group"] == template.extract_entities(
+    assert MATCH_ALL == template.extract_entities(
         hass, "{{ expand('group.empty_group') | list | length }}"
     )
 
     hass.states.async_set("test_domain.object", "exists")
     await group.Group.async_create_group(hass, "expand group", ["test_domain.object"])
 
-    assert sorted(["group.expand_group", "test_domain.object"]) == sorted(
+    # expand, extract finds the underlying entities
+    assert sorted(["test_domain.object"]) == sorted(
         template.extract_entities(
             hass, "{{ expand('group.expand_group') | list | length }}"
         )
     )
-
     assert ["test_domain.entity"] == template.Template(
         '{{ is_state("test_domain.entity", "on") }}', hass
     ).extract_entities()
+
+    # No expand, extract finds the group
+    assert template.extract_entities(hass, "{{ states('group.empty_group') }}") == [
+        "group.empty_group"
+    ]
 
 
 def test_extract_entities_with_variables(hass):
@@ -1790,7 +1866,9 @@ def test_extract_entities_with_variables(hass):
         {"trigger": {"entity_id": "input_boolean.switch"}},
     )
 
-    assert MATCH_ALL == template.extract_entities(
+    # If we ever add entity validation here
+    # it is likely ok for this test to change
+    assert ["no_state"] == template.extract_entities(
         hass, "{{ is_state(data, 'off') }}", {"data": "no_state"}
     )
 
@@ -1809,6 +1887,17 @@ def test_extract_entities_with_variables(hass):
         hass,
         "{{ is_state('media_player.' ~ where , 'playing') }}",
         {"where": "livingroom"},
+    )
+
+
+def test_extract_entities_all_states(hass):
+    """Test extraction with all states."""
+
+    assert (
+        template.extract_entities(
+            hass, "{{ states | list | count > data }}", {"data": 1}
+        )
+        == MATCH_ALL
     )
 
 
@@ -1853,7 +1942,7 @@ def test_extract_entities_domain_states_outer_with_group(hass):
     assert set(
         template.extract_entities(
             hass,
-            "{{ states.light | selectattr('entity_id', 'in', state_attr('group.lights', 'entity_id')) }}",
+            "{{ states.light | selectattr('entity_id', 'in', state_attr('group.lights', 'entity_id')) | list | count > 0 }}",
             {},
         )
     ) == {"light.switch", "light.switch2", "light.switch3", "group.lights"}

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1586,6 +1586,19 @@ def test_extract_entities_with_complex_branching(hass):
     )
 
 
+def test_nested_case(hass):
+    """Test a deeply nested state."""
+
+    hass.states.async_set("input_select.picker", "vacuum.a")
+    hass.states.async_set("vacuum.a", "off")
+
+    assert set(
+        template.extract_entities(
+            hass, "{{ states[states['input_select.picker'].state].state }}", {}
+        )
+    ) == {"input_select.picker", "vacuum.a"}
+
+
 def test_closest_function_invalid_coordinates(hass):
     """Test closest function invalid coordinates."""
     hass.states.async_set(


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This gets rid of the giant regex that was used to make a best effort
extraction of the states and domains in the template in favor
or processing the template and capturing all the states and domains.

This change should solve all the cases where we miss tracking
an entity in a template.

When expand() is used, the state of the underlying entities in the
group is returned by extract_entities instead of the group itself
as expand() works like an alias for all the entities in the group.

This avoids re-rendering the template again when the group
had finished processing the state change of the underlying entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
