### PR TITLE
Update script helper constructor parameters

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -545,6 +545,8 @@ async def _async_process_config(hass, config, component):
                 hass,
                 config_block[CONF_ACTION],
                 name,
+                DOMAIN,
+                description="automation actions",
                 script_mode=config_block[CONF_MODE],
                 max_runs=config_block[CONF_MAX],
                 logger=_LOGGER,

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -546,7 +546,7 @@ async def _async_process_config(hass, config, component):
                 config_block[CONF_ACTION],
                 name,
                 DOMAIN,
-                description="automation actions",
+                running_description="automation actions",
                 script_mode=config_block[CONF_MODE],
                 max_runs=config_block[CONF_MAX],
                 logger=_LOGGER,

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -55,7 +55,7 @@ async def async_setup(hass, config):
     for intent_type, conf in intents.items():
         if CONF_ACTION in conf:
             conf[CONF_ACTION] = script.Script(
-                hass, conf[CONF_ACTION], f"Intent Script {intent_type}"
+                hass, conf[CONF_ACTION], f"Intent Script {intent_type}", DOMAIN
             )
         intent.async_register(hass, ScriptIntentHandler(intent_type, conf))
 

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -310,7 +310,7 @@ class KNXAutomation:
         self.hass = hass
         self.device = device
         script_name = f"{device.get_name()} turn ON script"
-        self.script = Script(hass, action, script_name)
+        self.script = Script(hass, action, script_name, DOMAIN)
 
         self.action = ActionCallback(
             hass.data[DATA_KNX].xknx, self.script.async_run, hook=hook, counter=counter

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -327,13 +327,15 @@ class KodiDevice(MediaPlayerEntity):
                 self.hass,
                 turn_on_action,
                 f"{self.name} turn ON script",
-                self.async_update_ha_state(True),
+                DOMAIN,
+                change_listener=self.async_update_ha_state(True),
             )
         if turn_off_action is not None:
             turn_off_action = script.Script(
                 self.hass,
                 _check_deprecated_turn_off(hass, turn_off_action),
                 f"{self.name} turn OFF script",
+                DOMAIN,
             )
         self._turn_on_action = turn_on_action
         self._turn_off_action = turn_off_action

--- a/homeassistant/components/lg_netcast/media_player.py
+++ b/homeassistant/components/lg_netcast/media_player.py
@@ -70,7 +70,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     on_action = config.get(CONF_ON_ACTION)
 
     client = LgNetCastClient(host, access_token)
-    on_action_script = Script(hass, on_action) if on_action else None
+    domain = __name__.split(".")[-2]
+    on_action_script = Script(hass, on_action, name, domain) if on_action else None
 
     add_entities([LgTVDevice(client, name, on_action_script)], True)
 

--- a/homeassistant/components/panasonic_viera/__init__.py
+++ b/homeassistant/components/panasonic_viera/__init__.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass, config_entry):
 
     on_action = config[CONF_ON_ACTION]
     if on_action is not None:
-        on_action = Script(hass, on_action)
+        on_action = Script(hass, on_action, config[CONF_NAME], DOMAIN)
 
     params = {}
     if CONF_APP_ID in config and CONF_ENCRYPTION_KEY in config:

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -77,7 +77,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     turn_on_action = config.get(CONF_ON_ACTION)
 
     tvapi = PhilipsTV(host, api_version)
-    on_script = Script(hass, turn_on_action) if turn_on_action else None
+    domain = __name__.split(".")[-2]
+    on_script = Script(hass, turn_on_action, name, domain) if turn_on_action else None
 
     add_entities([PhilipsTVMediaPlayer(tvapi, name, on_script)])
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -34,7 +34,14 @@ from homeassistant.helpers.script import Script
 from homeassistant.util import dt as dt_util
 
 from .bridge import SamsungTVBridge
-from .const import CONF_MANUFACTURER, CONF_MODEL, CONF_ON_ACTION, DOMAIN, LOGGER
+from .const import (
+    CONF_MANUFACTURER,
+    CONF_MODEL,
+    CONF_ON_ACTION,
+    DEFAULT_NAME,
+    DOMAIN,
+    LOGGER,
+)
 
 KEY_PRESS_TIMEOUT = 1.2
 SOURCES = {"TV": "KEY_TV", "HDMI": "KEY_HDMI"}
@@ -63,7 +70,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         and hass.data[DOMAIN][ip_address][CONF_ON_ACTION]
     ):
         turn_on_action = hass.data[DOMAIN][ip_address][CONF_ON_ACTION]
-        on_script = Script(hass, turn_on_action)
+        on_script = Script(
+            hass, turn_on_action, config_entry.data.get(CONF_NAME, DEFAULT_NAME), DOMAIN
+        )
 
     # Initialize bridge
     data = config_entry.data.copy()

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -255,10 +255,11 @@ class ScriptEntity(ToggleEntity):
             hass,
             cfg[CONF_SEQUENCE],
             cfg.get(CONF_ALIAS, object_id),
-            self.async_change_listener,
-            cfg[CONF_MODE],
-            cfg[CONF_MAX],
-            logging.getLogger(f"{__name__}.{object_id}"),
+            DOMAIN,
+            change_listener=self.async_change_listener,
+            script_mode=cfg[CONF_MODE],
+            max_runs=cfg[CONF_MAX],
+            logger=logging.getLogger(f"{__name__}.{object_id}"),
         )
         self._changed = asyncio.Event()
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -256,6 +256,7 @@ class ScriptEntity(ToggleEntity):
             cfg[CONF_SEQUENCE],
             cfg.get(CONF_ALIAS, object_id),
             DOMAIN,
+            running_description="script sequence",
             change_listener=self.async_change_listener,
             script_mode=cfg[CONF_MODE],
             max_runs=cfg[CONF_MAX],

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -147,17 +147,18 @@ class AlarmControlPanelTemplate(AlarmControlPanelEntity):
         self._template = state_template
         self._disarm_script = None
         self._code_arm_required = code_arm_required
+        domain = __name__.split(".")[-2]
         if disarm_action is not None:
-            self._disarm_script = Script(hass, disarm_action)
+            self._disarm_script = Script(hass, disarm_action, name, domain)
         self._arm_away_script = None
         if arm_away_action is not None:
-            self._arm_away_script = Script(hass, arm_away_action)
+            self._arm_away_script = Script(hass, arm_away_action, name, domain)
         self._arm_home_script = None
         if arm_home_action is not None:
-            self._arm_home_script = Script(hass, arm_home_action)
+            self._arm_home_script = Script(hass, arm_home_action, name, domain)
         self._arm_night_script = None
         if arm_night_action is not None:
-            self._arm_night_script = Script(hass, arm_night_action)
+            self._arm_night_script = Script(hass, arm_night_action, name, domain)
 
         self._state = None
         self._entities = template_entity_ids

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -205,20 +205,21 @@ class CoverTemplate(CoverEntity):
         self._entity_picture_template = entity_picture_template
         self._availability_template = availability_template
         self._open_script = None
+        domain = __name__.split(".")[-2]
         if open_action is not None:
-            self._open_script = Script(hass, open_action)
+            self._open_script = Script(hass, open_action, friendly_name, domain)
         self._close_script = None
         if close_action is not None:
-            self._close_script = Script(hass, close_action)
+            self._close_script = Script(hass, close_action, friendly_name, domain)
         self._stop_script = None
         if stop_action is not None:
-            self._stop_script = Script(hass, stop_action)
+            self._stop_script = Script(hass, stop_action, friendly_name, domain)
         self._position_script = None
         if position_action is not None:
-            self._position_script = Script(hass, position_action)
+            self._position_script = Script(hass, position_action, friendly_name, domain)
         self._tilt_script = None
         if tilt_action is not None:
-            self._tilt_script = Script(hass, tilt_action)
+            self._tilt_script = Script(hass, tilt_action, friendly_name, domain)
         self._optimistic = optimistic or (not state_template and not position_template)
         self._tilt_optimistic = tilt_optimistic or not tilt_template
         self._icon = None

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -176,20 +176,28 @@ class TemplateFan(FanEntity):
         self._available = True
         self._supported_features = 0
 
-        self._on_script = Script(hass, on_action)
-        self._off_script = Script(hass, off_action)
+        domain = __name__.split(".")[-2]
+
+        self._on_script = Script(hass, on_action, friendly_name, domain)
+        self._off_script = Script(hass, off_action, friendly_name, domain)
 
         self._set_speed_script = None
         if set_speed_action:
-            self._set_speed_script = Script(hass, set_speed_action)
+            self._set_speed_script = Script(
+                hass, set_speed_action, friendly_name, domain
+            )
 
         self._set_oscillating_script = None
         if set_oscillating_action:
-            self._set_oscillating_script = Script(hass, set_oscillating_action)
+            self._set_oscillating_script = Script(
+                hass, set_oscillating_action, friendly_name, domain
+            )
 
         self._set_direction_script = None
         if set_direction_action:
-            self._set_direction_script = Script(hass, set_direction_action)
+            self._set_direction_script = Script(
+                hass, set_direction_action, friendly_name, domain
+            )
 
         self._state = STATE_OFF
         self._speed = None

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -186,23 +186,28 @@ class LightTemplate(LightEntity):
         self._icon_template = icon_template
         self._entity_picture_template = entity_picture_template
         self._availability_template = availability_template
-        self._on_script = Script(hass, on_action)
-        self._off_script = Script(hass, off_action)
+        domain = __name__.split(".")[-2]
+        self._on_script = Script(hass, on_action, friendly_name, domain)
+        self._off_script = Script(hass, off_action, friendly_name, domain)
         self._level_script = None
         if level_action is not None:
-            self._level_script = Script(hass, level_action)
+            self._level_script = Script(hass, level_action, friendly_name, domain)
         self._level_template = level_template
         self._temperature_script = None
         if temperature_action is not None:
-            self._temperature_script = Script(hass, temperature_action)
+            self._temperature_script = Script(
+                hass, temperature_action, friendly_name, domain
+            )
         self._temperature_template = temperature_template
         self._color_script = None
         if color_action is not None:
-            self._color_script = Script(hass, color_action)
+            self._color_script = Script(hass, color_action, friendly_name, domain)
         self._color_template = color_template
         self._white_value_script = None
         if white_value_action is not None:
-            self._white_value_script = Script(hass, white_value_action)
+            self._white_value_script = Script(
+                hass, white_value_action, friendly_name, domain
+            )
         self._white_value_template = white_value_template
 
         self._state = False

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -97,8 +97,9 @@ class TemplateLock(LockEntity):
         self._state_template = value_template
         self._availability_template = availability_template
         self._state_entities = entity_ids
-        self._command_lock = Script(hass, command_lock)
-        self._command_unlock = Script(hass, command_unlock)
+        domain = __name__.split(".")[-2]
+        self._command_lock = Script(hass, command_lock, name, domain)
+        self._command_unlock = Script(hass, command_unlock, name, domain)
         self._optimistic = optimistic
         self._available = True
         self._unique_id = unique_id

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -126,8 +126,9 @@ class SwitchTemplate(SwitchEntity, RestoreEntity):
         )
         self._name = friendly_name
         self._template = state_template
-        self._on_script = Script(hass, on_action)
-        self._off_script = Script(hass, off_action)
+        domain = __name__.split(".")[-2]
+        self._on_script = Script(hass, on_action, friendly_name, domain)
+        self._off_script = Script(hass, off_action, friendly_name, domain)
         self._state = False
         self._icon_template = icon_template
         self._entity_picture_template = entity_picture_template

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -195,36 +195,44 @@ class TemplateVacuum(StateVacuumEntity):
         self._attribute_templates = attribute_templates
         self._attributes = {}
 
-        self._start_script = Script(hass, start_action)
+        domain = __name__.split(".")[-2]
+
+        self._start_script = Script(hass, start_action, friendly_name, domain)
 
         self._pause_script = None
         if pause_action:
-            self._pause_script = Script(hass, pause_action)
+            self._pause_script = Script(hass, pause_action, friendly_name, domain)
             self._supported_features |= SUPPORT_PAUSE
 
         self._stop_script = None
         if stop_action:
-            self._stop_script = Script(hass, stop_action)
+            self._stop_script = Script(hass, stop_action, friendly_name, domain)
             self._supported_features |= SUPPORT_STOP
 
         self._return_to_base_script = None
         if return_to_base_action:
-            self._return_to_base_script = Script(hass, return_to_base_action)
+            self._return_to_base_script = Script(
+                hass, return_to_base_action, friendly_name, domain
+            )
             self._supported_features |= SUPPORT_RETURN_HOME
 
         self._clean_spot_script = None
         if clean_spot_action:
-            self._clean_spot_script = Script(hass, clean_spot_action)
+            self._clean_spot_script = Script(
+                hass, clean_spot_action, friendly_name, domain
+            )
             self._supported_features |= SUPPORT_CLEAN_SPOT
 
         self._locate_script = None
         if locate_action:
-            self._locate_script = Script(hass, locate_action)
+            self._locate_script = Script(hass, locate_action, friendly_name, domain)
             self._supported_features |= SUPPORT_LOCATE
 
         self._set_fan_speed_script = None
         if set_fan_speed_action:
-            self._set_fan_speed_script = Script(hass, set_fan_speed_action)
+            self._set_fan_speed_script = Script(
+                hass, set_fan_speed_action, friendly_name, domain
+            )
             self._supported_features |= SUPPORT_FAN_SPEED
 
         self._state = None

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -81,7 +81,10 @@ class WolSwitch(SwitchEntity):
         self._mac_address = mac_address
         self._broadcast_address = broadcast_address
         self._broadcast_port = broadcast_port
-        self._off_script = Script(hass, off_action) if off_action else None
+        domain = __name__.split(".")[-2]
+        self._off_script = (
+            Script(hass, off_action, name, domain) if off_action else None
+        )
         self._state = False
 
     @property

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -75,7 +75,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     turn_on_action = discovery_info.get(CONF_ON_ACTION)
 
     client = hass.data[DOMAIN][host]["client"]
-    on_script = Script(hass, turn_on_action) if turn_on_action else None
+    on_script = Script(hass, turn_on_action, name, DOMAIN) if turn_on_action else None
 
     entity = LgWebOSMediaPlayerEntity(client, name, customize, on_script)
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -176,7 +176,7 @@ class _ScriptRun:
         try:
             if self._stop.is_set():
                 return
-            self._log("Running %s", self._script.description)
+            self._log("Running %s", self._script.running_description)
             for self._step, self._action in enumerate(self._script.sequence):
                 if self._stop.is_set():
                     break
@@ -618,7 +618,8 @@ class Script:
         name: str,
         domain: str,
         *,
-        description: Optional[str] = "script",
+        # Used in "Running <running_description>" log message
+        running_description: Optional[str] = None,
         change_listener: Optional[Callable[..., Any]] = None,
         script_mode: str = DEFAULT_SCRIPT_MODE,
         max_runs: int = DEFAULT_MAX,
@@ -644,7 +645,7 @@ class Script:
         template.attach(hass, self.sequence)
         self.name = name
         self.domain = domain
-        self.description = description or f"{domain} script"
+        self.running_description = running_description or f"{domain} script"
         self.change_listener = change_listener
         self.script_mode = script_mode
         self._set_logger(logger)
@@ -835,7 +836,7 @@ class Script:
             action[CONF_REPEAT][CONF_SEQUENCE],
             f"{self.name}: {step_name}",
             self.domain,
-            description=self.description,
+            running_description=self.running_description,
             script_mode=SCRIPT_MODE_PARALLEL,
             max_runs=self.max_runs,
             logger=self._logger,
@@ -865,7 +866,7 @@ class Script:
                 choice[CONF_SEQUENCE],
                 f"{self.name}: {step_name}: choice {idx}",
                 self.domain,
-                description=self.description,
+                running_description=self.running_description,
                 script_mode=SCRIPT_MODE_PARALLEL,
                 max_runs=self.max_runs,
                 logger=self._logger,
@@ -882,7 +883,7 @@ class Script:
                 action[CONF_DEFAULT],
                 f"{self.name}: {step_name}: default",
                 self.domain,
-                description=self.description,
+                running_description=self.running_description,
                 script_mode=SCRIPT_MODE_PARALLEL,
                 max_runs=self.max_runs,
                 logger=self._logger,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -176,7 +176,7 @@ class _ScriptRun:
         try:
             if self._stop.is_set():
                 return
-            self._log("Running script")
+            self._log("Running %s", self._script.description)
             for self._step, self._action in enumerate(self._script.sequence):
                 if self._stop.is_set():
                     break
@@ -615,7 +615,10 @@ class Script:
         self,
         hass: HomeAssistant,
         sequence: Sequence[Dict[str, Any]],
-        name: Optional[str] = None,
+        name: str,
+        domain: str,
+        *,
+        description: Optional[str] = "script",
         change_listener: Optional[Callable[..., Any]] = None,
         script_mode: str = DEFAULT_SCRIPT_MODE,
         max_runs: int = DEFAULT_MAX,
@@ -640,6 +643,8 @@ class Script:
         self.sequence = sequence
         template.attach(hass, self.sequence)
         self.name = name
+        self.domain = domain
+        self.description = description
         self.change_listener = change_listener
         self.script_mode = script_mode
         self._set_logger(logger)
@@ -662,10 +667,7 @@ class Script:
         if logger:
             self._logger = logger
         else:
-            logger_name = __name__
-            if self.name:
-                logger_name = ".".join([logger_name, slugify(self.name)])
-            self._logger = logging.getLogger(logger_name)
+            self._logger = logging.getLogger(".".join([__name__, slugify(self.name)]))
 
     def update_logger(self, logger: Optional[logging.Logger] = None) -> None:
         """Update logger."""
@@ -832,6 +834,8 @@ class Script:
             self._hass,
             action[CONF_REPEAT][CONF_SEQUENCE],
             f"{self.name}: {step_name}",
+            self.domain,
+            description=self.description,
             script_mode=SCRIPT_MODE_PARALLEL,
             max_runs=self.max_runs,
             logger=self._logger,
@@ -860,6 +864,8 @@ class Script:
                 self._hass,
                 choice[CONF_SEQUENCE],
                 f"{self.name}: {step_name}: choice {idx}",
+                self.domain,
+                description=self.description,
                 script_mode=SCRIPT_MODE_PARALLEL,
                 max_runs=self.max_runs,
                 logger=self._logger,
@@ -875,6 +881,8 @@ class Script:
                 self._hass,
                 action[CONF_DEFAULT],
                 f"{self.name}: {step_name}: default",
+                self.domain,
+                description=self.description,
                 script_mode=SCRIPT_MODE_PARALLEL,
                 max_runs=self.max_runs,
                 logger=self._logger,
@@ -896,9 +904,8 @@ class Script:
         return choose_data
 
     def _log(self, msg, *args, level=logging.INFO):
-        if self.name:
-            msg = f"%s: {msg}"
-            args = [self.name, *args]
+        msg = f"%s: {msg}"
+        args = [self.name, *args]
 
         if level == _LOG_EXCEPTION:
             self._logger.exception(msg, *args)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -644,7 +644,7 @@ class Script:
         template.attach(hass, self.sequence)
         self.name = name
         self.domain = domain
-        self.description = description
+        self.description = description or f"{domain} script"
         self.change_listener = change_listener
         self.script_mode = script_mode
         self._set_logger(logger)
@@ -667,7 +667,7 @@ class Script:
         if logger:
             self._logger = logger
         else:
-            self._logger = logging.getLogger(".".join([__name__, slugify(self.name)]))
+            self._logger = logging.getLogger(f"{__name__}.{slugify(self.name)}")
 
     def update_logger(self, logger: Optional[logging.Logger] = None) -> None:
         """Update logger."""

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -85,14 +85,16 @@ def async_watch_for_action(script_obj, message):
     return flag
 
 
-async def test_firing_event_basic(hass):
+async def test_firing_event_basic(hass, caplog):
     """Test the firing of events."""
     event = "test_event"
     context = Context()
     events = async_capture_events(hass, event)
 
     sequence = cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(
+        hass, sequence, "Test Name", "test_domain", description="test script"
+    )
 
     await script_obj.async_run(context=context)
     await hass.async_block_till_done()
@@ -100,6 +102,8 @@ async def test_firing_event_basic(hass):
     assert len(events) == 1
     assert events[0].context is context
     assert events[0].data.get("hello") == "world"
+    assert ".test_name:" in caplog.text
+    assert "Test Name: Running test script" in caplog.text
 
 
 async def test_firing_event_template(hass):
@@ -121,7 +125,7 @@ async def test_firing_event_template(hass):
             },
         }
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(MappingProxyType({"is_world": "yes"}), context=context)
     await hass.async_block_till_done()
@@ -140,7 +144,7 @@ async def test_calling_service_basic(hass):
     calls = async_mock_service(hass, "test", "script")
 
     sequence = cv.SCRIPT_SCHEMA({"service": "test.script", "data": {"hello": "world"}})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(context=context)
     await hass.async_block_till_done()
@@ -174,7 +178,7 @@ async def test_calling_service_template(hass):
             },
         }
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(MappingProxyType({"is_world": "yes"}), context=context)
     await hass.async_block_till_done()
@@ -227,7 +231,9 @@ async def test_multiple_runs_no_wait(hass):
             },
         ]
     )
-    script_obj = script.Script(hass, sequence, script_mode="parallel", max_runs=2)
+    script_obj = script.Script(
+        hass, sequence, "Test Name", "test_domain", script_mode="parallel", max_runs=2
+    )
 
     # Start script twice in such a way that second run will be started while first run
     # is in the middle of the first service call.
@@ -259,7 +265,7 @@ async def test_activating_scene(hass):
     calls = async_mock_service(hass, scene.DOMAIN, SERVICE_TURN_ON)
 
     sequence = cv.SCRIPT_SCHEMA({"scene": "scene.hello"})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(context=context)
     await hass.async_block_till_done()
@@ -285,7 +291,14 @@ async def test_stop_no_wait(hass, count):
     hass.services.async_register("test", "script", async_simulate_long_service)
 
     sequence = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
-    script_obj = script.Script(hass, sequence, script_mode="parallel", max_runs=count)
+    script_obj = script.Script(
+        hass,
+        sequence,
+        "Test Name",
+        "test_domain",
+        script_mode="parallel",
+        max_runs=count,
+    )
 
     # Get script started specified number of times and wait until the test.script
     # service has started for each run.
@@ -317,7 +330,7 @@ async def test_delay_basic(hass, mock_timeout):
     """Test the delay."""
     delay_alias = "delay step"
     sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": 5}, "alias": delay_alias})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     delay_started_flag = async_watch_for_action(script_obj, delay_alias)
 
     try:
@@ -349,7 +362,9 @@ async def test_multiple_runs_delay(hass, mock_timeout):
             {"event": event, "event_data": {"value": 2}},
         ]
     )
-    script_obj = script.Script(hass, sequence, script_mode="parallel", max_runs=2)
+    script_obj = script.Script(
+        hass, sequence, "Test Name", "test_domain", script_mode="parallel", max_runs=2
+    )
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
@@ -381,7 +396,7 @@ async def test_multiple_runs_delay(hass, mock_timeout):
 async def test_delay_template_ok(hass, mock_timeout):
     """Test the delay as a template."""
     sequence = cv.SCRIPT_SCHEMA({"delay": "00:00:{{ 5 }}"})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
@@ -411,7 +426,7 @@ async def test_delay_template_invalid(hass, caplog):
             {"event": event},
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     start_idx = len(caplog.records)
 
     await script_obj.async_run()
@@ -429,7 +444,7 @@ async def test_delay_template_invalid(hass, caplog):
 async def test_delay_template_complex_ok(hass, mock_timeout):
     """Test the delay with a working complex template."""
     sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": "{{ 5 }}"}})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
@@ -458,7 +473,7 @@ async def test_delay_template_complex_invalid(hass, caplog):
             {"event": event},
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     start_idx = len(caplog.records)
 
     await script_obj.async_run()
@@ -478,7 +493,7 @@ async def test_cancel_delay(hass):
     event = "test_event"
     events = async_capture_events(hass, event)
     sequence = cv.SCRIPT_SCHEMA([{"delay": {"seconds": 5}}, {"event": event}])
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
@@ -513,7 +528,7 @@ async def test_wait_template_basic(hass):
             "alias": wait_alias,
         }
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, wait_alias)
 
     try:
@@ -545,7 +560,9 @@ async def test_multiple_runs_wait_template(hass):
             {"event": event, "event_data": {"value": 2}},
         ]
     )
-    script_obj = script.Script(hass, sequence, script_mode="parallel", max_runs=2)
+    script_obj = script.Script(
+        hass, sequence, "Test Name", "test_domain", script_mode="parallel", max_runs=2
+    )
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
@@ -582,7 +599,7 @@ async def test_cancel_wait_template(hass):
             {"event": event},
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
@@ -620,7 +637,7 @@ async def test_wait_template_not_schedule(hass):
             {"event": event},
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     hass.states.async_set("switch.test", "on")
     await script_obj.async_run()
@@ -644,7 +661,7 @@ async def test_wait_template_timeout(hass, mock_timeout, continue_on_timeout, n_
     if continue_on_timeout is not None:
         sequence[0]["continue_on_timeout"] = continue_on_timeout
     sequence = cv.SCRIPT_SCHEMA(sequence)
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
@@ -668,7 +685,7 @@ async def test_wait_template_timeout(hass, mock_timeout, continue_on_timeout, n_
 async def test_wait_template_variables(hass):
     """Test the wait template with variables."""
     sequence = cv.SCRIPT_SCHEMA({"wait_template": "{{ is_state(data, 'off') }}"})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
@@ -703,7 +720,7 @@ async def test_condition_basic(hass):
             {"event": event},
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     hass.states.async_set("test.entity", "hello")
     await script_obj.async_run()
@@ -728,7 +745,9 @@ async def test_condition_created_once(async_from_config, hass):
             "value_template": '{{ states.test.entity.state == "hello" }}',
         }
     )
-    script_obj = script.Script(hass, sequence, script_mode="parallel", max_runs=2)
+    script_obj = script.Script(
+        hass, sequence, "Test Name", "test_domain", script_mode="parallel", max_runs=2
+    )
 
     async_from_config.reset_mock()
 
@@ -755,7 +774,7 @@ async def test_condition_all_cached(hass):
             },
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     hass.states.async_set("test.entity", "hello")
     await script_obj.async_run()
@@ -785,7 +804,7 @@ async def test_repeat_count(hass):
             }
         }
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run()
     await hass.async_block_till_done()
@@ -829,7 +848,9 @@ async def test_repeat_conditional(hass, condition):
             "condition": "template",
             "value_template": "{{ is_state('sensor.test', 'done') }}",
         }
-    script_obj = script.Script(hass, cv.SCRIPT_SCHEMA(sequence))
+    script_obj = script.Script(
+        hass, cv.SCRIPT_SCHEMA(sequence), "Test Name", "test_domain"
+    )
 
     wait_started = async_watch_for_action(script_obj, "wait")
     hass.states.async_set("sensor.test", "1")
@@ -876,7 +897,9 @@ async def test_repeat_var_in_condition(hass, condition):
             "condition": "template",
             "value_template": "{{ repeat.index == 2 }}",
         }
-    script_obj = script.Script(hass, cv.SCRIPT_SCHEMA(sequence))
+    script_obj = script.Script(
+        hass, cv.SCRIPT_SCHEMA(sequence), "Test Name", "test_domain"
+    )
 
     with mock.patch(
         "homeassistant.helpers.condition._LOGGER.error",
@@ -956,7 +979,7 @@ async def test_repeat_nested(hass, variables, first_last, inside_x):
             },
         ]
     )
-    script_obj = script.Script(hass, sequence, "test script")
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     with mock.patch(
         "homeassistant.helpers.condition._LOGGER.error",
@@ -1014,7 +1037,7 @@ async def test_choose(hass, var, result):
             "default": {"event": event, "event_data": {"choice": "default"}},
         }
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(MappingProxyType({"var": var}))
     await hass.async_block_till_done()
@@ -1035,7 +1058,12 @@ async def test_multiple_runs_repeat_choose(hass, caplog, action):
     """Test parallel runs with repeat & choose actions & max_runs > default."""
     max_runs = script.DEFAULT_MAX + 1
     script_obj = script.Script(
-        hass, cv.SCRIPT_SCHEMA(action), script_mode="parallel", max_runs=max_runs
+        hass,
+        cv.SCRIPT_SCHEMA(action),
+        "Test Name",
+        "test_domain",
+        script_mode="parallel",
+        max_runs=max_runs,
     )
 
     events = async_capture_events(hass, "abc")
@@ -1052,7 +1080,7 @@ async def test_last_triggered(hass):
     """Test the last_triggered."""
     event = "test_event"
     sequence = cv.SCRIPT_SCHEMA({"event": event})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     assert script_obj.last_triggered is None
 
@@ -1069,7 +1097,7 @@ async def test_propagate_error_service_not_found(hass):
     event = "test_event"
     events = async_capture_events(hass, event)
     sequence = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     with pytest.raises(exceptions.ServiceNotFound):
         await script_obj.async_run()
@@ -1086,7 +1114,7 @@ async def test_propagate_error_invalid_service_data(hass):
     sequence = cv.SCRIPT_SCHEMA(
         [{"service": "test.script", "data": {"text": 1}}, {"event": event}]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     with pytest.raises(vol.Invalid):
         await script_obj.async_run()
@@ -1109,7 +1137,7 @@ async def test_propagate_error_service_exception(hass):
     hass.services.async_register("test", "script", record_call)
 
     sequence = cv.SCRIPT_SCHEMA([{"service": "test.script"}, {"event": event}])
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     with pytest.raises(ValueError):
         await script_obj.async_run()
@@ -1143,6 +1171,8 @@ async def test_referenced_entities(hass):
                 {"delay": "{{ delay_period }}"},
             ]
         ),
+        "Test Name",
+        "test_domain",
     )
     assert script_obj.referenced_entities == {
         "light.service_not_list",
@@ -1168,6 +1198,8 @@ async def test_referenced_devices(hass):
                 },
             ]
         ),
+        "Test Name",
+        "test_domain",
     )
     assert script_obj.referenced_devices == {"script-dev-id", "condition-dev-id"}
     # Test we cache results.
@@ -1191,7 +1223,7 @@ async def test_script_mode_single(hass, caplog):
             {"event": event, "event_data": {"value": 2}},
         ]
     )
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
     try:
@@ -1239,7 +1271,13 @@ async def test_script_mode_2(hass, caplog, script_mode, messages, last_events):
     logger = logging.getLogger("TEST")
     max_runs = 1 if script_mode == "restart" else 2
     script_obj = script.Script(
-        hass, sequence, script_mode=script_mode, max_runs=max_runs, logger=logger
+        hass,
+        sequence,
+        "Test Name",
+        "test_domain",
+        script_mode=script_mode,
+        max_runs=max_runs,
+        logger=logger,
     )
     wait_started_flag = async_watch_for_action(script_obj, "wait")
 
@@ -1303,7 +1341,13 @@ async def test_script_mode_queued(hass):
     )
     logger = logging.getLogger("TEST")
     script_obj = script.Script(
-        hass, sequence, script_mode="queued", max_runs=2, logger=logger
+        hass,
+        sequence,
+        "Test Name",
+        "test_domain",
+        script_mode="queued",
+        max_runs=2,
+        logger=logger,
     )
 
     watch_messages = []
@@ -1379,7 +1423,8 @@ async def test_script_mode_queued_cancel(hass):
     script_obj = script.Script(
         hass,
         cv.SCRIPT_SCHEMA({"wait_template": "{{ false }}"}),
-        "test",
+        "Test Name",
+        "test_domain",
         script_mode="queued",
         max_runs=2,
     )
@@ -1417,21 +1462,17 @@ async def test_script_mode_queued_cancel(hass):
 
 async def test_script_logging(hass, caplog):
     """Test script logging."""
-    script_obj = script.Script(hass, [], "Script with % Name")
+    script_obj = script.Script(hass, [], "Script with % Name", "test_domain")
     script_obj._log("Test message with name %s", 1)
 
     assert "Script with % Name: Test message with name 1" in caplog.text
-
-    script_obj = script.Script(hass, [])
-    script_obj._log("Test message without name %s", 2)
-    assert "Test message without name 2" in caplog.text
 
 
 async def test_shutdown_at(hass, caplog):
     """Test stopping scripts at shutdown."""
     delay_alias = "delay step"
     sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": 120}, "alias": delay_alias})
-    script_obj = script.Script(hass, sequence, "test script")
+    script_obj = script.Script(hass, sequence, "test script", "test_domain")
     delay_started_flag = async_watch_for_action(script_obj, delay_alias)
 
     try:
@@ -1455,7 +1496,7 @@ async def test_shutdown_after(hass, caplog):
     """Test stopping scripts at shutdown."""
     delay_alias = "delay step"
     sequence = cv.SCRIPT_SCHEMA({"delay": {"seconds": 120}, "alias": delay_alias})
-    script_obj = script.Script(hass, sequence, "test script")
+    script_obj = script.Script(hass, sequence, "test script", "test_domain")
     delay_started_flag = async_watch_for_action(script_obj, delay_alias)
 
     hass.state = CoreState.stopping
@@ -1485,7 +1526,7 @@ async def test_shutdown_after(hass, caplog):
 async def test_update_logger(hass, caplog):
     """Test updating logger."""
     sequence = cv.SCRIPT_SCHEMA({"event": "test_event"})
-    script_obj = script.Script(hass, sequence)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run()
     await hass.async_block_till_done()

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -93,7 +93,7 @@ async def test_firing_event_basic(hass, caplog):
 
     sequence = cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
     script_obj = script.Script(
-        hass, sequence, "Test Name", "test_domain", description="test script"
+        hass, sequence, "Test Name", "test_domain", running_description="test script"
     )
 
     await script_obj.async_run(context=context)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Constructor parameters of the `homeassistant.helpers.script.Script` class have changed. Consequently, any custom component using it will need to adjust accordingly.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The "script helper" (`homeassistant.helpers.script.Script`) needs to be supplied a name, otherwise the functions to stop script runs at shutdown will cause an exception. So make `name` a required parameter.

Also, add a `domain` parameter that will be used in another upcoming PR.

Add an optional `running_description` parameter that will be used in the "Running XXX" log message (which currently always says "Running script", which people find confusing, especially when used in an automation.)

Lastly update all the script helper users accordingly.

A call to the constructor might now look something like this:
```python
from homeassistant.helpers.script import Script

on_action = config[CONF_ON_ACTION]
name = config[CONF_NAME]
# Get domain name of this integration
domain = __name__.split(".")[-2]
turn_on_script = Script(
    hass,
    on_action,
    name,
    domain,
    running_description="turn on actions",
)
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
