### PR TITLE
Upgrade to  aioymaps==1.1.0 to support new types of stops #39006

### DIFF
--- a/homeassistant/components/yandex_transport/manifest.json
+++ b/homeassistant/components/yandex_transport/manifest.json
@@ -2,6 +2,6 @@
   "domain": "yandex_transport",
   "name": "Yandex Transport",
   "documentation": "https://www.home-assistant.io/integrations/yandex_transport",
-  "requirements": ["aioymaps==1.0.0"],
+  "requirements": ["aioymaps==1.1.0"],
   "codeowners": ["@rishatik92", "@devbis"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -228,7 +228,7 @@ aioswitcher==1.2.0
 aiounifi==23
 
 # homeassistant.components.yandex_transport
-aioymaps==1.0.0
+aioymaps==1.1.0
 
 # homeassistant.components.airly
 airly==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -138,7 +138,7 @@ aioswitcher==1.2.0
 aiounifi==23
 
 # homeassistant.components.yandex_transport
-aioymaps==1.0.0
+aioymaps==1.1.0
 
 # homeassistant.components.airly
 airly==0.0.2

--- a/tests/components/yandex_transport/test_yandex_transport_sensor.py
+++ b/tests/components/yandex_transport/test_yandex_transport_sensor.py
@@ -24,13 +24,13 @@ def mock_requester():
         yield instance
 
 
-STOP_ID = 9639579
+STOP_ID = "stop__9639579"
 ROUTES = ["194", "т36", "т47", "м10"]
 NAME = "test_name"
 TEST_CONFIG = {
     "sensor": {
         "platform": "yandex_transport",
-        "stop_id": 9639579,
+        "stop_id": "stop__9639579",
         "routes": ROUTES,
         "name": NAME,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Here is the changes in the library: https://github.com/devbis/aioymaps/commit/d71aa969d1de3d4896a8b8a9f121a9101ed57199

Library stops interpolating `f'stop__{number}'` as Yandex Maps internally has different types of stops and the prefix `'stop__'` may vary or even the stop_id don't have any prefix.

The component will accept full stop ID in text notation: `'stop__1234'` or `'group_345'` or `'6789'`

To update existing configuration.yaml users have to update `stop_id: 1234567` to `stop_id: stop__1234567` as it is used in yandex maps API.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It seems the best way to support all types of stops is to use the original full notation from yandex maps

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
# Example configuration.yaml
sensor:
  - platform: yandex_transport
    name: Bus_to_subway
    stop_id: stop__9639579
```
(Upgraded stop_id format to text)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39006
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14268

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
