### PR TITLE
Get more detailed info for growatt_server

### DIFF
--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -2,6 +2,6 @@
   "domain": "growatt_server",
   "name": "Growatt",
   "documentation": "https://www.home-assistant.io/integrations/growatt_server/",
-  "requirements": ["growattServer==0.1.0"],
+  "requirements": ["growattServer==0.1.1"],
   "codeowners": ["@indykoning"]
 }

--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -2,6 +2,6 @@
   "domain": "growatt_server",
   "name": "Growatt",
   "documentation": "https://www.home-assistant.io/integrations/growatt_server/",
-  "requirements": ["growattServer==0.0.4"],
+  "requirements": ["growattServer==0.1.0"],
   "codeowners": ["@indykoning"]
 }

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     FREQUENCY_HERTZ,
     POWER_WATT,
+    TEMP_CELSIUS,
     VOLT,
 )
 import homeassistant.helpers.config_validation as cv
@@ -56,77 +57,94 @@ TOTAL_SENSOR_TYPES = {
 }
 
 INVERTER_SENSOR_TYPES = {
-    "inverter_energy_today": ("Energy today", ENERGY_KILO_WATT_HOUR, "e_today", {},),
+    "inverter_energy_today": (
+        "Energy today",
+        ENERGY_KILO_WATT_HOUR,
+        "powerToday",
+        {"round": 1},
+    ),
     "inverter_energy_total": (
         "Lifetime energy output",
         ENERGY_KILO_WATT_HOUR,
-        "e_total",
-        {},
+        "powerTotal",
+        {"round": 1},
     ),
-    "inverter_voltage_input_1": ("Input 1 voltage", VOLT, "vpv1", {}),
+    "inverter_voltage_input_1": ("Input 1 voltage", VOLT, "vpv1", {"round": 2}),
     "inverter_amperage_input_1": (
         "Input 1 Amperage",
         ELECTRICAL_CURRENT_AMPERE,
         "ipv1",
-        {},
+        {"round": 1},
     ),
     "inverter_wattage_input_1": (
         "Input 1 Wattage",
         POWER_WATT,
         "ppv1",
-        {"device_class": "power"},
+        {"device_class": "power", "round": 1},
     ),
-    "inverter_voltage_input_2": ("Input 2 voltage", VOLT, "vpv2", {}),
+    "inverter_voltage_input_2": ("Input 2 voltage", VOLT, "vpv2", {"round": 1}),
     "inverter_amperage_input_2": (
         "Input 2 Amperage",
         ELECTRICAL_CURRENT_AMPERE,
         "ipv2",
-        {},
+        {"round": 1},
     ),
     "inverter_wattage_input_2": (
         "Input 2 Wattage",
         POWER_WATT,
         "ppv2",
-        {"device_class": "power"},
+        {"device_class": "power", "round": 1},
     ),
-    "inverter_voltage_input_3": ("Input 3 voltage", VOLT, "vpv3", {}),
+    "inverter_voltage_input_3": ("Input 3 voltage", VOLT, "vpv3", {"round": 1}),
     "inverter_amperage_input_3": (
         "Input 3 Amperage",
         ELECTRICAL_CURRENT_AMPERE,
         "ipv3",
-        {},
+        {"round": 1},
     ),
     "inverter_wattage_input_3": (
         "Input 3 Wattage",
         POWER_WATT,
         "ppv3",
-        {"device_class": "power"},
+        {"device_class": "power", "round": 1},
     ),
     "inverter_internal_wattage": (
         "Internal wattage",
         POWER_WATT,
         "ppv",
-        {"device_class": "power"},
+        {"device_class": "power", "round": 1},
     ),
-    "inverter_reactive_voltage": ("Reactive voltage", VOLT, "vacr", {}),
+    "inverter_reactive_voltage": ("Reactive voltage", VOLT, "vacr", {"round": 1}),
     "inverter_inverter_reactive_amperage": (
         "Reactive amperage",
         ELECTRICAL_CURRENT_AMPERE,
         "iacr",
-        {},
+        {"round": 1},
     ),
-    "inverter_frequency": ("AC frequency", FREQUENCY_HERTZ, "fac", {}),
+    "inverter_frequency": ("AC frequency", FREQUENCY_HERTZ, "fac", {"round": 1}),
     "inverter_current_wattage": (
         "Output power",
         POWER_WATT,
         "pac",
-        {"device_class": "power"},
+        {"device_class": "power", "round": 1},
     ),
     "inverter_current_reactive_wattage": (
         "Reactive wattage",
         POWER_WATT,
         "pacr",
-        {"device_class": "power"},
+        {"device_class": "power", "round": 1},
+    ),
+    "inverter_ipm_temperature": (
+        "Intelligent Power Management temperature",
+        TEMP_CELSIUS,
+        "ipmTemperature",
+        {"device_class": "temperature", "round": 1},
+    ),
+    "inverter_temperature": (
+        "Temperature",
+        TEMP_CELSIUS,
+        "temperature",
+        {"device_class": "temperature", "round": 1},
     ),
 }
 
@@ -326,6 +344,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         elif device["deviceType"] == "storage":
             probe.plant_id = plant_id
             sensors = STORAGE_SENSOR_TYPES
+        else:
+            _LOGGER.debug(
+                "Device type %s was found but is not supported right now.",
+                device["deviceType"],
+            )
 
         for sensor in sensors:
             entities.append(
@@ -420,7 +443,7 @@ class GrowattData:
                 self.data = total_info
             elif self.growatt_type == "inverter":
                 inverter_info = self.api.inverter_detail(self.device_id)
-                self.data = inverter_info["data"]
+                self.data = inverter_info
             elif self.growatt_type == "storage":
                 storage_info_detail = self.api.storage_params(self.device_id)[
                     "storageDetailBean"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -697,7 +697,7 @@ greenwavereality==0.5.1
 griddypower==0.1.0
 
 # homeassistant.components.growatt_server
-growattServer==0.1.0
+growattServer==0.1.1
 
 # homeassistant.components.gstreamer
 gstreamer-player==1.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -697,7 +697,7 @@ greenwavereality==0.5.1
 griddypower==0.1.0
 
 # homeassistant.components.growatt_server
-growattServer==0.0.4
+growattServer==0.1.0
 
 # homeassistant.components.gstreamer
 gstreamer-player==1.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Bump Growatt Server package to 0.1.0
Add Support for temperature sensor on inverters
Most values were now tripple decimals. Apply rounding.
Added debug logging if the found device type is not yet supported

https://github.com/indykoning/PyPi_GrowattServer/compare/0.0.4...0.1.0

<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml
# Example configuration.yaml entry
sensor:
  - platform: growatt_server
    username: GROWATT_SERVER_USERNAME
    password: GROWATT_SERVER_PASSWORD
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
