### PR TITLE
Improve climate support for fibaro

### DIFF
--- a/homeassistant/components/fibaro/climate.py
+++ b/homeassistant/components/fibaro/climate.py
@@ -120,12 +120,24 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
         self._preset_support = []
         self._fan_support = []
 
-        siblings = fibaro_device.fibaro_controller.get_siblings(fibaro_device.id)
+        siblings = fibaro_device.fibaro_controller.get_siblings(fibaro_device)
+        _LOGGER.debug("%s siblings: %s", fibaro_device.ha_id, siblings)
         tempunit = "C"
         for device in siblings:
+            # Detecting temperature device, one strong and one weak way of
+            # doing so, so we prefer the hard evidence, if there is such.
             if device.type == "com.fibaro.temperatureSensor":
                 self._temp_sensor_device = FibaroDevice(device)
                 tempunit = device.properties.unit
+            elif (
+                self._temp_sensor_device is None
+                and "unit" in device.properties
+                and "value" in device.properties
+                and (device.properties.unit == "C" or device.properties.unit == "F")
+            ):
+                self._temp_sensor_device = FibaroDevice(device)
+                tempunit = device.properties.unit
+
             if (
                 "setTargetLevel" in device.actions
                 or "setThermostatSetpoint" in device.actions
@@ -133,9 +145,11 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
                 self._target_temp_device = FibaroDevice(device)
                 self._support_flags |= SUPPORT_TARGET_TEMPERATURE
                 tempunit = device.properties.unit
+
             if "setMode" in device.actions or "setOperatingMode" in device.actions:
                 self._op_mode_device = FibaroDevice(device)
                 self._support_flags |= SUPPORT_PRESET_MODE
+
             if "setFanMode" in device.actions:
                 self._fan_mode_device = FibaroDevice(device)
                 self._support_flags |= SUPPORT_FAN_MODE
@@ -188,9 +202,7 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
         await super().async_added_to_hass()
 
         # Register update callback for child devices
-        siblings = self.fibaro_device.fibaro_controller.get_siblings(
-            self.fibaro_device.id
-        )
+        siblings = self.fibaro_device.fibaro_controller.get_siblings(self.fibaro_device)
         for device in siblings:
             if device != self.fibaro_device:
                 self.controller.register(device.id, self._update_callback)
@@ -225,7 +237,7 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
     def fibaro_op_mode(self):
         """Return the operating mode of the device."""
         if not self._op_mode_device:
-            return 6  # Fan only
+            return 3  # Default to AUTO
 
         if "operatingMode" in self._op_mode_device.fibaro_device.properties:
             return int(self._op_mode_device.fibaro_device.properties.operatingMode)
@@ -241,7 +253,7 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
     def hvac_modes(self):
         """Return the list of available operation modes."""
         if not self._op_mode_device:
-            return [HVAC_MODE_FAN_ONLY]
+            return [HVAC_MODE_AUTO]  # Default to this
         return self._hvac_support
 
     def set_hvac_mode(self, hvac_mode):


### PR DESCRIPTION
1, Implemented support for multinode climate devices, such as Danfoss HC10, differentiating zones based on endPointId
2, Improved recognition of temperature sensor subdevice for climate devices
3, Changed default opmode for devices without an opmode to "auto" instead of "fan_only", for better clarity and to avoid misunderstandings

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
1, Implemented support for multinode climate devices, such as Danfoss HC10, differentiating zones based on endPointId
2, Improved recognition of temperature sensor subdevice for climate devices
3, Changed default opmode for devices without an opmode to "auto" instead of "fan_only", for better clarity and to avoid misunderstandings

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38930
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
