### PR TITLE
Fix device_tracker ids with more than one Mikrotik 

### DIFF
--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -96,7 +96,7 @@ class MikrotikHubTracker(ScannerEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this device."""
-        return self.device.mac
+        return f"{self.device.mac}-{self.hub.serial_num}"
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
Fix more than one Mikrotik device tracker

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds unique device ids for more than one Mikrotik device tracker instance. Similar to what the Unifi device tracker component. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Fixes the following issue: 

Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 6C:71:D9:FC:97:EB already exists - ignoring device_tracker.6c_71_d9_fc_97_eb_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 30:FD:38:0D:35:0D already exists - ignoring device_tracker.30_fd_38_0d_35_0d_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 30:FD:38:0D:4E:26 already exists - ignoring device_tracker.30_fd_38_0d_4e_26_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 30:FD:38:0C:40:03 already exists - ignoring device_tracker.30_fd_38_0c_40_03_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 00:09:B0:1D:1B:9B already exists - ignoring device_tracker.00_09_b0_1d_1b_9b_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 38:8B:59:7E:D0:F1 already exists - ignoring device_tracker.38_8b_59_7e_d0_f1_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 00:F6:20:5D:16:68 already exists - ignoring device_tracker.00_f6_20_5d_16_68_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 30:FD:38:0A:4A:F0 already exists - ignoring device_tracker.30_fd_38_0a_4a_f0_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID A4:CF:12:C9:0E:D8 already exists - ignoring device_tracker.a4_cf_12_c9_0e_d8_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID F0:86:20:48:DF:E4 already exists - ignoring device_tracker.f0_86_20_48_df_e4_2
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID B8:27:EB:3A:55:B0 already exists - ignoring device_tracker.b8_27_eb_3a_55_b0_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 9C:8E:CD:28:E5:1E already exists - ignoring device_tracker.9c_8e_cd_28_e5_1e_2
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID CC:50:E3:38:06:B7 already exists - ignoring device_tracker.cc_50_e3_38_06_b7_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 60:6B:FF:F0:90:B3 already exists - ignoring device_tracker.60_6b_ff_f0_90_b3_4
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 8C:45:00:1A:97:5F already exists - ignoring device_tracker.8c_45_00_1a_97_5f_3
Aug 19 11:43:51 home-assistant hass[961004]: 2020-08-19 11:43:51 ERROR (MainThread) [homeassistant.components.device_tracker] Platform mikrotik does not generate unique IDs. ID 1C:4D:66:B8:8F:A4 already exists - ignoring device_tracker.1c_4d_66_b8_8f_a4_2



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
