### PR TITLE
Add track_template_result method to events

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -905,7 +905,9 @@ class StateMachine:
         return future.result()
 
     @callback
-    def async_entity_ids(self, domain_filter: Optional[str] = None) -> List[str]:
+    def async_entity_ids(
+        self, domain_filter: Optional[Union[str, Iterable]] = None
+    ) -> List[str]:
         """List of entity ids that are being tracked.
 
         This method must be run in the event loop.
@@ -913,12 +915,13 @@ class StateMachine:
         if domain_filter is None:
             return list(self._states.keys())
 
-        domain_filter = domain_filter.lower()
+        if isinstance(domain_filter, str):
+            domain_filter = [domain_filter.lower()]
 
         return [
             state.entity_id
             for state in self._states.values()
-            if state.domain == domain_filter
+            if state.domain in domain_filter
         ]
 
     def all(self) -> List[State]:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -916,7 +916,7 @@ class StateMachine:
             return list(self._states.keys())
 
         if isinstance(domain_filter, str):
-            domain_filter = [domain_filter.lower()]
+            domain_filter = (domain_filter.lower(),)
 
         return [
             state.entity_id

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -371,11 +371,7 @@ def async_track_template(
     in an error state when the value changes, this will be logged and not
     passed through.
 
-    On template registration, the action will be called with an entity_id
-    and state of some entity referenced by the template, or '*' if no
-    entity is referenced by the template.
-
-    If the initial run of the template is invalid and results in an
+    If the initial check of the template is invalid and results in an
     exception, the listener will still be registered but will only
     fire if the template result becomes true without an exception.
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -509,16 +509,15 @@ class TrackTemplateResultInfo:
             )
             return
 
-        entities = set(self._info._entities)
-
         if self._info._domains:
             self._domains_listener = async_track_state_added_domain(
                 self.hass, self._info._domains, self._state_changed_listener
             )
-            for entity_id in self.hass.states.async_entity_ids(self._info._domains):
-                entities.add(entity_id)
 
-        if entities:
+        if self._info._entities or self._info._domains:
+            entities = set(self._info._entities)
+            for entity_id in self.hass.states.async_entity_ids(self._info._domains):
+                entities.add(entity_id)            
             self._entities_listener = async_track_state_change_event(
                 self.hass, entities, self._state_changed_listener
             )
@@ -567,9 +566,8 @@ class TrackTemplateResultInfo:
 
         if domains_changed or self._info._entities != self._last_info._entities:
             entities = set(self._info._entities)
-            if domains_changed:
-                for entity_id in self.hass.states.async_entity_ids(self._info._domains):
-                    entities.add(entity_id)
+            for entity_id in self.hass.states.async_entity_ids(self._info._domains):
+                entities.add(entity_id)
             self._cancel_entities_listener()
             self._entities_listener = async_track_state_change_event(
                 self.hass, entities, self._state_changed_listener

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -465,7 +465,14 @@ class TrackTemplateResultInfo:
 
     @callback
     def _create_listeners(self) -> None:
-        if self._info.all_states or self._info.exception:
+        if self._info.is_static:
+            return
+
+        if (
+            self._info.all_states
+            or self._info.exception
+            or (not self._info.domains and not self._info.entities)
+        ):
             self._setup_all_listener()
             return
 
@@ -498,7 +505,11 @@ class TrackTemplateResultInfo:
 
     @callback
     def _update_listeners(self) -> None:
-        if self._info.all_states or self._info.exception:
+        if (
+            self._info.all_states
+            or self._info.exception
+            or (not self._info.domains and not self._info.entities)
+        ):
             if self._all_listener:
                 return
             self._cancel_domains_listener()
@@ -561,11 +572,12 @@ class TrackTemplateResultInfo:
         new_state = event.data.get("new_state")
         entity_id = event.data["entity_id"]
 
-        if old_state is not None and new_state is not None:
-            if not self._info.filter(entity_id):
+        if self._info.domains or self._info.entities:
+            if old_state is not None and new_state is not None:
+                if not self._info.filter(entity_id):
+                    return
+            elif not self._info.filter_lifecycle(entity_id):
                 return
-        elif not self._info.filter_lifecycle(entity_id):
-            return
 
         self._refresh(event)
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -466,7 +466,7 @@ class TrackTemplateResultInfo:
 
     @callback
     def _create_listeners(self) -> None:
-        if self._info.all_states:
+        if self._info.all_states or self._info.exception:
             self._setup_all_listener()
             return
 
@@ -499,7 +499,7 @@ class TrackTemplateResultInfo:
 
     @callback
     def _update_listeners(self) -> None:
-        if self._info.all_states:
+        if self._info.all_states or self._info.exception:
             if self._all_listener:
                 return
             self._cancel_domains_listener()

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -529,13 +529,12 @@ class TrackTemplateResultInfo:
             self._setup_all_listener()
             return
 
-        had_all_listner = False
-        if self._all_listener:
-            had_all_listner = True
+        had_all_listner = True if self._all_listener else False
+        if had_all_listner:
             self._cancel_all_listener()
 
-        domains_changed = False
-        if had_all_listner or self._info.domains != self._last_info.domains:
+        domains_changed = self._info.domains != self._last_info.domains
+        if had_all_listner or domains_changed:
             domains_changed = True
             self._cancel_domains_listener()
             self._setup_domains_listener()

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -529,18 +529,18 @@ class TrackTemplateResultInfo:
             self._setup_all_listener()
             return
 
-        had_all_listner = self._all_listener is not None
-        if had_all_listner:
+        had_all_listener = self._all_listener is not None
+        if had_all_listener:
             self._cancel_all_listener()
 
         domains_changed = self._info.domains != self._last_info.domains
-        if had_all_listner or domains_changed:
+        if had_all_listener or domains_changed:
             domains_changed = True
             self._cancel_domains_listener()
             self._setup_domains_listener()
 
         if (
-            had_all_listner
+            had_all_listener
             or domains_changed
             or self._info.entities != self._last_info.entities
         ):

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -517,13 +517,22 @@ class TrackTemplateResultInfo:
             self._setup_all_listener()
             return
 
+        had_all_listner = False
+        if self._all_listener:
+            had_all_listner = True
+            self._cancel_all_listener()
+
         domains_changed = False
-        if self._info.domains != self._last_info.domains:
+        if had_all_listner or self._info.domains != self._last_info.domains:
             domains_changed = True
             self._cancel_domains_listener()
             self._setup_domains_listener()
 
-        if domains_changed or self._info.entities != self._last_info.entities:
+        if (
+            had_all_listner
+            or domains_changed
+            or self._info.entities != self._last_info.entities
+        ):
             self._cancel_entities_listener()
             self._setup_entities_listener()
 
@@ -533,19 +542,19 @@ class TrackTemplateResultInfo:
         for entity_id in self.hass.states.async_entity_ids(self._info.domains):
             entities.add(entity_id)
         self._entities_listener = async_track_state_change_event(
-            self.hass, entities, self._state_changed_listener
+            self.hass, entities, self._refresh
         )
 
     @callback
     def _setup_domains_listener(self) -> None:
         self._domains_listener = async_track_state_added_domain(
-            self.hass, self._info.domains, self._state_changed_listener
+            self.hass, self._info.domains, self._refresh
         )
 
     @callback
     def _setup_all_listener(self) -> None:
         self._all_listener = self.hass.bus.async_listen(
-            EVENT_STATE_CHANGED, self._state_changed_listener
+            EVENT_STATE_CHANGED, self._refresh
         )
 
     @callback
@@ -560,28 +569,9 @@ class TrackTemplateResultInfo:
         """Force recalculate the template."""
         if variables is not _UNCHANGED:
             self._variables = variables
-        self._refresh()
+        self._refresh(None)
 
-    @callback
-    def _state_changed_listener(self, event: Event) -> None:
-        """Check if condition is correct and run action."""
-        # Optimisation: if the old and new states are not None then this is
-        # a state change rather than a life-cycle event, and therefore we
-        # only need to check the include entities.
-        old_state = event.data.get("old_state")
-        new_state = event.data.get("new_state")
-        entity_id = event.data["entity_id"]
-
-        if self._info.domains or self._info.entities:
-            if old_state is not None and new_state is not None:
-                if not self._info.filter(entity_id):
-                    return
-            elif not self._info.filter_lifecycle(entity_id):
-                return
-
-        self._refresh(event)
-
-    def _refresh(self, event: Optional[Event] = None) -> None:
+    def _refresh(self, event: Optional[Event]) -> None:
         self._info = self._template.async_render_to_info(self._variables)
         self._update_listeners()
         self._last_info = self._info

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -461,6 +461,9 @@ class TrackTemplateResultInfo:
         self._domains_listener: Optional[Callable] = None
         self._entities_listener: Optional[Callable] = None
         self._info = template.async_render_to_info(variables)
+        if self._info.exception:
+            self._last_exception = True
+            _LOGGER.exception(self._info.exception)
         self._create_listeners()
         self._last_info = self._info
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -438,8 +438,7 @@ def async_track_template(
         info = template.async_render_to_info(variables)
         state = None
         entity_id = None
-        #  pylint: disable=protected-access
-        for eid in info._entities:
+        for eid in info.entities:
             state = hass.states.get(eid)
             if state:
                 entity_id = eid
@@ -502,14 +501,14 @@ class TrackTemplateResultInfo:
 
     @callback
     def _create_listeners(self) -> None:
-        if self._info._all_states:
+        if self._info.all_states:
             self._setup_all_listener()
             return
 
-        if self._info._domains:
+        if self._info.domains:
             self._setup_domains_listener()
 
-        if self._info._entities or self._info._domains:
+        if self._info.entities or self._info.domains:
             self._setup_entities_listener()
 
     @callback
@@ -535,8 +534,7 @@ class TrackTemplateResultInfo:
 
     @callback
     def _update_listeners(self) -> None:
-        # pylint: disable=protected-access
-        if self._info._all_states:
+        if self._info.all_states:
             if self._all_listener:
                 return
             self._cancel_domains_listener()
@@ -545,20 +543,19 @@ class TrackTemplateResultInfo:
             return
 
         domains_changed = False
-        if self._info._domains != self._last_info._domains:
+        if self._info.domains != self._last_info.domains:
             domains_changed = True
             self._cancel_domains_listener()
             self._setup_domains_listener()
 
-        if domains_changed or self._info._entities != self._last_info._entities:
+        if domains_changed or self._info.entities != self._last_info.entities:
             self._cancel_entities_listener()
             self._setup_entities_listener()
 
     @callback
     def _setup_entities_listener(self) -> None:
-        # pylint: disable=protected-access
-        entities = set(self._info._entities)
-        for entity_id in self.hass.states.async_entity_ids(self._info._domains):
+        entities = set(self._info.entities)
+        for entity_id in self.hass.states.async_entity_ids(self._info.domains):
             entities.add(entity_id)
         self._entities_listener = async_track_state_change_event(
             self.hass, entities, self._state_changed_listener
@@ -566,14 +563,12 @@ class TrackTemplateResultInfo:
 
     @callback
     def _setup_domains_listener(self) -> None:
-        # pylint: disable=protected-access
         self._domains_listener = async_track_state_added_domain(
-            self.hass, self._info._domains, self._state_changed_listener
+            self.hass, self._info.domains, self._state_changed_listener
         )
 
     @callback
     def _setup_all_listener(self) -> None:
-        # pylint: disable=protected-access
         self._all_listener = self.hass.bus.async_listen(
             EVENT_STATE_CHANGED, self._state_changed_listener
         )

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -7,7 +7,6 @@ import time
 from typing import Any, Awaitable, Callable, Iterable, Optional, Union
 
 import attr
-import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_NOW,
@@ -27,10 +26,9 @@ from homeassistant.core import (
     split_entity_id,
 )
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
 from homeassistant.helpers.sun import get_astral_event_next
-from homeassistant.helpers.template import Template
+from homeassistant.helpers.template import Template, result_as_boolean
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
@@ -353,9 +351,6 @@ def async_track_state_added_domain(
     return remove_listener
 
 
-_boolean_coerce = vol.Any(cv.boolean, lambda val: False)
-
-
 @callback
 @bind_hass
 def async_track_template(
@@ -413,7 +408,7 @@ def async_track_template(
             _LOGGER.exception(result)
             return
 
-        if _boolean_coerce(last_result) or not _boolean_coerce(result):
+        if result_as_boolean(last_result) or not result_as_boolean(result):
             return
 
         hass.async_run_job(

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -529,7 +529,7 @@ class TrackTemplateResultInfo:
             self._setup_all_listener()
             return
 
-        had_all_listner = True if self._all_listener else False
+        had_all_listner = self._all_listener is not None
         if had_all_listner:
             self._cancel_all_listener()
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -177,9 +177,6 @@ class RenderInfo:
         self.entities = frozenset(self.entities)
         self.domains = frozenset(self.domains)
 
-        if not self.entities and not self.domains:
-            self.all_states = True
-
         if self.all_states:
             return
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -16,6 +16,7 @@ import jinja2
 from jinja2 import contextfilter, contextfunction
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace  # type: ignore
+import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -28,7 +29,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import State, callback, split_entity_id, valid_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import location as loc_helper
+from homeassistant.helpers import config_validation as cv, location as loc_helper
 from homeassistant.helpers.typing import HomeAssistantType, TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util import convert, dt as dt_util, location as loc_util
@@ -523,6 +524,19 @@ def _resolve_state(
     if isinstance(entity_id_or_state, str):
         return _get_state(hass, entity_id_or_state)
     return None
+
+
+def result_as_boolean(template_result: Optional[str]) -> bool:
+    """Convert the template result to a boolean.
+
+    True/not 0/'1'/'true'/'yes'/'on'/'enable' are considered truthy
+    False/0/None/'0'/'false'/'no'/'off'/'disable' are considered falsy
+
+    """
+    try:
+        return cv.boolean(template_result)
+    except vol.Invalid:
+        return False
 
 
 def expand(hass: HomeAssistantType, *args: Any) -> Iterable[State]:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -142,6 +142,7 @@ class RenderInfo:
         # Will be set sensibly once frozen.
         self.filter_lifecycle = _true
         self._result = None
+        self.is_static = False
         self.exception = None
         self.all_states = False
         self.domains = set()
@@ -165,6 +166,7 @@ class RenderInfo:
         return self._result
 
     def _freeze_static(self) -> None:
+        self.is_static = True
         self.entities = frozenset(self.entities)
         self.domains = frozenset(self.domains)
         self.all_states = False

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -8,7 +8,7 @@ import logging
 import math
 import random
 import re
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Iterable, List, Optional, Union
 from urllib.parse import urlencode as urllib_urlencode
 import weakref
 
@@ -79,7 +79,7 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
 def extract_entities(
     hass: HomeAssistantType,
     template: Optional[str],
-    variables: Optional[Dict[str, Any]] = None,
+    variables: TemplateVarsType = None,
 ) -> Union[str, List[str]]:
     """Extract all entities for state_changed listener from template string."""
     if template is None or _RE_JINJA_DELIMITERS.search(template) is None:
@@ -206,7 +206,7 @@ class Template:
             raise TemplateError(err)
 
     def extract_entities(
-        self, variables: Optional[Dict[str, Any]] = None
+        self, variables: TemplateVarsType = None
     ) -> Union[str, List[str]]:
         """Extract all entities for state_changed listener."""
         return extract_entities(self.hass, self.template, variables)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -133,10 +133,6 @@ def _true(arg: Any) -> bool:
     return True
 
 
-def _false(arg: Any) -> bool:
-    return False
-
-
 class RenderInfo:
     """Holds information about a template render."""
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -146,7 +146,7 @@ class RenderInfo:
         # Will be set sensibly once frozen.
         self.filter_lifecycle = _true
         self._result = None
-        self._exception = None
+        self.exception = None
         self.all_states = False
         self.domains = set()
         self.entities = set()
@@ -164,8 +164,8 @@ class RenderInfo:
     @property
     def result(self) -> str:
         """Results of the template computation."""
-        if self._exception is not None:
-            raise self._exception
+        if self.exception is not None:
+            raise self.exception
         return self._result
 
     def _freeze_static(self) -> None:
@@ -260,7 +260,7 @@ class Template:
         try:
             render_info._result = self.async_render(variables, **kwargs)
         except TemplateError as ex:
-            render_info._exception = ex
+            render_info.exception = ex
         finally:
             del self.hass.data[_RENDER_INFO]
             if _RE_JINJA_DELIMITERS.search(self.template) is None:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -560,27 +560,13 @@ def expand(hass: HomeAssistantType, *args: Any) -> Iterable[State]:
             continue
 
         if entity_id.startswith(_GROUP_DOMAIN_PREFIX):
-            # Collect state would be called in here since it's wrapped
-            # so we call hass.states.get since we only want to collect
-            # the underlying entity ids.
-            #
-            # We only want to look at the underlying entities because
-            # when a expand() is in the template we check each entity
-            # instead of the state of the group. If we were to include
-            # the group we would end up re-rendering the template again
-            # when the group had finished processing the state change of
-            # the underlying entities.
-            #
-            state = hass.states.get(entity_id)
-            if state:
-                group_entities = state.attributes.get(ATTR_ENTITY_ID)
-                if group_entities:
-                    search += group_entities
+            # Collect state will be called in here since it's wrapped
+            group_entities = entity.attributes.get(ATTR_ENTITY_ID)
+            if group_entities:
+                search += group_entities
         else:
+            _collect_state(hass, entity_id)
             found[entity_id] = entity
-
-    for entity_id in found:
-        _collect_state(hass, entity_id)
 
     return sorted(found.values(), key=lambda a: a.entity_id)
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -38,7 +38,10 @@ async def test_if_fires_on_change_bool(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": "{{ true }}"},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": "{{ states('test.entity') and 'true' }}",
+                },
                 "action": {"service": "test.automation"},
             }
         },
@@ -58,12 +61,16 @@ async def test_if_fires_on_change_bool(hass, calls):
 
 async def test_if_fires_on_change_str(hass, calls):
     """Test for firing on change."""
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": '{{ "true" }}'},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": '{{ states("test.entity") or "true" }}',
+                },
                 "action": {"service": "test.automation"},
             }
         },
@@ -71,17 +78,21 @@ async def test_if_fires_on_change_str(hass, calls):
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 0
 
 
 async def test_if_fires_on_change_str_crazy(hass, calls):
     """Test for firing on change."""
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": '{{ "TrUE" }}'},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": '{{ "TrUE" or states("test.entity") }}',
+                },
                 "action": {"service": "test.automation"},
             }
         },
@@ -89,7 +100,7 @@ async def test_if_fires_on_change_str_crazy(hass, calls):
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 0
 
 
 async def test_if_not_fires_on_change_bool(hass, calls):
@@ -177,7 +188,10 @@ async def test_if_fires_on_two_change(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": "{{ true }}"},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": "{{ states('test.entity') and 'true' }}",
+                },
                 "action": {"service": "test.automation"},
             }
         },

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -110,8 +110,8 @@ async def test_if_not_fires_on_change_bool(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_fires_on_change_bare_str(hass, calls):
-    """Test should fire once for a bare string of true."""
+async def test_if_not_fires_on_change_str(hass, calls):
+    """Test for not firing on string change."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -122,12 +122,10 @@ async def test_if_fires_on_change_bare_str(hass, calls):
             }
         },
     )
-    await hass.async_block_till_done()
-    assert len(calls) == 1
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 0
 
 
 async def test_if_not_fires_on_change_str_crazy(hass, calls):
@@ -234,11 +232,10 @@ async def test_if_not_fires_on_change_with_template(hass, calls):
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 0
 
 
 async def test_if_fires_on_change_with_template_advanced(hass, calls):
@@ -332,27 +329,27 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set("test.entity", "home")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_set("test.entity", "work")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_set("test.entity", "not_home")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
     assert len(calls) == 1
 
     hass.states.async_set("test.entity", "home")
     await hass.async_block_till_done()
     assert len(calls) == 2
-
-    hass.states.async_set("test.entity", "work")
-    await hass.async_block_till_done()
-    assert len(calls) == 2
-
-    hass.states.async_set("test.entity", "not_home")
-    await hass.async_block_till_done()
-    assert len(calls) == 2
-
-    hass.states.async_set("test.entity", "world")
-    await hass.async_block_till_done()
-    assert len(calls) == 2
-
-    hass.states.async_set("test.entity", "home")
-    await hass.async_block_till_done()
-    assert len(calls) == 3
 
 
 async def test_if_action(hass, calls):

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -110,8 +110,8 @@ async def test_if_not_fires_on_change_bool(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_not_fires_on_change_str(hass, calls):
-    """Test for not firing on string change."""
+async def test_if_fires_on_change_bare_str(hass, calls):
+    """Test should fire once for a bare string of true."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -122,10 +122,12 @@ async def test_if_not_fires_on_change_str(hass, calls):
             }
         },
     )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_not_fires_on_change_str_crazy(hass, calls):
@@ -232,10 +234,11 @@ async def test_if_not_fires_on_change_with_template(hass, calls):
     )
 
     await hass.async_block_till_done()
+    assert len(calls) == 1
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_fires_on_change_with_template_advanced(hass, calls):
@@ -329,27 +332,27 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 0
-
-    hass.states.async_set("test.entity", "home")
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set("test.entity", "work")
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set("test.entity", "not_home")
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set("test.entity", "world")
-    await hass.async_block_till_done()
     assert len(calls) == 1
 
     hass.states.async_set("test.entity", "home")
     await hass.async_block_till_done()
     assert len(calls) == 2
+
+    hass.states.async_set("test.entity", "work")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set("test.entity", "not_home")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set("test.entity", "home")
+    await hass.async_block_till_done()
+    assert len(calls) == 3
 
 
 async def test_if_action(hass, calls):

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -38,10 +38,7 @@ async def test_if_fires_on_change_bool(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {
-                    "platform": "template",
-                    "value_template": "{{ states('test.entity') and 'true' }}",
-                },
+                "trigger": {"platform": "template", "value_template": "{{ true }}"},
                 "action": {"service": "test.automation"},
             }
         },
@@ -61,16 +58,12 @@ async def test_if_fires_on_change_bool(hass, calls):
 
 async def test_if_fires_on_change_str(hass, calls):
     """Test for firing on change."""
-
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {
-                    "platform": "template",
-                    "value_template": '{{ states("test.entity") or "true" }}',
-                },
+                "trigger": {"platform": "template", "value_template": '{{ "true" }}'},
                 "action": {"service": "test.automation"},
             }
         },
@@ -78,21 +71,17 @@ async def test_if_fires_on_change_str(hass, calls):
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_fires_on_change_str_crazy(hass, calls):
     """Test for firing on change."""
-
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {
-                    "platform": "template",
-                    "value_template": '{{ "TrUE" or states("test.entity") }}',
-                },
+                "trigger": {"platform": "template", "value_template": '{{ "TrUE" }}'},
                 "action": {"service": "test.automation"},
             }
         },
@@ -100,7 +89,7 @@ async def test_if_fires_on_change_str_crazy(hass, calls):
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_not_fires_on_change_bool(hass, calls):
@@ -188,10 +177,7 @@ async def test_if_fires_on_two_change(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {
-                    "platform": "template",
-                    "value_template": "{{ states('test.entity') and 'true' }}",
-                },
+                "trigger": {"platform": "template", "value_template": "{{ true }}"},
                 "action": {"service": "test.automation"},
             }
         },

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,4 +1,6 @@
 """Test the condition helper."""
+from logging import ERROR
+
 import pytest
 
 from homeassistant.exceptions import HomeAssistantError
@@ -576,3 +578,18 @@ async def test_extract_devices():
             ],
         }
     ) == {"abcd", "qwer", "abcd_not", "qwer_not", "abcd_or", "qwer_or"}
+
+
+async def test_condition_template_error(hass, caplog):
+    """Test invalid template."""
+    caplog.set_level(ERROR)
+
+    test = await condition.async_from_config(
+        hass, {"condition": "template", "value_template": "{{ undefined.state }}"}
+    )
+
+    assert not test(hass)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message.startswith(
+        "Error during template condition: UndefinedError:"
+    )

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -633,30 +633,36 @@ async def test_track_template_result_complex(hass):
 
     hass.states.async_set("sensor.domain", "light")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 1
     assert specific_runs[0].strip() == "['light.one']"
 
     hass.states.async_set("sensor.domain", "lock")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 2
     assert specific_runs[1].strip() == "['lock.one']"
 
     hass.states.async_set("sensor.domain", "all")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 3
     assert "light.one" in specific_runs[2]
     assert "lock.one" in specific_runs[2]
     assert "sensor.domain" in specific_runs[2]
 
     hass.states.async_set("sensor.domain", "light")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 4
     assert specific_runs[3].strip() == "['light.one']"
 
     hass.states.async_set("light.two", "on")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 5
     assert "light.one" in specific_runs[4]
     assert "light.two" in specific_runs[4]
     assert "sensor.domain" not in specific_runs[4]
 
     hass.states.async_set("light.three", "on")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 6
     assert "light.one" in specific_runs[5]
     assert "light.two" in specific_runs[5]
     assert "light.three" in specific_runs[5]
@@ -664,18 +670,22 @@ async def test_track_template_result_complex(hass):
 
     hass.states.async_set("sensor.domain", "lock")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 7
     assert specific_runs[6].strip() == "['lock.one']"
 
     hass.states.async_set("sensor.domain", "single_binary_sensor")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 8
     assert specific_runs[7].strip() == "unknown"
 
     hass.states.async_set("binary_sensor.single", "binary_sensor_on")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 9
     assert specific_runs[8].strip() == "binary_sensor_on"
 
     hass.states.async_set("sensor.domain", "lock")
     await hass.async_block_till_done()
+    assert len(specific_runs) == 10
     assert specific_runs[9].strip() == "['lock.one']"
 
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -530,6 +530,23 @@ async def test_track_template_error(hass, caplog):
     assert "lunch" in caplog.text
     assert "TemplateAssertionError" in caplog.text
 
+    caplog.clear()
+
+    with patch.object(Template, "async_render") as render:
+        render.return_value = "ok"
+
+        hass.states.async_set("switch.not_exist", "off")
+        await hass.async_block_till_done()
+
+    assert "lunch" not in caplog.text
+    assert "TemplateAssertionError" not in caplog.text
+
+    hass.states.async_set("switch.not_exist", "on")
+    await hass.async_block_till_done()
+
+    assert "lunch" in caplog.text
+    assert "TemplateAssertionError" in caplog.text
+
 
 async def test_track_template_result(hass):
     """Test tracking template."""

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 import asyncio
 from datetime import datetime, timedelta
+from logging import Logger
 
 from astral import Astral
 import pytest
@@ -10,6 +11,7 @@ from homeassistant.components import sun
 from homeassistant.const import MATCH_ALL
 import homeassistant.core as ha
 from homeassistant.core import callback
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
 from homeassistant.helpers.event import (
     async_call_later,
@@ -22,6 +24,7 @@ from homeassistant.helpers.event import (
     async_track_sunrise,
     async_track_sunset,
     async_track_template,
+    async_track_template_result,
     async_track_time_change,
     async_track_time_interval,
     async_track_utc_time_change,
@@ -435,7 +438,7 @@ async def test_track_template(hass):
         "{{states.switch.test.state == 'on' and test == 5}}", hass
     )
 
-    hass.states.async_set("switch.test", "off")
+    hass.states.async_set("switch.test", "on")
 
     def specific_run_callback(entity_id, old_state, new_state):
         specific_runs.append(1)
@@ -448,14 +451,14 @@ async def test_track_template(hass):
 
     async_track_template(hass, template_condition, wildcard_run_callback)
 
-    async def wildercard_run_callback(entity_id, old_state, new_state):
+    @asyncio.coroutine
+    def wildercard_run_callback(entity_id, old_state, new_state):
         wildercard_runs.append((old_state, new_state))
 
     async_track_template(
         hass, template_condition_var, wildercard_run_callback, {"test": 5}
     )
 
-    hass.states.async_set("switch.test", "on")
     await hass.async_block_till_done()
 
     assert len(specific_runs) == 1
@@ -490,61 +493,277 @@ async def test_track_template(hass):
     assert len(wildcard_runs) == 2
     assert len(wildercard_runs) == 2
 
-
-async def test_track_same_state_simple_trigger(hass):
-    """Test track_same_change with trigger simple."""
-    thread_runs = []
-    callback_runs = []
-    coroutine_runs = []
-    period = timedelta(minutes=1)
-
-    def thread_run_callback():
-        thread_runs.append(1)
-
-    async_track_same_state(
-        hass,
-        period,
-        thread_run_callback,
-        lambda _, _2, to_s: to_s.state == "on",
-        entity_ids="light.Bowl",
-    )
+    template_iterate = Template("{{ (states.switch | length) > 0 }}", hass)
+    iterate_calls = []
 
     @ha.callback
-    def callback_run_callback():
-        callback_runs.append(1)
+    def iterate_callback(entity_id, old_state, new_state):
+        iterate_calls.append((entity_id, old_state, new_state))
 
-    async_track_same_state(
-        hass,
-        period,
-        callback_run_callback,
-        callback(lambda _, _2, to_s: to_s.state == "on"),
-        entity_ids="light.Bowl",
+    async_track_template(hass, template_iterate, iterate_callback)
+    await hass.async_block_till_done()
+
+    assert len(iterate_calls) == 1
+    assert iterate_calls[0][0] == "switch.test"
+    assert iterate_calls[0][1].state == "on"
+    assert iterate_calls[0][2].state == "on"
+
+
+async def test_track_template_error(hass):
+    """Test tracking template with error."""
+    template_error = Template("{{ (states.switch | lunch) > 0 }}", hass)
+    error_calls = []
+
+    @ha.callback
+    def error_callback(entity_id, old_state, new_state):
+        error_calls.append((entity_id, old_state, new_state))
+
+    with patch.object(Logger, "exception") as call:
+        async_track_template(hass, template_error, error_callback)
+        await hass.async_block_till_done()
+
+        assert not error_calls
+        assert call.call_count == 1
+
+
+async def test_track_template_result(hass):
+    """Test tracking template."""
+    specific_runs = []
+    wildcard_runs = []
+    wildercard_runs = []
+
+    template_condition = Template("{{states.sensor.test.state}}", hass)
+    template_condition_var = Template(
+        "{{(states.sensor.test.state|int) + test }}", hass
     )
 
-    async def coroutine_run_callback():
-        coroutine_runs.append(1)
+    hass.states.async_set("sensor.test", 5)
 
-    async_track_same_state(
-        hass,
-        period,
-        coroutine_run_callback,
-        callback(lambda _, _2, to_s: to_s.state == "on"),
+    def specific_run_callback(event, template, old_result, new_result):
+        specific_runs.append(int(new_result))
+
+    async_track_template_result(hass, template_condition, specific_run_callback)
+
+    @ha.callback
+    def wildcard_run_callback(event, template, old_result, new_result):
+        wildcard_runs.append((int(old_result or 0), int(new_result)))
+
+    async_track_template_result(hass, template_condition, wildcard_run_callback)
+
+    async def wildercard_run_callback(event, template, old_result, new_result):
+        wildercard_runs.append((int(old_result or 0), int(new_result)))
+
+    async_track_template_result(
+        hass, template_condition_var, wildercard_run_callback, {"test": 5}
     )
-
-    # Adding state to state machine
-    hass.states.async_set("light.Bowl", "on")
     await hass.async_block_till_done()
-    assert len(thread_runs) == 0
-    assert len(callback_runs) == 0
-    assert len(coroutine_runs) == 0
 
-    # change time to track and see if they trigger
-    future = dt_util.utcnow() + period
-    async_fire_time_changed(hass, future)
+    assert specific_runs == [5]
+    assert wildcard_runs == [(0, 5)]
+    assert wildercard_runs == [(0, 10)]
+
+    hass.states.async_set("sensor.test", 30)
     await hass.async_block_till_done()
-    assert len(thread_runs) == 1
-    assert len(callback_runs) == 1
-    assert len(coroutine_runs) == 1
+
+    assert specific_runs == [5, 30]
+    assert wildcard_runs == [(0, 5), (5, 30)]
+    assert wildercard_runs == [(0, 10), (10, 35)]
+
+    hass.states.async_set("sensor.test", 30)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 2
+    assert len(wildcard_runs) == 2
+    assert len(wildercard_runs) == 2
+
+    hass.states.async_set("sensor.test", 5)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 3
+    assert len(wildcard_runs) == 3
+    assert len(wildercard_runs) == 3
+
+    hass.states.async_set("sensor.test", 5)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 3
+    assert len(wildcard_runs) == 3
+    assert len(wildercard_runs) == 3
+
+    hass.states.async_set("sensor.test", 20)
+    await hass.async_block_till_done()
+
+    assert len(specific_runs) == 4
+    assert len(wildcard_runs) == 4
+    assert len(wildercard_runs) == 4
+
+
+async def test_track_template_result_iterator(hass):
+    """Test tracking template."""
+    iterator_runs = []
+
+    @ha.callback
+    def iterator_callback(event, template, old_result, new_result):
+        iterator_runs.append(new_result)
+
+    async_track_template_result(
+        hass,
+        Template(
+            """
+            {% for state in states.sensor %}
+                {% if state.state == 'on' %}
+                    {{ state.entity_id }},
+                {% endif %}
+            {% endfor %}
+            """,
+            hass,
+        ),
+        iterator_callback,
+    )
+    await hass.async_block_till_done()
+
+    assert iterator_runs == [""]
+
+    filter_runs = []
+
+    @ha.callback
+    def filter_callback(event, template, old_result, new_result):
+        filter_runs.append(new_result)
+
+    async_track_template_result(
+        hass,
+        Template(
+            """{{ states.sensor|selectattr("state","equalto","on")
+                |join(",", attribute="entity_id") }}""",
+            hass,
+        ),
+        filter_callback,
+    )
+    await hass.async_block_till_done()
+    assert filter_runs == [""]
+
+    hass.states.async_set("sensor.test", 5)
+    await hass.async_block_till_done()
+    assert iterator_runs == [""]
+    assert filter_runs == [""]
+
+    hass.states.async_set("sensor.new", "on")
+    await hass.async_block_till_done()
+    assert iterator_runs == ["", "sensor.new,"]
+    assert filter_runs == ["", "sensor.new"]
+
+
+async def test_track_template_result_errors(hass):
+    """Test tracking template with errors in the template."""
+    template_syntax_error = Template("{{states.switch", hass)
+
+    template_not_exist = Template("{{states.switch.not_exist.state }}", hass)
+
+    syntax_error_runs = []
+    not_exist_runs = []
+
+    def syntax_error_listener(event, template, last_result, result):
+        syntax_error_runs.append((event, template, last_result, result))
+
+    async_track_template_result(hass, template_syntax_error, syntax_error_listener)
+    await hass.async_block_till_done()
+
+    assert len(syntax_error_runs) == 1
+    assert syntax_error_runs[0][1] == template_syntax_error
+    assert isinstance(syntax_error_runs[0][3], TemplateError)
+
+    async_track_template_result(
+        hass,
+        template_not_exist,
+        lambda event, template, last_result, result: (
+            not_exist_runs.append((event, template, last_result, result))
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert len(syntax_error_runs) == 1
+    assert len(not_exist_runs) == 1
+    assert not_exist_runs[0] == (None, template_not_exist, None, "")
+
+    hass.states.async_set("switch.not_exist", "off")
+    await hass.async_block_till_done()
+
+    assert len(not_exist_runs) == 2
+    assert not_exist_runs[1][0].data.get("entity_id") == "switch.not_exist"
+    assert not_exist_runs[1][1] == template_not_exist
+    assert not_exist_runs[1][2] == ""
+    assert not_exist_runs[1][3] == "off"
+
+    hass.states.async_set("switch.not_exist", "on")
+    await hass.async_block_till_done()
+
+    assert len(syntax_error_runs) == 1
+    assert len(not_exist_runs) == 3
+    assert not_exist_runs[2][0].data.get("entity_id") == "switch.not_exist"
+    assert not_exist_runs[2][1] == template_not_exist
+    assert not_exist_runs[2][2] == "off"
+    assert not_exist_runs[2][3] == "on"
+
+    with patch.object(Template, "async_render") as render:
+        render.side_effect = TemplateError("Test")
+
+        hass.states.async_set("switch.not_exist", "off")
+        await hass.async_block_till_done()
+
+        assert len(not_exist_runs) == 4
+        assert not_exist_runs[3][0].data.get("entity_id") == "switch.not_exist"
+        assert not_exist_runs[3][1] == template_not_exist
+        assert not_exist_runs[3][2] == "on"
+        assert isinstance(not_exist_runs[3][3], TemplateError)
+
+
+async def test_track_template_result_refresh_cancel(hass):
+    """Test cancelling and refreshing result."""
+    template_refresh = Template("{{states.switch.test.state == 'on' and now() }}", hass)
+
+    refresh_runs = []
+
+    def refresh_listener(event, template, last_result, result):
+        refresh_runs.append(result)
+
+    info = async_track_template_result(hass, template_refresh, refresh_listener)
+    await hass.async_block_till_done()
+
+    assert refresh_runs == ["False"]
+
+    hass.states.async_set("switch.test", "on")
+    await hass.async_block_till_done()
+
+    assert len(refresh_runs) == 2
+
+    info.async_refresh()
+    await hass.async_block_till_done()
+
+    assert len(refresh_runs) == 3
+    assert refresh_runs[1] != refresh_runs[2]
+
+    info.async_remove()
+    hass.states.async_set("switch.test", "off")
+    await hass.async_block_till_done()
+
+    assert len(refresh_runs) == 3
+
+    template_refresh = Template("{{ value }}", hass)
+    refresh_runs = []
+
+    info = async_track_template_result(
+        hass, template_refresh, refresh_listener, {"value": "duck"}
+    )
+    await hass.async_block_till_done()
+    assert refresh_runs == ["duck"]
+
+    info.async_refresh()
+    await hass.async_block_till_done()
+    assert refresh_runs == ["duck"]
+
+    info.async_refresh({"value": "dog"})
+    await hass.async_block_till_done()
+    assert refresh_runs == ["duck", "dog"]
 
 
 async def test_track_same_state_simple_no_trigger(hass):

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -739,6 +739,63 @@ async def test_track_template_result_with_wildcard(hass):
     assert "cover.office_skylight=open" in specific_runs[0]
 
 
+async def test_track_template_result_with_group(hass):
+    """Test tracking template with a group."""
+    hass.states.async_set("sensor.power_1", 0)
+    hass.states.async_set("sensor.power_2", 200.2)
+    hass.states.async_set("sensor.power_3", 400.4)
+    hass.states.async_set("sensor.power_4", 800.8)
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {"group": {"power_sensors": "sensor.power_1,sensor.power_2,sensor.power_3"}},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.power_sensors")
+    assert hass.states.get("group.power_sensors").state
+
+    specific_runs = []
+    template_complex_str = r"""
+
+{{ states.group.power_sensors.attributes.entity_id | expand | map(attribute='state')|map('float')|sum  }}
+
+"""
+    template_complex = Template(template_complex_str, hass)
+
+    def specific_run_callback(event, template, old_result, new_result):
+        specific_runs.append(new_result)
+
+    async_track_template_result(hass, template_complex, specific_run_callback)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.power_1", 100.1)
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 1
+
+    assert specific_runs[0] == str(100.1 + 200.2 + 400.4)
+
+    hass.states.async_set("sensor.power_3", 0)
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 2
+
+    assert specific_runs[1] == str(100.1 + 200.2 + 0)
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        return_value={
+            "group": {
+                "power_sensors": "sensor.power_1,sensor.power_2,sensor.power_3,sensor.power_4",
+            }
+        },
+    ):
+        await hass.services.async_call("group", "reload")
+        await hass.async_block_till_done()
+
+    assert specific_runs[-1] == str(100.1 + 200.2 + 0 + 800.8)
+
+
 async def test_track_template_result_iterator(hass):
     """Test tracking template."""
     iterator_runs = []

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -610,13 +610,13 @@ async def test_track_template_result_complex(hass):
     template_complex_str = """
 
 {% if states("sensor.domain") == "light" %}
-  {{ states.light | list }}
+  {{ states.light | map(attribute='entity_id') | list }}
 {% elif states("sensor.domain") == "lock" %}
-  {{ states.lock | list }}
+  {{ states.lock | map(attribute='entity_id') | list }}
 {% elif states("sensor.domain") == "single_binary_sensor" %}
   {{ states("binary_sensor.single") }}
 {% else %}
-  {{ states | list }}
+  {{ states | map(attribute='entity_id') | list }}
 {% endif %}
 
 """
@@ -633,11 +633,11 @@ async def test_track_template_result_complex(hass):
 
     hass.states.async_set("sensor.domain", "light")
     await hass.async_block_till_done()
-    assert specific_runs[0].strip() == "light.one"
+    assert specific_runs[0].strip() == "['light.one']"
 
     hass.states.async_set("sensor.domain", "lock")
     await hass.async_block_till_done()
-    assert specific_runs[1].strip() == "lock.one"
+    assert specific_runs[1].strip() == "['lock.one']"
 
     hass.states.async_set("sensor.domain", "all")
     await hass.async_block_till_done()
@@ -647,7 +647,7 @@ async def test_track_template_result_complex(hass):
 
     hass.states.async_set("sensor.domain", "light")
     await hass.async_block_till_done()
-    assert specific_runs[3].strip() == "light.one"
+    assert specific_runs[3].strip() == "['light.one']"
 
     hass.states.async_set("light.two", "on")
     await hass.async_block_till_done()
@@ -657,7 +657,6 @@ async def test_track_template_result_complex(hass):
 
     hass.states.async_set("light.three", "on")
     await hass.async_block_till_done()
-    assert specific_runs[4].strip() == "light.three"
     assert "light.one" in specific_runs[5]
     assert "light.two" in specific_runs[5]
     assert "light.three" in specific_runs[5]
@@ -665,7 +664,7 @@ async def test_track_template_result_complex(hass):
 
     hass.states.async_set("sensor.domain", "lock")
     await hass.async_block_till_done()
-    assert specific_runs[6].strip() == "lock.one"
+    assert specific_runs[6].strip() == "['lock.one']"
 
     hass.states.async_set("sensor.domain", "single_binary_sensor")
     await hass.async_block_till_done()
@@ -677,7 +676,7 @@ async def test_track_template_result_complex(hass):
 
     hass.states.async_set("sensor.domain", "lock")
     await hass.async_block_till_done()
-    assert specific_runs[9].strip() == "lock.one"
+    assert specific_runs[9].strip() == "['lock.one']"
 
 
 async def test_track_template_result_iterator(hass):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1459,6 +1459,31 @@ def test_nested_async_render_to_info_case(hass):
     assert_result_info(info, "off", {"input_select.picker", "vacuum.a"})
 
 
+def test_result_as_boolean(hass):
+    """Test converting a template result to a boolean."""
+
+    template.result_as_boolean(True) is True
+    template.result_as_boolean(" 1 ") is True
+    template.result_as_boolean(" true ") is True
+    template.result_as_boolean(" TrUE ") is True
+    template.result_as_boolean(" YeS ") is True
+    template.result_as_boolean(" On ") is True
+    template.result_as_boolean(" Enable ") is True
+    template.result_as_boolean(1) is True
+    template.result_as_boolean(-1) is True
+    template.result_as_boolean(500) is True
+
+    template.result_as_boolean(False) is False
+    template.result_as_boolean(" 0 ") is False
+    template.result_as_boolean(" false ") is False
+    template.result_as_boolean(" FaLsE ") is False
+    template.result_as_boolean(" no ") is False
+    template.result_as_boolean(" off ") is False
+    template.result_as_boolean(" disable ") is False
+    template.result_as_boolean(0) is False
+    template.result_as_boolean(None) is False
+
+
 def test_closest_function_to_entity_id(hass):
     """Test closest function to entity id."""
     hass.states.async_set(


### PR DESCRIPTION
This is a updated version of #23590 

##  Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


This is the continuation from #23283

#### Add `async_track_template_result` method

This uses the previous changes to template for the next layer of the algorithm. This method fires on any change of a template, and will automatically listen for state changes on any referenced entities.

I've also updated `track_template` to be a wrapper around this method.

**Related issue:** #22587

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22587
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
