### PR TITLE
Add Slack url icon support

### DIFF
--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -195,9 +195,11 @@ class SlackNotificationService(BaseNotificationService):
         """Send a text-only message."""
         username = self._username
         icon = self._icon
-        icon_type = (
-            "url" if self._icon.lower().startswith(("http://", "https://")) else "emoji"
-        )
+
+        if self._icon.lower().startswith(("http://", "https://")):
+            icon_type = "url"
+        else:
+            icon_type = "emoji"
 
         tasks = {
             target: self._client.chat_postMessage(

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -206,7 +206,6 @@ class SlackNotificationService(BaseNotificationService):
                     "text": message,
                     "blocks": blocks,
                     "link_names": True,
-                    "as_user": True,
                     "username": username,
                     "icon_" + icon_type: icon,
                 }

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -207,7 +207,7 @@ class SlackNotificationService(BaseNotificationService):
                     "blocks": blocks,
                     "link_names": True,
                     "username": username,
-                    "icon_" + icon_type: icon,
+                    f"icon_{icon_type}": icon,
                 }
             )
             for target in targets

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -193,14 +193,23 @@ class SlackNotificationService(BaseNotificationService):
 
     async def _async_send_text_only_message(self, targets, message, title, blocks):
         """Send a text-only message."""
+        username = self._username
+        icon = self._icon
+        icon_type = (
+            "url" if self._icon.lower().startswith(("http://", "https://")) else "emoji"
+        )
+
         tasks = {
             target: self._client.chat_postMessage(
-                channel=target,
-                text=message,
-                blocks=blocks,
-                icon_emoji=self._icon,
-                link_names=True,
-                username=self._username,
+                **{
+                    "channel": target,
+                    "text": message,
+                    "blocks": blocks,
+                    "link_names": True,
+                    "as_user": True,
+                    "username": username,
+                    "icon_" + icon_type: icon,
+                }
             )
             for target in targets
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A previous update to the Slack component added support for the new `icon_emoji` property in the [`chat.postMessage`](https://api.slack.com/methods/chat.postMessage) endpoint. However, the API also allows for non-emoji icons to be used by specifying the icon URL in the `icon_url` property.

This adds support for `icon_url`'s by checking if the value in `CONF_ICON` is a URL and setting the appropriate `icon_url` property, otherwise it defaults to the existing behaviour of setting `icon_emoji` property.

Verified working locally. Unit tests not possible due to third-party dependency (component is listed in `.coveragerc`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
notify:
  - name: slack
    platform: slack
    api_key: abc-123-def-456
    default_channel: '#general'
    username: i-am-bot
    icon: https://example.com/icon.jpg
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14239

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
