### PR TITLE
Allow using environment cacert file

### DIFF
--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -1,9 +1,9 @@
 """Helper to create SSL contexts."""
+from os import environ
 import ssl
 
 import certifi
 
-from os import environ
 
 def client_context() -> ssl.SSLContext:
     """Return an SSL context for making requests."""
@@ -12,9 +12,7 @@ def client_context() -> ssl.SSLContext:
     # If the environment variable has no value, fall back to using certs from certifi package
     cafile = environ.get("REQUESTS_CA_BUNDLE", certifi.where())
 
-    context = ssl.create_default_context(
-        purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile
-    )
+    context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile)
     return context
 
 

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -3,11 +3,17 @@ import ssl
 
 import certifi
 
+from os import environ
 
 def client_context() -> ssl.SSLContext:
     """Return an SSL context for making requests."""
+
+    # Reuse environment variable definition from requests, since it's already a requirement
+    # If the environment variable has no value, fall back to using certs from certifi package
+    cafile = environ.get("REQUESTS_CA_BUNDLE", certifi.where())
+
     context = ssl.create_default_context(
-        purpose=ssl.Purpose.SERVER_AUTH, cafile=certifi.where()
+        purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile
     )
     return context
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Re-use the REQUESTS_CA_BUNDLE environment variable from the requests
package in order to allow using system (or any other) cacert file
for users who are using their own CA to sign certificates for local
services.

Since requests is already a requirement, and allows this environment
variable, this is both a feature and a fix of sorts, as whether certs
created by a local CA would work or not is currently dependent on whether
requests or aiohttp is used to fetch the resource.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I've tested this by using the pi-hole integration using my own ca signed certificate, telling it to verify ssl. That integration did not work prior to this change.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
