### PR TITLE
Skip the sqlite quick_check on clean restarts

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -30,11 +30,18 @@ _LOGGER = logging.getLogger(__name__)
 
 DB_TIMEZONE = "+00:00"
 
+TABLE_EVENTS = "events"
+TABLE_STATES = "states"
+TABLE_RECORDER_RUNS = "recorder_runs"
+TABLE_SCHEMA_CHANGES = "schema_changes"
+
+ALL_TABLES = [TABLE_EVENTS, TABLE_STATES, TABLE_RECORDER_RUNS, TABLE_SCHEMA_CHANGES]
+
 
 class Events(Base):  # type: ignore
     """Event history data."""
 
-    __tablename__ = "events"
+    __tablename__ = TABLE_EVENTS
     event_id = Column(Integer, primary_key=True)
     event_type = Column(String(32))
     event_data = Column(Text)
@@ -88,7 +95,7 @@ class Events(Base):  # type: ignore
 class States(Base):  # type: ignore
     """State change history."""
 
-    __tablename__ = "states"
+    __tablename__ = TABLE_STATES
     state_id = Column(Integer, primary_key=True)
     domain = Column(String(64))
     entity_id = Column(String(255))
@@ -153,7 +160,7 @@ class States(Base):  # type: ignore
 class RecorderRuns(Base):  # type: ignore
     """Representation of recorder run."""
 
-    __tablename__ = "recorder_runs"
+    __tablename__ = TABLE_RECORDER_RUNS
     run_id = Column(Integer, primary_key=True)
     start = Column(DateTime(timezone=True), default=dt_util.utcnow)
     end = Column(DateTime(timezone=True))
@@ -191,7 +198,7 @@ class RecorderRuns(Base):  # type: ignore
 class SchemaChanges(Base):  # type: ignore
     """Representation of schema version changes."""
 
-    __tablename__ = "schema_changes"
+    __tablename__ = TABLE_SCHEMA_CHANGES
     change_id = Column(Integer, primary_key=True)
     schema_version = Column(Integer)
     changed = Column(DateTime(timezone=True), default=dt_util.utcnow)

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -168,7 +168,7 @@ def validate_sqlite_database(dbpath: str) -> bool:
 
 
 def run_checks_on_open_db(dbpath, cursor):
-    """Run checks that will generate a databsae exception if there is corruption."""
+    """Run checks that will generate a sqlite3 exception if there is corruption."""
     if basic_sanity_check(cursor) and last_run_was_recently_clean(cursor):
         _LOGGER.debug(
             "The quick_check will be skipped as the system was restarted cleanly and passed the basic sanity check"

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -1,5 +1,6 @@
 """SQLAlchemy util functions."""
 from contextlib import contextmanager
+from datetime import timedelta
 import logging
 import os
 import time
@@ -9,12 +10,18 @@ from sqlalchemy.exc import OperationalError, SQLAlchemyError
 import homeassistant.util.dt as dt_util
 
 from .const import DATA_INSTANCE, SQLITE_URL_PREFIX
+from .models import ALL_TABLES, process_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 
 RETRIES = 3
 QUERY_RETRY_WAIT = 0.1
 SQLITE3_POSTFIXES = ["", "-wal", "-shm"]
+
+# This is the maximum time after the recorder ends the session
+# before we no longer consider startup to be a "restart" and we
+# should conisder doing a check on the database.
+MAX_RESTART_TIME = timedelta(minutes=6)
 
 
 @contextmanager
@@ -116,13 +123,51 @@ def validate_or_move_away_sqlite_database(dburl: str) -> bool:
     return True
 
 
+def last_run_was_recently_clean(cursor):
+    """Verify the last recorder run was recently clean."""
+
+    cursor.execute("SELECT end FROM recorder_runs ORDER BY start DESC LIMIT 1;")
+    end_time = cursor.fetchone()
+
+    if not end_time or not end_time[0]:
+        return False
+
+    last_run_end_time = process_timestamp(dt_util.parse_datetime(end_time[0]))
+    now = dt_util.utcnow()
+
+    _LOGGER.debug("The last run ended at: %s (now: %s)", last_run_end_time, now)
+
+    if last_run_end_time + MAX_RESTART_TIME < now:
+        return False
+
+    return True
+
+
+def basic_sanity_check(cursor):
+    """Check tables to make sure select does not fail."""
+
+    for table in ALL_TABLES:
+        cursor.execute(f"SELECT * FROM {table} LIMIT 1;")  # sec: not injection
+
+    return True
+
+
 def validate_sqlite_database(dbpath: str) -> bool:
     """Run a quick check on an sqlite database to see if it is corrupt."""
     import sqlite3  # pylint: disable=import-outside-toplevel
 
     try:
         conn = sqlite3.connect(dbpath)
-        conn.cursor().execute("PRAGMA QUICK_CHECK")
+        cursor = conn.cursor()
+        if last_run_was_recently_clean(cursor) and basic_sanity_check(cursor):
+            _LOGGER.debug(
+                "The quick_check will be skipped as the system was restarted cleanly and passed the basic sanity check"
+            )
+        else:
+            _LOGGER.debug(
+                "A quick_check is being performed on the sqlite3 database at %s", dbpath
+            )
+            cursor.execute("PRAGMA QUICK_CHECK")
         conn.close()
     except sqlite3.DatabaseError:
         _LOGGER.exception("The database at %s is corrupt or malformed.", dbpath)

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -158,22 +158,27 @@ def validate_sqlite_database(dbpath: str) -> bool:
 
     try:
         conn = sqlite3.connect(dbpath)
-        cursor = conn.cursor()
-        if last_run_was_recently_clean(cursor) and basic_sanity_check(cursor):
-            _LOGGER.debug(
-                "The quick_check will be skipped as the system was restarted cleanly and passed the basic sanity check"
-            )
-        else:
-            _LOGGER.debug(
-                "A quick_check is being performed on the sqlite3 database at %s", dbpath
-            )
-            cursor.execute("PRAGMA QUICK_CHECK")
+        run_checks_on_open_db(dbpath, conn.cursor())
         conn.close()
     except sqlite3.DatabaseError:
         _LOGGER.exception("The database at %s is corrupt or malformed.", dbpath)
         return False
 
     return True
+
+
+def run_checks_on_open_db(dbpath, cursor):
+    """Run checks that will generate a databsae exception if there is corruption."""
+    if basic_sanity_check(cursor) and last_run_was_recently_clean(cursor):
+        _LOGGER.debug(
+            "The quick_check will be skipped as the system was restarted cleanly and passed the basic sanity check"
+        )
+        return
+
+    _LOGGER.debug(
+        "A quick_check is being performed on the sqlite3 database at %s", dbpath
+    )
+    cursor.execute("PRAGMA QUICK_CHECK")
 
 
 def _move_away_broken_database(dbfile: str) -> None:

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -20,7 +20,7 @@ SQLITE3_POSTFIXES = ["", "-wal", "-shm"]
 
 # This is the maximum time after the recorder ends the session
 # before we no longer consider startup to be a "restart" and we
-# should conisder doing a check on the database.
+# should do a check on the sqlite3 database.
 MAX_RESTART_TIME = timedelta(minutes=6)
 
 

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -1,10 +1,13 @@
 """Test util methods."""
+from datetime import timedelta
 import os
+import sqlite3
 
 import pytest
 
 from homeassistant.components.recorder import util
 from homeassistant.components.recorder.const import DATA_INSTANCE, SQLITE_URL_PREFIX
+from homeassistant.util import dt as dt_util
 
 from tests.async_mock import MagicMock, patch
 from tests.common import get_test_home_assistant, init_recorder_component
@@ -74,7 +77,7 @@ def test_validate_or_move_away_sqlite_database(hass, tmpdir, caplog):
     util.validate_sqlite_database(test_db_file) is True
 
     assert os.path.exists(test_db_file) is True
-    assert util.validate_or_move_away_sqlite_database(dburl) is True
+    assert util.validate_or_move_away_sqlite_database(dburl) is False
 
     _corrupt_db_file(test_db_file)
 
@@ -83,6 +86,41 @@ def test_validate_or_move_away_sqlite_database(hass, tmpdir, caplog):
     assert "corrupt or malformed" in caplog.text
 
     assert util.validate_or_move_away_sqlite_database(dburl) is True
+
+
+def test_last_run_was_recently_clean(hass_recorder):
+    """Test we can check if the last recorder run was recently clean."""
+    hass = hass_recorder()
+
+    cursor = hass.data[DATA_INSTANCE].engine.raw_connection().cursor()
+
+    assert util.last_run_was_recently_clean(cursor) is False
+
+    hass.data[DATA_INSTANCE]._close_run()
+
+    assert util.last_run_was_recently_clean(cursor) is True
+
+    thirty_min_future_time = dt_util.utcnow() + timedelta(minutes=30)
+
+    with patch(
+        "homeassistant.components.recorder.dt_util.utcnow",
+        return_value=thirty_min_future_time,
+    ):
+        assert util.last_run_was_recently_clean(cursor) is False
+
+
+def test_basic_sanity_check(hass_recorder):
+    """Test the basic sanity checks with a missing table."""
+    hass = hass_recorder()
+
+    cursor = hass.data[DATA_INSTANCE].engine.raw_connection().cursor()
+
+    assert util.basic_sanity_check(cursor) is True
+
+    cursor.execute("DROP TABLE states;")
+
+    with pytest.raises(sqlite3.DatabaseError):
+        util.basic_sanity_check(cursor)
 
 
 def _corrupt_db_file(test_db_file):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If we had a clean shutdown and the basic sanity check passes, skip
the sqlite `quick_check` as it was taking far too long for users with
slow hardware (mostly RPi3s) and large databases.

Depending on the extent of the corruption, the downside is that may
 require two restarts to detect a broken database.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38973, fixes #39061
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
