### PR TITLE
Discover Plex clients using GDM

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -13,6 +13,7 @@ PLEXTV_THROTTLE = 60
 
 DEBOUNCE_TIMEOUT = 1
 DISPATCHERS = "dispatchers"
+GDM_DEBOUNCER = "gdm_debouncer"
 GDM_SCANNER = "gdm_scanner"
 PLATFORMS = frozenset(["media_player", "sensor"])
 PLATFORMS_COMPLETED = "platforms_completed"
@@ -22,7 +23,6 @@ WEBSOCKETS = "websockets"
 
 PLEX_SERVER_CONFIG = "server_config"
 
-PLEX_GDM_CLIENT_SCAN_SIGNAL = "plex_gdm_client_scan_signal"
 PLEX_NEW_MP_SIGNAL = "plex_new_mp_signal.{}"
 PLEX_UPDATE_MEDIA_PLAYER_SIGNAL = "plex_update_mp_signal.{}"
 PLEX_UPDATE_PLATFORMS_SIGNAL = "plex_update_platforms_signal.{}"

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -13,6 +13,7 @@ PLEXTV_THROTTLE = 60
 
 DEBOUNCE_TIMEOUT = 1
 DISPATCHERS = "dispatchers"
+GDM_SCANNER = "gdm_scanner"
 PLATFORMS = frozenset(["media_player", "sensor"])
 PLATFORMS_COMPLETED = "platforms_completed"
 PLAYER_SOURCE = "player_source"
@@ -21,6 +22,7 @@ WEBSOCKETS = "websockets"
 
 PLEX_SERVER_CONFIG = "server_config"
 
+PLEX_GDM_CLIENT_SCAN_SIGNAL = "plex_gdm_client_scan_signal"
 PLEX_NEW_MP_SIGNAL = "plex_new_mp_signal.{}"
 PLEX_UPDATE_MEDIA_PLAYER_SIGNAL = "plex_update_mp_signal.{}"
 PLEX_UPDATE_PLATFORMS_SIGNAL = "plex_update_platforms_signal.{}"

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -46,7 +46,7 @@ def setup_plex_server(hass, entry, mock_plex_account, mock_websocket):
         disable_gdm = kwargs.pop("disable_gdm", True)
         plex_server = MockPlexServer(**kwargs)
         with patch("plexapi.server.PlexServer", return_value=plex_server), patch(
-                "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=disable_gdm)):
+                "homeassistant.components.plex.GDM", return_value=MockGDM(disabled=disable_gdm)):
             config_entry.add_to_hass(hass)
             assert await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -46,7 +46,9 @@ def setup_plex_server(hass, entry, mock_plex_account, mock_websocket):
         disable_gdm = kwargs.pop("disable_gdm", True)
         plex_server = MockPlexServer(**kwargs)
         with patch("plexapi.server.PlexServer", return_value=plex_server), patch(
-                "homeassistant.components.plex.GDM", return_value=MockGDM(disabled=disable_gdm)):
+            "homeassistant.components.plex.GDM",
+            return_value=MockGDM(disabled=disable_gdm),
+        ):
             config_entry.add_to_hass(hass)
             assert await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.components.plex.const import DOMAIN
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
-from .mock_classes import MockPlexAccount, MockPlexServer
+from .mock_classes import MockGDM, MockPlexAccount, MockPlexServer
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
@@ -43,8 +43,10 @@ def setup_plex_server(hass, entry, mock_plex_account, mock_websocket):
     async def _wrapper(**kwargs):
         """Wrap the fixture to allow passing arguments to the MockPlexServer instance."""
         config_entry = kwargs.get("config_entry", entry)
+        disable_gdm = kwargs.pop("disable_gdm", True)
         plex_server = MockPlexServer(**kwargs)
-        with patch("plexapi.server.PlexServer", return_value=plex_server):
+        with patch("plexapi.server.PlexServer", return_value=plex_server), patch(
+                "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=disable_gdm)):
             config_entry.add_to_hass(hass)
             assert await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -212,6 +212,10 @@ class MockPlexServer:
         """Mock the clients method."""
         return self._clients
 
+    def createToken(self):
+        """Mock the createToken method."""
+        return "temporary_token"
+
     def sessions(self):
         """Mock the sessions method."""
         return self._sessions

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_URL
 
 from .const import DEFAULT_DATA, MOCK_SERVERS, MOCK_USERS
 
-GDM_PAYLOAD = [
+GDM_SERVER_PAYLOAD = [
     {
         "data": {
             "Content-Type": "plex/media-server",
@@ -27,17 +27,73 @@ GDM_PAYLOAD = [
     }
 ]
 
+GDM_CLIENT_PAYLOAD = [
+    {
+        "data": {
+            "Content-Type": "plex/media-player",
+            "Device-Class": "stb",
+            "Name": "plexamp",
+            "Port": "36000",
+            "Product": "Plexamp",
+            "Protocol": "plex",
+            "Protocol-Capabilities": "timeline,playback,playqueues,playqueues-creation",
+            "Protocol-Version": "1",
+            "Resource-Identifier": "client-2",
+            "Version": "1.1.0",
+        },
+        "from": ("1.2.3.10", 32412),
+    },
+    {
+        "data": {
+            "Content-Type": "plex/media-player",
+            "Device-Class": "pc",
+            "Name": "Chrome",
+            "Port": "32400",
+            "Product": "Plex Web",
+            "Protocol": "plex",
+            "Protocol-Capabilities": "timeline,playback,navigation,mirror,playqueues",
+            "Protocol-Version": "3",
+            "Resource-Identifier": "client-1",
+            "Version": "4.40.1",
+        },
+        "from": ("1.2.3.4", 32412),
+    },
+    {
+        "data": {
+            "Content-Type": "plex/media-player",
+            "Device-Class": "mobile",
+            "Name": "SHIELD Android TV",
+            "Port": "32500",
+            "Product": "Plex for Android (TV)",
+            "Protocol": "plex",
+            "Protocol-Capabilities": "timeline,playback,navigation,mirror,playqueues,provider-playback",
+            "Protocol-Version": "1",
+            "Resource-Identifier": "client-999",
+            "Updated-At": "1597686153",
+            "Version": "8.5.0.19697",
+        },
+        "from": ("1.2.3.11", 32412),
+    },
+]
+
 
 class MockGDM:
     """Mock a GDM instance."""
 
-    def __init__(self):
+    def __init__(self, disabled=False):
         """Initialize the object."""
-        self.entries = GDM_PAYLOAD
+        self.entries = []
+        self.disabled = disabled
 
-    def scan(self):
+    def scan(self, scan_for_clients=False):
         """Mock the scan call."""
-        pass
+        if self.disabled:
+            return
+
+        if scan_for_clients:
+            self.entries = GDM_CLIENT_PAYLOAD
+        else:
+            self.entries = GDM_SERVER_PAYLOAD
 
 
 class MockResource:
@@ -56,7 +112,9 @@ class MockResource:
             self.name = f"plex.tv Resource Player {index+10}"
             self.clientIdentifier = f"client-{index+10}"
             self.provides = ["player"]
-            self.device = MockPlexClient(f"http://192.168.0.1{index}:32500", index + 10)
+            self.device = MockPlexClient(
+                baseurl=f"http://192.168.0.1{index}:32500", index=index + 10
+            )
             self.presence = index == 0
             self.publicAddressMatches = True
 
@@ -122,6 +180,7 @@ class MockPlexServer:
         self._systemAccounts = list(map(MockPlexSystemAccount, range(num_users)))
 
         self._clients = []
+        self._session = None
         self._sessions = []
         self.set_clients(num_users)
         self.set_sessions(num_users, session_type)
@@ -130,7 +189,9 @@ class MockPlexServer:
 
     def set_clients(self, num_clients):
         """Set up mock PlexClients for this PlexServer."""
-        self._clients = [MockPlexClient(self._baseurl, x) for x in range(num_clients)]
+        self._clients = [
+            MockPlexClient(baseurl=self._baseurl, index=x) for x in range(num_clients)
+        ]
 
     def set_sessions(self, num_sessions, session_type):
         """Set up mock PlexSessions for this PlexServer."""
@@ -204,10 +265,10 @@ class MockPlexServer:
 class MockPlexClient:
     """Mock a PlexClient instance."""
 
-    def __init__(self, url, index=0):
+    def __init__(self, server=None, baseurl=None, token=None, index=0):
         """Initialize the object."""
         self.machineIdentifier = f"client-{index+1}"
-        self._baseurl = url
+        self._baseurl = baseurl
         self._index = index
 
     def url(self, key):

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -17,7 +17,6 @@ from homeassistant.components.plex.const import (
     CONF_USE_EPISODE_ART,
     DOMAIN,
     MANUAL_SETUP_STRING,
-    PLEX_GDM_CLIENT_SCAN_SIGNAL,
     PLEX_SERVER_CONFIG,
     SERVERS,
 )
@@ -35,7 +34,6 @@ from homeassistant.const import (
     CONF_URL,
     CONF_VERIFY_SSL,
 )
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
 from .helpers import trigger_plex_update
@@ -443,9 +441,6 @@ async def test_option_flow_new_users_available(
     entry.options = OPTIONS_OWNER_ONLY
 
     mock_plex_server = await setup_plex_server(config_entry=entry, disable_gdm=False)
-
-    # Multiple debouncers with cooldowns involved, easier to trigger manually
-    async_dispatcher_send(hass, PLEX_GDM_CLIENT_SCAN_SIGNAL)
 
     with patch("homeassistant.components.plex.server.PlexClient", new=MockPlexClient):
         trigger_plex_update(mock_websocket)

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -37,7 +37,13 @@ from homeassistant.const import (
 
 from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
 from .helpers import trigger_plex_update
-from .mock_classes import MockGDM, MockPlexAccount, MockPlexServer, MockResource
+from .mock_classes import (
+    MockGDM,
+    MockPlexAccount,
+    MockPlexClient,
+    MockPlexServer,
+    MockResource,
+)
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
@@ -434,10 +440,11 @@ async def test_option_flow_new_users_available(
     OPTIONS_OWNER_ONLY[MP_DOMAIN][CONF_MONITORED_USERS] = {"Owner": {"enabled": True}}
     entry.options = OPTIONS_OWNER_ONLY
 
-    mock_plex_server = await setup_plex_server(config_entry=entry)
+    mock_plex_server = await setup_plex_server(config_entry=entry, disable_gdm=False)
 
-    trigger_plex_update(mock_websocket)
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.plex.server.PlexClient", new=MockPlexClient):
+        trigger_plex_update(mock_websocket)
+        await hass.async_block_till_done()
 
     server_id = mock_plex_server.machineIdentifier
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
@@ -640,7 +647,11 @@ async def test_manual_config(hass):
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
         "homeassistant.components.plex.PlexWebsocket", autospec=True
-    ), patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()):
+    ), patch(
+        "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=True)
+    ), patch(
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MANUAL_SERVER
         )
@@ -674,7 +685,11 @@ async def test_manual_config_with_token(hass):
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()), patch(
         "plexapi.server.PlexServer", return_value=mock_plex_server
-    ), patch("homeassistant.components.plex.PlexWebsocket", autospec=True):
+    ), patch(
+        "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=True)
+    ), patch(
+        "homeassistant.components.plex.PlexWebsocket", autospec=True
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.components.plex.const import (
     CONF_USE_EPISODE_ART,
     DOMAIN,
     MANUAL_SETUP_STRING,
+    PLEX_GDM_CLIENT_SCAN_SIGNAL,
     PLEX_SERVER_CONFIG,
     SERVERS,
 )
@@ -34,6 +35,7 @@ from homeassistant.const import (
     CONF_URL,
     CONF_VERIFY_SSL,
 )
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
 from .helpers import trigger_plex_update
@@ -442,6 +444,9 @@ async def test_option_flow_new_users_available(
 
     mock_plex_server = await setup_plex_server(config_entry=entry, disable_gdm=False)
 
+    # Multiple debouncers with cooldowns involved, easier to trigger manually
+    async_dispatcher_send(hass, PLEX_GDM_CLIENT_SCAN_SIGNAL)
+
     with patch("homeassistant.components.plex.server.PlexClient", new=MockPlexClient):
         trigger_plex_update(mock_websocket)
         await hass.async_block_till_done()
@@ -648,7 +653,7 @@ async def test_manual_config(hass):
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
         "homeassistant.components.plex.PlexWebsocket", autospec=True
     ), patch(
-        "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=True)
+        "homeassistant.components.plex.GDM", return_value=MockGDM(disabled=True)
     ), patch(
         "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
     ):
@@ -686,7 +691,7 @@ async def test_manual_config_with_token(hass):
     with patch("plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()), patch(
         "plexapi.server.PlexServer", return_value=mock_plex_server
     ), patch(
-        "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=True)
+        "homeassistant.components.plex.GDM", return_value=MockGDM(disabled=True)
     ), patch(
         "homeassistant.components.plex.PlexWebsocket", autospec=True
     ):

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -18,7 +18,7 @@ import homeassistant.util.dt as dt_util
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .helpers import trigger_plex_update
-from .mock_classes import MockPlexAccount, MockPlexServer
+from .mock_classes import MockGDM, MockPlexAccount, MockPlexServer
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -183,6 +183,8 @@ async def test_bad_token_with_tokenless_server(hass, entry):
     """Test setup with a bad token and a server with token auth disabled."""
     with patch("plexapi.server.PlexServer", return_value=MockPlexServer()), patch(
         "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
+    ), patch(
+        "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=True)
     ), patch(
         "homeassistant.components.plex.PlexWebsocket", autospec=True
     ) as mock_websocket:

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -184,7 +184,7 @@ async def test_bad_token_with_tokenless_server(hass, entry):
     with patch("plexapi.server.PlexServer", return_value=MockPlexServer()), patch(
         "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
     ), patch(
-        "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=True)
+        "homeassistant.components.plex.GDM", return_value=MockGDM(disabled=True)
     ), patch(
         "homeassistant.components.plex.PlexWebsocket", autospec=True
     ) as mock_websocket:

--- a/tests/components/plex/test_media_players.py
+++ b/tests/components/plex/test_media_players.py
@@ -26,7 +26,7 @@ async def test_plex_tv_clients(hass, entry, mock_plex_account, setup_plex_server
     # Ensure one more client is discovered
     await hass.config_entries.async_unload(entry.entry_id)
 
-    mock_plex_server = await setup_plex_server(config_entry=entry)
+    mock_plex_server = await setup_plex_server()
     plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
     await plex_server._async_update_platforms()
@@ -38,7 +38,7 @@ async def test_plex_tv_clients(hass, entry, mock_plex_account, setup_plex_server
     # Ensure only plex.tv resource client is found
     await hass.config_entries.async_unload(entry.entry_id)
 
-    mock_plex_server = await setup_plex_server(config_entry=entry)
+    mock_plex_server = await setup_plex_server()
     mock_plex_server.clear_clients()
     mock_plex_server.clear_sessions()
 

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -21,11 +21,9 @@ from homeassistant.components.plex.const import (
     CONF_MONITORED_USERS,
     CONF_SERVER,
     DOMAIN,
-    PLEX_GDM_CLIENT_SCAN_SIGNAL,
     SERVERS,
 )
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .helpers import trigger_plex_update
@@ -131,9 +129,6 @@ async def test_network_error_during_refresh(
 async def test_gdm_client_failure(hass, mock_websocket, setup_plex_server):
     """Test connection failure to a GDM discovered client."""
     mock_plex_server = await setup_plex_server(disable_gdm=False)
-
-    # Multiple debouncers with cooldowns involved, easier to trigger manually
-    async_dispatcher_send(hass, PLEX_GDM_CLIENT_SCAN_SIGNAL)
 
     with patch(
         "homeassistant.components.plex.server.PlexClient", side_effect=ConnectionError

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -131,8 +131,6 @@ async def test_network_error_during_refresh(
 async def test_gdm_client_failure(hass, mock_websocket, setup_plex_server):
     """Test connection failure to a GDM discovered client."""
     mock_plex_server = await setup_plex_server(disable_gdm=False)
-    server_id = mock_plex_server.machineIdentifier
-    loaded_server = hass.data[DOMAIN][SERVERS][server_id]
 
     # Multiple debouncers with cooldowns involved, easier to trigger manually
     async_dispatcher_send(hass, PLEX_GDM_CLIENT_SCAN_SIGNAL)
@@ -182,9 +180,7 @@ async def test_ignore_plex_web_client(hass, entry, mock_websocket):
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
         "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount(players=0)
-    ), patch(
-        "homeassistant.components.plex.GDM", return_value=MockGDM(disabled=True)
-    ):
+    ), patch("homeassistant.components.plex.GDM", return_value=MockGDM(disabled=True)):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -2,7 +2,7 @@
 import copy
 
 from plexapi.exceptions import BadRequest, NotFound
-from requests.exceptions import RequestException
+from requests.exceptions import ConnectionError, RequestException
 
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.media_player.const import (
@@ -28,6 +28,7 @@ from homeassistant.const import ATTR_ENTITY_ID
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .helpers import trigger_plex_update
 from .mock_classes import (
+    MockGDM,
     MockPlexAccount,
     MockPlexAlbum,
     MockPlexArtist,
@@ -125,7 +126,27 @@ async def test_network_error_during_refresh(
     )
 
 
-async def test_mark_sessions_idle(hass, mock_plex_server, mock_websocket):
+async def test_gdm_client_failure(hass, entry, mock_websocket, setup_plex_server):
+    """Test connection failure to a GDM discovered client."""
+    mock_plex_server = await setup_plex_server(disable_gdm=False)
+    server_id = mock_plex_server.machineIdentifier
+    loaded_server = hass.data[DOMAIN][SERVERS][server_id]
+
+    with patch(
+        "homeassistant.components.plex.server.PlexClient", side_effect=ConnectionError
+    ):
+        trigger_plex_update(mock_websocket)
+        await hass.async_block_till_done()
+
+    sensor = hass.states.get("sensor.plex_plex_server_1")
+    assert sensor.state == str(len(mock_plex_server.accounts))
+
+    with patch.object(mock_plex_server, "clients", side_effect=RequestException):
+        await loaded_server._async_update_platforms()
+        await hass.async_block_till_done()
+
+
+async def test_mark_sessions_idle(hass, entry, mock_plex_server, mock_websocket):
     """Test marking media_players as idle when sessions end."""
     server_id = mock_plex_server.machineIdentifier
     loaded_server = hass.data[DOMAIN][SERVERS][server_id]
@@ -156,6 +177,8 @@ async def test_ignore_plex_web_client(hass, entry, mock_websocket):
 
     with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
         "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount(players=0)
+    ), patch(
+        "homeassistant.components.plex.server.GDM", return_value=MockGDM(disabled=True)
     ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds HA-initiated GDM network scanning as another method to discover controllable Plex clients. GDM uses UDP broadcasts to discover other Plex servers/clients. As some Plex servers are in a different subnet (read: Docker), this client discovery is sometimes unreliable. Throttles the updates to avoid unnecessary scans.

Current order for Plex client discovery:
1. Provided by Plex server (does its own GDM discovery)
2. GDM broadcast from HA
3. plex.tv
4. Active playback session from Plex server (usually not controllable)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
