### PR TITLE
Implement local discovery of Smappee series-2 devices and improvements

### DIFF
--- a/homeassistant/components/smappee/config_flow.py
+++ b/homeassistant/components/smappee/config_flow.py
@@ -8,7 +8,14 @@ from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from . import api
-from .const import CONF_HOSTNAME, CONF_SERIALNUMBER, DOMAIN, ENV_CLOUD, ENV_LOCAL
+from .const import (
+    CONF_HOSTNAME,
+    CONF_SERIALNUMBER,
+    DOMAIN,
+    ENV_CLOUD,
+    ENV_LOCAL,
+    SUPPORTED_LOCAL_DEVICES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +42,7 @@ class SmappeeFlowHandler(
     async def async_step_zeroconf(self, discovery_info):
         """Handle zeroconf discovery."""
 
-        if not discovery_info[CONF_HOSTNAME].startswith("Smappee1"):
+        if not discovery_info[CONF_HOSTNAME].startswith(SUPPORTED_LOCAL_DEVICES):
             # We currently only support Energy and Solar models (legacy)
             return self.async_abort(reason="invalid_mdns")
 
@@ -152,7 +159,9 @@ class SmappeeFlowHandler(
             if config_item["key"] == "mdnsHostName":
                 serial_number = config_item["value"]
 
-        if serial_number is None or not serial_number.startswith("Smappee1"):
+        if serial_number is None or not serial_number.startswith(
+            SUPPORTED_LOCAL_DEVICES
+        ):
             # We currently only support Energy and Solar models (legacy)
             return self.async_abort(reason="invalid_mdns")
 

--- a/homeassistant/components/smappee/const.py
+++ b/homeassistant/components/smappee/const.py
@@ -14,6 +14,8 @@ ENV_LOCAL = "local"
 
 SMAPPEE_PLATFORMS = ["binary_sensor", "sensor", "switch"]
 
+SUPPORTED_LOCAL_DEVICES = ("Smappee1", "Smappee2")
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=20)
 
 AUTHORIZE_URL = {

--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/smappee",
   "dependencies": ["http"],
   "requirements": [
-    "pysmappee==0.2.9"
+    "pysmappee==0.2.10"
   ],
   "codeowners": [
     "@bsmappee"

--- a/homeassistant/components/smappee/switch.py
+++ b/homeassistant/components/smappee/switch.py
@@ -1,5 +1,4 @@
 """Support for interacting with Smappee Comport Plugs, Switches and Output Modules."""
-from datetime import timedelta
 import logging
 
 from homeassistant.components.switch import SwitchEntity
@@ -10,7 +9,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SWITCH_PREFIX = "Switch"
 ICON = "mdi:toggle-switch"
-SCAN_INTERVAL = timedelta(seconds=5)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1629,7 +1629,7 @@ pyskyqhub==0.1.1
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.2.9
+pysmappee==0.2.10
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -761,7 +761,7 @@ pysignalclirestapi==0.3.4
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.2.9
+pysmappee==0.2.10
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -119,7 +119,7 @@ async def test_full_user_wrong_mdns(hass):
     """Test we abort user flow if unsupported mDNS name got resolved."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value={}), patch(
         "pysmappee.api.SmappeeLocalApi.load_advanced_config",
-        return_value=[{"key": "mdnsHostName", "value": "Smappee2006000212"}],
+        return_value=[{"key": "mdnsHostName", "value": "Smappee5010000001"}],
     ), patch(
         "pysmappee.api.SmappeeLocalApi.load_command_control_config", return_value=[]
     ), patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Extend supported Smappee devices for local discovery (Smappee Pro/Plus series)
* Improvements for current status of Smappee Switches in local environment (dependency bump)
* Cache load values in local environment (dependency bump)

Also includes Smappee dependency update to version 0.2.10:
Release notes: <https://github.com/smappee/pysmappee/releases/tag/0.2.10>, 
Commit compare: <https://github.com/smappee/pysmappee/compare/0.2.9...0.2.10>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
smappee:
   client_id: 1234
   client_secret: 5678
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
