### PR TITLE
Improve time_pattern validation schema

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time_pattern.py
+++ b/homeassistant/components/homeassistant/triggers/time_pattern.py
@@ -18,39 +18,41 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TimePattern:
-    """Limit a value to a time pattern.
+    """Validate a time pattern value.
 
     :raises Invalid: If the value has a wrong format or is outside the range.
     """
 
-    def __init__(self, max):
-        self.max = max
+    def __init__(self, maximum):
+        """Initialize time pattern."""
+        self.maximum = maximum
 
-    def __call__(self, v):
+    def __call__(self, value):
+        """Validate input."""
         try:
-            value = str(v)
             if value == "*":
-                return v
-            if value[0] == "/":
-                value = int(value[1:])
+                return value
+
+            if isinstance(value, str) and value.startswith("/"):
+                number = int(value[1:])
             else:
-                value = int(value)
+                number = int(value)
 
-            if not (0 <= value <= self.max):
-                raise vol.Invalid(f"must be a value between 0 and {self.max}")
+            if not (0 <= number <= self.maximum):
+                raise vol.Invalid(f"must be a value between 0 and {self.maximum}")
         except ValueError:
-            raise vol.Invalid(f"invalid time_pattern value")
+            raise vol.Invalid("invalid time_pattern value")
 
-        return v
+        return value
 
 
 TRIGGER_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_PLATFORM): "time_pattern",
-            CONF_HOURS: TimePattern(max=23),
-            CONF_MINUTES: TimePattern(max=59),
-            CONF_SECONDS: TimePattern(max=59),
+            CONF_HOURS: TimePattern(maximum=23),
+            CONF_MINUTES: TimePattern(maximum=59),
+            CONF_SECONDS: TimePattern(maximum=59),
         }
     ),
     cv.has_at_least_one_key(CONF_HOURS, CONF_MINUTES, CONF_SECONDS),

--- a/homeassistant/components/homeassistant/triggers/time_pattern.py
+++ b/homeassistant/components/homeassistant/triggers/time_pattern.py
@@ -16,13 +16,41 @@ CONF_SECONDS = "seconds"
 
 _LOGGER = logging.getLogger(__name__)
 
+
+class TimePattern:
+    """Limit a value to a time pattern.
+
+    :raises Invalid: If the value has a wrong format or is outside the range.
+    """
+
+    def __init__(self, max):
+        self.max = max
+
+    def __call__(self, v):
+        try:
+            value = str(v)
+            if value == "*":
+                return v
+            if value[0] == "/":
+                value = int(value[1:])
+            else:
+                value = int(value)
+
+            if not (0 <= value <= self.max):
+                raise vol.Invalid(f"must be a value between 0 and {self.max}")
+        except ValueError:
+            raise vol.Invalid(f"invalid time_pattern value")
+
+        return v
+
+
 TRIGGER_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_PLATFORM): "time_pattern",
-            CONF_HOURS: vol.Any(vol.Coerce(int), vol.Coerce(str)),
-            CONF_MINUTES: vol.Any(vol.Coerce(int), vol.Coerce(str)),
-            CONF_SECONDS: vol.Any(vol.Coerce(int), vol.Coerce(str)),
+            CONF_HOURS: TimePattern(max=23),
+            CONF_MINUTES: TimePattern(max=59),
+            CONF_SECONDS: TimePattern(max=59),
         }
     ),
     cv.has_at_least_one_key(CONF_HOURS, CONF_MINUTES, CONF_SECONDS),

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -1,8 +1,10 @@
 """The tests for the time_pattern automation."""
 from asynctest.mock import patch
 import pytest
+import voluptuous as vol
 
 import homeassistant.components.automation as automation
+import homeassistant.components.automation.time_pattern as time_pattern
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -294,3 +296,20 @@ async def test_default_values(hass, calls):
 
     await hass.async_block_till_done()
     assert len(calls) == 2
+
+
+async def test_invalid_schemas(hass, calls):
+    """Test invalid schemas."""
+    schemas = (
+        None,
+        {},
+        {"platform": "time_pattern"},
+        {"platform": "time_pattern", "minutes": "/",},
+        {"platform": "time_pattern", "minutes": "*/5",},
+        {"platform": "time_pattern", "minutes": "/90",},
+        {"platform": "time_pattern", "hours": "12", "minutes": "0", "seconds": "100",},
+    )
+
+    for value in schemas:
+        with pytest.raises(vol.Invalid):
+            time_pattern.TRIGGER_SCHEMA(value)

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -304,10 +304,10 @@ async def test_invalid_schemas(hass, calls):
         None,
         {},
         {"platform": "time_pattern"},
-        {"platform": "time_pattern", "minutes": "/",},
-        {"platform": "time_pattern", "minutes": "*/5",},
-        {"platform": "time_pattern", "minutes": "/90",},
-        {"platform": "time_pattern", "hours": "12", "minutes": "0", "seconds": "100",},
+        {"platform": "time_pattern", "minutes": "/"},
+        {"platform": "time_pattern", "minutes": "*/5"},
+        {"platform": "time_pattern", "minutes": "/90"},
+        {"platform": "time_pattern", "hours": 12, "minutes": 0, "seconds": 100},
     )
 
     for value in schemas:

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -4,7 +4,7 @@ import pytest
 import voluptuous as vol
 
 import homeassistant.components.automation as automation
-import homeassistant.components.automation.time_pattern as time_pattern
+import homeassistant.components.homeassistant.triggers.time_pattern as time_pattern
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `time_pattern` trigger will now reject invalid expressions that were previously accepted (but did not work as expected). 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Tighten the `time_pattern` schema to only accept valid expressions. This helps a little bit when people expect
```yaml
trigger:
- platform: time_pattern
  minutes: /90    
```
to fire every hour and a half. Until now it has actually fired every hour (because only 0 is divisible by 90); with this PR the configuration is rejected.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34503
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
