### PR TITLE
Set up konnected entities even if panel isn't immediately reachable

### DIFF
--- a/homeassistant/components/konnected/panel.py
+++ b/homeassistant/components/konnected/panel.py
@@ -134,14 +134,14 @@ class AlarmPanel:
         except self.client.ClientError as err:
             _LOGGER.warning("Exception trying to connect to panel: %s", err)
 
-            # retry in a bit, never more than ~2 min
+            # retry in a bit, never more than ~3 min
             self.connect_attempts += 1
             self.cancel_connect_retry = self.hass.helpers.event.async_call_later(
                 2 ** min(self.connect_attempts, 5) * 5, self.async_connect
             )
             return
 
-        self.connect_attempts += 0
+        self.connect_attempts = 0
         self.connected = True
         _LOGGER.info(
             "Set up Konnected device %s. Open http://%s:%s in a "

--- a/homeassistant/components/konnected/panel.py
+++ b/homeassistant/components/konnected/panel.py
@@ -73,6 +73,9 @@ class AlarmPanel:
         self.client = None
         self.status = None
         self.api_version = KONN_API_VERSIONS[KONN_MODEL]
+        self.connected = False
+        self.connect_attempts = 0
+        self.cancel_connect_retry = None
 
     @property
     def device_id(self):
@@ -84,6 +87,11 @@ class AlarmPanel:
         """Return the configuration stored in `hass.data` for this device."""
         return self.hass.data[DOMAIN][CONF_DEVICES].get(self.device_id)
 
+    @property
+    def available(self):
+        """Return whether the device is available."""
+        return self.connected
+
     def format_zone(self, zone, other_items=None):
         """Get zone or pin based dict based on the client type."""
         payload = {
@@ -94,8 +102,15 @@ class AlarmPanel:
         payload.update(other_items or {})
         return payload
 
-    async def async_connect(self):
+    async def async_connect(self, now=None):
         """Connect to and setup a Konnected device."""
+        if self.connected:
+            return
+
+        if self.cancel_connect_retry:
+            # cancel any pending connect attempt and try now
+            self.cancel_connect_retry()
+
         try:
             self.client = konnected.Client(
                 host=self.host,
@@ -118,8 +133,16 @@ class AlarmPanel:
 
         except self.client.ClientError as err:
             _LOGGER.warning("Exception trying to connect to panel: %s", err)
-            raise CannotConnect
 
+            # retry in a bit, never more than ~2 min
+            self.connect_attempts += 1
+            self.cancel_connect_retry = self.hass.helpers.event.async_call_later(
+                2 ** min(self.connect_attempts, 5) * 5, self.async_connect
+            )
+            return
+
+        self.connect_attempts += 0
+        self.connected = True
         _LOGGER.info(
             "Set up Konnected device %s. Open http://%s:%s in a "
             "web browser to view device status",
@@ -129,7 +152,6 @@ class AlarmPanel:
         )
 
         device_registry = await dr.async_get_registry(self.hass)
-
         device_registry.async_get_or_create(
             config_entry_id=self.config_entry.entry_id,
             connections={(dr.CONNECTION_NETWORK_MAC, self.status.get("mac"))},

--- a/homeassistant/components/konnected/switch.py
+++ b/homeassistant/components/konnected/switch.py
@@ -81,6 +81,11 @@ class KonnectedSwitch(ToggleEntity):
             "identifiers": {(KONNECTED_DOMAIN, self._device_id)},
         }
 
+    @property
+    def available(self):
+        """Return whether the panel is available."""
+        return self.panel.available
+
     async def async_turn_on(self, **kwargs):
         """Send a command to turn on the switch."""
         resp = await self.panel.update_switch(

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -411,12 +411,14 @@ async def test_api(hass, aiohttp_client, mock_panel):
             "id": "112233445566",
             "model": "Konnected Pro",
             "access_token": "abcdefgh",
+            "api_host": "http://192.168.86.32:8123",
             "default_options": config_flow.OPTIONS_SCHEMA({config_flow.CONF_IO: {}}),
         }
     )
 
     device_options = config_flow.OPTIONS_SCHEMA(
         {
+            "api_host": "http://192.168.86.32:8123",
             "io": {
                 "1": "Binary Sensor",
                 "2": "Binary Sensor",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Konnected Alarm Panels will occasionally restart with brief downtime intervals (5-35 seconds) when network conditions change, settings are updated, etc. These delays can sometimes result in a config entry setup attempt failing since the panel is not reachable during the restart window.  Usually a subsequent retry attempt results in a successful connection and completion of the config entry setup.  However, with the exponential backoff of config entry setup retries this behavior can result in panels appearing unresponsive for several minutes.

To address this condition we now allow the config entry setup to complete even if we can't immediate connect to and synchronize with the panel.  This has several benefits...
1. Retry attempts to connect to the panel are now managed in the konnected component where the intervals can be optimized to avoid race conditions with the panel behavior.
2. Konnected entities are setup immediately which means the panel can post async updates to sensor entities even if the component is waiting to connect to the panel
3. Async updates from the panel can force an immediate connect retry

The end result of these changes is a much stabler interface between HA and the Konnected Alarm Panels. It also nearly eliminates downtime associated with retries.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
