### PR TITLE
Install a threading.excepthook on python 3.8 and later

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -6,6 +6,7 @@ import logging
 import logging.handlers
 import os
 import sys
+import threading
 from time import monotonic
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set
 
@@ -307,6 +308,12 @@ def async_enable_logging(
     sys.excepthook = lambda *args: logging.getLogger(None).exception(
         "Uncaught exception", exc_info=args  # type: ignore
     )
+
+    if sys.version_info[:2] >= (3, 8):
+        threading.excepthook = lambda args: logging.getLogger(None).exception(
+            "Uncaught thread exception",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
 
     # Log errors to a file if we have write access to file or config dir
     if log_file is None:


### PR DESCRIPTION
##  Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exceptions in threads were being silently discarded and never
logged as the new in python 3.8 threading.excepthook was not
being set.

If zeroconf dies off from an unhandled exception, we don't have to guess why anymore 🙈 

```
2020-08-11 00:46:39 ERROR (zeroconf-ServiceBrowser__hap._tcp.local.-_googlecast._tcp.local.-_api._udp.local.-_printer._tcp.local.-_touch-able._tcp.local.-_ipp._tcp.local.-_miio._udp.local.-_dkapi._tcp.local.-_axis-video._tcp.local.-_elg._tcp.local.-_viziocast._tcp.local.-_plugwise._tcp.local.-_nut._tcp.local.-_Volumio._tcp.local.-_ssh._tcp.local.-_ipps._tcp.local.-_esphomelib._tcp.local.-_mediaremotetv._tcp.local.-_spotify-connect._tcp.local.-_daap._tcp.local.-_wled._tcp.local.-_bond._tcp.local.-_appletv-v2._tcp.local._293) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/site-packages/zeroconf/__init__.py", line 1680, in run
    self._service_state_changed.fire(
  File "/usr/local/lib/python3.8/site-packages/zeroconf/__init__.py", line 1438, in fire
    h(**kwargs)
  File "/usr/src/homeassistant/homeassistant/components/zeroconf/__init__.py", line 211, in service_update
    raise ValueError
ValueError
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38197
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
