### PR TITLE
Add Ecobee services

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     STATE_ON,
     TEMP_FAHRENHEIT,
 )
+from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.temperature import convert
 
@@ -49,6 +50,10 @@ ATTR_RESUME_ALL = "resume_all"
 ATTR_START_DATE = "start_date"
 ATTR_START_TIME = "start_time"
 ATTR_VACATION_NAME = "vacation_name"
+ATTR_DST_ENABLED = "dst_enabled"
+ATTR_MIC_ENABLED = "mic_enabled"
+ATTR_AUTO_AWAY = "auto_away"
+ATTR_FOLLOW_ME = "follow_me"
 
 DEFAULT_RESUME_ALL = False
 PRESET_TEMPERATURE = "temp"
@@ -98,6 +103,9 @@ SERVICE_CREATE_VACATION = "create_vacation"
 SERVICE_DELETE_VACATION = "delete_vacation"
 SERVICE_RESUME_PROGRAM = "resume_program"
 SERVICE_SET_FAN_MIN_ON_TIME = "set_fan_min_on_time"
+SERVICE_SET_DST_MODE = "set_dst_mode"
+SERVICE_SET_MIC_MODE = "set_mic_mode"
+SERVICE_SET_OCCUPANCY_MODES = "set_occupancy_modes"
 
 DTGROUP_INCLUSIVE_MSG = (
     f"{ATTR_START_DATE}, {ATTR_START_TIME}, {ATTR_END_DATE}, "
@@ -164,6 +172,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     devices = [Thermostat(data, index) for index in range(len(data.ecobee.thermostats))]
 
     async_add_entities(devices, True)
+
+    platform = entity_platform.current_platform.get()
 
     def create_vacation_service(service):
         """Create a vacation on the target thermostat."""
@@ -246,6 +256,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         SERVICE_RESUME_PROGRAM,
         resume_program_set_service,
         schema=RESUME_PROGRAM_SCHEMA,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_SET_DST_MODE,
+        {vol.Required(ATTR_DST_ENABLED): cv.boolean},
+        "set_dst_mode",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_SET_MIC_MODE,
+        {vol.Required(ATTR_MIC_ENABLED): cv.boolean},
+        "set_mic_mode",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_SET_OCCUPANCY_MODES,
+        {
+            vol.Optional(ATTR_AUTO_AWAY): cv.boolean,
+            vol.Optional(ATTR_FOLLOW_ME): cv.boolean,
+        },
+        "set_occupancy_modes",
     )
 
 
@@ -720,3 +751,17 @@ class Thermostat(ClimateEntity):
             self._last_active_hvac_mode,
         )
         self.set_hvac_mode(self._last_active_hvac_mode)
+
+    def set_dst_mode(self, dst_enabled):
+        """Enable/disable automatic daylight savings time."""
+        self.data.ecobee.set_dst_mode(self.thermostat_index, dst_enabled)
+
+    def set_mic_mode(self, mic_enabled):
+        """Enable/disable Alexa mic (only for Ecobee 4)."""
+        self.data.ecobee.set_mic_mode(self.thermostat_index, mic_enabled)
+
+    def set_occupancy_modes(self, auto_away=None, follow_me=None):
+        """Enable/disable Smart Home/Away and Follow Me modes."""
+        self.data.ecobee.set_occupancy_modes(
+            self.thermostat_index, auto_away, follow_me
+        )

--- a/homeassistant/components/ecobee/services.yaml
+++ b/homeassistant/components/ecobee/services.yaml
@@ -69,3 +69,36 @@ set_fan_min_on_time:
     fan_min_on_time:
       description: New value of fan min on time.
       example: 5
+
+set_dst_mode:
+  description: Enable/disable automatic daylight savings time.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: "climate.kitchen"
+    dst_enabled:
+      description: Enable automatic daylight savings time.
+      example: "true"
+
+set_mic_mode:
+  description: Enable/disable Alexa mic (only for Ecobee 4).
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: "climate.kitchen"
+    mic_enabled:
+      description: Enable Alexa mic.
+      example: "true"
+
+set_occupancy_modes:
+  description: Enable/disable Smart Home/Away and Follow Me modes.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: "climate.kitchen"
+    auto_away:
+      description: Enable Smart Home/Away mode.
+      example: "true"
+    follow_me:
+      description: Enable Follow Me mode.
+      example: "true"


### PR DESCRIPTION
Enable/disable automatic daylight savings time
Enable/disable the Alexa mic on the Ecobee 4
Enable/disable Smart Home/Away and follow me modes

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This enables additional services for the Ecobee.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I did not add tests since a) that looked daunting, and b) there were other Ecobee services that didn't have tests.
However, I did manually test all the added services on my existing HA installation and they all worked properly on my Ecobee.
I can probably figure out how to add tests if necessary.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->
"Local tests pass" -- are these the tests that will run automatically after creating the PR?
Sorry for my ignorance -- I'm comfortable in Python, but I mainly write my own code, so all these guidelines and formats sound awesome, but are a little overwhelming :)

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist] (I think so...)
- [x] The code has been formatted using Black (`black --fast homeassistant tests`) (formatted using Black in VSCode -- not sure what to make of that command)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
