### PR TITLE
Adjust async_fire_time_changed to account for time between fetching hass.loop.time and time.time

### DIFF
--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -55,6 +55,7 @@ async def test_if_fires_using_at(hass, calls):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     now = dt_util.utcnow()
 
@@ -114,6 +115,7 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
                 }
             },
         )
+        await hass.async_block_till_done()
 
     async_fire_time_changed(hass, trigger_dt)
     await hass.async_block_till_done()
@@ -170,6 +172,7 @@ async def test_if_fires_using_multiple_at(hass, calls):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     now = dt_util.utcnow()
 
@@ -219,6 +222,7 @@ async def test_if_not_fires_using_wrong_at(hass, calls):
                     }
                 },
             )
+            await hass.async_block_till_done()
 
     async_fire_time_changed(
         hass, now.replace(year=now.year + 1, hour=1, minute=0, second=5)
@@ -378,6 +382,7 @@ async def test_untrack_time_change(hass):
                 }
             },
         )
+        await hass.async_block_till_done()
 
     await hass.services.async_call(
         automation.DOMAIN,

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -35,7 +35,7 @@ async def test_if_fires_using_at(hass, calls):
 
     time_that_will_not_match_right_away = now.replace(
         hour=4, minute=59, second=0
-    ) + timedelta(2)
+    ) + timedelta(days=2)
 
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
@@ -60,7 +60,8 @@ async def test_if_fires_using_at(hass, calls):
     now = dt_util.utcnow()
 
     async_fire_time_changed(
-        hass, now.replace(hour=5, minute=0, second=0) + timedelta(2)
+        hass,
+        now.replace(hour=5, minute=0, second=0, microsecond=999999) + timedelta(days=2),
     )
 
     await hass.async_block_till_done()
@@ -152,7 +153,7 @@ async def test_if_fires_using_multiple_at(hass, calls):
 
     time_that_will_not_match_right_away = now.replace(
         hour=4, minute=59, second=0
-    ) + timedelta(2)
+    ) + timedelta(days=2)
 
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
@@ -177,7 +178,8 @@ async def test_if_fires_using_multiple_at(hass, calls):
     now = dt_util.utcnow()
 
     async_fire_time_changed(
-        hass, now.replace(hour=5, minute=0, second=0) + timedelta(2)
+        hass,
+        now.replace(hour=5, minute=0, second=0, microsecond=999999) + timedelta(days=2),
     )
 
     await hass.async_block_till_done()
@@ -185,7 +187,8 @@ async def test_if_fires_using_multiple_at(hass, calls):
     assert calls[0].data["some"] == "time - 5"
 
     async_fire_time_changed(
-        hass, now.replace(hour=6, minute=0, second=0) + timedelta(2)
+        hass,
+        now.replace(hour=6, minute=0, second=0, microsecond=999999) + timedelta(days=2),
     )
 
     await hass.async_block_till_done()
@@ -225,7 +228,8 @@ async def test_if_not_fires_using_wrong_at(hass, calls):
             await hass.async_block_till_done()
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 1, hour=1, minute=0, second=5)
+        hass,
+        now.replace(year=now.year + 1, hour=1, minute=0, second=5, microsecond=999999),
     )
 
     await hass.async_block_till_done()


### PR DESCRIPTION
Sending this to the CI again to see if https://github.com/home-assistant/core/pull/38985 passing was a fluke or repeatable since https://github.com/home-assistant/core/pull/38988 didn't pass the first time.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add missing async_block_till_done to triggers time test and microseconds to 999999


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
