### PR TITLE
Deprecate optional script context

### DIFF
--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -84,7 +84,7 @@ class ScriptIntentHandler(intent.IntentHandler):
                     action.async_run(slots, intent_obj.context)
                 )
             else:
-                await action.async_run(slots)
+                await action.async_run(slots, intent_obj.context)
 
         response = intent_obj.create_response()
 

--- a/homeassistant/components/panasonic_viera/__init__.py
+++ b/homeassistant/components/panasonic_viera/__init__.py
@@ -190,10 +190,10 @@ class Remote:
 
         await self._handle_errors(self._control.send_key, key)
 
-    async def async_turn_on(self):
+    async def async_turn_on(self, context):
         """Turn on the TV."""
         if self._on_action is not None:
-            await self._on_action.async_run()
+            await self._on_action.async_run(context=context)
             self.state = STATE_ON
         elif self.state != STATE_ON:
             await self.async_send_key(Keys.power)

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -101,7 +101,7 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
 
     async def async_turn_on(self):
         """Turn on the media player."""
-        await self._remote.async_turn_on()
+        await self._remote.async_turn_on(self._context)
 
     async def async_turn_off(self):
         """Turn off media player."""

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -101,7 +101,7 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
 
     async def async_turn_on(self):
         """Turn on the media player."""
-        await self._remote.async_turn_on(self._context)
+        await self._remote.async_turn_on(context=self._context)
 
     async def async_turn_off(self):
         """Turn off media player."""

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -254,7 +254,7 @@ class SamsungTVDevice(MediaPlayerEntity):
     async def async_turn_on(self):
         """Turn the media player on."""
         if self._on_script:
-            await self._on_script.async_run()
+            await self._on_script.async_run(context=self._context)
 
     def select_source(self, source):
         """Select input source."""

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -334,7 +334,7 @@ class LightTemplate(TemplateEntityWithAvailabilityAndImages, LightEntity):
                 context=self._context,
             )
         else:
-            await self._on_script.async_run()
+            await self._on_script.async_run(context=self._context)
 
         if optimistic_set:
             self.async_write_ha_state()

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -331,7 +331,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     async def async_turn_on(self):
         """Turn on the media player."""
         if self._on_script:
-            await self._on_script.async_run()
+            await self._on_script.async_run(context=self._context)
 
     @cmd
     async def async_volume_up(self):

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -860,7 +860,9 @@ class Script:
     ) -> None:
         """Run script."""
         if context is None:
-            self._log("Running script requires passing in a context", level=logging.WARNING)
+            self._log(
+                "Running script requires passing in a context", level=logging.WARNING
+            )
             context = Context()
 
         if self.is_running:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -860,7 +860,7 @@ class Script:
     ) -> None:
         """Run script."""
         if context is None:
-            self._logger.warning("Running script requires passing in a context")
+            self._log("Running script requires passing in a context", level=logging.WARNING)
             context = Context()
 
         if self.is_running:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -859,6 +859,10 @@ class Script:
         self, variables: Optional[_VarsType] = None, context: Optional[Context] = None
     ) -> None:
         """Run script."""
+        if context is None:
+            self._logger.warning("Running script requires passing in a context")
+            context = Context()
+
         if self.is_running:
             if self.script_mode == SCRIPT_MODE_SINGLE:
                 self._log("Already running", level=logging.WARNING)
@@ -875,6 +879,7 @@ class Script:
         # during the run back to the caller.
         if self._top_level:
             variables = dict(variables) if variables is not None else {}
+            variables["context"] = context
 
         if self.script_mode != SCRIPT_MODE_QUEUED:
             cls = _ScriptRun

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1000,6 +1000,7 @@ async def test_repeat_conditional(hass, condition):
             wait_started.clear()
             hass.states.async_set("sensor.test", index)
         await asyncio.wait_for(wait_started.wait(), 1)
+        wait_started.clear()
         hass.states.async_set("sensor.test", "next")
         await asyncio.wait_for(wait_started.wait(), 1)
         wait_started.clear()

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -200,7 +200,8 @@ async def test_multiple_runs_no_wait(hass):
         script_obj.async_run(
             MappingProxyType(
                 {"fire1": "1", "listen1": "2", "fire2": "3", "listen2": "4"}
-            )
+            ),
+            Context(),
         )
     )
     await asyncio.wait_for(heard_event.wait(), 1)
@@ -208,7 +209,8 @@ async def test_multiple_runs_no_wait(hass):
 
     logger.debug("starting 2nd script")
     await script_obj.async_run(
-        MappingProxyType({"fire1": "2", "listen1": "3", "fire2": "4", "listen2": "4"})
+        MappingProxyType({"fire1": "2", "listen1": "3", "fire2": "4", "listen2": "4"}),
+        Context(),
     )
     await hass.async_block_till_done()
 
@@ -260,7 +262,7 @@ async def test_stop_no_wait(hass, count):
     # service has started for each run.
     tasks = []
     for _ in range(count):
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         tasks.append(hass.async_create_task(service_started_sem.acquire()))
     await asyncio.wait_for(asyncio.gather(*tasks), 1)
 
@@ -290,7 +292,7 @@ async def test_delay_basic(hass):
     delay_started_flag = async_watch_for_action(script_obj, delay_alias)
 
     try:
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -324,7 +326,7 @@ async def test_multiple_runs_delay(hass):
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -337,7 +339,7 @@ async def test_multiple_runs_delay(hass):
         # Start second run of script while first run is in a delay.
         script_obj.sequence[1]["alias"] = "delay run 2"
         delay_started_flag = async_watch_for_action(script_obj, "delay run 2")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
         async_fire_time_changed(hass, dt_util.utcnow() + delay)
         await hass.async_block_till_done()
@@ -356,7 +358,7 @@ async def test_delay_template_ok(hass):
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -385,7 +387,7 @@ async def test_delay_template_invalid(hass, caplog):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     start_idx = len(caplog.records)
 
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert any(
@@ -404,7 +406,7 @@ async def test_delay_template_complex_ok(hass):
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
         assert script_obj.is_running
     except (AssertionError, asyncio.TimeoutError):
@@ -432,7 +434,7 @@ async def test_delay_template_complex_invalid(hass, caplog):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     start_idx = len(caplog.records)
 
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert any(
@@ -453,7 +455,7 @@ async def test_cancel_delay(hass):
     delay_started_flag = async_watch_for_action(script_obj, "delay")
 
     try:
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -494,7 +496,7 @@ async def test_wait_basic(hass, action_type):
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -539,7 +541,7 @@ async def test_multiple_runs_wait(hass, action_type):
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -585,7 +587,7 @@ async def test_cancel_wait(hass, action_type):
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -621,7 +623,7 @@ async def test_wait_template_not_schedule(hass):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     hass.states.async_set("switch.test", "on")
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert not script_obj.is_running
@@ -654,7 +656,7 @@ async def test_wait_timeout(hass, caplog, timeout_param, action_type):
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -706,7 +708,7 @@ async def test_wait_continue_on_timeout(
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -731,7 +733,7 @@ async def test_wait_template_variables_in(hass):
     try:
         hass.states.async_set("switch.test", "on")
         hass.async_create_task(
-            script_obj.async_run(MappingProxyType({"data": "switch.test"}))
+            script_obj.async_run(MappingProxyType({"data": "switch.test"}), Context())
         )
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
@@ -783,7 +785,7 @@ async def test_wait_variables_out(hass, mode, action_type):
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -856,14 +858,14 @@ async def test_condition_basic(hass):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     hass.states.async_set("test.entity", "hello")
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert len(events) == 2
 
     hass.states.async_set("test.entity", "goodbye")
 
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert len(events) == 3
@@ -885,8 +887,8 @@ async def test_condition_created_once(async_from_config, hass):
     async_from_config.reset_mock()
 
     hass.states.async_set("test.entity", "hello")
-    await script_obj.async_run()
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     async_from_config.assert_called_once()
@@ -910,7 +912,7 @@ async def test_condition_all_cached(hass):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     hass.states.async_set("test.entity", "hello")
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert len(script_obj._config_cache) == 2
@@ -939,7 +941,7 @@ async def test_repeat_count(hass):
     )
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert len(events) == count
@@ -988,7 +990,7 @@ async def test_repeat_conditional(hass, condition):
     wait_started = async_watch_for_action(script_obj, "wait")
     hass.states.async_set("sensor.test", "1")
 
-    hass.async_create_task(script_obj.async_run())
+    hass.async_create_task(script_obj.async_run(context=Context()))
     try:
         for index in range(2, count + 1):
             await asyncio.wait_for(wait_started.wait(), 1)
@@ -1038,7 +1040,7 @@ async def test_repeat_var_in_condition(hass, condition):
         "homeassistant.helpers.condition._LOGGER.error",
         side_effect=AssertionError("Template Error"),
     ):
-        await script_obj.async_run()
+        await script_obj.async_run(context=Context())
 
     assert len(events) == 2
 
@@ -1118,7 +1120,7 @@ async def test_repeat_nested(hass, variables, first_last, inside_x):
         "homeassistant.helpers.condition._LOGGER.error",
         side_effect=AssertionError("Template Error"),
     ):
-        await script_obj.async_run(variables)
+        await script_obj.async_run(variables, Context())
 
     assert len(events) == 10
     assert events[0].data == first_last
@@ -1172,7 +1174,7 @@ async def test_choose(hass, var, result):
     )
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
-    await script_obj.async_run(MappingProxyType({"var": var}))
+    await script_obj.async_run(MappingProxyType({"var": var}), Context())
     await hass.async_block_till_done()
 
     assert len(events) == 1
@@ -1201,7 +1203,7 @@ async def test_multiple_runs_repeat_choose(hass, caplog, action):
 
     events = async_capture_events(hass, "abc")
     for _ in range(max_runs):
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
     await hass.async_block_till_done()
 
     assert "WARNING" not in caplog.text
@@ -1219,7 +1221,7 @@ async def test_last_triggered(hass):
 
     time = dt_util.utcnow()
     with mock.patch("homeassistant.helpers.script.utcnow", return_value=time):
-        await script_obj.async_run()
+        await script_obj.async_run(context=Context())
         await hass.async_block_till_done()
 
     assert script_obj.last_triggered == time
@@ -1233,7 +1235,7 @@ async def test_propagate_error_service_not_found(hass):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     with pytest.raises(exceptions.ServiceNotFound):
-        await script_obj.async_run()
+        await script_obj.async_run(context=Context())
 
     assert len(events) == 0
     assert not script_obj.is_running
@@ -1250,7 +1252,7 @@ async def test_propagate_error_invalid_service_data(hass):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     with pytest.raises(vol.Invalid):
-        await script_obj.async_run()
+        await script_obj.async_run(context=Context())
 
     assert len(events) == 0
     assert len(calls) == 0
@@ -1273,7 +1275,7 @@ async def test_propagate_error_service_exception(hass):
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     with pytest.raises(ValueError):
-        await script_obj.async_run()
+        await script_obj.async_run(context=Context())
 
     assert len(events) == 0
     assert not script_obj.is_running
@@ -1361,7 +1363,7 @@ async def test_script_mode_single(hass, caplog):
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -1370,7 +1372,7 @@ async def test_script_mode_single(hass, caplog):
 
         # Start second run of script while first run is suspended in wait_template.
 
-        await script_obj.async_run()
+        await script_obj.async_run(context=Context())
 
         assert "Already running" in caplog.text
         assert script_obj.is_running
@@ -1416,7 +1418,7 @@ async def test_script_mode_2(hass, caplog, script_mode, messages, last_events):
 
     try:
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -1426,7 +1428,7 @@ async def test_script_mode_2(hass, caplog, script_mode, messages, last_events):
         # Start second run of script while first run is suspended in wait_template.
 
         wait_started_flag.clear()
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -1502,7 +1504,7 @@ async def test_script_mode_queued(hass):
         assert script_obj.runs == 0
 
         hass.states.async_set("switch.test", "on")
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag_1.wait(), 1)
 
         assert script_obj.is_running
@@ -1513,7 +1515,7 @@ async def test_script_mode_queued(hass):
         # Start second run of script while first run is suspended in wait_template.
         # This second run should not start until the first run has finished.
 
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.sleep(0)
 
         assert script_obj.is_running
@@ -1567,9 +1569,9 @@ async def test_script_mode_queued_cancel(hass):
         assert not script_obj.is_running
         assert script_obj.runs == 0
 
-        task1 = hass.async_create_task(script_obj.async_run())
+        task1 = hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(wait_started_flag.wait(), 1)
-        task2 = hass.async_create_task(script_obj.async_run())
+        task2 = hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.sleep(0)
 
         assert script_obj.is_running
@@ -1609,7 +1611,7 @@ async def test_shutdown_at(hass, caplog):
     delay_started_flag = async_watch_for_action(script_obj, delay_alias)
 
     try:
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -1637,7 +1639,7 @@ async def test_shutdown_after(hass, caplog):
     await hass.async_block_till_done()
 
     try:
-        hass.async_create_task(script_obj.async_run())
+        hass.async_create_task(script_obj.async_run(context=Context()))
         await asyncio.wait_for(delay_started_flag.wait(), 1)
 
         assert script_obj.is_running
@@ -1661,7 +1663,7 @@ async def test_update_logger(hass, caplog):
     sequence = cv.SCRIPT_SCHEMA({"event": "test_event"})
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert script.__name__ in caplog.text
@@ -1669,7 +1671,7 @@ async def test_update_logger(hass, caplog):
     log_name = "testing.123"
     script_obj.update_logger(logging.getLogger(log_name))
 
-    await script_obj.async_run()
+    await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
     assert log_name in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Custom components: It is deprecated to not pass a context to `script.async_run()`. This will now print a warning. If you're inside an entity, use `self._context`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes it mandatory to pass a context to `script.async_run`. If not passed in, it will print a warning so custom integrations get time to adapt. 

Context will now also be available as one of the variables inside a script. This will make it easy to see if a state has been last changed by the script itself.

- Turn on light
- Wait 10 minutes
- If light last state was done by this script, turn off

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
