### PR TITLE
Adjust homekit controller pairing to have a new step for each potentially recoverable error

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -285,6 +285,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
             try:
                 self.finish_pairing = await discovery.start_pairing(self.hkid)
+                self.try_later_reason = None
 
             except aiohomekit.BusyError:
                 # Already performing a pair setup operation with a different
@@ -316,7 +317,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
     async def async_step_try_pair_later(self, user_input=None):
         """Retry pairing after the accessory is busy or unavailable."""
         if user_input is not None:
-            self.try_later_reason = None
             return await self.async_step_pair()
 
         return self.async_show_form(

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -307,9 +307,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
                 self.finish_pairing = None
                 errors["pairing_code"] = "pairing_failed"
 
-        if errors and "base" in errors:
-            return self.async_step_try_pair_later()
-
         return self._async_step_pair_show_form(errors)
 
     async def async_step_try_pair_later(self, pairing_retry=None):

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -282,10 +282,8 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             # we always check to see if self.finish_paring has been
             # set.
             discovery = await self.controller.find_ip_by_device_id(self.hkid)
-            _LOGGER.warning("start discovery")
 
             try:
-                _LOGGER.warning("start start_pairing")
                 self.finish_pairing = await discovery.start_pairing(self.hkid)
 
             except aiohomekit.BusyError:

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -307,7 +307,14 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
                 self.finish_pairing = None
                 errors["pairing_code"] = "pairing_failed"
 
+        if errors and "base" in errors:
+            return self.async_show_form(step_id="try_pair_later", errors=errors)
+
         return self._async_step_pair_show_form(errors)
+
+    async def async_step_try_pair_later(self, pair_info=None):
+        """Retry pairing after the accessory is busy or unavailable."""
+        return await self.async_step_pair(pair_info)
 
     @callback
     def _async_step_pair_show_form(self, errors=None):

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -254,11 +254,13 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except aiohomekit.BusyError:
                 # Already performing a pair setup operation with a different
                 # controller
-                return self.async_step_try_pair_later({"reason": "busy_error"})
+                return await self.async_step_try_pair_later({"reason": "busy_error"})
             except aiohomekit.MaxTriesError:
                 # The accessory has received more than 100 unsuccessful auth
                 # attempts.
-                return self.async_step_try_pair_later({"reason": "max_tries_error"})
+                return await self.async_step_try_pair_later(
+                    {"reason": "max_tries_error"}
+                )
             except aiohomekit.UnavailableError:
                 # The accessory is already paired - cannot try to pair again.
                 return self.async_abort(reason="already_paired")
@@ -268,7 +270,9 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except IndexError:
                 # TLV error, usually not in pairing mode
                 _LOGGER.exception("Pairing communication failed")
-                return self.async_step_try_pair_later({"reason": "protocol_error"})
+                return await self.async_step_try_pair_later(
+                    {"reason": "protocol_error"}
+                )
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Pairing attempt failed with an unhandled exception")
                 errors["pairing_code"] = "pairing_failed"

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -307,14 +307,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
                 self.finish_pairing = None
                 errors["pairing_code"] = "pairing_failed"
 
-        if errors and "base" in errors:
-            return self.async_show_form(step_id="try_pair_later", errors=errors)
-
         return self._async_step_pair_show_form(errors)
-
-    async def async_step_try_pair_later(self, pair_info=None):
-        """Retry pairing after the accessory is busy or unavailable."""
-        return await self.async_step_pair(pair_info)
 
     @callback
     def _async_step_pair_show_form(self, errors=None):

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -62,7 +62,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         self.devices = {}
         self.controller = None
         self.finish_pairing = None
-        self.try_later_reason = None
 
     async def _async_setup_controller(self):
         """Create the controller."""
@@ -285,18 +284,15 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
             try:
                 self.finish_pairing = await discovery.start_pairing(self.hkid)
-                self.try_later_reason = None
 
             except aiohomekit.BusyError:
                 # Already performing a pair setup operation with a different
                 # controller
-                self.try_later_reason = "busy_error"
-                return await self.async_step_try_pair_later()
+                return await self.async_step_busy_error()
             except aiohomekit.MaxTriesError:
                 # The accessory has received more than 100 unsuccessful auth
                 # attempts.
-                self.try_later_reason = "max_tries_error"
-                return await self.async_step_try_pair_later()
+                return await self.async_step_max_tries_error()
             except aiohomekit.UnavailableError:
                 # The accessory is already paired - cannot try to pair again.
                 return self.async_abort(reason="already_paired")
@@ -306,22 +302,33 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             except IndexError:
                 # TLV error, usually not in pairing mode
                 _LOGGER.exception("Pairing communication failed")
-                self.try_later_reason = "protocol_error"
-                return await self.async_step_try_pair_later()
+                return await self.async_step_protocol_error()
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Pairing attempt failed with an unhandled exception")
                 errors["pairing_code"] = "pairing_failed"
 
         return self._async_step_pair_show_form(errors)
 
-    async def async_step_try_pair_later(self, user_input=None):
-        """Retry pairing after the accessory is busy or unavailable."""
+    async def async_step_busy_error(self, user_input=None):
+        """Retry pairing after the accessory is busy."""
         if user_input is not None:
             return await self.async_step_pair()
 
-        return self.async_show_form(
-            step_id="try_pair_later", errors={"base": self.try_later_reason}
-        )
+        return self.async_show_form(step_id="busy_error")
+
+    async def async_step_max_tries_error(self, user_input=None):
+        """Retry pairing after the accessory has reached max tries."""
+        if user_input is not None:
+            return await self.async_step_pair()
+
+        return self.async_show_form(step_id="max_tries_error")
+
+    async def async_step_protocol_error(self, user_input=None):
+        """Retry pairing after the accessory has a protocol error."""
+        if user_input is not None:
+            return await self.async_step_pair()
+
+        return self.async_show_form(step_id="protocol_error")
 
     @callback
     def _async_step_pair_show_form(self, errors=None):

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -17,19 +17,24 @@
           "pairing_code": "Pairing Code"
         }
       },
-      "try_pair_later": {
-        "title": "Pairing Unavailable",
-        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
-      }      
+      "protocol_error": {
+        "title": "Error communicating with the accessory",
+        "description": "The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then continue to resume pairing."
+      },
+      "busy_error": {
+        "title": "The device is already pairing with another controller",
+        "description": "Abort pairing on all controllers, or try restarting the device, then continue to resume pairing."
+      },
+      "max_tries_error": {
+        "title": "Maximum authentication attempts exceeded",
+        "description": "The device has received more than 100 unsuccessful authentication attempts. Try restarting the device, then continue to resume pairing."
+      }
     },
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
-      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -16,16 +16,20 @@
         "data": {
           "pairing_code": "Pairing Code"
         }
-      }
+      },
+      "try_pair_later": {
+        "title": "Pairing Unavailable",
+        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
+      }      
     },
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "protocol_error": "Error communicating with the accessory. The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then continue to resume pairing.",
+      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "busy_error": "The device refused to add pairing as it is already pairing with another controller. Abort pairing on all controllers, or try restarting the device, then continue to resume pairing.",
-      "max_tries_error": "The device refused to add pairing as it has received more than 100 unsuccessful authentication attempts. Try restarting the device, then continue to resume pairing.",
+      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
+      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -16,20 +16,16 @@
         "data": {
           "pairing_code": "Pairing Code"
         }
-      },
-      "try_pair_later": {
-        "title": "Pairing Unavailable",
-        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
-      }      
+      }
     },
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
+      "protocol_error": "Error communicating with the accessory. The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then continue to resume pairing.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
-      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
+      "busy_error": "The device refused to add pairing as it is already pairing with another controller. Abort pairing on all controllers, or try restarting the device, then continue to resume pairing.",
+      "max_tries_error": "The device refused to add pairing as it has received more than 100 unsuccessful authentication attempts. Try restarting the device, then continue to resume pairing.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -17,19 +17,24 @@
           "pairing_code": "Pairing Code"
         }
       },
-      "try_pair_later": {
-        "title": "Pairing Unavailable",
-        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
-      }      
+      "protocol_error": {
+        "title": "Error communicating with the accessory",
+        "description": "The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then continue to resume pairing."
+      },
+      "busy_error": {
+        "title": "The device is already pairing with another controller",
+        "description": "Abort pairing on all controllers, or try restarting the device, then continue to resume pairing."
+      },
+      "max_tries_error": {
+        "title": "Maximum authentication attempts exceeded",
+        "description": "The device has received more than 100 unsuccessful authentication attempts. Try restarting the device, then continue to resume pairing."
+      }
     },
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
-      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -16,16 +16,20 @@
         "data": {
           "pairing_code": "Pairing Code"
         }
-      }
+      },
+      "try_pair_later": {
+        "title": "Pairing Unavailable",
+        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
+      }      
     },
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "protocol_error": "Error communicating with the accessory. The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then continue to resume pairing.",
+      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "busy_error": "The device refused to add pairing as it is already pairing with another controller. Abort pairing on all controllers, or try restarting the device, then continue to resume pairing.",
-      "max_tries_error": "The device refused to add pairing as it has received more than 100 unsuccessful authentication attempts. Try restarting the device, then continue to resume pairing.",
+      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
+      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -16,20 +16,16 @@
         "data": {
           "pairing_code": "Pairing Code"
         }
-      },
-      "try_pair_later": {
-        "title": "Pairing Unavailable",
-        "description": "Ensure the device is in pairing mode or try restarting the device, then continue to re-start pairing."
-      }      
+      }
     },
     "error": {
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
-      "protocol_error": "Error communicating with the accessory. Device may not be in pairing mode and may require a physical or virtual button press.",
+      "protocol_error": "Error communicating with the accessory. The device may not be in pairing mode and may require a physical or virtual button press. Ensure the device is in pairing mode or try restarting the device, then continue to resume pairing.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
       "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
-      "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
-      "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
+      "busy_error": "The device refused to add pairing as it is already pairing with another controller. Abort pairing on all controllers, or try restarting the device, then continue to resume pairing.",
+      "max_tries_error": "The device refused to add pairing as it has received more than 100 unsuccessful authentication attempts. Try restarting the device, then continue to resume pairing.",
       "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
     },
     "abort": {

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -341,12 +341,15 @@ async def test_pair_try_later_errors_on_start(hass, controller, exception, expec
     # Device is rebooted or placed into pairing mode as they have been instructed
 
     # We start pairing again
-    result3 = await hass.config_entries.flow.async_configure(result2["flow_id"])
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], user_input={"any": "key"}
+    )
 
     # .. and successfully complete pair
     result4 = await hass.config_entries.flow.async_configure(
         result3["flow_id"], user_input={"pairing_code": "111-22-333"}
     )
+
     assert result4["type"] == "create_entry"
     assert result4["title"] == "Koogeek-LS1-20833F"
 
@@ -373,7 +376,9 @@ async def test_pair_form_errors_on_start(hass, controller, exception, expected):
     # User initiates pairing - device refuses to enter pairing mode
     test_exc = exception("error")
     with patch.object(device, "start_pairing", side_effect=test_exc):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"pairing_code": "111-22-333"}
+        )
     assert result["type"] == "form"
     assert result["errors"]["pairing_code"] == expected
 
@@ -384,10 +389,16 @@ async def test_pair_form_errors_on_start(hass, controller, exception, expected):
         "source": "zeroconf",
     }
 
+    # User gets back the form
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
     # User re-tries entering pairing code
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"pairing_code": "111-22-333"}
     )
+
     assert result["type"] == "create_entry"
     assert result["title"] == "Koogeek-LS1-20833F"
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -334,9 +334,8 @@ async def test_pair_try_later_errors_on_start(hass, controller, exception, expec
     test_exc = exception("error")
     with patch.object(device, "start_pairing", side_effect=test_exc):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result2["step_id"] == "try_pair_later"
+    assert result2["step_id"] == expected
     assert result2["type"] == "form"
-    assert result2["errors"]["base"] == expected
 
     # Device is rebooted or placed into pairing mode as they have been instructed
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -334,7 +334,7 @@ async def test_pair_try_later_errors_on_start(hass, controller, exception, expec
     test_exc = exception("error")
     with patch.object(device, "start_pairing", side_effect=test_exc):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result2["step_id"] == "pair"
+    assert result2["step_id"] == "try_pair_later"
     assert result2["type"] == "form"
     assert result2["errors"]["base"] == expected
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -334,7 +334,7 @@ async def test_pair_try_later_errors_on_start(hass, controller, exception, expec
     test_exc = exception("error")
     with patch.object(device, "start_pairing", side_effect=test_exc):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
-    assert result2["step_id"] == "try_pair_later"
+    assert result2["step_id"] == "pair"
     assert result2["type"] == "form"
     assert result2["errors"]["base"] == expected
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Followup per:
https://github.com/home-assistant/core/pull/38605#discussion_r467788676

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
