### PR TITLE
Prefer mac for onvif device identifier

### DIFF
--- a/homeassistant/components/onvif/base.py
+++ b/homeassistant/components/onvif/base.py
@@ -28,16 +28,16 @@ class ONVIFBaseEntity(Entity):
             "model": self.device.info.model,
             "name": self.device.name,
             "sw_version": self.device.info.fw_version,
+            "identifiers": {
+                # MAC address is not always available, and given the number
+                # of non-conformant ONVIF devices we have historically supported,
+                # we can not guarantee serial number either.  Due to this, we have
+                # adopted an either/or approach in the config entry setup, and can
+                # guarantee that one or the other will be populated.
+                # See: https://github.com/home-assistant/core/issues/35883
+                (DOMAIN, self.device.info.mac or self.device.info.serial_number)
+            },
         }
-
-        # MAC address is not always available, and given the number
-        # of non-conformant ONVIF devices we have historically supported,
-        # we can not guarantee serial number either.  Due to this, we have
-        # adopted an either/or approach in the config entry setup, and can
-        # guarantee that one or the other will be populated.
-        # See: https://github.com/home-assistant/core/issues/35883
-        if self.device.info.serial_number:
-            device_info["identifiers"] = {(DOMAIN, self.device.info.serial_number)}
 
         if self.device.info.mac:
             device_info["connections"] = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Some of ONVIF I have devices report same fake serial number: 'SerialNumber'. Which leads to merging camera devices into one.
The change proposed id to use mac as primary source of identifier as i'ts made for [`ONVIFCameraEntity`](/home-assistant/core/blob/dev/homeassistant/components/onvif/camera.py)
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #35883
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
