### PR TITLE
Use the shared Zeroconf instance in esphome

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -17,6 +17,7 @@ from aioesphomeapi import (
 import voluptuous as vol
 
 from homeassistant import const
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
@@ -66,12 +67,15 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     port = entry.data[CONF_PORT]
     password = entry.data[CONF_PASSWORD]
 
+    zeroconf_instance = await zeroconf.async_get_instance(hass)
+
     cli = APIClient(
         hass.loop,
         host,
         port,
         password,
         client_info=f"Home Assistant {const.__version__}",
+        zeroconf_instance=zeroconf_instance,
     )
 
     # Store client in per-config-entry hass.data

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -5,6 +5,7 @@ from typing import Optional
 from aioesphomeapi import APIClient, APIConnectionError
 import voluptuous as vol
 
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import callback
@@ -165,7 +166,14 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def fetch_device_info(self):
         """Fetch device info from API and return any errors."""
-        cli = APIClient(self.hass.loop, self._host, self._port, "")
+        zeroconf_instance = await zeroconf.async_get_instance(self.hass)
+        cli = APIClient(
+            self.hass.loop,
+            self._host,
+            self._port,
+            "",
+            zeroconf_instance=zeroconf_instance,
+        )
 
         try:
             await cli.connect()
@@ -181,7 +189,14 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def try_login(self):
         """Try logging in to device and return any errors."""
-        cli = APIClient(self.hass.loop, self._host, self._port, self._password)
+        zeroconf_instance = await zeroconf.async_get_instance(self.hass)
+        cli = APIClient(
+            self.hass.loop,
+            self._host,
+            self._port,
+            self._password,
+            zeroconf_instance=zeroconf_instance,
+        )
 
         try:
             await cli.connect(login=True)

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -5,5 +5,8 @@
   "documentation": "https://www.home-assistant.io/integrations/esphome",
   "requirements": ["aioesphomeapi==2.6.1"],
   "zeroconf": ["_esphomelib._tcp.local."],
-  "codeowners": ["@OttoWinter"]
+  "codeowners": ["@OttoWinter"],
+  "after_dependencies": [
+    "zeroconf"
+  ]
 }

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==2.6.1"],
+  "requirements": ["aioesphomeapi==2.6.3"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "codeowners": ["@OttoWinter"],
   "after_dependencies": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -160,7 +160,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.1
+aioesphomeapi==2.6.3
 
 # homeassistant.components.flo
 aioflo==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -88,7 +88,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.1
+aioesphomeapi==2.6.3
 
 # homeassistant.components.flo
 aioflo==0.4.1

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -22,11 +22,12 @@ def mock_client():
     """Mock APIClient."""
     with patch("homeassistant.components.esphome.config_flow.APIClient") as mock_client:
 
-        def mock_constructor(loop, host, port, password):
+        def mock_constructor(loop, host, port, password, zeroconf_instance=None):
             """Fake the client constructor."""
             mock_client.host = host
             mock_client.port = port
             mock_client.password = password
+            mock_client.zeroconf_instance = zeroconf_instance
             return mock_client
 
         mock_client.side_effect = mock_constructor


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use the shared Zeroconf instance in esphome instead of instantiating
another instance which causes cpu spikes.

Fixes https://community.home-assistant.io/t/high-cpu-usage-after-0-113/214655/30?u=bdraco

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38862
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
