### PR TITLE
Add number parsing for OpenHardwareMonitor

### DIFF
--- a/homeassistant/components/openhardwaremonitor/sensor.py
+++ b/homeassistant/components/openhardwaremonitor/sensor.py
@@ -80,7 +80,7 @@ class OpenHardwareMonitorDevice(Entity):
     @classmethod
     def parse_number(cls, string):
         """In some locales a decimal numbers uses ',' instead of '.'."""
-        return float(string.replace(",", "."))
+        return string.replace(",", ".")
 
     def update(self):
         """Update the device from a new JSON object."""

--- a/homeassistant/components/openhardwaremonitor/sensor.py
+++ b/homeassistant/components/openhardwaremonitor/sensor.py
@@ -77,6 +77,11 @@ class OpenHardwareMonitorDevice(Entity):
         """Return the state attributes of the sun."""
         return self.attributes
 
+    @classmethod
+    def parse_number(cls, string):
+        """In some locales a decimal numbers uses ',' instead of '.'."""
+        return float(string.replace(",", "."))
+
     def update(self):
         """Update the device from a new JSON object."""
         self._data.update()
@@ -89,12 +94,16 @@ class OpenHardwareMonitorDevice(Entity):
             values = array[path_number]
 
             if path_index == len(self.path) - 1:
-                self.value = values[OHM_VALUE].split(" ")[0]
+                self.value = self.parse_number(values[OHM_VALUE].split(" ")[0])
                 _attributes.update(
                     {
                         "name": values[OHM_NAME],
-                        STATE_MIN_VALUE: values[OHM_MIN].split(" ")[0],
-                        STATE_MAX_VALUE: values[OHM_MAX].split(" ")[0],
+                        STATE_MIN_VALUE: self.parse_number(
+                            values[OHM_MIN].split(" ")[0]
+                        ),
+                        STATE_MAX_VALUE: self.parse_number(
+                            values[OHM_MAX].split(" ")[0]
+                        ),
                     }
                 )
 

--- a/tests/components/openhardwaremonitor/test_sensor.py
+++ b/tests/components/openhardwaremonitor/test_sensor.py
@@ -41,8 +41,15 @@ class TestOpenHardwareMonitorSetup(unittest.TestCase):
         assert len(entities) == 38
 
         state = self.hass.states.get(
-            "sensor.test_pc_intel_core_i7_7700_clocks_bus_speed"
+            "sensor.test_pc_intel_core_i7_7700_temperatures_cpu_core_1"
         )
 
         assert state is not None
-        assert state.state == "100.0"
+        assert state.state == "31.0"
+
+        state = self.hass.states.get(
+            "sensor.test_pc_intel_core_i7_7700_temperatures_cpu_core_2"
+        )
+
+        assert state is not None
+        assert state.state == "30.0"

--- a/tests/components/openhardwaremonitor/test_sensor.py
+++ b/tests/components/openhardwaremonitor/test_sensor.py
@@ -45,4 +45,4 @@ class TestOpenHardwareMonitorSetup(unittest.TestCase):
         )
 
         assert state is not None
-        assert state.state == "100"
+        assert state.state == "100.0"

--- a/tests/fixtures/openhardwaremonitor.json
+++ b/tests/fixtures/openhardwaremonitor.json
@@ -91,9 +91,9 @@
                                     "id": 12,
                                     "Text": "CPU Core #2",
                                     "Children": [],
-                                    "Min": "29.0 °C",
-                                    "Value": "30.0 °C",
-                                    "Max": "61.0 °C",
+                                    "Min": "29,0 °C",
+                                    "Value": "30,0 °C",
+                                    "Max": "61,0 °C",
                                     "ImageURL": "images/transparent.png"
                                 },
                                 {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
This will store the value of each sensor in OpenHardwareMonitor as a float instead of a string.


## Proposed change

In some locales numbers with decimals uses "," instead of "." and this causes an issue when trying to use **InfluxDB** for example as the stored value becomes a string.
This PR fixes the issue by parsing the sensor values as a floats instead which works in all locales.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #35113

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved
