### PR TITLE
Add websocket command to get a list of OZW instances and their status

### DIFF
--- a/homeassistant/components/ozw/websocket_api.py
+++ b/homeassistant/components/ozw/websocket_api.py
@@ -36,9 +36,7 @@ def websocket_get_instances(hass, connection, msg):
     instances = []
 
     for instance in manager.collections["instance"]:
-        status = instance.get_status().data
-        status["id"] = instance.id
-        instances.append(status)
+        instances.append(dict(instance.get_status().data, id=instance.id))
 
     connection.send_result(
         msg[ID], instances,

--- a/homeassistant/components/ozw/websocket_api.py
+++ b/homeassistant/components/ozw/websocket_api.py
@@ -21,11 +21,28 @@ NODE_ID = "node_id"
 @callback
 def async_register_api(hass):
     """Register all of our api endpoints."""
+    websocket_api.async_register_command(hass, websocket_get_instances)
     websocket_api.async_register_command(hass, websocket_network_status)
     websocket_api.async_register_command(hass, websocket_node_metadata)
     websocket_api.async_register_command(hass, websocket_node_status)
     websocket_api.async_register_command(hass, websocket_node_statistics)
     websocket_api.async_register_command(hass, websocket_refresh_node_info)
+
+
+@websocket_api.websocket_command({vol.Required(TYPE): "ozw/get_instances"})
+def websocket_get_instances(hass, connection, msg):
+    """Get a list of OZW instances."""
+    manager = hass.data[DOMAIN][MANAGER]
+    instances = []
+
+    for instance in manager.collections["instance"]:
+        status = instance.get_status().data
+        status["id"] = instance.id
+        instances.append(status)
+
+    connection.send_result(
+        msg[ID], instances,
+    )
 
 
 @websocket_api.websocket_command(

--- a/tests/components/ozw/test_websocket_api.py
+++ b/tests/components/ozw/test_websocket_api.py
@@ -16,6 +16,10 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     await client.send_json({ID: 4, TYPE: "ozw/get_instances"})
     msg = await client.receive_json()
     assert len(msg["result"]) == 1
+    result = msg["result"][0]
+    assert result["id"] == 1
+    assert result["Status"] == "driverAllNodesQueried"
+    assert result["OpenZWave_Version"] == "1.6.1008"
 
     # Test network status
     await client.send_json({ID: 5, TYPE: "ozw/network_status"})

--- a/tests/components/ozw/test_websocket_api.py
+++ b/tests/components/ozw/test_websocket_api.py
@@ -12,6 +12,11 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     await setup_ozw(hass, fixture=generic_data)
     client = await hass_ws_client(hass)
 
+    # Test instance list
+    await client.send_json({ID: 4, TYPE: "ozw/get_instances"})
+    msg = await client.receive_json()
+    assert len(msg["result"]) == 1
+
     # Test network status
     await client.send_json({ID: 5, TYPE: "ozw/network_status"})
     msg = await client.receive_json()


### PR DESCRIPTION
## Proposed change
Adds a websocket command to return a list of OpenZWave instances and the status of each instance


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.