### PR TITLE
Improve solaredge error handling

### DIFF
--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -426,24 +426,24 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
         self.unit = energy_details["unit"]
         meters = energy_details["meters"]
 
-        try:
-            for entity in meters:
-                for key, data in entity.items():
-                    if key == "type" and data in [
-                        "Production",
-                        "SelfConsumption",
-                        "FeedIn",
-                        "Purchased",
-                        "Consumption",
-                    ]:
-                        energy_type = data
-                    if key == "values":
-                        for row in data:
+        for entity in meters:
+            for key, data in entity.items():
+                if key == "type" and data in [
+                    "Production",
+                    "SelfConsumption",
+                    "FeedIn",
+                    "Purchased",
+                    "Consumption",
+                ]:
+                    energy_type = data
+                if key == "values":
+                    for row in data:
+                        try:
                             self.data[energy_type] = row["value"]
                             self.attributes[energy_type] = {"date": row["date"]}
-        except KeyError:
-            _LOGGER.error("Missing energy details value, skipping update")
-            return
+                        except KeyError:
+                            _LOGGER.error("Missing energy details value, skipping update")
+                            return
 
         _LOGGER.debug(
             "Updated SolarEdge energy details: %s, %s", self.data, self.attributes

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -426,20 +426,24 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
         self.unit = energy_details["unit"]
         meters = energy_details["meters"]
 
-        for entity in meters:
-            for key, data in entity.items():
-                if key == "type" and data in [
-                    "Production",
-                    "SelfConsumption",
-                    "FeedIn",
-                    "Purchased",
-                    "Consumption",
-                ]:
-                    energy_type = data
-                if key == "values":
-                    for row in data:
-                        self.data[energy_type] = row["value"]
-                        self.attributes[energy_type] = {"date": row["date"]}
+        try:
+            for entity in meters:
+               for key, data in entity.items():
+                   if key == "type" and data in [
+                       "Production",
+                       "SelfConsumption",
+                       "FeedIn",
+                       "Purchased",
+                       "Consumption",
+                   ]:
+                       energy_type = data
+                   if key == "values":
+                       for row in data:
+                           self.data[energy_type] = row["value"]
+                           self.attributes[energy_type] = {"date": row["date"]}
+        except KeyError:
+            _LOGGER.error("Missing energy details value, skipping update")
+            return
 
         _LOGGER.debug(
             "Updated SolarEdge energy details: %s, %s", self.data, self.attributes

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -428,19 +428,19 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
 
         try:
             for entity in meters:
-               for key, data in entity.items():
-                   if key == "type" and data in [
-                       "Production",
-                       "SelfConsumption",
-                       "FeedIn",
-                       "Purchased",
-                       "Consumption",
-                   ]:
-                       energy_type = data
-                   if key == "values":
-                       for row in data:
-                           self.data[energy_type] = row["value"]
-                           self.attributes[energy_type] = {"date": row["date"]}
+                for key, data in entity.items():
+                    if key == "type" and data in [
+                        "Production",
+                        "SelfConsumption",
+                        "FeedIn",
+                        "Purchased",
+                        "Consumption",
+                    ]:
+                        energy_type = data
+                    if key == "values":
+                        for row in data:
+                            self.data[energy_type] = row["value"]
+                            self.attributes[energy_type] = {"date": row["date"]}
         except KeyError:
             _LOGGER.error("Missing energy details value, skipping update")
             return

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -442,7 +442,9 @@ class SolarEdgeEnergyDetailsService(SolarEdgeDataService):
                             self.data[energy_type] = row["value"]
                             self.attributes[energy_type] = {"date": row["date"]}
                         except KeyError:
-                            _LOGGER.error("Missing energy details value, skipping update")
+                            _LOGGER.error(
+                                "Missing energy details value, skipping update"
+                            )
                             return
 
         _LOGGER.debug(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
It seems like API data aren't available for energy details feed (and we got an KeyError on value) in the first hours in the morning. Dunno why: maybe no data is sent from inverter to solaredge, due the fact we have no power production? Or 'cause there are some server side problems?

Anyway I've added an try/except block in the interesting block code section in order to handle the KeyError and quit the function.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/38015


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
