### PR TITLE
Sentry integration enhancements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -747,7 +747,6 @@ omit =
     homeassistant/components/sensehat/light.py
     homeassistant/components/sensehat/sensor.py
     homeassistant/components/sensibo/climate.py
-    homeassistant/components/sentry/__init__.py
     homeassistant/components/serial/sensor.py
     homeassistant/components/serial_pm/sensor.py
     homeassistant/components/sesame/lock.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -360,7 +360,7 @@ homeassistant/components/script/* @home-assistant/core
 homeassistant/components/search/* @home-assistant/core
 homeassistant/components/sense/* @kbickar
 homeassistant/components/sensibo/* @andrey-git
-homeassistant/components/sentry/* @dcramer
+homeassistant/components/sentry/* @dcramer @frenck
 homeassistant/components/serial/* @fabaff
 homeassistant/components/seven_segments/* @fabaff
 homeassistant/components/seventeentrack/* @bachya

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -92,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         # Additional extra data to add to the event
         extra_data = {
             **system_info,
-            "custom_components": "\n".join(sorted(custom_components.keys())),
+            "custom_components": "\n".join(sorted(custom_components)),
             "integrations": "\n".join(sorted(integrations)),
         }
 

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # https://docs.sentry.io/platforms/python/logging/
     sentry_logging = LoggingIntegration(
-        level=logging.WARNING,  # Capture info and above as breadcrumbs
+        level=logging.WARNING,  # Capture warning and above as breadcrumbs
         event_level=logging.ERROR,  # Send errors as events
     )
 

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -1,17 +1,21 @@
 """The sentry integration."""
 import logging
+import re
 
 import sentry_sdk
+from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import __version__
+from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.loader import async_get_custom_components
 
-from .const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN
+from .const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN, ENTITY_COMPONENTS
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -21,6 +25,9 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+
+LOGGER_INFO_REGEX = re.compile(r"^(\w+)\.?(\w+)?\.?(\w+)?\.?(\w+)?(?:\..*)?$")
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -44,15 +51,98 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # https://docs.sentry.io/platforms/python/logging/
     sentry_logging = LoggingIntegration(
-        level=logging.INFO,  # Capture info and above as breadcrumbs
+        level=logging.WARNING,  # Capture info and above as breadcrumbs
         event_level=logging.ERROR,  # Send errors as events
     )
+
+    # Find channel based on version number
+    channel = "stable"
+    if "dev0" in current_version:
+        channel = "dev"
+    elif "dev" in current_version:
+        channel = "nightly"
+    elif "b" in current_version:
+        channel = "beta"
+
+    # Additional/extra data collection
+    huuid = await hass.helpers.instance_id.async_get()
+    system_info = await hass.helpers.system_info.async_get_system_info()
+    custom_components = await async_get_custom_components(hass)
+
+    def before_send(event, hint):
+        # Filter out handled events by default
+        if "tags" in event and event.tags.get("handled", "no") == "yes":
+            return None
+
+        # Additional tags to add to the event
+        additional_tags = {
+            "channel": channel,
+            "installation_type": system_info["installation_type"],
+            "uuid": huuid,
+        }
+
+        # Find out all integrations in use, filter "auth", because it
+        # triggers security rules, hiding all data.
+        integrations = [
+            integration
+            for integration in hass.config.components
+            if integration != "auth" and "." not in integration
+        ]
+
+        # Additional extra data to add to the event
+        extra_data = {
+            **system_info,
+            "custom_components": "\n".join(sorted(custom_components.keys())),
+            "integrations": "\n".join(sorted(integrations)),
+        }
+
+        # Add additional tags based on what caused the event.
+        platform = entity_platform.current_platform.get()
+        if platform is not None:
+            # This event happened in a platform
+            additional_tags["custom_component"] = "no"
+            additional_tags["integration"] = platform.platform_name
+            additional_tags["platform"] = platform.domain
+        elif "logger" in event:
+            # Logger event, try to get integration information from the logger name.
+            matches = LOGGER_INFO_REGEX.findall(event["logger"])
+            if matches:
+                group1, group2, group3, group4 = matches[0]
+                # Handle the "homeassistant." package differently
+                if group1 == "homeassistant" and group2 and group3:
+                    if group2 == "components":
+                        # This logger is from a component
+                        additional_tags["custom_component"] = "no"
+                        additional_tags["integration"] = group3
+                        if group4 and group4 in ENTITY_COMPONENTS:
+                            additional_tags["platform"] = group4
+                    else:
+                        # Not a component, could be helper, or something else.
+                        additional_tags[group2] = group3
+                else:
+                    # Not the "homeassistant" package, this third-party
+                    additional_tags["package"] = group1
+
+        # If this event is caused by an integration, add a tag if this
+        # integration is custom or not.
+        if (
+            "integration" in additional_tags
+            and additional_tags["integration"] in custom_components
+        ):
+            additional_tags["custom_component"] = "yes"
+
+        # Update event with all additional data
+        event.setdefault("tags", {}).update(additional_tags)
+        event.setdefault("extra", {}).update(extra_data)
+
+        return event
 
     sentry_sdk.init(
         dsn=conf.get(CONF_DSN),
         environment=conf.get(CONF_ENVIRONMENT),
-        integrations=[sentry_logging],
-        release=f"homeassistant-{__version__}",
+        integrations=[sentry_logging, AioHttpIntegration(), SqlalchemyIntegration()],
+        release=current_version,
+        before_send=before_send,
     )
 
     return True

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -89,13 +89,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if integration != "auth" and "." not in integration
         ]
 
-        # Additional extra data to add to the event
-        extra_data = {
-            **system_info,
-            "custom_components": "\n".join(sorted(custom_components)),
-            "integrations": "\n".join(sorted(integrations)),
-        }
-
         # Add additional tags based on what caused the event.
         platform = entity_platform.current_platform.get()
         if platform is not None:
@@ -131,10 +124,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         ):
             additional_tags["custom_component"] = "yes"
 
-        # Update event with all additional data
+        # Update event with the additional tags
         event.setdefault("tags", {}).update(additional_tags)
-        event.setdefault("extra", {}).update(extra_data)
 
+        # Update event data with Home Assistant Context
+        event.setdefault("contexts", {}).update(
+            {
+                "Home Assistant": {
+                    "channel": channel,
+                    "custom_components": "\n".join(sorted(custom_components)),
+                    "integrations": "\n".join(sorted(integrations)),
+                    **system_info,
+                },
+            }
+        )
         return event
 
     sentry_sdk.init(

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -1,5 +1,6 @@
 """The sentry integration."""
 import re
+from typing import Dict, Union
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -10,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.loader import async_get_custom_components
+from homeassistant.loader import Integration, async_get_custom_components
 
 from .const import (
     CONF_DSN,
@@ -20,8 +21,11 @@ from .const import (
     CONF_EVENT_THIRD_PARTY_PACKAGES,
     CONF_LOGGING_EVENT_LEVEL,
     CONF_LOGGING_LEVEL,
+    CONF_TRACING,
+    CONF_TRACING_SAMPLE_RATE,
     DEFAULT_LOGGING_EVENT_LEVEL,
     DEFAULT_LOGGING_LEVEL,
+    DEFAULT_TRACING_SAMPLE_RATE,
     DOMAIN,
     ENTITY_COMPONENTS,
 )
@@ -32,12 +36,12 @@ CONFIG_SCHEMA = cv.deprecated(DOMAIN, invalidation_version="0.117")
 LOGGER_INFO_REGEX = re.compile(r"^(\w+)\.?(\w+)?\.?(\w+)?\.?(\w+)?(?:\..*)?$")
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Sentry component."""
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Sentry from a config entry."""
 
     # Migrate environment from config entry data to config entry options
@@ -65,6 +69,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     system_info = await hass.helpers.system_info.async_get_system_info()
     custom_components = await async_get_custom_components(hass)
 
+    tracing = {}
+    if entry.options.get(CONF_TRACING):
+        tracing = {
+            "traceparent_v2": True,
+            "traces_sample_rate": entry.options.get(
+                CONF_TRACING_SAMPLE_RATE, DEFAULT_TRACING_SAMPLE_RATE
+            ),
+        }
+
     sentry_sdk.init(
         dsn=entry.data[CONF_DSN],
         environment=entry.options.get(CONF_ENVIRONMENT),
@@ -80,12 +93,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             event,
             hint,
         ),
+        **tracing,
     )
 
     return True
 
 
-def get_channel(version) -> str:
+def get_channel(version: str) -> str:
     """Find channel based on version number."""
     if "dev0" in version:
         return "dev"
@@ -97,7 +111,14 @@ def get_channel(version) -> str:
 
 
 def process_before_send(
-    hass, options, channel, huuid, system_info, custom_components, event, hint
+    hass: HomeAssistant,
+    options,
+    channel: str,
+    huuid: str,
+    system_info: Dict[str, Union[bool, str]],
+    custom_components: Dict[str, Integration],
+    event,
+    hint,
 ):
     """Process a Sentry event before sending it to Sentry."""
     # Filter out handled events by default

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -6,26 +6,45 @@ from sentry_sdk.utils import BadDsn, Dsn
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.core import callback
 
-from .const import CONF_DSN, DOMAIN  # pylint: disable=unused-import
+from .const import (  # pylint: disable=unused-import
+    CONF_DSN,
+    CONF_ENVIRONMENT,
+    CONF_EVENT_CUSTOM_COMPONENTS,
+    CONF_EVENT_HANDLED,
+    CONF_EVENT_THIRD_PARTY_PACKAGES,
+    CONF_LOGGING_EVENT_LEVEL,
+    CONF_LOGGING_LEVEL,
+    DEFAULT_LOGGING_EVENT_LEVEL,
+    DEFAULT_LOGGING_LEVEL,
+    DOMAIN,
+    LOGGING_LEVELS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_DSN): str})
 
 
-class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class SentryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Sentry config flow."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return SentryOptionsFlow(config_entry)
 
     async def async_step_user(
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Handle a user config flow."""
         if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
+            return self.async_abort(reason="single_instance_allowed")
 
         errors = {}
         if user_input is not None:
@@ -41,4 +60,61 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class SentryOptionsFlow(config_entries.OptionsFlow):
+    """Handle Sentry options."""
+
+    def __init__(self, config_entry):
+        """Initialize Sentry options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Manage Sentry options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_LOGGING_EVENT_LEVEL,
+                        default=self.config_entry.options.get(
+                            CONF_LOGGING_EVENT_LEVEL, DEFAULT_LOGGING_EVENT_LEVEL
+                        ),
+                    ): vol.In(LOGGING_LEVELS),
+                    vol.Optional(
+                        CONF_LOGGING_LEVEL,
+                        default=self.config_entry.options.get(
+                            CONF_LOGGING_LEVEL, DEFAULT_LOGGING_LEVEL
+                        ),
+                    ): vol.In(LOGGING_LEVELS),
+                    vol.Optional(
+                        CONF_ENVIRONMENT,
+                        default=self.config_entry.options.get(CONF_ENVIRONMENT),
+                    ): str,
+                    vol.Optional(
+                        CONF_EVENT_HANDLED,
+                        default=self.config_entry.options.get(
+                            CONF_EVENT_HANDLED, False
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_EVENT_CUSTOM_COMPONENTS,
+                        default=self.config_entry.options.get(
+                            CONF_EVENT_CUSTOM_COMPONENTS, False
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_EVENT_THIRD_PARTY_PACKAGES,
+                        default=self.config_entry.options.get(
+                            CONF_EVENT_THIRD_PARTY_PACKAGES, False
+                        ),
+                    ): bool,
+                }
+            ),
         )

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow for sentry integration."""
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict, Optional
 
@@ -16,8 +18,11 @@ from .const import (  # pylint: disable=unused-import
     CONF_EVENT_THIRD_PARTY_PACKAGES,
     CONF_LOGGING_EVENT_LEVEL,
     CONF_LOGGING_LEVEL,
+    CONF_TRACING,
+    CONF_TRACING_SAMPLE_RATE,
     DEFAULT_LOGGING_EVENT_LEVEL,
     DEFAULT_LOGGING_LEVEL,
+    DEFAULT_TRACING_SAMPLE_RATE,
     DOMAIN,
     LOGGING_LEVELS,
 )
@@ -35,7 +40,9 @@ class SentryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> SentryOptionsFlow:
         """Get the options flow for this handler."""
         return SentryOptionsFlow(config_entry)
 
@@ -66,7 +73,7 @@ class SentryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class SentryOptionsFlow(config_entries.OptionsFlow):
     """Handle Sentry options."""
 
-    def __init__(self, config_entry):
+    def __init__(self, config_entry: config_entries.ConfigEntry):
         """Initialize Sentry options flow."""
         self.config_entry = config_entry
 
@@ -115,6 +122,16 @@ class SentryOptionsFlow(config_entries.OptionsFlow):
                             CONF_EVENT_THIRD_PARTY_PACKAGES, False
                         ),
                     ): bool,
+                    vol.Optional(
+                        CONF_TRACING,
+                        default=self.config_entry.options.get(CONF_TRACING, False),
+                    ): bool,
+                    vol.Optional(
+                        CONF_TRACING_SAMPLE_RATE,
+                        default=self.config_entry.options.get(
+                            CONF_TRACING_SAMPLE_RATE, DEFAULT_TRACING_SAMPLE_RATE
+                        ),
+                    ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0)),
                 }
             ),
         )

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -1,10 +1,11 @@
 """Config flow for sentry integration."""
 import logging
+from typing import Any, Dict, Optional
 
 from sentry_sdk.utils import BadDsn, Dsn
 import voluptuous as vol
 
-from homeassistant import config_entries, core
+from homeassistant import config_entries
 
 from .const import CONF_DSN, DOMAIN  # pylint: disable=unused-import
 
@@ -13,24 +14,15 @@ _LOGGER = logging.getLogger(__name__)
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_DSN): str})
 
 
-async def validate_input(hass: core.HomeAssistant, data):
-    """Validate the DSN input allows us to connect.
-
-    Data has the keys from DATA_SCHEMA with values provided by the user.
-    """
-    # validate the dsn
-    Dsn(data["dsn"])
-
-    return {"title": "Sentry"}
-
-
 class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Sentry config flow."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Handle a user config flow."""
         if self._async_current_entries():
             return self.async_abort(reason="already_configured")
@@ -38,19 +30,15 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             try:
-                info = await validate_input(self.hass, user_input)
-
-                return self.async_create_entry(title=info["title"], data=user_input)
+                Dsn(user_input["dsn"])
             except BadDsn:
                 errors["base"] = "bad_dsn"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title="Sentry", data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
-
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user(import_config)

--- a/homeassistant/components/sentry/const.py
+++ b/homeassistant/components/sentry/const.py
@@ -1,56 +1,31 @@
 """Constants for the sentry integration."""
 
-from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_DOMAIN
-from homeassistant.components.alarm_control_panel import (
-    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
-)
-from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.calendar import DOMAIN as CALENDAR_DOMAIN
-from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
-from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
-from homeassistant.components.geo_location import DOMAIN as GEO_LOCATION_DOMAIN
-from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
-from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
-from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
-from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
-from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
-from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
-from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
-
 DOMAIN = "sentry"
 
 CONF_DSN = "dsn"
 CONF_ENVIRONMENT = "environment"
 
 ENTITY_COMPONENTS = [
-    AIR_QUALITY_DOMAIN,
-    ALARM_CONTROL_PANEL_DOMAIN,
-    BINARY_SENSOR_DOMAIN,
-    CALENDAR_DOMAIN,
-    CAMERA_DOMAIN,
-    CLIMATE_DOMAIN,
-    COVER_DOMAIN,
-    DEVICE_TRACKER_DOMAIN,
-    FAN_DOMAIN,
-    GEO_LOCATION_DOMAIN,
-    GROUP_DOMAIN,
-    HUMIDIFIER_DOMAIN,
-    LIGHT_DOMAIN,
-    LOCK_DOMAIN,
-    MEDIA_PLAYER_DOMAIN,
-    REMOTE_DOMAIN,
-    SCENE_DOMAIN,
-    SENSOR_DOMAIN,
-    SWITCH_DOMAIN,
-    VACUUM_DOMAIN,
-    WATER_HEATER_DOMAIN,
-    WEATHER_DOMAIN,
+    "air_quality",
+    "alarm_control_panel",
+    "binary_sensor",
+    "calendar",
+    "camera",
+    "climate",
+    "cover",
+    "device_tracker",
+    "fan",
+    "geo_location",
+    "group",
+    "humidifier",
+    "light",
+    "lock",
+    "media_player",
+    "remote",
+    "scene",
+    "sensor",
+    "switch",
+    "vacuum",
+    "water_heater",
+    "weather",
 ]

--- a/homeassistant/components/sentry/const.py
+++ b/homeassistant/components/sentry/const.py
@@ -1,6 +1,56 @@
 """Constants for the sentry integration."""
 
+from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_DOMAIN
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.calendar import DOMAIN as CALENDAR_DOMAIN
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.geo_location import DOMAIN as GEO_LOCATION_DOMAIN
+from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
+from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
+
 DOMAIN = "sentry"
 
 CONF_DSN = "dsn"
 CONF_ENVIRONMENT = "environment"
+
+ENTITY_COMPONENTS = [
+    AIR_QUALITY_DOMAIN,
+    ALARM_CONTROL_PANEL_DOMAIN,
+    BINARY_SENSOR_DOMAIN,
+    CALENDAR_DOMAIN,
+    CAMERA_DOMAIN,
+    CLIMATE_DOMAIN,
+    COVER_DOMAIN,
+    DEVICE_TRACKER_DOMAIN,
+    FAN_DOMAIN,
+    GEO_LOCATION_DOMAIN,
+    GROUP_DOMAIN,
+    HUMIDIFIER_DOMAIN,
+    LIGHT_DOMAIN,
+    LOCK_DOMAIN,
+    MEDIA_PLAYER_DOMAIN,
+    REMOTE_DOMAIN,
+    SCENE_DOMAIN,
+    SENSOR_DOMAIN,
+    SWITCH_DOMAIN,
+    VACUUM_DOMAIN,
+    WATER_HEATER_DOMAIN,
+    WEATHER_DOMAIN,
+]

--- a/homeassistant/components/sentry/const.py
+++ b/homeassistant/components/sentry/const.py
@@ -1,9 +1,27 @@
 """Constants for the sentry integration."""
 
+import logging
+
 DOMAIN = "sentry"
 
 CONF_DSN = "dsn"
 CONF_ENVIRONMENT = "environment"
+CONF_EVENT_CUSTOM_COMPONENTS = "event_custom_components"
+CONF_EVENT_HANDLED = "event_handled"
+CONF_EVENT_THIRD_PARTY_PACKAGES = "event_third_party_packages"
+CONF_LOGGING_EVENT_LEVEL = "logging_event_level"
+CONF_LOGGING_LEVEL = "logging_level"
+
+DEFAULT_LOGGING_EVENT_LEVEL = logging.ERROR
+DEFAULT_LOGGING_LEVEL = logging.WARNING
+
+LOGGING_LEVELS = {
+    logging.DEBUG: "debug",
+    logging.INFO: "info",
+    logging.WARNING: "warning",
+    logging.ERROR: "error",
+    logging.CRITICAL: "critical",
+}
 
 ENTITY_COMPONENTS = [
     "air_quality",

--- a/homeassistant/components/sentry/const.py
+++ b/homeassistant/components/sentry/const.py
@@ -11,9 +11,12 @@ CONF_EVENT_HANDLED = "event_handled"
 CONF_EVENT_THIRD_PARTY_PACKAGES = "event_third_party_packages"
 CONF_LOGGING_EVENT_LEVEL = "logging_event_level"
 CONF_LOGGING_LEVEL = "logging_level"
+CONF_TRACING = "tracing"
+CONF_TRACING_SAMPLE_RATE = "tracing_sample_rate"
 
 DEFAULT_LOGGING_EVENT_LEVEL = logging.ERROR
 DEFAULT_LOGGING_LEVEL = logging.WARNING
+DEFAULT_TRACING_SAMPLE_RATE = 1.0
 
 LOGGING_LEVELS = {
     logging.DEBUG: "debug",

--- a/homeassistant/components/sentry/manifest.json
+++ b/homeassistant/components/sentry/manifest.json
@@ -3,6 +3,6 @@
   "name": "Sentry",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sentry",
-  "requirements": ["sentry-sdk==0.13.5"],
+  "requirements": ["sentry-sdk==0.16.3"],
   "codeowners": ["@dcramer"]
 }

--- a/homeassistant/components/sentry/manifest.json
+++ b/homeassistant/components/sentry/manifest.json
@@ -4,5 +4,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sentry",
   "requirements": ["sentry-sdk==0.16.3"],
-  "codeowners": ["@dcramer"]
+  "codeowners": ["@dcramer", "@frenck"]
 }

--- a/homeassistant/components/sentry/manifest.json
+++ b/homeassistant/components/sentry/manifest.json
@@ -4,5 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sentry",
   "requirements": ["sentry-sdk==0.16.5"],
-  "codeowners": ["@dcramer", "@frenck"]
+  "codeowners": ["@dcramer", "@frenck"],
+  "quality_scale": "gold"
 }

--- a/homeassistant/components/sentry/manifest.json
+++ b/homeassistant/components/sentry/manifest.json
@@ -3,6 +3,6 @@
   "name": "Sentry",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sentry",
-  "requirements": ["sentry-sdk==0.16.3"],
+  "requirements": ["sentry-sdk==0.16.5"],
   "codeowners": ["@dcramer", "@frenck"]
 }

--- a/homeassistant/components/sentry/manifest.json
+++ b/homeassistant/components/sentry/manifest.json
@@ -4,6 +4,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sentry",
   "requirements": ["sentry-sdk==0.16.5"],
-  "codeowners": ["@dcramer", "@frenck"],
-  "quality_scale": "gold"
+  "codeowners": ["@dcramer", "@frenck"]
 }

--- a/homeassistant/components/sentry/strings.json
+++ b/homeassistant/components/sentry/strings.json
@@ -1,9 +1,29 @@
 {
   "config": {
     "step": {
-      "user": { "title": "Sentry", "description": "Enter your Sentry DSN" }
+      "user": {
+        "title": "Sentry",
+        "description": "Enter your Sentry DSN",
+        "data": { "dsn": "DSN" }
+      }
     },
     "error": { "unknown": "Unexpected error", "bad_dsn": "Invalid DSN" },
-    "abort": { "already_configured": "Sentry is already configured" }
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "environment": "Optional name of the environment.",
+          "event_custom_components": "Send events from custom components",
+          "event_handled": "Send handled events",
+          "event_third_party_packages": "Send events from third-party packages",
+          "logging_event_level": "The log level Sentry will register an event for",
+          "logging_level": "The log level Sentry will record logs as breadcrums for"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/sentry/strings.json
+++ b/homeassistant/components/sentry/strings.json
@@ -21,7 +21,9 @@
           "event_handled": "Send handled events",
           "event_third_party_packages": "Send events from third-party packages",
           "logging_event_level": "The log level Sentry will register an event for",
-          "logging_level": "The log level Sentry will record logs as breadcrums for"
+          "logging_level": "The log level Sentry will record logs as breadcrums for",
+          "tracing": "Enable performance tracing",
+          "tracing_sample_rate": "Tracing sample rate; between 0.0 and 1.0 (1.0 = 100%)"
         }
       }
     }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1960,7 +1960,7 @@ sense-hat==2.2.0
 sense_energy==0.7.2
 
 # homeassistant.components.sentry
-sentry-sdk==0.13.5
+sentry-sdk==0.16.3
 
 # homeassistant.components.aquostv
 sharp_aquos_rc==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1960,7 +1960,7 @@ sense-hat==2.2.0
 sense_energy==0.7.2
 
 # homeassistant.components.sentry
-sentry-sdk==0.16.3
+sentry-sdk==0.16.5
 
 # homeassistant.components.aquostv
 sharp_aquos_rc==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -887,7 +887,7 @@ samsungtvws[websocket]==1.4.0
 sense_energy==0.7.2
 
 # homeassistant.components.sentry
-sentry-sdk==0.13.5
+sentry-sdk==0.16.3
 
 # homeassistant.components.sighthound
 simplehound==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -887,7 +887,7 @@ samsungtvws[websocket]==1.4.0
 sense_energy==0.7.2
 
 # homeassistant.components.sentry
-sentry-sdk==0.16.3
+sentry-sdk==0.16.5
 
 # homeassistant.components.sighthound
 simplehound==0.3

--- a/tests/components/sentry/test_config_flow.py
+++ b/tests/components/sentry/test_config_flow.py
@@ -1,8 +1,19 @@
 """Test the sentry config flow."""
+import logging
+
 from sentry_sdk.utils import BadDsn
 
-from homeassistant.components.sentry.const import DOMAIN
+from homeassistant.components.sentry.const import (
+    CONF_ENVIRONMENT,
+    CONF_EVENT_CUSTOM_COMPONENTS,
+    CONF_EVENT_HANDLED,
+    CONF_EVENT_THIRD_PARTY_PACKAGES,
+    CONF_LOGGING_EVENT_LEVEL,
+    CONF_LOGGING_LEVEL,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
@@ -15,7 +26,7 @@ async def test_full_user_flow_implementation(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {}
 
     with patch("homeassistant.components.sentry.config_flow.Dsn"), patch(
@@ -45,8 +56,8 @@ async def test_integration_already_exists(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_user_flow_bad_dsn(hass):
@@ -62,7 +73,7 @@ async def test_user_flow_bad_dsn(hass):
             result["flow_id"], {"dsn": "foo"},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "bad_dsn"}
 
 
@@ -79,5 +90,44 @@ async def test_user_flow_unkown_exception(hass):
             result["flow_id"], {"dsn": "foo"},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "unknown"}
+
+
+async def test_options_flow(hass):
+    """Test options config flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={"dsn": "http://public@sentry.local/1"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.sentry.async_setup_entry", return_value=True):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ENVIRONMENT: "Test",
+            CONF_EVENT_CUSTOM_COMPONENTS: True,
+            CONF_EVENT_HANDLED: True,
+            CONF_EVENT_THIRD_PARTY_PACKAGES: True,
+            CONF_LOGGING_EVENT_LEVEL: logging.DEBUG,
+            CONF_LOGGING_LEVEL: logging.DEBUG,
+        },
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == {
+        CONF_ENVIRONMENT: "Test",
+        CONF_EVENT_CUSTOM_COMPONENTS: True,
+        CONF_EVENT_HANDLED: True,
+        CONF_EVENT_THIRD_PARTY_PACKAGES: True,
+        CONF_LOGGING_EVENT_LEVEL: logging.DEBUG,
+        CONF_LOGGING_LEVEL: logging.DEBUG,
+    }

--- a/tests/components/sentry/test_config_flow.py
+++ b/tests/components/sentry/test_config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.components.sentry.const import (
     CONF_EVENT_THIRD_PARTY_PACKAGES,
     CONF_LOGGING_EVENT_LEVEL,
     CONF_LOGGING_LEVEL,
+    CONF_TRACING,
+    CONF_TRACING_SAMPLE_RATE,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
@@ -119,6 +121,8 @@ async def test_options_flow(hass):
             CONF_EVENT_THIRD_PARTY_PACKAGES: True,
             CONF_LOGGING_EVENT_LEVEL: logging.DEBUG,
             CONF_LOGGING_LEVEL: logging.DEBUG,
+            CONF_TRACING: True,
+            CONF_TRACING_SAMPLE_RATE: 0.5,
         },
     )
 
@@ -130,4 +134,6 @@ async def test_options_flow(hass):
         CONF_EVENT_THIRD_PARTY_PACKAGES: True,
         CONF_LOGGING_EVENT_LEVEL: logging.DEBUG,
         CONF_LOGGING_LEVEL: logging.DEBUG,
+        CONF_TRACING: True,
+        CONF_TRACING_SAMPLE_RATE: 0.5,
     }

--- a/tests/components/sentry/test_init.py
+++ b/tests/components/sentry/test_init.py
@@ -1,0 +1,208 @@
+"""Tests for Sentry integration."""
+import logging
+
+import pytest
+
+from homeassistant.components.sentry import get_channel, process_before_send
+from homeassistant.components.sentry.const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN
+from homeassistant.const import __version__ as current_version
+from homeassistant.core import HomeAssistant
+
+from tests.async_mock import Mock, patch
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(hass: HomeAssistant) -> None:
+    """Test integration setup from entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DSN: "http://public@example.com/1", CONF_ENVIRONMENT: "production"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.sentry.AioHttpIntegration"
+    ) as sentry_aiohttp_mock, patch(
+        "homeassistant.components.sentry.SqlalchemyIntegration"
+    ) as sentry_sqlalchemy_mock, patch(
+        "homeassistant.components.sentry.LoggingIntegration"
+    ) as sentry_logging_mock, patch(
+        "homeassistant.components.sentry.sentry_sdk"
+    ) as sentry_mock:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert sentry_logging_mock.call_count == 1
+    assert sentry_logging_mock.called_once_with(
+        level=logging.WARNING, event_level=logging.WARNING
+    )
+
+    assert sentry_aiohttp_mock.call_count == 1
+    assert sentry_sqlalchemy_mock.call_count == 1
+    assert sentry_mock.init.call_count == 1
+
+    call_args = sentry_mock.init.call_args[1]
+    assert set(call_args) == {
+        "dsn",
+        "environment",
+        "integrations",
+        "release",
+        "before_send",
+    }
+    assert call_args["dsn"] == "http://public@example.com/1"
+    assert call_args["environment"] == "production"
+    assert call_args["integrations"] == [
+        sentry_logging_mock.return_value,
+        sentry_aiohttp_mock.return_value,
+        sentry_sqlalchemy_mock.return_value,
+    ]
+    assert call_args["release"] == current_version
+    assert call_args["before_send"]
+
+
+@pytest.mark.parametrize(
+    "version,channel",
+    [
+        ("0.115.0.dev20200815", "nightly"),
+        ("0.115.0", "stable"),
+        ("0.115.0b4", "beta"),
+        ("0.115.0dev0", "dev"),
+    ],
+)
+async def test_get_channel(version, channel) -> None:
+    """Test if channel detection works from Home Assistant version number."""
+    assert get_channel(version) == channel
+
+
+async def test_process_before_send(hass: HomeAssistant):
+    """Test regular use of the Sentry process before sending function."""
+    hass.config.components.add("puppies")
+    hass.config.components.add("a_integration")
+
+    # These should not show up in the result.
+    hass.config.components.add("puppies.light")
+    hass.config.components.add("auth")
+
+    result = process_before_send(
+        hass,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=["ironing_robot", "fridge_opener"],
+        event={},
+        hint={},
+    )
+
+    assert result
+    assert result["tags"]
+    assert result["contexts"]
+    assert result["contexts"]
+
+    ha_context = result["contexts"]["Home Assistant"]
+    assert ha_context["channel"] == "test"
+    assert ha_context["custom_components"] == "fridge_opener\nironing_robot"
+    assert ha_context["integrations"] == "a_integration\npuppies"
+
+    tags = result["tags"]
+    assert tags["channel"] == "test"
+    assert tags["uuid"] == "12345"
+    assert tags["installation_type"] == "pytest"
+
+
+async def test_event_with_platform_context(hass: HomeAssistant):
+    """Test extraction of platform context information during Sentry events."""
+
+    current_platform_mock = Mock()
+    current_platform_mock.get().platform_name = "hue"
+    current_platform_mock.get().domain = "light"
+
+    with patch(
+        "homeassistant.components.sentry.entity_platform.current_platform",
+        new=current_platform_mock,
+    ):
+        result = process_before_send(
+            hass,
+            channel="test",
+            huuid="12345",
+            system_info={"installation_type": "pytest"},
+            custom_components=["ironing_robot"],
+            event={},
+            hint={},
+        )
+
+    assert result
+    assert result["tags"]["integration"] == "hue"
+    assert result["tags"]["platform"] == "light"
+    assert result["tags"]["custom_component"] == "no"
+
+    current_platform_mock.get().platform_name = "ironing_robot"
+    current_platform_mock.get().domain = "switch"
+
+    with patch(
+        "homeassistant.components.sentry.entity_platform.current_platform",
+        new=current_platform_mock,
+    ):
+        result = process_before_send(
+            hass,
+            channel="test",
+            huuid="12345",
+            system_info={"installation_type": "pytest"},
+            custom_components=["ironing_robot"],
+            event={},
+            hint={},
+        )
+
+    assert result
+    assert result["tags"]["integration"] == "ironing_robot"
+    assert result["tags"]["platform"] == "switch"
+    assert result["tags"]["custom_component"] == "yes"
+
+
+@pytest.mark.parametrize(
+    "logger,tags",
+    [
+        ("adguard", {"package": "adguard"}),
+        (
+            "homeassistant.components.hue.coordinator",
+            {"integration": "hue", "custom_component": "no"},
+        ),
+        (
+            "homeassistant.components.hue.light",
+            {"integration": "hue", "platform": "light", "custom_component": "no"},
+        ),
+        (
+            "homeassistant.components.ironing_robot.switch",
+            {
+                "integration": "ironing_robot",
+                "platform": "switch",
+                "custom_component": "yes",
+            },
+        ),
+        (
+            "homeassistant.components.ironing_robot",
+            {"integration": "ironing_robot", "custom_component": "yes"},
+        ),
+        ("homeassistant.helpers.network", {"helpers": "network"}),
+        ("tuyapi.test", {"package": "tuyapi"}),
+    ],
+)
+async def test_logger_event_extraction(hass: HomeAssistant, logger, tags):
+    """Test extraction of information from Sentry logger events."""
+
+    result = process_before_send(
+        hass,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=["ironing_robot"],
+        event={"logger": logger},
+        hint={},
+    )
+
+    assert result
+    assert result["tags"] == {
+        "channel": "test",
+        "uuid": "12345",
+        "installation_type": "pytest",
+        **tags,
+    }

--- a/tests/components/sentry/test_init.py
+++ b/tests/components/sentry/test_init.py
@@ -4,11 +4,18 @@ import logging
 import pytest
 
 from homeassistant.components.sentry import get_channel, process_before_send
-from homeassistant.components.sentry.const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN
+from homeassistant.components.sentry.const import (
+    CONF_DSN,
+    CONF_ENVIRONMENT,
+    CONF_EVENT_CUSTOM_COMPONENTS,
+    CONF_EVENT_HANDLED,
+    CONF_EVENT_THIRD_PARTY_PACKAGES,
+    DOMAIN,
+)
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import MagicMock, Mock, patch
 from tests.common import MockConfigEntry
 
 
@@ -31,6 +38,11 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
     ) as sentry_mock:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+    # Test CONF_ENVIRONMENT is migrated to entry options
+    assert CONF_ENVIRONMENT not in entry.data
+    assert CONF_ENVIRONMENT in entry.options
+    assert entry.options[CONF_ENVIRONMENT] == "production"
 
     assert sentry_logging_mock.call_count == 1
     assert sentry_logging_mock.called_once_with(
@@ -85,6 +97,7 @@ async def test_process_before_send(hass: HomeAssistant):
 
     result = process_before_send(
         hass,
+        options={},
         channel="test",
         huuid="12345",
         system_info={"installation_type": "pytest"},
@@ -122,6 +135,7 @@ async def test_event_with_platform_context(hass: HomeAssistant):
     ):
         result = process_before_send(
             hass,
+            options={},
             channel="test",
             huuid="12345",
             system_info={"installation_type": "pytest"},
@@ -144,6 +158,7 @@ async def test_event_with_platform_context(hass: HomeAssistant):
     ):
         result = process_before_send(
             hass,
+            options={CONF_EVENT_CUSTOM_COMPONENTS: True},
             channel="test",
             huuid="12345",
             system_info={"installation_type": "pytest"},
@@ -191,6 +206,10 @@ async def test_logger_event_extraction(hass: HomeAssistant, logger, tags):
 
     result = process_before_send(
         hass,
+        options={
+            CONF_EVENT_CUSTOM_COMPONENTS: True,
+            CONF_EVENT_THIRD_PARTY_PACKAGES: True,
+        },
         channel="test",
         huuid="12345",
         system_info={"installation_type": "pytest"},
@@ -206,3 +225,73 @@ async def test_logger_event_extraction(hass: HomeAssistant, logger, tags):
         "installation_type": "pytest",
         **tags,
     }
+
+
+@pytest.mark.parametrize(
+    "logger,options,event",
+    [
+        ("adguard", {CONF_EVENT_THIRD_PARTY_PACKAGES: True}, True),
+        ("adguard", {CONF_EVENT_THIRD_PARTY_PACKAGES: False}, False),
+        (
+            "homeassistant.components.ironing_robot.switch",
+            {CONF_EVENT_CUSTOM_COMPONENTS: True},
+            True,
+        ),
+        (
+            "homeassistant.components.ironing_robot.switch",
+            {CONF_EVENT_CUSTOM_COMPONENTS: False},
+            False,
+        ),
+    ],
+)
+async def test_filter_log_events(hass: HomeAssistant, logger, options, event):
+    """Test filtering of events based on configuration options."""
+    result = process_before_send(
+        hass,
+        options=options,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=["ironing_robot"],
+        event={"logger": logger},
+        hint={},
+    )
+
+    if event:
+        assert result
+    else:
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    "handled,options,event",
+    [
+        ("yes", {CONF_EVENT_HANDLED: True}, True),
+        ("yes", {CONF_EVENT_HANDLED: False}, False),
+        ("no", {CONF_EVENT_HANDLED: False}, True),
+        ("no", {CONF_EVENT_HANDLED: True}, True),
+    ],
+)
+async def test_filter_handled_events(hass: HomeAssistant, handled, options, event):
+    """Tests filtering of handled events based on configuration options."""
+
+    event_mock = MagicMock()
+    event_mock.__iter__ = ["tags"]
+    event_mock.__contains__ = lambda _, val: val == "tags"
+    event_mock.tags = {"handled": handled}
+
+    result = process_before_send(
+        hass,
+        options=options,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=[],
+        event=event_mock,
+        hint={},
+    )
+
+    if event:
+        assert result
+    else:
+        assert result is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The YAML configuration for Sentry is now deprecated and no longer works. If you had Sentry configured via YAML previously, you can safely remove the YAML configuration (without the need to reconfigure) as it has been imported into the UI before.

The `release` is now formatted with only the version number of Home Assistant Core, for example, `0.115.0`. previously, this was prefixed with `homeassistant-`, for example, `homeassistant-0.115.0`. This prefix is now removed.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enhances the Sentry integration to provide more (processed) data.

- Bumps Sentry SDK
- Adds Sentry aiohttp integration
- Adds Sentry sqlalchemy integration
- Filters out handled events (should be made optional)
- Extracts information from the logger, if the logger caused the event.
- Added information:
  - Adds all available HA `system_info` as additional data
  - Determines the channel of the release (dev, nightly, beta, stable) as a tag
  - Adds the installation type as a tag
  - Adds system UUID as a tag
  - Adds a list of active integrations on the system to the additional data
  - Adds a list of custom components on the system to the additional data
  - Adds `integration` tag with the domain of the integration that caused the event (if that can be determined).
  - Adds `platform` tag with the platform that caused the event (e.g, light, air_quality, switch)
  - Adds `custom_component` yes/no, in case the event was caused by integration.
  - Adds `helpers` tag in case the event is caused by a helper
  - Adds `package` tag in case the event can be traced back to a third-party package. 


![image](https://user-images.githubusercontent.com/195327/90112161-ec9ba680-dd4f-11ea-90d7-dc2c03c8adc8.png)


![image](https://user-images.githubusercontent.com/195327/90320670-5cbe4e00-df43-11ea-92a0-a489fb363035.png)

![image](https://user-images.githubusercontent.com/195327/90112293-15bc3700-dd50-11ea-8047-9efd07a1476a.png)


## Todo

I'll be splitting this in multiple smaller PRs against this branch.

- [x] Don't include domains from components for entity_components list
- [x] Add tests for the `before_send` method: Implemented in PR #38913
- [x] Add option flow to allow setting: Implemented in PR #38975
   - [x] Environment name: Implemented in PR #38975
   - [x] Breadcrum log level: Implemented in PR #38975
   - [x] Event log level: Implemented in PR #38975
   - [x] Handled events yes/no: Implemented in PR #38975
   - [x] Custom component events yes/no: Implemented in PR #38975
   - [x] Third-party package events yes/no: Implemented in PR #38975
- [x] Add missing test coverage to configuration flow: Implemented in PR #38915
- [x] Add migration for existing environment names in entry data to options: Implemented in PR #38975
- [x] Remove YAML support: Implemented in PR #38915
- [x] Revive PR #30482: Implemented in PR #38975
- [x] Address/fix issue #35424: Fixed in PR #38915
- [x] Revive PR #34486: Implemented in #39078
- [x] Improve type hinting across the integration: Implemented in #39078
- [x] Get it up to the highest integration quality scale possible


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35424
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14278

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

### Silver 🥈

Since this integration doesn't provide actual entities, most checks do not apply.

- [x] Connection/configuration is handled via a component.
- [x] ~~Set an appropriate `SCAN_INTERVAL` (if a polling integration)~~
- [x] ~~Raise `PlatformNotReady` if unable to connect during platform setup (if appropriate)~~
- [x] ~~Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.~~
- [ ] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] ~~Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.~~
- [x] ~~Set `available` property to `False` if appropriate~~
- [x] ~~Entities have unique ID (if available)~~

### Gold 🥇

Since this integration doesn't provide actual entities, most checks do not apply.

- [x] Configurable via config entries.
  - [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub)
  - [x] Tests for the config flow
  - [x] ~~Discoverable (if available)~~
  - [x] ~~Set unique ID in config flow (if available)~~
- [x] ~~Entities have device info (if available)~~
- [x] Tests for fetching data from the integration and controlling it.
- [x] Has a code owner
- [x] ~~Entities only subscribe to updates inside `async_added_to_hass` and unsubscribe inside `async_will_remove_from_hass`.~~
- [x] ~~Entities have correct device classes where appropriate~~
- [x] ~~Supports entities being disabled and leverages `Entity.entity_registry_enabled_default` to disable less popular entities.~~
- [x] ~~If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.~~

### Platinum 🏆

ℹ️  This integration cannot reach this level due to its nature and underlying library.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io


