### PR TITLE
Add options flow to Sentry

### DIFF
--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -42,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     custom_components = await async_get_custom_components(hass)
 
     sentry_sdk.init(
-        dsn=entry.data.get(CONF_DSN),
+        dsn=entry.data[CONF_DSN],
         environment=entry.data.get(CONF_ENVIRONMENT),
         integrations=[sentry_logging, AioHttpIntegration(), SqlalchemyIntegration()],
         release=current_version,

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -1,5 +1,4 @@
 """The sentry integration."""
-import logging
 import re
 
 import sentry_sdk
@@ -13,7 +12,19 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.loader import async_get_custom_components
 
-from .const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN, ENTITY_COMPONENTS
+from .const import (
+    CONF_DSN,
+    CONF_ENVIRONMENT,
+    CONF_EVENT_CUSTOM_COMPONENTS,
+    CONF_EVENT_HANDLED,
+    CONF_EVENT_THIRD_PARTY_PACKAGES,
+    CONF_LOGGING_EVENT_LEVEL,
+    CONF_LOGGING_LEVEL,
+    DEFAULT_LOGGING_EVENT_LEVEL,
+    DEFAULT_LOGGING_LEVEL,
+    DOMAIN,
+    ENTITY_COMPONENTS,
+)
 
 CONFIG_SCHEMA = cv.deprecated(DOMAIN, invalidation_version="0.117")
 
@@ -29,10 +40,23 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Sentry from a config entry."""
 
+    # Migrate environment from config entry data to config entry options
+    if (
+        CONF_ENVIRONMENT not in entry.options
+        and CONF_ENVIRONMENT in entry.data
+        and entry.data[CONF_ENVIRONMENT]
+    ):
+        options = {**entry.options, CONF_ENVIRONMENT: entry.data[CONF_ENVIRONMENT]}
+        data = entry.data.copy()
+        data.pop(CONF_ENVIRONMENT)
+        hass.config_entries.async_update_entry(entry, data=data, options=options)
+
     # https://docs.sentry.io/platforms/python/logging/
     sentry_logging = LoggingIntegration(
-        level=logging.WARNING,  # Capture warning and above as breadcrumbs
-        event_level=logging.ERROR,  # Send errors as events
+        level=entry.options.get(CONF_LOGGING_LEVEL, DEFAULT_LOGGING_LEVEL),
+        event_level=entry.options.get(
+            CONF_LOGGING_EVENT_LEVEL, DEFAULT_LOGGING_EVENT_LEVEL
+        ),
     )
 
     # Additional/extra data collection
@@ -43,11 +67,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     sentry_sdk.init(
         dsn=entry.data[CONF_DSN],
-        environment=entry.data.get(CONF_ENVIRONMENT),
+        environment=entry.options.get(CONF_ENVIRONMENT),
         integrations=[sentry_logging, AioHttpIntegration(), SqlalchemyIntegration()],
         release=current_version,
         before_send=lambda event, hint: process_before_send(
-            hass, channel, huuid, system_info, custom_components, event, hint
+            hass,
+            entry.options,
+            channel,
+            huuid,
+            system_info,
+            custom_components,
+            event,
+            hint,
         ),
     )
 
@@ -66,12 +97,15 @@ def get_channel(version) -> str:
 
 
 def process_before_send(
-    hass, channel, huuid, system_info, custom_components, event, hint
+    hass, options, channel, huuid, system_info, custom_components, event, hint
 ):
     """Process a Sentry event before sending it to Sentry."""
-
     # Filter out handled events by default
-    if "tags" in event and event.tags.get("handled", "no") == "yes":
+    if (
+        "tags" in event
+        and event.tags.get("handled", "no") == "yes"
+        and not options.get(CONF_EVENT_HANDLED)
+    ):
         return None
 
     # Additional tags to add to the event
@@ -114,6 +148,8 @@ def process_before_send(
                     additional_tags[group2] = group3
             else:
                 # Not the "homeassistant" package, this third-party
+                if not options.get(CONF_EVENT_THIRD_PARTY_PACKAGES):
+                    return None
                 additional_tags["package"] = group1
 
     # If this event is caused by an integration, add a tag if this
@@ -122,6 +158,8 @@ def process_before_send(
         "integration" in additional_tags
         and additional_tags["integration"] in custom_components
     ):
+        if not options.get(CONF_EVENT_CUSTOM_COMPONENTS):
+            return None
         additional_tags["custom_component"] = "yes"
 
     # Update event with the additional tags

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 from sentry_sdk.utils import BadDsn, Dsn
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL, ConfigFlow
 
 from .const import CONF_DSN, DOMAIN  # pylint: disable=unused-import
 
@@ -14,18 +14,18 @@ _LOGGER = logging.getLogger(__name__)
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_DSN): str})
 
 
-class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class SentryConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a Sentry config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+    CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
 
     async def async_step_user(
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Handle a user config flow."""
         if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
+            return self.async_abort(reason="single_instance_allowed")
 
         errors = {}
         if user_input is not None:

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -5,20 +5,39 @@ from typing import Any, Dict, Optional
 from sentry_sdk.utils import BadDsn, Dsn
 import voluptuous as vol
 
-from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL, ConfigFlow
+from homeassistant import config_entries
+from homeassistant.core import callback
 
-from .const import CONF_DSN, DOMAIN  # pylint: disable=unused-import
+from .const import (  # pylint: disable=unused-import
+    CONF_DSN,
+    CONF_ENVIRONMENT,
+    CONF_EVENT_CUSTOM_COMPONENTS,
+    CONF_EVENT_HANDLED,
+    CONF_EVENT_THIRD_PARTY_PACKAGES,
+    CONF_LOGGING_EVENT_LEVEL,
+    CONF_LOGGING_LEVEL,
+    DEFAULT_LOGGING_EVENT_LEVEL,
+    DEFAULT_LOGGING_LEVEL,
+    DOMAIN,
+    LOGGING_LEVELS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_DSN): str})
 
 
-class SentryConfigFlow(ConfigFlow, domain=DOMAIN):
+class SentryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Sentry config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return SentryOptionsFlow(config_entry)
 
     async def async_step_user(
         self, user_input: Optional[Dict[str, Any]] = None
@@ -41,4 +60,61 @@ class SentryConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class SentryOptionsFlow(config_entries.OptionsFlow):
+    """Handle Sentry options."""
+
+    def __init__(self, config_entry):
+        """Initialize Sentry options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Manage Sentry options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_LOGGING_EVENT_LEVEL,
+                        default=self.config_entry.options.get(
+                            CONF_LOGGING_EVENT_LEVEL, DEFAULT_LOGGING_EVENT_LEVEL
+                        ),
+                    ): vol.In(LOGGING_LEVELS),
+                    vol.Optional(
+                        CONF_LOGGING_LEVEL,
+                        default=self.config_entry.options.get(
+                            CONF_LOGGING_LEVEL, DEFAULT_LOGGING_LEVEL
+                        ),
+                    ): vol.In(LOGGING_LEVELS),
+                    vol.Optional(
+                        CONF_ENVIRONMENT,
+                        default=self.config_entry.options.get(CONF_ENVIRONMENT),
+                    ): str,
+                    vol.Optional(
+                        CONF_EVENT_HANDLED,
+                        default=self.config_entry.options.get(
+                            CONF_EVENT_HANDLED, False
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_EVENT_CUSTOM_COMPONENTS,
+                        default=self.config_entry.options.get(
+                            CONF_EVENT_CUSTOM_COMPONENTS, False
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_EVENT_THIRD_PARTY_PACKAGES,
+                        default=self.config_entry.options.get(
+                            CONF_EVENT_THIRD_PARTY_PACKAGES, False
+                        ),
+                    ): bool,
+                }
+            ),
         )

--- a/homeassistant/components/sentry/const.py
+++ b/homeassistant/components/sentry/const.py
@@ -1,9 +1,27 @@
 """Constants for the sentry integration."""
 
+import logging
+
 DOMAIN = "sentry"
 
 CONF_DSN = "dsn"
 CONF_ENVIRONMENT = "environment"
+CONF_EVENT_CUSTOM_COMPONENTS = "event_custom_components"
+CONF_EVENT_HANDLED = "event_handled"
+CONF_EVENT_THIRD_PARTY_PACKAGES = "event_third_party_packages"
+CONF_LOGGING_EVENT_LEVEL = "logging_event_level"
+CONF_LOGGING_LEVEL = "logging_level"
+
+DEFAULT_LOGGING_EVENT_LEVEL = logging.ERROR
+DEFAULT_LOGGING_LEVEL = logging.WARNING
+
+LOGGING_LEVELS = {
+    logging.DEBUG: "debug",
+    logging.INFO: "info",
+    logging.WARNING: "warning",
+    logging.ERROR: "error",
+    logging.CRITICAL: "critical",
+}
 
 ENTITY_COMPONENTS = [
     "air_quality",

--- a/homeassistant/components/sentry/strings.json
+++ b/homeassistant/components/sentry/strings.json
@@ -11,5 +11,19 @@
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "environment": "Optional name of the environment.",
+          "event_custom_components": "Send events from custom components",
+          "event_handled": "Send handled events",
+          "event_third_party_packages": "Send events from third-party packages",
+          "logging_event_level": "The log level Sentry will register an event for",
+          "logging_level": "The log level Sentry will record logs as breadcrums for"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/sentry/strings.json
+++ b/homeassistant/components/sentry/strings.json
@@ -1,9 +1,15 @@
 {
   "config": {
     "step": {
-      "user": { "title": "Sentry", "description": "Enter your Sentry DSN" }
+      "user": {
+        "title": "Sentry",
+        "description": "Enter your Sentry DSN",
+        "data": { "dsn": "DSN" }
+      }
     },
     "error": { "unknown": "Unexpected error", "bad_dsn": "Invalid DSN" },
-    "abort": { "already_configured": "Sentry is already configured" }
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    }
   }
 }

--- a/tests/components/sentry/test_config_flow.py
+++ b/tests/components/sentry/test_config_flow.py
@@ -3,6 +3,7 @@ from sentry_sdk.utils import BadDsn
 
 from homeassistant.components.sentry.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
@@ -15,7 +16,7 @@ async def test_full_user_flow_implementation(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {}
 
     with patch("homeassistant.components.sentry.config_flow.Dsn"), patch(
@@ -45,8 +46,8 @@ async def test_integration_already_exists(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_user_flow_bad_dsn(hass):
@@ -62,7 +63,7 @@ async def test_user_flow_bad_dsn(hass):
             result["flow_id"], {"dsn": "foo"},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "bad_dsn"}
 
 
@@ -79,5 +80,5 @@ async def test_user_flow_unkown_exception(hass):
             result["flow_id"], {"dsn": "foo"},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "unknown"}

--- a/tests/components/sentry/test_init.py
+++ b/tests/components/sentry/test_init.py
@@ -4,11 +4,18 @@ import logging
 import pytest
 
 from homeassistant.components.sentry import get_channel, process_before_send
-from homeassistant.components.sentry.const import CONF_DSN, CONF_ENVIRONMENT, DOMAIN
+from homeassistant.components.sentry.const import (
+    CONF_DSN,
+    CONF_ENVIRONMENT,
+    CONF_EVENT_CUSTOM_COMPONENTS,
+    CONF_EVENT_HANDLED,
+    CONF_EVENT_THIRD_PARTY_PACKAGES,
+    DOMAIN,
+)
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import MagicMock, Mock, patch
 from tests.common import MockConfigEntry
 
 
@@ -31,6 +38,11 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
     ) as sentry_mock:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+    # Test CONF_ENVIRONMENT is migrated to entry options
+    assert CONF_ENVIRONMENT not in entry.data
+    assert CONF_ENVIRONMENT in entry.options
+    assert entry.options[CONF_ENVIRONMENT] == "production"
 
     assert sentry_logging_mock.call_count == 1
     assert sentry_logging_mock.called_once_with(
@@ -85,6 +97,7 @@ async def test_process_before_send(hass: HomeAssistant):
 
     result = process_before_send(
         hass,
+        options={},
         channel="test",
         huuid="12345",
         system_info={"installation_type": "pytest"},
@@ -122,6 +135,7 @@ async def test_event_with_platform_context(hass: HomeAssistant):
     ):
         result = process_before_send(
             hass,
+            options={},
             channel="test",
             huuid="12345",
             system_info={"installation_type": "pytest"},
@@ -144,6 +158,7 @@ async def test_event_with_platform_context(hass: HomeAssistant):
     ):
         result = process_before_send(
             hass,
+            options={CONF_EVENT_CUSTOM_COMPONENTS: True},
             channel="test",
             huuid="12345",
             system_info={"installation_type": "pytest"},
@@ -191,6 +206,10 @@ async def test_logger_event_extraction(hass: HomeAssistant, logger, tags):
 
     result = process_before_send(
         hass,
+        options={
+            CONF_EVENT_CUSTOM_COMPONENTS: True,
+            CONF_EVENT_THIRD_PARTY_PACKAGES: True,
+        },
         channel="test",
         huuid="12345",
         system_info={"installation_type": "pytest"},
@@ -206,3 +225,73 @@ async def test_logger_event_extraction(hass: HomeAssistant, logger, tags):
         "installation_type": "pytest",
         **tags,
     }
+
+
+@pytest.mark.parametrize(
+    "logger,options,event",
+    [
+        ("adguard", {CONF_EVENT_THIRD_PARTY_PACKAGES: True}, True),
+        ("adguard", {CONF_EVENT_THIRD_PARTY_PACKAGES: False}, False),
+        (
+            "homeassistant.components.ironing_robot.switch",
+            {CONF_EVENT_CUSTOM_COMPONENTS: True},
+            True,
+        ),
+        (
+            "homeassistant.components.ironing_robot.switch",
+            {CONF_EVENT_CUSTOM_COMPONENTS: False},
+            False,
+        ),
+    ],
+)
+async def test_filter_log_events(hass: HomeAssistant, logger, options, event):
+    """Test filtering of events based on configuration options."""
+    result = process_before_send(
+        hass,
+        options=options,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=["ironing_robot"],
+        event={"logger": logger},
+        hint={},
+    )
+
+    if event:
+        assert result
+    else:
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    "handled,options,event",
+    [
+        ("yes", {CONF_EVENT_HANDLED: True}, True),
+        ("yes", {CONF_EVENT_HANDLED: False}, False),
+        ("no", {CONF_EVENT_HANDLED: False}, True),
+        ("no", {CONF_EVENT_HANDLED: True}, True),
+    ],
+)
+async def test_filter_handled_events(hass: HomeAssistant, handled, options, event):
+    """Tests filtering of handled events based on configuration options."""
+
+    event_mock = MagicMock()
+    event_mock.__iter__ = ["tags"]
+    event_mock.__contains__ = lambda _, val: val == "tags"
+    event_mock.tags = {"handled": handled}
+
+    result = process_before_send(
+        hass,
+        options=options,
+        channel="test",
+        huuid="12345",
+        system_info={"installation_type": "pytest"},
+        custom_components=[],
+        event=event_mock,
+        hint={},
+    )
+
+    if event:
+        assert result
+    else:
+        assert result is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

⚠️ This PR builds on top of #38833 and targets the branch of that PR.

Add an options flow to the Sentry integration, allow the user to:

- Environment name
- Breadcrumb log level
- Event log level
- Handled events yes/no
- Custom component events yes/no
- Third-party package events yes/no

To achieve this, the `process_before_send` has been extended to handle these new options.

Fixes some styling along the way, pushing the test coverage for the whole integration to 100%.

- Addresses comments on the original/initial Sentry PR:
  - <https://github.com/home-assistant/core/pull/30422#discussion_r363004455>
  - <https://github.com/home-assistant/core/pull/30422#discussion_r363004796>
- Addresses comment on previous PR:
  - <https://github.com/home-assistant/core/pull/38915/files#r471146295>
- Revives part of the implementation originally proposed in PR #30482 (closed)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
