### PR TITLE
Unsubscribe ozw listeners

### DIFF
--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -193,13 +193,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         ]
 
     # Listen to events for node and value changes
-    options.listen(EVENT_NODE_ADDED, async_node_added)
-    options.listen(EVENT_NODE_CHANGED, async_node_changed)
-    options.listen(EVENT_NODE_REMOVED, async_node_removed)
-    options.listen(EVENT_VALUE_ADDED, async_value_added)
-    options.listen(EVENT_VALUE_CHANGED, async_value_changed)
-    options.listen(EVENT_VALUE_REMOVED, async_value_removed)
-    options.listen(EVENT_INSTANCE_EVENT, async_instance_event)
+    for event, event_callback in (
+        (EVENT_NODE_ADDED, async_node_added),
+        (EVENT_NODE_CHANGED, async_node_changed),
+        (EVENT_NODE_REMOVED, async_node_removed),
+        (EVENT_VALUE_ADDED, async_value_added),
+        (EVENT_VALUE_CHANGED, async_value_changed),
+        (EVENT_VALUE_REMOVED, async_value_removed),
+        (EVENT_INSTANCE_EVENT, async_instance_event),
+    ):
+        ozw_data[DATA_UNSUBSCRIBE].append(options.listen(event, event_callback))
 
     # Register Services
     services = ZWaveServices(hass, manager)

--- a/homeassistant/components/ozw/entity.py
+++ b/homeassistant/components/ozw/entity.py
@@ -162,10 +162,14 @@ class ZWaveDeviceEntity(Entity):
 
     async def async_added_to_hass(self):
         """Call when entity is added."""
-        # add dispatcher and OZW listeners callbacks,
-        self.options.listen(EVENT_VALUE_CHANGED, self._value_changed)
-        self.options.listen(EVENT_INSTANCE_STATUS_CHANGED, self._instance_updated)
-        # add to on_remove so they will be cleaned up on entity removal
+        # Add dispatcher and OZW listeners callbacks.
+        # Add to on_remove so they will be cleaned up on entity removal.
+        self.async_on_remove(
+            self.options.listen(EVENT_VALUE_CHANGED, self._value_changed)
+        )
+        self.async_on_remove(
+            self.options.listen(EVENT_INSTANCE_STATUS_CHANGED, self._instance_updated)
+        )
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, const.SIGNAL_DELETE_ENTITY, self._delete_callback
@@ -265,14 +269,6 @@ class ZWaveDeviceEntity(Entity):
             return  # race condition: delete already requested
         if values_id == self.values.values_id:
             await self.async_remove()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Call when entity will be removed from hass."""
-        # cleanup OZW listeners
-        self.options.listeners[EVENT_VALUE_CHANGED].remove(self._value_changed)
-        self.options.listeners[EVENT_INSTANCE_STATUS_CHANGED].remove(
-            self._instance_updated
-        )
 
 
 def create_device_name(node: OZWNode):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Use the new unsubscribe callback to unsubscribe all OpenZWave listeners.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
