### PR TITLE
Add HomeKit Controller heater-cooler devices

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -5,6 +5,10 @@ from aiohomekit.model.characteristics import (
     CharacteristicsTypes,
     HeatingCoolingCurrentValues,
     HeatingCoolingTargetValues,
+    ActivationStateValues,
+    SwingModeValues,
+    CurrentHeaterCoolerStateValues,
+    TargetHeaterCoolerStateValues,
 )
 from aiohomekit.utils import clamp_enum_to_char
 
@@ -14,15 +18,20 @@ from homeassistant.components.climate import (
     ClimateEntity,
 )
 from homeassistant.components.climate.const import (
+    CURRENT_HVAC_OFF,
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
+    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
+    SWING_OFF,
+    SWING_VERTICAL,
     SUPPORT_TARGET_HUMIDITY,
     SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_SWING_MODE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import callback
@@ -39,14 +48,38 @@ MODE_HOMEKIT_TO_HASS = {
     HeatingCoolingTargetValues.AUTO: HVAC_MODE_HEAT_COOL,
 }
 
-# Map of hass operation modes to homekit modes
-MODE_HASS_TO_HOMEKIT = {v: k for k, v in MODE_HOMEKIT_TO_HASS.items()}
-
 CURRENT_MODE_HOMEKIT_TO_HASS = {
     HeatingCoolingCurrentValues.IDLE: CURRENT_HVAC_IDLE,
     HeatingCoolingCurrentValues.HEATING: CURRENT_HVAC_HEAT,
     HeatingCoolingCurrentValues.COOLING: CURRENT_HVAC_COOL,
 }
+
+SWING_MODE_HOMEKIT_TO_HASS = {
+    SwingModeValues.DISABLED: SWING_OFF,
+    SwingModeValues.ENABLED: SWING_VERTICAL,
+}
+
+CURRENT_HEATER_COOLER_STATE_HOMEKIT_TO_HASS = {
+    CurrentHeaterCoolerStateValues.INACTIVE: CURRENT_HVAC_OFF,
+    CurrentHeaterCoolerStateValues.IDLE: CURRENT_HVAC_IDLE,
+    CurrentHeaterCoolerStateValues.HEATING: CURRENT_HVAC_HEAT,
+    CurrentHeaterCoolerStateValues.COOLING: CURRENT_HVAC_COOL,
+}
+
+TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS = {
+    TargetHeaterCoolerStateValues.AUTOMATIC: HVAC_MODE_AUTO,
+    TargetHeaterCoolerStateValues.HEAT: HVAC_MODE_HEAT,
+    TargetHeaterCoolerStateValues.COOL: HVAC_MODE_COOL,
+}
+
+# Map of hass operation modes to homekit modes
+MODE_HASS_TO_HOMEKIT = {v: k for k, v in MODE_HOMEKIT_TO_HASS.items()}
+
+TARGET_HEATER_COOLER_STATE_HASS_TO_HOMEKIT = {
+    v: k for k, v in TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS.items()
+}
+
+SWING_MODE_HASS_TO_HOMEKIT = {v: k for k, v in SWING_MODE_HOMEKIT_TO_HASS.items()}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -56,13 +89,217 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     @callback
     def async_add_service(aid, service):
-        if service["stype"] != "thermostat":
-            return False
         info = {"aid": aid, "iid": service["iid"]}
-        async_add_entities([HomeKitClimateEntity(conn, info)], True)
-        return True
+        if service["stype"] == "thermostat":
+            async_add_entities([HomeKitClimateEntity(conn, info)], True)
+            return True
+        if service["stype"] == "heater-cooler":
+            async_add_entities([HomeKitHeaterCoolerEntity(conn, info)], True)
+            return True
+        return False
 
     conn.add_listener(async_add_service)
+
+
+class HomeKitHeaterCoolerEntity(HomeKitEntity, ClimateEntity):
+    """Representation of a Homekit climate device."""
+
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
+        return [
+            CharacteristicsTypes.ACTIVE,
+            CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE,
+            CharacteristicsTypes.TARGET_HEATER_COOLER_STATE,
+            CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD,
+            CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD,
+            CharacteristicsTypes.SWING_MODE,
+            CharacteristicsTypes.TEMPERATURE_CURRENT,
+        ]
+
+    async def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temp = kwargs.get(ATTR_TEMPERATURE)
+
+        await self.async_put_characteristics(
+            {CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD: temp}
+        )
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Set new target operation mode."""
+        if hvac_mode == HVAC_MODE_OFF:
+            await self.async_put_characteristics(
+                {CharacteristicsTypes.ACTIVE: ActivationStateValues.INACTIVE}
+            )
+            return
+        await self.async_put_characteristics(
+            {
+                CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TARGET_HEATER_COOLER_STATE_HASS_TO_HOMEKIT[
+                    hvac_mode
+                ],
+            }
+        )
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self.service.value(CharacteristicsTypes.TEMPERATURE_CURRENT)
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+        if state == TargetHeaterCoolerStateValues.COOL and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+            ].value
+        if state == TargetHeaterCoolerStateValues.HEAT and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+            ].value
+        return None
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+        if state == TargetHeaterCoolerStateValues.COOL and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+            ].minStep
+        if state == TargetHeaterCoolerStateValues.HEAT and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+            ].minStep
+        return None
+
+    @property
+    def min_temp(self):
+        """Return the minimum target temp."""
+        state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+        if state == TargetHeaterCoolerStateValues.COOL and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+            ].minValue
+        if state == TargetHeaterCoolerStateValues.HEAT and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+            ].minValue
+        return super().min_temp
+
+    @property
+    def max_temp(self):
+        """Return the maximum target temp."""
+        state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+        if state == TargetHeaterCoolerStateValues.COOL and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+            ].maxValue
+        if state == TargetHeaterCoolerStateValues.HEAT and self.service.has(
+            CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+        ):
+            return self.service[
+                CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+            ].maxValue
+        return super().max_temp
+
+    @property
+    def hvac_action(self):
+        """Return the current running hvac operation."""
+        # This characteristic describes the current mode of a device,
+        # e.g. a thermostat is "heating" a room to 75 degrees Fahrenheit.
+        # Can be 0 - 3 (Off, Idle, Heat, Cool)
+        value = self.service.value(CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE)
+        return CURRENT_HEATER_COOLER_STATE_HOMEKIT_TO_HASS.get(value)
+
+    @property
+    def hvac_mode(self):
+        """Return hvac operation ie. heat, cool mode."""
+        # This characteristic describes the target mode
+        # E.g. should the device start heating a room if the temperature
+        # falls below the target temperature.
+        # CCan be 0 - 2 (Auto, Heat, Cool)
+        if (
+            self.service.has(CharacteristicsTypes.ACTIVE)
+            and self.service.value(CharacteristicsTypes.ACTIVE)
+            == ActivationStateValues.INACTIVE
+        ):
+            return HVAC_MODE_OFF
+        value = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+        return TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS.get(value)
+
+    @property
+    def hvac_modes(self):
+        """Return the list of available hvac operation modes."""
+        char = self.service[CharacteristicsTypes.TARGET_HEATER_COOLER_STATE]
+        ret = [
+            TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS[state]
+            for state in range(char.minValue, char.maxValue + 1)
+        ]
+        if self.service.has(CharacteristicsTypes.ACTIVE):
+            ret.append(HVAC_MODE_OFF)
+        return ret
+
+    @property
+    def swing_mode(self):
+        """Return the swing setting.
+
+        Requires SUPPORT_SWING_MODE.
+        """
+        value = self.service.value(CharacteristicsTypes.SWING_MODE)
+        return SWING_MODE_HOMEKIT_TO_HASS[value]
+
+    @property
+    def swing_modes(self):
+        """Return the list of available swing modes.
+
+        Requires SUPPORT_SWING_MODE.
+        """
+        char = self.service[CharacteristicsTypes.SWING_MODE]
+        return [
+            SWING_MODE_HOMEKIT_TO_HASS[swing]
+            for swing in range(char.minValue, char.maxValue + 1)
+        ]
+
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set new target swing operation."""
+        await self.async_put_characteristics(
+            {CharacteristicsTypes.SWING_MODE: SWING_MODE_HASS_TO_HOMEKIT[swing_mode]}
+        )
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        features = 0
+
+        if self.service.has(CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD):
+            features |= SUPPORT_TARGET_TEMPERATURE
+
+        if self.service.has(CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD):
+            features |= SUPPORT_TARGET_TEMPERATURE
+
+        if self.service.has(CharacteristicsTypes.SWING_MODE):
+            features |= SUPPORT_SWING_MODE
+
+        return features
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
 
 
 class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -22,7 +22,6 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
     CURRENT_HVAC_OFF,
-    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
@@ -67,7 +66,7 @@ CURRENT_HEATER_COOLER_STATE_HOMEKIT_TO_HASS = {
 }
 
 TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS = {
-    TargetHeaterCoolerStateValues.AUTOMATIC: HVAC_MODE_AUTO,
+    TargetHeaterCoolerStateValues.AUTOMATIC: HVAC_MODE_HEAT_COOL,
     TargetHeaterCoolerStateValues.HEAT: HVAC_MODE_HEAT,
     TargetHeaterCoolerStateValues.COOL: HVAC_MODE_COOL,
 }
@@ -126,6 +125,14 @@ class HomeKitHeaterCoolerEntity(HomeKitEntity, ClimateEntity):
             await self.async_put_characteristics(
                 {CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD: temp}
             )
+        else:
+            hvac_mode = TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS.get(state)
+            _LOGGER.warning(
+                "HomeKit device %s: Setting temperature in %s mode is not supported yet."
+                " Consider raising a ticket if you have this device and want to help us implement this feature.",
+                self.entity_id,
+                hvac_mode,
+            )
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target operation mode."""
@@ -134,6 +141,13 @@ class HomeKitHeaterCoolerEntity(HomeKitEntity, ClimateEntity):
                 {CharacteristicsTypes.ACTIVE: ActivationStateValues.INACTIVE}
             )
             return
+        if hvac_mode not in {HVAC_MODE_HEAT, HVAC_MODE_COOL}:
+            _LOGGER.warning(
+                "HomeKit device %s: Setting temperature in %s mode is not supported yet."
+                " Consider raising a ticket if you have this device and want to help us implement this feature.",
+                self.entity_id,
+                hvac_mode,
+            )
         await self.async_put_characteristics(
             {
                 CharacteristicsTypes.TARGET_HEATER_COOLER_STATE: TARGET_HEATER_COOLER_STATE_HASS_TO_HOMEKIT[

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -235,6 +235,11 @@ class HomeKitHeaterCoolerEntity(HomeKitEntity, ClimateEntity):
         # This characteristic describes the current mode of a device,
         # e.g. a thermostat is "heating" a room to 75 degrees Fahrenheit.
         # Can be 0 - 3 (Off, Idle, Heat, Cool)
+        if (
+            self.service.value(CharacteristicsTypes.ACTIVE)
+            == ActivationStateValues.INACTIVE
+        ):
+            return CURRENT_HVAC_OFF
         value = self.service.value(CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE)
         return CURRENT_HEATER_COOLER_STATE_HOMEKIT_TO_HASS.get(value)
 

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -249,8 +249,7 @@ class HomeKitHeaterCoolerEntity(HomeKitEntity, ClimateEntity):
         modes = [
             TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS[mode] for mode in valid_values
         ]
-        if self.service.has(CharacteristicsTypes.ACTIVE):
-            modes.append(HVAC_MODE_OFF)
+        modes.append(HVAC_MODE_OFF)
         return modes
 
     @property

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -2,12 +2,12 @@
 import logging
 
 from aiohomekit.model.characteristics import (
+    ActivationStateValues,
     CharacteristicsTypes,
+    CurrentHeaterCoolerStateValues,
     HeatingCoolingCurrentValues,
     HeatingCoolingTargetValues,
-    ActivationStateValues,
     SwingModeValues,
-    CurrentHeaterCoolerStateValues,
     TargetHeaterCoolerStateValues,
 )
 from aiohomekit.utils import clamp_enum_to_char
@@ -18,20 +18,20 @@ from homeassistant.components.climate import (
     ClimateEntity,
 )
 from homeassistant.components.climate.const import (
-    CURRENT_HVAC_OFF,
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
-    SWING_OFF,
-    SWING_VERTICAL,
+    SUPPORT_SWING_MODE,
     SUPPORT_TARGET_HUMIDITY,
     SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_SWING_MODE,
+    SWING_OFF,
+    SWING_VERTICAL,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import callback

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -14,6 +14,7 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     "outlet": "switch",
     "switch": "switch",
     "thermostat": "climate",
+    "heater-cooler": "climate",
     "security-system": "alarm_control_panel",
     "garage-door-opener": "cover",
     "window": "cover",

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit[IP]==0.2.47"],
+  "requirements": ["aiohomekit[IP]==0.2.49"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,7 +179,7 @@ aioguardian==1.0.1
 aioharmony==0.2.6
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.47
+aiohomekit[IP]==0.2.49
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -104,7 +104,7 @@ aioguardian==1.0.1
 aioharmony==0.2.6
 
 # homeassistant.components.homekit_controller
-aiohomekit[IP]==0.2.47
+aiohomekit[IP]==0.2.49
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -291,7 +291,7 @@ async def test_heater_cooler_respect_supported_op_modes_1(hass, utcnow):
     """Test that climate respects minValue/maxValue hints."""
     helper = await setup_test_component(hass, create_heater_cooler_service_min_max)
     state = await helper.poll_and_get_state()
-    assert state.attributes["hvac_modes"] == ["heat", "cool"]
+    assert state.attributes["hvac_modes"] == ["heat", "cool", "off"]
 
 
 def create_theater_cooler_service_valid_vals(accessory):
@@ -306,7 +306,7 @@ async def test_heater_cooler_respect_supported_op_modes_2(hass, utcnow):
     """Test that climate respects validValue hints."""
     helper = await setup_test_component(hass, create_theater_cooler_service_valid_vals)
     state = await helper.poll_and_get_state()
-    assert state.attributes["hvac_modes"] == ["heat", "cool"]
+    assert state.attributes["hvac_modes"] == ["heat", "cool", "off"]
 
 
 async def test_heater_cooler_change_thermostat_state(hass, utcnow):

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -1,9 +1,16 @@
 """Basic checks for HomeKitclimate."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.characteristics import (
+    TargetHeaterCoolerStateValues,
+    ActivationStateValues,
+    SwingModeValues,
+    CurrentHeaterCoolerStateValues,
+)
 
 from homeassistant.components.climate.const import (
     DOMAIN,
+    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
@@ -11,6 +18,7 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_TEMPERATURE,
+    SERVICE_SET_SWING_MODE,
 )
 
 from tests.components.homekit_controller.common import setup_test_component
@@ -21,6 +29,8 @@ TEMPERATURE_TARGET = ("thermostat", "temperature.target")
 TEMPERATURE_CURRENT = ("thermostat", "temperature.current")
 HUMIDITY_TARGET = ("thermostat", "relative-humidity.target")
 HUMIDITY_CURRENT = ("thermostat", "relative-humidity.current")
+
+# Test thermostat devices
 
 
 def create_thermostat_service(accessory):
@@ -226,3 +236,261 @@ async def test_hvac_mode_vs_hvac_action(hass, utcnow):
     state = await helper.poll_and_get_state()
     assert state.state == "heat"
     assert state.attributes["hvac_action"] == "heating"
+
+
+TARGET_HEATER_COOLER_STATE = ("heater-cooler", "heater-cooler.state.target")
+CURRENT_HEATER_COOLER_STATE = ("heater-cooler", "heater-cooler.state.current")
+HEATER_COOLER_ACTIVE = ("heater-cooler", "active")
+HEATER_COOLER_TEMPERATURE_CURRENT = ("heater-cooler", "temperature.current")
+TEMPERATURE_COOLING_THRESHOLD = ("heater-cooler", "temperature.cooling-threshold")
+TEMPERATURE_HEATING_THRESHOLD = ("heater-cooler", "temperature.heating-threshold")
+SWING_MODE = ("heater-cooler", "swing-mode")
+
+
+def create_heater_cooler_service(accessory):
+    """Define thermostat characteristics."""
+    service = accessory.add_service(ServicesTypes.HEATER_COOLER)
+
+    char = service.add_char(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.CURRENT_HEATER_COOLER_STATE)
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.ACTIVE)
+    char.value = 1
+
+    char = service.add_char(CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD)
+    char.minValue = 7
+    char.maxValue = 35
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD)
+    char.minValue = 7
+    char.maxValue = 35
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.TEMPERATURE_CURRENT)
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.SWING_MODE)
+    char.value = 0
+
+
+# Test heater-cooler devices
+def create_heater_cooler_service_min_max(accessory):
+    """Define thermostat characteristics."""
+    service = accessory.add_service(ServicesTypes.HEATER_COOLER)
+    char = service.add_char(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+    char.value = 1
+    char.minValue = 1
+    char.maxValue = 2
+
+
+async def test_heater_cooler_respect_supported_op_modes_1(hass, utcnow):
+    """Test that climate respects minValue/maxValue hints."""
+    helper = await setup_test_component(hass, create_heater_cooler_service_min_max)
+    state = await helper.poll_and_get_state()
+    assert state.attributes["hvac_modes"] == ["heat", "cool"]
+
+
+def create_theater_cooler_service_valid_vals(accessory):
+    """Define heater-cooler characteristics."""
+    service = accessory.add_service(ServicesTypes.HEATER_COOLER)
+    char = service.add_char(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
+    char.value = 1
+    char.valid_values = [1, 2]
+
+
+async def test_heater_cooler_respect_supported_op_modes_2(hass, utcnow):
+    """Test that climate respects validValue hints."""
+    helper = await setup_test_component(hass, create_theater_cooler_service_valid_vals)
+    state = await helper.poll_and_get_state()
+    assert state.attributes["hvac_modes"] == ["heat", "cool"]
+
+
+async def test_heater_cooler_change_thermostat_state(hass, utcnow):
+    """Test that we can change the operational mode."""
+    helper = await setup_test_component(hass, create_heater_cooler_service)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_HEAT},
+        blocking=True,
+    )
+
+    assert (
+        helper.characteristics[TARGET_HEATER_COOLER_STATE].value
+        == TargetHeaterCoolerStateValues.HEAT
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_COOL},
+        blocking=True,
+    )
+    assert (
+        helper.characteristics[TARGET_HEATER_COOLER_STATE].value
+        == TargetHeaterCoolerStateValues.COOL
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_AUTO},
+        blocking=True,
+    )
+    assert (
+        helper.characteristics[TARGET_HEATER_COOLER_STATE].value
+        == TargetHeaterCoolerStateValues.AUTOMATIC
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_OFF},
+        blocking=True,
+    )
+    assert (
+        helper.characteristics[HEATER_COOLER_ACTIVE].value
+        == ActivationStateValues.INACTIVE
+    )
+
+
+async def test_heater_cooler_change_thermostat_temperature(hass, utcnow):
+    """Test that we can change the target temperature"""
+    helper = await setup_test_component(hass, create_heater_cooler_service)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_HEAT},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {"entity_id": "climate.testdevice", "temperature": 20},
+        blocking=True,
+    )
+    assert helper.characteristics[TEMPERATURE_HEATING_THRESHOLD].value == 20
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_COOL},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {"entity_id": "climate.testdevice", "temperature": 26},
+        blocking=True,
+    )
+    assert helper.characteristics[TEMPERATURE_COOLING_THRESHOLD].value == 26
+
+
+async def test_heater_cooler_read_thermostat_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit thermostat accessory."""
+    helper = await setup_test_component(hass, create_heater_cooler_service)
+
+    # Simulate that heating is on
+    helper.characteristics[HEATER_COOLER_TEMPERATURE_CURRENT].value = 19
+    helper.characteristics[TEMPERATURE_HEATING_THRESHOLD].value = 20
+    helper.characteristics[
+        CURRENT_HEATER_COOLER_STATE
+    ].value = CurrentHeaterCoolerStateValues.HEATING
+    helper.characteristics[
+        TARGET_HEATER_COOLER_STATE
+    ].value = TargetHeaterCoolerStateValues.HEAT
+    helper.characteristics[SWING_MODE].value = SwingModeValues.DISABLED
+
+    state = await helper.poll_and_get_state()
+    assert state.state == HVAC_MODE_HEAT
+    assert state.attributes["current_temperature"] == 19
+    assert state.attributes["min_temp"] == 7
+    assert state.attributes["max_temp"] == 35
+
+    # Simulate that cooling is on
+    helper.characteristics[HEATER_COOLER_TEMPERATURE_CURRENT].value = 21
+    helper.characteristics[TEMPERATURE_COOLING_THRESHOLD].value = 19
+    helper.characteristics[
+        CURRENT_HEATER_COOLER_STATE
+    ].value = CurrentHeaterCoolerStateValues.COOLING
+    helper.characteristics[
+        TARGET_HEATER_COOLER_STATE
+    ].value = TargetHeaterCoolerStateValues.COOL
+    helper.characteristics[SWING_MODE].value = SwingModeValues.DISABLED
+
+    state = await helper.poll_and_get_state()
+    assert state.state == HVAC_MODE_COOL
+    assert state.attributes["current_temperature"] == 21
+
+    # Simulate that we are in auto mode
+    helper.characteristics[HEATER_COOLER_TEMPERATURE_CURRENT].value = 21
+    helper.characteristics[TEMPERATURE_COOLING_THRESHOLD].value = 21
+    helper.characteristics[
+        CURRENT_HEATER_COOLER_STATE
+    ].value = CurrentHeaterCoolerStateValues.COOLING
+    helper.characteristics[
+        TARGET_HEATER_COOLER_STATE
+    ].value = TargetHeaterCoolerStateValues.AUTOMATIC
+    helper.characteristics[SWING_MODE].value = SwingModeValues.DISABLED
+
+    state = await helper.poll_and_get_state()
+    assert state.state == HVAC_MODE_AUTO
+
+
+async def test_heater_cooler_hvac_mode_vs_hvac_action(hass, utcnow):
+    """Check that we haven't conflated hvac_mode and hvac_action."""
+    helper = await setup_test_component(hass, create_heater_cooler_service)
+
+    # Simulate that current temperature is above target temp
+    # Heating might be on, but hvac_action currently 'off'
+    helper.characteristics[HEATER_COOLER_TEMPERATURE_CURRENT].value = 22
+    helper.characteristics[TEMPERATURE_HEATING_THRESHOLD].value = 21
+    helper.characteristics[
+        CURRENT_HEATER_COOLER_STATE
+    ].value = CurrentHeaterCoolerStateValues.IDLE
+    helper.characteristics[
+        TARGET_HEATER_COOLER_STATE
+    ].value = TargetHeaterCoolerStateValues.HEAT
+    helper.characteristics[SWING_MODE].value = SwingModeValues.DISABLED
+
+    state = await helper.poll_and_get_state()
+    assert state.state == "heat"
+    assert state.attributes["hvac_action"] == "idle"
+
+    # Simulate that current temperature is below target temp
+    # Heating might be on and hvac_action currently 'heat'
+    helper.characteristics[HEATER_COOLER_TEMPERATURE_CURRENT].value = 19
+    helper.characteristics[
+        CURRENT_HEATER_COOLER_STATE
+    ].value = CurrentHeaterCoolerStateValues.HEATING
+
+    state = await helper.poll_and_get_state()
+    assert state.state == "heat"
+    assert state.attributes["hvac_action"] == "heating"
+
+
+async def test_heater_cooler_change_swing_mode(hass, utcnow):
+    """Test that we can change the swing mode"""
+    helper = await setup_test_component(hass, create_heater_cooler_service)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_SWING_MODE,
+        {"entity_id": "climate.testdevice", "swing_mode": "vertical"},
+        blocking=True,
+    )
+    assert helper.characteristics[SWING_MODE].value == SwingModeValues.ENABLED
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_SWING_MODE,
+        {"entity_id": "climate.testdevice", "swing_mode": "off"},
+        blocking=True,
+    )
+    assert helper.characteristics[SWING_MODE].value == SwingModeValues.DISABLED

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -10,7 +10,6 @@ from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.climate.const import (
     DOMAIN,
-    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
@@ -339,7 +338,7 @@ async def test_heater_cooler_change_thermostat_state(hass, utcnow):
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_HVAC_MODE,
-        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_AUTO},
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_HEAT_COOL},
         blocking=True,
     )
     assert (
@@ -440,7 +439,7 @@ async def test_heater_cooler_read_thermostat_state(hass, utcnow):
     helper.characteristics[SWING_MODE].value = SwingModeValues.DISABLED
 
     state = await helper.poll_and_get_state()
-    assert state.state == HVAC_MODE_AUTO
+    assert state.state == HVAC_MODE_HEAT_COOL
 
 
 async def test_heater_cooler_hvac_mode_vs_hvac_action(hass, utcnow):

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -1,12 +1,12 @@
 """Basic checks for HomeKitclimate."""
-from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
 from aiohomekit.model.characteristics import (
-    TargetHeaterCoolerStateValues,
     ActivationStateValues,
-    SwingModeValues,
+    CharacteristicsTypes,
     CurrentHeaterCoolerStateValues,
+    SwingModeValues,
+    TargetHeaterCoolerStateValues,
 )
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.climate.const import (
     DOMAIN,
@@ -17,8 +17,8 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_HVAC_MODE,
-    SERVICE_SET_TEMPERATURE,
     SERVICE_SET_SWING_MODE,
+    SERVICE_SET_TEMPERATURE,
 )
 
 from tests.components.homekit_controller.common import setup_test_component
@@ -360,7 +360,7 @@ async def test_heater_cooler_change_thermostat_state(hass, utcnow):
 
 
 async def test_heater_cooler_change_thermostat_temperature(hass, utcnow):
-    """Test that we can change the target temperature"""
+    """Test that we can change the target temperature."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
     await hass.services.async_call(
@@ -476,7 +476,7 @@ async def test_heater_cooler_hvac_mode_vs_hvac_action(hass, utcnow):
 
 
 async def test_heater_cooler_change_swing_mode(hass, utcnow):
-    """Test that we can change the swing mode"""
+    """Test that we can change the swing mode."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
     await hass.services.async_call(

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -493,3 +493,19 @@ async def test_heater_cooler_change_swing_mode(hass, utcnow):
         blocking=True,
     )
     assert helper.characteristics[SWING_MODE].value == SwingModeValues.DISABLED
+
+
+async def test_heater_cooler_turn_off(hass, utcnow):
+    """Test that both hvac_action and hvac_mode return "off" when turned off."""
+    helper = await setup_test_component(hass, create_heater_cooler_service)
+    # Simulate that the device is turned off but CURRENT_HEATER_COOLER_STATE still returns HEATING/COOLING
+    helper.characteristics[HEATER_COOLER_ACTIVE].value = ActivationStateValues.INACTIVE
+    helper.characteristics[
+        CURRENT_HEATER_COOLER_STATE
+    ].value = CurrentHeaterCoolerStateValues.HEATING
+    helper.characteristics[
+        TARGET_HEATER_COOLER_STATE
+    ].value = TargetHeaterCoolerStateValues.HEAT
+    state = await helper.poll_and_get_state()
+    assert state.state == "off"
+    assert state.attributes["hvac_action"] == "off"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Some new HomeKit climate devices, like [XiaoMi  Aqara Air Conditioning Controller P3][1] are heater-cooler devices instead of
thermostat devices. They work fine when pairing with iPhone but are not shown in home-assistant homekit controller integration.

This PR adds heater-cooler devices to HomeKit Controller.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Requires https://github.com/Jc2k/aiohomekit/pull/18 to function.
- Tested with my XiaoMi Air Conditioning Controller P3 but not other devices:
<img width="684" alt="Screen Shot 2020-08-18 at 2 31 48 AM" src="https://user-images.githubusercontent.com/9941773/90435654-da2fbd00-e101-11ea-9e6e-77faa9e24233.png">
<img width="442" alt="Screen Shot 2020-08-18 at 2 32 00 AM" src="https://user-images.githubusercontent.com/9941773/90435657-dbf98080-e101-11ea-8382-8e3b7077f038.png">
<img width="1653" alt="Screen Shot 2020-08-18 at 2 34 10 AM" src="https://user-images.githubusercontent.com/9941773/90435659-dc921700-e101-11ea-95ef-44e876cd081d.png">

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/30384


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

[1]: https://www.aqara.com/cn/productDetail/d33
