### PR TITLE
Fix the CONF_LOOP check to use the config

### DIFF
--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -53,7 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         )
 
     add_devices(
-        [ECCamera(radar_object, config.get(CONF_NAME), config.get(CONF_LOOP))], True
+        [ECCamera(radar_object, config.get(CONF_NAME), config[CONF_LOOP])], True
     )
 
 

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -52,18 +52,19 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             coordinates=(lat, lon), precip_type=config.get(CONF_PRECIP_TYPE)
         )
 
-    add_devices([ECCamera(radar_object, config.get(CONF_NAME))], True)
+    add_devices([ECCamera(radar_object, config.get(CONF_NAME), config.get(CONF_LOOP))], True)
 
 
 class ECCamera(Camera):
     """Implementation of an Environment Canada radar camera."""
 
-    def __init__(self, radar_object, camera_name):
+    def __init__(self, radar_object, camera_name, is_loop):
         """Initialize the camera."""
         super().__init__()
 
         self.radar_object = radar_object
         self.camera_name = camera_name
+        self.is_loop = is_loop
         self.content_type = "image/gif"
         self.image = None
         self.timestamp = None
@@ -90,7 +91,7 @@ class ECCamera(Camera):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update radar image."""
-        if CONF_LOOP:
+        if self.is_loop:
             self.image = self.radar_object.get_loop()
         else:
             self.image = self.radar_object.get_latest_frame()

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -52,7 +52,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             coordinates=(lat, lon), precip_type=config.get(CONF_PRECIP_TYPE)
         )
 
-    add_devices([ECCamera(radar_object, config.get(CONF_NAME), config.get(CONF_LOOP))], True)
+    add_devices(
+        [ECCamera(radar_object, config.get(CONF_NAME), config.get(CONF_LOOP))], True
+    )
 
 
 class ECCamera(Camera):


### PR DESCRIPTION
The CONF_LOOP check was not using the config value but rather just the string.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Inside the Environment Canada camera, it checks CONF_LOOP as a string but it's supposed to check the config value associated with this key to see if it loops or not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
camera:
  - platform: environment_canada
    latitude: 43.6532
    longitude: -79.3832
    name: Weather Camera
    loop: false
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38889
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
