### PR TITLE
Use the shared zeroconf instance when attempting to create another Zeroconf instance

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.singleton import singleton
 from homeassistant.loader import async_get_homekit, async_get_zeroconf
 
-from .usage import install_multiple_zeroconf_warning
+from .usage import install_multiple_zeroconf_catcher
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def setup(hass, config):
         ipv6=zc_config.get(CONF_IPV6, DEFAULT_IPV6),
     )
 
-    install_multiple_zeroconf_warning(zeroconf)
+    install_multiple_zeroconf_catcher(zeroconf)
 
     # Get instance UUID
     uuid = asyncio.run_coroutine_threadsafe(

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -30,6 +30,8 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.singleton import singleton
 from homeassistant.loader import async_get_homekit, async_get_zeroconf
 
+from .usage import install_multiple_zeroconf_warning
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "zeroconf"
@@ -134,6 +136,8 @@ def setup(hass, config):
         ),
         ipv6=zc_config.get(CONF_IPV6, DEFAULT_IPV6),
     )
+
+    install_multiple_zeroconf_warning()
 
     # Get instance UUID
     uuid = asyncio.run_coroutine_threadsafe(

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -137,7 +137,7 @@ def setup(hass, config):
         ipv6=zc_config.get(CONF_IPV6, DEFAULT_IPV6),
     )
 
-    install_multiple_zeroconf_warning()
+    install_multiple_zeroconf_warning(zeroconf)
 
     # Get instance UUID
     uuid = asyncio.run_coroutine_threadsafe(

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -16,13 +16,17 @@ _LOGGER = logging.getLogger(__name__)
 def install_multiple_zeroconf_catcher(hass_zc) -> None:
     """Wrap the Zeroconf class to return the shared instance if multiple instances are detected."""
 
-    def new_zeroconf_new(self, *k, **kw) -> zeroconf.Zeroconf:  # type: ignore
+    def new_zeroconf_new(self, *k, **kw):
         _report(
             "attempted to create another Zeroconf instance. Please use the shared Zeroconf via await homeassistant.components.zeroconf.async_get_instance(hass)",
         )
         return hass_zc
 
+    def new_zeroconf_init(self, *k, **kw):
+        return
+
     zeroconf.Zeroconf.__new__ = new_zeroconf_new
+    zeroconf.Zeroconf.__init__ = new_zeroconf_init
 
 
 def _report(what: str) -> None:

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -1,18 +1,46 @@
 """Zeroconf usage utility to warn about multiple instances."""
 
+import logging
+
 import zeroconf
 
-from homeassistant.helpers.frame import report
+from homeassistant.helpers.frame import (
+    MissingIntegrationFrame,
+    get_integration_frame,
+    report_integration,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 
-def install_multiple_zeroconf_catcher(zc) -> None:
+def install_multiple_zeroconf_catcher(hass_zc) -> None:
     """Wrap the Zeroconf class to return the shared instance if multiple instances are detected."""
 
     def new_zeroconf_new(self, *k, **kw) -> zeroconf.Zeroconf:  # type: ignore
-        report(
+        _report(
             "attempted to create another Zeroconf instance. Please use the shared Zeroconf via await homeassistant.components.zeroconf.async_get_instance(hass)",
-            exclude_integrations={"zeroconf"},
         )
-        return zc
+        return hass_zc
 
     zeroconf.Zeroconf.__new__ = new_zeroconf_new
+
+
+def _report(what: str) -> None:
+    """Report incorrect usage.
+
+    Async friendly.
+    """
+    integration_frame = None
+
+    try:
+        integration_frame = get_integration_frame(exclude_integrations={"zeroconf"})
+    except MissingIntegrationFrame:
+        pass
+
+    if not integration_frame:
+        _LOGGER.warning(
+            "Detected code that %s. Please report this issue.", what, exc_info=True
+        )
+        return
+
+    report_integration(what, integration_frame)

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -39,7 +39,7 @@ def _report(what: str) -> None:
 
     if not integration_frame:
         _LOGGER.warning(
-            "Detected code that %s. Please report this issue.", what, exc_info=True
+            "Detected code that %s. Please report this issue.", what, stack_info=True
         )
         return
 

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -5,12 +5,13 @@ import zeroconf
 from homeassistant.helpers.frame import report
 
 
-def install_multiple_zeroconf_protection(zc) -> None:
+def install_multiple_zeroconf_catcher(zc) -> None:
     """Wrap the Zeroconf class to return the shared instance if multiple instances are detected."""
 
     def new_zeroconf_new(self, *k, **kw) -> zeroconf.Zeroconf:  # type: ignore
         report(
-            "attempted to create another Zeroconf instance. Please use the shared Zeroconf via await homeassistant.components.zeroconf.async_get_instance(hass)"
+            "attempted to create another Zeroconf instance. Please use the shared Zeroconf via await homeassistant.components.zeroconf.async_get_instance(hass)",
+            exclude_integrations={"zeroconf"},
         )
         return zc
 

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -5,8 +5,8 @@ import zeroconf
 from homeassistant.helpers.frame import report
 
 
-def install_multiple_zeroconf_warning(zc) -> None:
-    """Wrap the Zeroconf class to warn if multiple instances are detected."""
+def install_multiple_zeroconf_protection(zc) -> None:
+    """Wrap the Zeroconf class to return the shared instance if multiple instances are detected."""
 
     def new_zeroconf_new(self, *k, **kw) -> zeroconf.Zeroconf:  # type: ignore
         report(

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -2,13 +2,16 @@
 
 import zeroconf
 
-from homeassistant.helpers.frame import warn_use
+from homeassistant.helpers.frame import report
 
 
-def install_multiple_zeroconf_warning() -> None:
+def install_multiple_zeroconf_warning(zc) -> None:
     """Wrap the Zeroconf class to warn if multiple instances are detected."""
 
-    zeroconf.Zeroconf.__init__ = warn_use(  # type: ignore
-        zeroconf.Zeroconf.__init__,
-        "created another Zeroconf instance. Please use the shared Zeroconf via homeassistant.components.zeroconf.async_get_instance()",
-    )
+    def new_zeroconf_new(self, *k, **kw) -> zeroconf.Zeroconf:  # type: ignore
+        report(
+            "attempted to create another Zeroconf instance. Please use the shared Zeroconf via await homeassistant.components.zeroconf.async_get_instance(hass)"
+        )
+        return zc
+
+    zeroconf.Zeroconf.__new__ = new_zeroconf_new

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -1,0 +1,14 @@
+"""Zeroconf usage utility to warn about multiple instances."""
+
+import zeroconf
+
+from homeassistant.helpers.frame import warn_use
+
+
+def install_multiple_zeroconf_warning() -> None:
+    """Wrap the Zeroconf class to warn if multiple instances are detected."""
+
+    zeroconf.Zeroconf.__init__ = warn_use(  # type: ignore
+        zeroconf.Zeroconf.__init__,
+        "created another Zeroconf instance. Please use the shared Zeroconf via homeassistant.components.zeroconf.async_get_instance()",
+    )

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -47,18 +47,29 @@ class MissingIntegrationFrame(HomeAssistantError):
     """Raised when no integration is found in the frame."""
 
 
-def report(what: str, exclude_integrations: Optional[set] = None) -> None:
+def report(what: str) -> None:
     """Report incorrect usage.
 
     Async friendly.
     """
     try:
-        found_frame, integration, path = get_integration_frame(
-            exclude_integrations=exclude_integrations
-        )
+        integration_frame = get_integration_frame()
     except MissingIntegrationFrame:
         # Did not source from an integration? Hard error.
         raise RuntimeError(f"Detected code that {what}. Please report this issue.")
+
+    report_integration(what, integration_frame)
+
+
+def report_integration(
+    what: str, integration_frame: Tuple[FrameSummary, str, str]
+) -> None:
+    """Report incorrect usage in an integration.
+
+    Async friendly.
+    """
+
+    found_frame, integration, path = integration_frame
 
     index = found_frame.filename.index(path)
     if path == "custom_components/":

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -3,7 +3,7 @@ import asyncio
 import functools
 import logging
 from traceback import FrameSummary, extract_stack
-from typing import Any, Callable, Tuple, TypeVar, cast
+from typing import Any, Callable, Optional, Tuple, TypeVar, cast
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -12,15 +12,24 @@ _LOGGER = logging.getLogger(__name__)
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)  # pylint: disable=invalid-name
 
 
-def get_integration_frame() -> Tuple[FrameSummary, str, str]:
+def get_integration_frame(
+    exclude_integrations: Optional[set] = None,
+) -> Tuple[FrameSummary, str, str]:
     """Return the frame, integration and integration path of the current stack frame."""
     found_frame = None
+    if not exclude_integrations:
+        exclude_integrations = set()
 
     for frame in reversed(extract_stack()):
         for path in ("custom_components/", "homeassistant/components/"):
             try:
                 index = frame.filename.index(path)
-                found_frame = frame
+                start = index + len(path)
+                end = frame.filename.index("/", start)
+                integration = frame.filename[start:end]
+                if integration not in exclude_integrations:
+                    found_frame = frame
+
                 break
             except ValueError:
                 continue
@@ -31,11 +40,6 @@ def get_integration_frame() -> Tuple[FrameSummary, str, str]:
     if found_frame is None:
         raise MissingIntegrationFrame
 
-    start = index + len(path)
-    end = found_frame.filename.index("/", start)
-
-    integration = found_frame.filename[start:end]
-
     return found_frame, integration, path
 
 
@@ -43,13 +47,15 @@ class MissingIntegrationFrame(HomeAssistantError):
     """Raised when no integration is found in the frame."""
 
 
-def report(what: str) -> None:
+def report(what: str, exclude_integrations: Optional[set] = None) -> None:
     """Report incorrect usage.
 
     Async friendly.
     """
     try:
-        found_frame, integration, path = get_integration_frame()
+        found_frame, integration, path = get_integration_frame(
+            exclude_integrations=exclude_integrations
+        )
     except MissingIntegrationFrame:
         # Did not source from an integration? Hard error.
         raise RuntimeError(f"Detected code that {what}. Please report this issue.")

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,7 +1,14 @@
 """Fixtures for component testing."""
 import pytest
 
+from homeassistant.components import zeroconf
+
 from tests.async_mock import patch
+
+zeroconf.orig_install_multiple_zeroconf_catcher = (
+    zeroconf.install_multiple_zeroconf_catcher
+)
+zeroconf.install_multiple_zeroconf_catcher = lambda zc: None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/zeroconf/conftest.py
+++ b/tests/components/zeroconf/conftest.py
@@ -1,0 +1,18 @@
+"""conftest for zeroconf."""
+import pytest
+
+from homeassistant.components import zeroconf
+
+from tests.async_mock import patch
+
+zeroconf.orig_install_multiple_zeroconf_catcher = (
+    zeroconf.install_multiple_zeroconf_catcher
+)
+zeroconf.install_multiple_zeroconf_catcher = lambda zc: None
+
+
+@pytest.fixture
+def mock_zeroconf():
+    """Mock zeroconf."""
+    with patch("homeassistant.components.zeroconf.HaZeroconf") as mock_zc:
+        yield mock_zc.return_value

--- a/tests/components/zeroconf/conftest.py
+++ b/tests/components/zeroconf/conftest.py
@@ -1,14 +1,7 @@
 """conftest for zeroconf."""
 import pytest
 
-from homeassistant.components import zeroconf
-
 from tests.async_mock import patch
-
-zeroconf.orig_install_multiple_zeroconf_catcher = (
-    zeroconf.install_multiple_zeroconf_catcher
-)
-zeroconf.install_multiple_zeroconf_catcher = lambda zc: None
 
 
 @pytest.fixture

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -339,14 +339,18 @@ async def test_get_instance(hass, mock_zeroconf):
     assert len(mock_zeroconf.ha_close.mock_calls) == 1
 
 
-async def test_multiple_zeroconf_instances(hass, mock_zeroconf):
+async def test_multiple_zeroconf_instances(hass, mock_zeroconf, caplog):
     """Test creating multiple zeroconf throws without an integration."""
 
     assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
     await hass.async_block_till_done()
 
-    with pytest.raises(RuntimeError):
-        zeroconf.Zeroconf()
+    zeroconf_instance = await zeroconf.async_get_instance(hass)
+
+    new_zeroconf_instance = zeroconf.Zeroconf()
+    assert new_zeroconf_instance == zeroconf_instance
+
+    assert "Zeroconf" in caplog.text
 
 
 async def test_multiple_zeroconf_instances_gives_shared(hass, mock_zeroconf, caplog):

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -337,3 +337,13 @@ async def test_get_instance(hass, mock_zeroconf):
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
     assert len(mock_zeroconf.ha_close.mock_calls) == 1
+
+
+async def test_multiple_zeroconf_instances(hass, mock_zeroconf, caplog):
+    """Test creating multiple zeroconf throws."""
+
+    assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    with pytest.raises(RuntimeError):
+        zeroconf.Zeroconf()

--- a/tests/components/zeroconf/test_usage.py
+++ b/tests/components/zeroconf/test_usage.py
@@ -1,0 +1,56 @@
+"""Test Zeroconf multiple instance protection."""
+import zeroconf
+
+from homeassistant.components.zeroconf import async_get_instance
+from homeassistant.components.zeroconf.usage import install_multiple_zeroconf_catcher
+
+from tests.async_mock import Mock, patch
+
+
+async def test_multiple_zeroconf_instances(hass, mock_zeroconf, caplog):
+    """Test creating multiple zeroconf throws without an integration."""
+
+    zeroconf_instance = await async_get_instance(hass)
+
+    install_multiple_zeroconf_catcher(zeroconf_instance)
+
+    new_zeroconf_instance = zeroconf.Zeroconf()
+    assert new_zeroconf_instance == zeroconf_instance
+
+    assert "Zeroconf" in caplog.text
+
+
+async def test_multiple_zeroconf_instances_gives_shared(hass, mock_zeroconf, caplog):
+    """Test creating multiple zeroconf gives the shared instance to an integration."""
+
+    zeroconf_instance = await async_get_instance(hass)
+
+    install_multiple_zeroconf_catcher(zeroconf_instance)
+
+    correct_frame = Mock(
+        filename="/config/custom_components/burncpu/light.py",
+        lineno="23",
+        line="self.light.is_on",
+    )
+    with patch(
+        "homeassistant.helpers.frame.extract_stack",
+        return_value=[
+            Mock(
+                filename="/home/dev/homeassistant/core.py",
+                lineno="23",
+                line="do_something()",
+            ),
+            correct_frame,
+            Mock(
+                filename="/home/dev/homeassistant/components/zeroconf/usage.py",
+                lineno="23",
+                line="self.light.is_on",
+            ),
+            Mock(filename="/home/dev/mdns/lights.py", lineno="2", line="something()",),
+        ],
+    ):
+        assert zeroconf.Zeroconf() == zeroconf_instance
+
+    assert "custom_components/burncpu/light.py" in caplog.text
+    assert "23" in caplog.text
+    assert "self.light.is_on" in caplog.text

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -36,6 +36,39 @@ async def test_extract_frame_integration(caplog):
     assert found_frame == correct_frame
 
 
+async def test_extract_frame_integration_with_excluded_intergration(caplog):
+    """Test extracting the current frame from integration context."""
+    correct_frame = Mock(
+        filename="/home/dev/homeassistant/components/mdns/light.py",
+        lineno="23",
+        line="self.light.is_on",
+    )
+    with patch(
+        "homeassistant.helpers.frame.extract_stack",
+        return_value=[
+            Mock(
+                filename="/home/dev/homeassistant/core.py",
+                lineno="23",
+                line="do_something()",
+            ),
+            correct_frame,
+            Mock(
+                filename="/home/dev/homeassistant/components/zeroconf/usage.py",
+                lineno="23",
+                line="self.light.is_on",
+            ),
+            Mock(filename="/home/dev/mdns/lights.py", lineno="2", line="something()",),
+        ],
+    ):
+        found_frame, integration, path = frame.get_integration_frame(
+            exclude_integrations={"zeroconf"}
+        )
+
+    assert integration == "mdns"
+    assert path == "homeassistant/components/"
+    assert found_frame == correct_frame
+
+
 async def test_extract_frame_no_integration(caplog):
     """Test extracting the current frame without integration context."""
     with patch(


### PR DESCRIPTION
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

Multiple Zeroconf instances keep causing us problems and reports of
high cpu usage.  Log when they are created.

```
2020-08-11 02:42:56 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that created another Zeroconf instance. Please use the shared Zeroconf via homeassistant.components.zeroconf.async_get_instance(). Please report issue to the custom component author for burncpu using this method at custom_components/burncpu/__init__.py, line 22: zeroconf.Zeroconf()
```

https://github.com/home-assistant/core/issues/38248#issuecomment-671098906
https://community.home-assistant.io/t/high-cpu-usage-after-0-113/214655/30

If an integration attempts to create another instance, we now provide them the shared
instance, and log.

Note: esphome is the last known integration in core that still does this and it is fixed here https://github.com/home-assistant/core/pull/38747

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38248 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
