### PR TITLE
Add tests coverage to Sentry integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -747,7 +747,6 @@ omit =
     homeassistant/components/sensehat/light.py
     homeassistant/components/sensehat/sensor.py
     homeassistant/components/sensibo/climate.py
-    homeassistant/components/sentry/__init__.py
     homeassistant/components/serial/sensor.py
     homeassistant/components/serial_pm/sensor.py
     homeassistant/components/sesame/lock.py

--- a/tests/components/sentry/test_init.py
+++ b/tests/components/sentry/test_init.py
@@ -1,0 +1,208 @@
+"""Tests for Sentry integration."""
+import logging
+
+import pytest
+
+from homeassistant.components.sentry import get_channel, process_before_send
+from homeassistant.components.sentry.const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN
+from homeassistant.const import __version__ as current_version
+from homeassistant.core import HomeAssistant
+
+from tests.async_mock import Mock, patch
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(hass: HomeAssistant) -> None:
+    """Test integration setup from entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DSN: "http://public@example.com/1", CONF_ENVIRONMENT: "production"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.sentry.AioHttpIntegration"
+    ) as sentry_aiohttp_mock, patch(
+        "homeassistant.components.sentry.SqlalchemyIntegration"
+    ) as sentry_sqlalchemy_mock, patch(
+        "homeassistant.components.sentry.LoggingIntegration"
+    ) as sentry_logging_mock, patch(
+        "homeassistant.components.sentry.sentry_sdk"
+    ) as sentry_mock:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert sentry_logging_mock.call_count == 1
+    assert sentry_logging_mock.called_once_with(
+        level=logging.WARNING, event_level=logging.WARNING
+    )
+
+    assert sentry_aiohttp_mock.call_count == 1
+    assert sentry_sqlalchemy_mock.call_count == 1
+    assert sentry_mock.init.call_count == 1
+
+    call_args = sentry_mock.init.call_args[1]
+    assert set(call_args) == {
+        "dsn",
+        "environment",
+        "integrations",
+        "release",
+        "before_send",
+    }
+    assert call_args["dsn"] == "http://public@example.com/1"
+    assert call_args["environment"] == "production"
+    assert call_args["integrations"] == [
+        sentry_logging_mock.return_value,
+        sentry_aiohttp_mock.return_value,
+        sentry_sqlalchemy_mock.return_value,
+    ]
+    assert call_args["release"] == current_version
+    assert call_args["before_send"]
+
+
+@pytest.mark.parametrize(
+    "version,channel",
+    [
+        ("0.115.0.dev20200815", "nightly"),
+        ("0.115.0", "stable"),
+        ("0.115.0b4", "beta"),
+        ("0.115.0dev0", "dev"),
+    ],
+)
+async def test_get_channel(version, channel) -> None:
+    """Test if channel detection works from Home Assistant version number."""
+    assert get_channel(version) == channel
+
+
+async def test_process_before_send(hass: HomeAssistant):
+    """Test regular use of the Sentry process before sending function."""
+    hass.config.components.add("puppies")
+    hass.config.components.add("a_integration")
+
+    # These should not show up in the result.
+    hass.config.components.add("puppies.light")
+    hass.config.components.add("auth")
+
+    result = process_before_send(
+        hass,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=["ironing_robot", "fridge_opener"],
+        event={},
+        hint={},
+    )
+
+    assert result
+    assert result["tags"]
+    assert result["contexts"]
+    assert result["contexts"]
+
+    ha_context = result["contexts"]["Home Assistant"]
+    assert ha_context["channel"] == "test"
+    assert ha_context["custom_components"] == "fridge_opener\nironing_robot"
+    assert ha_context["integrations"] == "a_integration\npuppies"
+
+    tags = result["tags"]
+    assert tags["channel"] == "test"
+    assert tags["uuid"] == "12345"
+    assert tags["installation_type"] == "pytest"
+
+
+async def test_event_with_platform_context(hass: HomeAssistant):
+    """Test extraction of platform context information during Sentry events."""
+
+    current_platform_mock = Mock()
+    current_platform_mock.get().platform_name = "hue"
+    current_platform_mock.get().domain = "light"
+
+    with patch(
+        "homeassistant.components.sentry.entity_platform.current_platform",
+        new=current_platform_mock,
+    ):
+        result = process_before_send(
+            hass,
+            channel="test",
+            huuid="12345",
+            system_info={"installation_type": "pytest"},
+            custom_components=["ironing_robot"],
+            event={},
+            hint={},
+        )
+
+    assert result
+    assert result["tags"]["integration"] == "hue"
+    assert result["tags"]["platform"] == "light"
+    assert result["tags"]["custom_component"] == "no"
+
+    current_platform_mock.get().platform_name = "ironing_robot"
+    current_platform_mock.get().domain = "switch"
+
+    with patch(
+        "homeassistant.components.sentry.entity_platform.current_platform",
+        new=current_platform_mock,
+    ):
+        result = process_before_send(
+            hass,
+            channel="test",
+            huuid="12345",
+            system_info={"installation_type": "pytest"},
+            custom_components=["ironing_robot"],
+            event={},
+            hint={},
+        )
+
+    assert result
+    assert result["tags"]["integration"] == "ironing_robot"
+    assert result["tags"]["platform"] == "switch"
+    assert result["tags"]["custom_component"] == "yes"
+
+
+@pytest.mark.parametrize(
+    "logger,tags",
+    [
+        ("adguard", {"package": "adguard"}),
+        (
+            "homeassistant.components.hue.coordinator",
+            {"integration": "hue", "custom_component": "no"},
+        ),
+        (
+            "homeassistant.components.hue.light",
+            {"integration": "hue", "platform": "light", "custom_component": "no"},
+        ),
+        (
+            "homeassistant.components.ironing_robot.switch",
+            {
+                "integration": "ironing_robot",
+                "platform": "switch",
+                "custom_component": "yes",
+            },
+        ),
+        (
+            "homeassistant.components.ironing_robot",
+            {"integration": "ironing_robot", "custom_component": "yes"},
+        ),
+        ("homeassistant.helpers.network", {"helpers": "network"}),
+        ("tuyapi.test", {"package": "tuyapi"}),
+    ],
+)
+async def test_logger_event_extraction(hass: HomeAssistant, logger, tags):
+    """Test extraction of information from Sentry logger events."""
+
+    result = process_before_send(
+        hass,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=["ironing_robot"],
+        event={"logger": logger},
+        hint={},
+    )
+
+    assert result
+    assert result["tags"] == {
+        "channel": "test",
+        "uuid": "12345",
+        "installation_type": "pytest",
+        **tags,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

⚠️ This PR builds on top of #38833 and targets the branch of that PR.

Adds test coverage for the event handling introduced in #38833 and coverage for `__init__.py` in general.

It also moves some things around in the integration to make it easier to test.

There are more steps to take, which are defined in the above-listed parent PR. This PR just focusses on adding tests to ensure working in the next development steps.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
