### PR TITLE
Pre-create homekit_controller device registry entries when processing entity map

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -13,7 +13,6 @@ from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components import zeroconf
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity
 
 from .config_flow import normalize_hkid
@@ -189,21 +188,6 @@ async def async_setup_entry(hass, entry):
     if not await conn.async_setup():
         del hass.data[KNOWN_DEVICES][conn.unique_id]
         raise ConfigEntryNotReady
-
-    conn_info = conn.connection_info
-
-    device_registry = await dr.async_get_registry(hass)
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={
-            (DOMAIN, "serial-number", conn_info["serial-number"]),
-            (DOMAIN, "accessory-id", conn.unique_id),
-        },
-        name=conn.name,
-        manufacturer=conn_info.get("manufacturer"),
-        model=conn_info.get("model"),
-        sw_version=conn_info.get("firmware.revision"),
-    )
 
     return True
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the homekit_controller code updates the device_registry in 2 places - via `Entity.device_info` and additionally the bridge device is identified and created during `async_setup_entry`.

Whilst working on adding support for homekit "stateless" accessories like the [Hue dimmer](https://www.philips-hue.com/en-us/p/hue-dimmer-switch/046677473372) I needed to know the device id in a third place so i could map incoming events against a HomeKit `aid` to a device registry`device id` for the device_trigger system.

My first attempt at this was horrible and I did indeed end up with 3 pieces of code responsible for updating the device registry. There was a lot of duplication and for a hypothetical device that was a single accessory button with a battery it was likely that all 3 pieces of code would be invoked for the same device. 

Attached is version 2 which factors away one of the existing code paths (in `async_setup_entry`) and instead does the work as part of `HKDevice.async_process_entity_map` (this is invoked both at start up AND when new devices are added to a HomeKit bridge externally to Home Assistant). In addition to creating the bridge device registry entry implicitly, it also builds a map of aid -> device_id which I use in a later PR to route stateless events to the correct device.

This doesn't add tests on its own - there is sufficient coverage that the right device registry entries are created in the device enumeration tests. These use metadata from real devices and verify that e.g. a bridge entry is created and it is properly linked to child devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

(38527 and 38979)

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
