### PR TITLE
Allow templating keys in data_template

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -846,7 +846,7 @@ EVENT_SCHEMA = vol.Schema(
         vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_EVENT): string,
         vol.Optional(CONF_EVENT_DATA): dict,
-        vol.Optional(CONF_EVENT_DATA_TEMPLATE): {match_all: template_complex},
+        vol.Optional(CONF_EVENT_DATA_TEMPLATE): template_complex,
     }
 )
 
@@ -857,7 +857,7 @@ SERVICE_SCHEMA = vol.All(
             vol.Exclusive(CONF_SERVICE, "service name"): service,
             vol.Exclusive(CONF_SERVICE_TEMPLATE, "service name"): template,
             vol.Optional("data"): dict,
-            vol.Optional("data_template"): {match_all: template_complex},
+            vol.Optional("data_template"): template_complex,
             vol.Optional(CONF_ENTITY_ID): comp_entity_ids,
         }
     ),

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -522,10 +522,10 @@ def template_complex(value: Any) -> Any:
             return_list[idx] = template_complex(element)
         return return_list
     if isinstance(value, dict):
-        return_dict = value.copy()
-        for key, element in return_dict.items():
-            return_dict[key] = template_complex(element)
-        return return_dict
+        return {
+            template_complex(key): template_complex(element)
+            for key, element in value.items()
+        }
     if isinstance(value, str):
         return template(value)
     return value

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -526,7 +526,7 @@ def template_complex(value: Any) -> Any:
             template_complex(key): template_complex(element)
             for key, element in value.items()
         }
-    if isinstance(value, str) and template_helper.is_dynamic_template(value):
+    if isinstance(value, str) and template_helper.is_template_string(value):
         return template(value)
 
     return value

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -521,16 +521,16 @@ def template_complex(value: Any) -> Any:
         for idx, element in enumerate(return_list):
             return_list[idx] = template_complex(element)
         return return_list
-    if isinstance(value, dict):
+    elif isinstance(value, dict):
         return {
             template_complex(key): template_complex(element)
             for key, element in value.items()
         }
-    if isinstance(value, str):
-        if template_helper._RE_JINJA_DELIMITERS.search(value) is not None:
+    elif isinstance(value, str):
+        # pylint: disable=protected-access
+        is_template = template_helper._RE_JINJA_DELIMITERS.search(value) is not None
+        if is_template:
             return template(value)
-        else:  # The value doesn't need to be a template.
-            return value
 
     return value
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -526,11 +526,8 @@ def template_complex(value: Any) -> Any:
             template_complex(key): template_complex(element)
             for key, element in value.items()
         }
-    elif isinstance(value, str):
-        # pylint: disable=protected-access
-        is_template = template_helper._RE_JINJA_DELIMITERS.search(value) is not None
-        if is_template:
-            return template(value)
+    elif isinstance(value, str) and template_helper.is_template(value):
+        return template(value)
 
     return value
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -521,12 +521,12 @@ def template_complex(value: Any) -> Any:
         for idx, element in enumerate(return_list):
             return_list[idx] = template_complex(element)
         return return_list
-    elif isinstance(value, dict):
+    if isinstance(value, dict):
         return {
             template_complex(key): template_complex(element)
             for key, element in value.items()
         }
-    elif isinstance(value, str) and template_helper.is_template(value):
+    if isinstance(value, str) and template_helper.is_template(value):
         return template(value)
 
     return value

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -79,7 +79,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import split_entity_id, valid_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper, _RE_JINJA_DELIMITERS
+from homeassistant.helpers import template as template_helper
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 import homeassistant.util.dt as dt_util
@@ -527,7 +527,7 @@ def template_complex(value: Any) -> Any:
             for key, element in value.items()
         }
     if isinstance(value, str):
-        if _RE_JINJA_DELIMITERS.search(value) is not None:
+        if template_helper._RE_JINJA_DELIMITERS.search(value) is not None:
             return template(value)
         else:  # The value doesn't need to be a template.
             return value

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -526,7 +526,7 @@ def template_complex(value: Any) -> Any:
             template_complex(key): template_complex(element)
             for key, element in value.items()
         }
-    if isinstance(value, str) and template_helper.is_template(value):
+    if isinstance(value, str) and template_helper.is_dynamic_template(value):
         return template(value)
 
     return value

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -79,7 +79,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import split_entity_id, valid_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper
+from homeassistant.helpers import template as template_helper, _RE_JINJA_DELIMITERS
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 import homeassistant.util.dt as dt_util
@@ -527,7 +527,11 @@ def template_complex(value: Any) -> Any:
             for key, element in value.items()
         }
     if isinstance(value, str):
-        return template(value)
+        if _RE_JINJA_DELIMITERS.search(value) is not None:
+            return template(value)
+        else:  # The value doesn't need to be a template.
+            return value
+
     return value
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -87,7 +87,7 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
 
 
 def is_template(maybe_template: str) -> bool:
-    """Returns whether the input is a Jinja2 template."""
+    """Check if the input is a Jinja2 template."""
     return _RE_JINJA_DELIMITERS.search(maybe_template) is not None
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -65,6 +65,8 @@ def attach(hass: HomeAssistantType, obj: Any) -> None:
         for child in obj:
             attach(hass, child)
     elif isinstance(obj, dict):
+        for child in obj.keys():
+            attach(hass, child)
         for child in obj.values():
             attach(hass, child)
     elif isinstance(obj, Template):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -86,13 +86,18 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
     return value
 
 
+def is_template(maybe_template: str) -> bool:
+    """Returns whether the input is a Jinja2 template."""
+    return _RE_JINJA_DELIMITERS.search(maybe_template) is not None
+
+
 def extract_entities(
     hass: HomeAssistantType,
     template: Optional[str],
     variables: TemplateVarsType = None,
 ) -> Union[str, List[str]]:
     """Extract all entities for state_changed listener from template string."""
-    if template is None or _RE_JINJA_DELIMITERS.search(template) is None:
+    if template is None or not is_template(template):
         return []
 
     if _RE_NONE_ENTITIES.search(template):
@@ -266,7 +271,7 @@ class Template:
             render_info.exception = ex
         finally:
             del self.hass.data[_RENDER_INFO]
-            if _RE_JINJA_DELIMITERS.search(self.template) is None:
+            if not is_template(self.template):
                 render_info._freeze_static()
             else:
                 render_info._freeze()

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -76,12 +76,12 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
     """Recursive template creator helper function."""
     if isinstance(value, list):
         return [render_complex(item, variables) for item in value]
-    if isinstance(value, dict):
+    elif isinstance(value, dict):
         return {
             render_complex(key, variables): render_complex(item, variables)
             for key, item in value.items()
         }
-    if isinstance(value, Template):
+    elif isinstance(value, Template):
         return value.async_render(variables)
     return value
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -76,13 +76,14 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
     """Recursive template creator helper function."""
     if isinstance(value, list):
         return [render_complex(item, variables) for item in value]
-    elif isinstance(value, dict):
+    if isinstance(value, dict):
         return {
             render_complex(key, variables): render_complex(item, variables)
             for key, item in value.items()
         }
-    elif isinstance(value, Template):
+    if isinstance(value, Template):
         return value.async_render(variables)
+
     return value
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -87,7 +87,7 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
     return value
 
 
-def is_template(maybe_template: str) -> bool:
+def is_dynamic_template(maybe_template: str) -> bool:
     """Check if the input is a Jinja2 template."""
     return _RE_JINJA_DELIMITERS.search(maybe_template) is not None
 
@@ -98,7 +98,7 @@ def extract_entities(
     variables: TemplateVarsType = None,
 ) -> Union[str, List[str]]:
     """Extract all entities for state_changed listener from template string."""
-    if template is None or not is_template(template):
+    if template is None or not is_dynamic_template(template):
         return []
 
     if _RE_NONE_ENTITIES.search(template):
@@ -272,7 +272,7 @@ class Template:
             render_info.exception = ex
         finally:
             del self.hass.data[_RENDER_INFO]
-            if not is_template(self.template):
+            if not is_dynamic_template(self.template):
                 render_info._freeze_static()
             else:
                 render_info._freeze()

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -87,7 +87,7 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
     return value
 
 
-def is_dynamic_template(maybe_template: str) -> bool:
+def is_template_string(maybe_template: str) -> bool:
     """Check if the input is a Jinja2 template."""
     return _RE_JINJA_DELIMITERS.search(maybe_template) is not None
 
@@ -98,7 +98,7 @@ def extract_entities(
     variables: TemplateVarsType = None,
 ) -> Union[str, List[str]]:
     """Extract all entities for state_changed listener from template string."""
-    if template is None or not is_dynamic_template(template):
+    if template is None or not is_template_string(template):
         return []
 
     if _RE_NONE_ENTITIES.search(template):
@@ -272,7 +272,7 @@ class Template:
             render_info.exception = ex
         finally:
             del self.hass.data[_RENDER_INFO]
-            if not is_dynamic_template(self.template):
+            if not is_template_string(self.template):
                 render_info._freeze_static()
             else:
                 render_info._freeze()

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -76,7 +76,10 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
     if isinstance(value, list):
         return [render_complex(item, variables) for item in value]
     if isinstance(value, dict):
-        return {key: render_complex(item, variables) for key, item in value.items()}
+        return {
+            render_complex(key, variables): render_complex(item, variables)
+            for key, item in value.items()
+        }
     if isinstance(value, Template):
         return value.async_render(variables)
     return value

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -65,10 +65,9 @@ def attach(hass: HomeAssistantType, obj: Any) -> None:
         for child in obj:
             attach(hass, child)
     elif isinstance(obj, dict):
-        for child in obj.keys():
-            attach(hass, child)
-        for child in obj.values():
-            attach(hass, child)
+        for child_key, child_value in obj.items():
+            attach(hass, child_key)
+            attach(hass, child_value)
     elif isinstance(obj, Template):
         obj.hass = hass
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -144,6 +144,26 @@ async def test_calling_service_template(hass):
     assert calls[0].data.get("hello") == "world"
 
 
+async def test_data_template_with_templated_key(hass):
+    """Test the calling of a service with a data_template with a templated key."""
+    context = Context()
+    calls = async_mock_service(hass, "test", "script")
+
+    sequence = cv.SCRIPT_SCHEMA(
+        {"service": "test.script", "data_template": {"{{ hello_var }}": "world"}}
+    )
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+
+    await script_obj.async_run(
+        MappingProxyType({"hello_var": "hello"}), context=context
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].context is context
+    assert "hello" in calls[0].data
+
+
 async def test_multiple_runs_no_wait(hass):
     """Test multiple runs with no wait in script."""
     logger = logging.getLogger("TEST")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This allows one to template keys instead of only values.

For example, in [this](https://github.com/basnijholt/home-assistant-config/blob/cc9571657e45898cb7cb745f2165867782c14953/scripts.yaml#L421-L452) script where I use a `choose`, most options only differ in the keys.

I brought this up in https://community.home-assistant.io/t/option-to-template-the-keys-in-data-template-in-addition-to-only-values/219513

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

This change allows one to change
```yaml
- conditions: # input_boolean.desk_mode changed
    condition: template
    value_template: "{{ trigger_entity_id == 'input_boolean.{}_{}'.format(name, attribute) }}"
  sequence:
    service: kef_custom.set_mode
    data_template:
      entity_id: "{{ 'media_player.{}'.format(name) }}"
      desk_mode: "{{ trigger_to_state }}"
- conditions: # input_boolean.wall_mode changed
    condition: template
    value_template: "{{ trigger_entity_id == 'input_boolean.{}_{}'.format(name, attribute) }}"
  sequence:
    service: kef_custom.set_mode
    data_template:
      entity_id: "{{ 'media_player.{}'.format(name) }}"
      wall_mode: "{{ trigger_to_state }}"
- conditions: # input_boolean.phase_correction changed
    condition: template
    value_template: "{{ trigger_entity_id == 'input_boolean.{}_{}'.format(name, attribute) }}"
  sequence:
    service: kef_custom.set_mode
    data_template:
      entity_id: "{{ 'media_player.{}'.format(name) }}"
      phase_correction: "{{ trigger_to_state }}"
- conditions: # ienput_boolean.high_pass changd
    condition: template
    value_template: "{{ trigger_entity_id == 'input_boolean.{}_{}'.format(name, attribute) }}"
  sequence:
    service: kef_custom.set_mode
    data_template:
      entity_id: "{{ 'media_player.{}'.format(name) }}"
      high_pass: "{{ trigger_to_state }}"
```
into this
```yaml
- conditions:
    condition: template
    value_template: "{{ trigger_entity_id == 'input_boolean.{}_{}'.format(name, attribute) }}"
  sequence:
    service: kef_custom.set_mode
    data_template:
      entity_id: "{{ 'media_player.{}'.format(name) }}"
      "{{ attribute }}": "{{ trigger_to_state }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
