### PR TITLE
Update template sensor to use async_track_template_result

### DIFF
--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -1,0 +1,143 @@
+"""TemplateEntity utility class."""
+
+import logging
+from typing import Optional, Callable, Any, Union
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.config_validation import match_all
+from homeassistant.helpers.event import async_track_template_result, Event
+from homeassistant.helpers.template import Template
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _TemplateAttribute:
+    """Attribute value linked to template result."""
+
+    def __init__(
+            self,
+            entity: Entity,
+            attribute: str,
+            template: Template,
+            validator: Callable[[Any], Any] = match_all,
+            on_update: Optional[Callable[[Any], None]] = None):
+        """Initialiser."""
+        self._entity = entity
+        self._attribute = attribute
+        self.template = template
+        self.validator = validator
+        if on_update is None:
+            if not hasattr(entity, attribute):
+                raise AttributeError(
+                    "Attribute '{}' does not exist.".format(attribute))
+
+            def _default_update(result):
+                setattr(entity, attribute, result)
+                entity.async_schedule_update_ha_state()
+            self.on_update = _default_update
+        else:
+            self.on_update = on_update
+        self.async_update = match_all
+        self.async_will_remove_from_hass = match_all
+
+    @callback
+    def _handle_result(
+            self,
+            event: Optional[Event],
+            template: Template,
+            last_result: Optional[str],
+            result: Union[str, TemplateError]) -> None:
+        if isinstance(result, TemplateError):
+            _LOGGER.error(
+                "TemplateError('%s') "
+                "while processing template '%s' "
+                "for attribute '%s' in entity '%s'",
+                result,
+                self.template,
+                self._attribute,
+                self._entity.entity_id)
+            self.on_update(None)
+            return
+
+        try:
+            validated = self.validator(result)
+        except vol.Invalid as ex:
+            _LOGGER.error(
+                "Error validating template result '%s' "
+                "from template '%s' "
+                "for attribute '%s' in entity %s "
+                "validation message '%s'",
+                result,
+                self.template,
+                self._attribute,
+                self._entity.entity_id,
+                ex.msg)
+            self.on_update(None)
+            return
+
+        self.on_update(validated)
+
+    @callback
+    def async_added_to_hass(self) -> None:
+        """Call from containing entity when added to hass."""
+        result_info = async_track_template_result(
+            self._entity.hass,
+            self.template,
+            self._handle_result
+        )
+        self.async_will_remove_from_hass = result_info.async_remove
+        self.async_update = result_info.async_refresh
+
+
+class TemplateEntity(Entity):
+    """Entity that uses templates to calculate attributes."""
+
+    def __init__(self):
+        """Initialiser."""
+        self._template_attrs = []
+
+    def add_template_attribute(
+            self,
+            attribute: str,
+            template: Template,
+            validator: Callable[[Any], Any] = match_all,
+            on_update: Optional[Callable[[Any], None]] = None) -> None:
+        """
+        Call in the constructor to add a template linked to a attribute.
+
+        Parameters
+        ----------
+        attribute
+            The name of the attribute to link to. This attribute must exist
+            unless a custom on_update method is supplied.
+        template
+            The template to calculate.
+        validator
+            Validator function to parse the result and ensure it's valid.
+        on_update
+            Called to store the template result rather than storing it
+            the supplied attribute. Passed the result of the validator, or None
+            if the template or validator resulted in an error.
+
+        """
+        self._template_attrs.append(_TemplateAttribute(
+            self, attribute, template, validator, on_update))
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        for attribute in self._template_attrs:
+            attribute.async_added_to_hass()
+
+    async def async_update(self) -> None:
+        """Call for forced update."""
+        for attribute in self._template_attrs:
+            attribute.async_update()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        for attribute in self._template_attrs:
+            attribute.async_will_remove_from_hass()

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -65,15 +65,16 @@ class _TemplateAttribute:
         result: Union[str, TemplateError],
     ) -> None:
         if isinstance(result, TemplateError):
-            _LOGGER.error(
-                "TemplateError('%s') "
-                "while processing template '%s' "
-                "for attribute '%s' in entity '%s'",
-                result,
-                self.template,
-                self._attribute,
-                self._entity.entity_id,
-            )
+            if self.add_complete:
+                _LOGGER.error(
+                    "TemplateError('%s') "
+                    "while processing template '%s' "
+                    "for attribute '%s' in entity '%s'",
+                    result,
+                    self.template,
+                    self._attribute,
+                    self._entity.entity_id,
+                )
             self.on_update(result)
             self._write_update_if_added()
 
@@ -87,17 +88,18 @@ class _TemplateAttribute:
         try:
             validated = self.validator(result)
         except vol.Invalid as ex:
-            _LOGGER.error(
-                "Error validating template result '%s' "
-                "from template '%s' "
-                "for attribute '%s' in entity %s "
-                "validation message '%s'",
-                result,
-                self.template,
-                self._attribute,
-                self._entity.entity_id,
-                ex.msg,
-            )
+            if self.add_complete:
+                _LOGGER.error(
+                    "Error validating template result '%s' "
+                    "from template '%s' "
+                    "for attribute '%s' in entity %s "
+                    "validation message '%s'",
+                    result,
+                    self.template,
+                    self._attribute,
+                    self._entity.entity_id,
+                    ex.msg,
+                )
             self.on_update(None)
             self._write_update_if_added()
             return

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -108,12 +108,8 @@ class _TemplateAttribute:
     @callback
     def async_added_to_hass(self) -> None:
         """Call from containing entity when added to hass."""
-        hass = self._entity.hass
-
-        self.template.hass = hass
-
         result_info = async_track_template_result(
-            hass, self.template, self._handle_result
+            self._entity.hass, self.template, self._handle_result
         )
         self.async_update = result_info.async_refresh
 

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -24,6 +24,7 @@ class TemplateError(HomeAssistantError):
 
     def __init__(self, exception: jinja2.TemplateError) -> None:
         """Init the error."""
+        self.message = exception.message
         super().__init__(f"{exception.__class__.__name__}: {exception}")
 
 

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -24,7 +24,6 @@ class TemplateError(HomeAssistantError):
 
     def __init__(self, exception: jinja2.TemplateError) -> None:
         """Init the error."""
-        self.message = exception.message
         super().__init__(f"{exception.__class__.__name__}: {exception}")
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -155,6 +155,17 @@ def boolean(value: Any) -> bool:
     raise vol.Invalid(f"invalid boolean value {value}")
 
 
+_WS = re.compile("\\s*")
+
+
+def whitespace(value: Any) -> str:
+    """Validate result contains only whitespace."""
+    if isinstance(value, str) and _WS.fullmatch(value):
+        return value
+
+    raise vol.Invalid(f"contain non-whitespace: {value}")
+
+
 def isdevice(value: Any) -> str:
     """Validate that value is a real device."""
     try:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -163,7 +163,7 @@ def whitespace(value: Any) -> str:
     if isinstance(value, str) and _WS.fullmatch(value):
         return value
 
-    raise vol.Invalid(f"contain non-whitespace: {value}")
+    raise vol.Invalid(f"contains non-whitespace: {value}")
 
 
 def isdevice(value: Any) -> str:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -600,6 +600,7 @@ class _TrackTemplateResultInfo:
             self._variables = variables
         self._refresh(None)
 
+    @callback
     def _refresh(self, event: Optional[Event]) -> None:
         self._info = self._template.async_render_to_info(self._variables)
         self._update_listeners()

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -448,6 +448,7 @@ class _TrackTemplateResultInfo:
         """Handle removal / refresh of tracker init."""
         self.hass = hass
         self._template = template
+        self._template.hass = hass
         self._action = action
         self._variables = variables
         self._last_result: Optional[Union[str, TemplateError]] = None

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 import unittest
 from unittest import mock
 
+import jinja2
+
 from homeassistant import setup
 from homeassistant.components.template import binary_sensor as template
 from homeassistant.const import (
@@ -318,10 +320,10 @@ class TestBinarySensorTemplate(unittest.TestCase):
             None,
             None,
         ).result()
-        mock_render.side_effect = TemplateError("foo")
+        mock_render.side_effect = TemplateError(jinja2.TemplateError("foo"))
         run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()
         mock_render.side_effect = TemplateError(
-            "UndefinedError: 'None' has no attribute"
+            jinja2.TemplateError("UndefinedError: 'None' has no attribute")
         )
         run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()
 

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -544,6 +544,9 @@ async def test_invalid_attribute_template(hass, caplog):
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 2
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
     await hass.helpers.entity_component.async_update_entity("sensor.invalid_template")
 
     assert "TemplateError" in caplog.text

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1092,3 +1092,24 @@ def test_script(caplog):
             cv.script_action(data)
 
         assert msg in str(excinfo.value)
+
+
+def test_whitespace():
+    """Test whitespace validation."""
+    schema = vol.Schema(cv.whitespace)
+
+    for value in (
+        None,
+        "" "T",
+        "negative",
+        "lock",
+        "tr  ue",
+        [],
+        [1, 2],
+        {"one": "two"},
+    ):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    for value in ("  ", "   "):
+        assert schema(value)

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime, timedelta
 
 from astral import Astral
+import jinja2
 import pytest
 
 from homeassistant.components import sun
@@ -942,7 +943,7 @@ async def test_track_template_result_errors(hass, caplog):
     hass.states.async_set("switch.not_exist", "on")
     await hass.async_block_till_done()
 
-    assert len(syntax_error_runs) == 0
+    assert len(syntax_error_runs) == 1
     assert len(not_exist_runs) == 2
     assert not_exist_runs[1][0].data.get("entity_id") == "switch.not_exist"
     assert not_exist_runs[1][1] == template_not_exist
@@ -950,7 +951,7 @@ async def test_track_template_result_errors(hass, caplog):
     assert not_exist_runs[1][3] == "on"
 
     with patch.object(Template, "async_render") as render:
-        render.side_effect = TemplateError("Test")
+        render.side_effect = TemplateError(jinja2.TemplateError())
 
         hass.states.async_set("switch.not_exist", "off")
         await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update template sensor to use async_track_template_result

~~**Feedback requested: The existing code deferred rendering these until the START event for _some_ of the template platforms (sensor did). The PR that this revived removed that. I'm not sure if we should keep it or not since it will continue to work but since the entity may not be available yet that its tracking and we may get some unexpected errors in the log.**~~


Edit: I've restarted 20-30 times and it clear we need to defer these until the start event or suppress the errors.  Instead of reinventing a solution, I'm going to add code to wait for these to render until the start event.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
