### PR TITLE
Fix creation of unrequired sensors in OVO energy

### DIFF
--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -27,25 +27,21 @@ async def async_setup_entry(
     ]
     client: OVOEnergy = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
 
+    entities = []
+
     if coordinator.data.electricity:
         currency = coordinator.data.electricity[
             len(coordinator.data.electricity) - 1
         ].cost.currency_unit
-        async_add_entities(
-            [
-                OVOEnergyLastElectricityReading(coordinator, client),
-                OVOEnergyLastElectricityCost(coordinator, client, currency),
-            ],
-            True,
-        )
+        entities.append(OVOEnergyLastElectricityReading(coordinator, client))
+        entities.append(OVOEnergyLastElectricityCost(coordinator, client, currency))
     if coordinator.data.gas:
-        async_add_entities(
-            [
-                OVOEnergyLastGasReading(coordinator, client),
-                OVOEnergyLastGasCost(coordinator, client, currency),
-            ],
-            True,
-        )
+        entities.append(OVOEnergyLastGasReading(coordinator, client))
+        entities.append(OVOEnergyLastGasCost(coordinator, client, currency))
+
+    async_add_entities(
+        entities, True,
+    )
 
 
 class OVOEnergySensor(OVOEnergyDeviceEntity):

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -27,19 +27,25 @@ async def async_setup_entry(
     ]
     client: OVOEnergy = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
 
-    currency = coordinator.data.electricity[
-        len(coordinator.data.electricity) - 1
-    ].cost.currency_unit
-
-    async_add_entities(
-        [
-            OVOEnergyLastElectricityReading(coordinator, client),
-            OVOEnergyLastGasReading(coordinator, client),
-            OVOEnergyLastElectricityCost(coordinator, client, currency),
-            OVOEnergyLastGasCost(coordinator, client, currency),
-        ],
-        True,
-    )
+    if coordinator.data.electricity:
+        currency = coordinator.data.electricity[
+            len(coordinator.data.electricity) - 1
+        ].cost.currency_unit
+        async_add_entities(
+            [
+                OVOEnergyLastElectricityReading(coordinator, client),
+                OVOEnergyLastElectricityCost(coordinator, client, currency),
+            ],
+            True,
+        )
+    if coordinator.data.gas:
+        async_add_entities(
+            [
+                OVOEnergyLastGasReading(coordinator, client),
+                OVOEnergyLastGasCost(coordinator, client, currency),
+            ],
+            True,
+        )
 
 
 class OVOEnergySensor(OVOEnergyDeviceEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the incorrect creation of sensors. Currently when there is no gas supply, the gas sensors are still created. This change implements a fix to only generate the sensors if there is data for them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a - created via UI

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/38834
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
