### PR TITLE
Update websocket api to use async_track_template_result

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -405,7 +405,11 @@ def async_track_template(
     ) -> None:
         """Check if condition is correct and run action."""
         if isinstance(result, TemplateError):
-            _LOGGER.exception(result)
+            _LOGGER.error(
+                "Error while processing template: %s",
+                template.template,
+                exc_info=result,
+            )
             return
 
         if result_as_boolean(last_result) or not result_as_boolean(result):
@@ -444,10 +448,10 @@ class _TrackTemplateResultInfo:
         """Handle removal / refresh of tracker init."""
         self.hass = hass
         self._template = template
+        self._template.hass = hass
         self._action = action
         self._variables = variables
-        self._last_result: Optional[str] = None
-        self._last_exception = False
+        self._last_result: Optional[Union[str, TemplateError]] = None
         self._all_listener: Optional[Callable] = None
         self._domains_listener: Optional[Callable] = None
         self._entities_listener: Optional[Callable] = None
@@ -458,8 +462,11 @@ class _TrackTemplateResultInfo:
         """Activation of template tracking."""
         self._info = self._template.async_render_to_info(self._variables)
         if self._info.exception:
-            self._last_exception = True
-            _LOGGER.exception(self._info.exception)
+            _LOGGER.error(
+                "Error while processing template: %s",
+                self._template.template,
+                exc_info=self._info.exception,
+            )
         self._create_listeners()
         self._last_info = self._info
 
@@ -593,24 +600,24 @@ class _TrackTemplateResultInfo:
             self._variables = variables
         self._refresh(None)
 
+    @callback
     def _refresh(self, event: Optional[Event]) -> None:
         self._info = self._template.async_render_to_info(self._variables)
         self._update_listeners()
         self._last_info = self._info
 
         try:
-            result = self._info.result
+            result: Union[str, TemplateError] = self._info.result
         except TemplateError as ex:
-            if not self._last_exception:
-                self.hass.async_run_job(
-                    self._action, event, self._template, self._last_result, ex
-                )
-            self._last_exception = True
-            return
-        self._last_exception = False
+            result = ex
 
         # Check to see if the result has changed
         if result == self._last_result:
+            return
+
+        if isinstance(result, TemplateError) and isinstance(
+            self._last_result, TemplateError
+        ):
             return
 
         self.hass.async_run_job(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -430,19 +430,17 @@ async def test_render_template_renders_template(
     assert event == {"result": "State is: off"}
 
 
-async def test_render_template_with_manual_entity_ids(
+async def test_render_template_manual_entity_ids_no_longer_needed(
     hass, websocket_client, hass_admin_user
 ):
     """Test that updates to specified entity ids cause a template rerender."""
     hass.states.async_set("light.test", "on")
-    hass.states.async_set("light.test2", "on")
 
     await websocket_client.send_json(
         {
             "id": 5,
             "type": "render_template",
             "template": "State is: {{ states('light.test') }}",
-            "entity_ids": ["light.test2"],
         }
     )
 
@@ -457,12 +455,35 @@ async def test_render_template_with_manual_entity_ids(
     event = msg["event"]
     assert event == {"result": "State is: on"}
 
-    hass.states.async_set("light.test2", "off")
+    hass.states.async_set("light.test", "off")
     msg = await websocket_client.receive_json()
     assert msg["id"] == 5
     assert msg["type"] == "event"
     event = msg["event"]
-    assert event == {"result": "State is: on"}
+    assert event == {"result": "State is: off"}
+
+
+async def test_render_template_with_error(
+    hass, websocket_client, hass_admin_user, caplog
+):
+    """Test a template with an error."""
+    await websocket_client.send_json(
+        {"id": 5, "type": "render_template", "template": "{{ my_unknown_var() + 1 }}"}
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    event = msg["event"]
+    assert event == {"result": None}
+
+    assert "my_unknown_var" in caplog.text
+    assert "TemplateError" in caplog.text
 
 
 async def test_render_template_returns_with_match_all(

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime, timedelta
 
 from astral import Astral
+import jinja2
 import pytest
 
 from homeassistant.components import sun
@@ -942,7 +943,7 @@ async def test_track_template_result_errors(hass, caplog):
     hass.states.async_set("switch.not_exist", "on")
     await hass.async_block_till_done()
 
-    assert len(syntax_error_runs) == 0
+    assert len(syntax_error_runs) == 1
     assert len(not_exist_runs) == 2
     assert not_exist_runs[1][0].data.get("entity_id") == "switch.not_exist"
     assert not_exist_runs[1][1] == template_not_exist
@@ -950,7 +951,7 @@ async def test_track_template_result_errors(hass, caplog):
     assert not_exist_runs[1][3] == "on"
 
     with patch.object(Template, "async_render") as render:
-        render.side_effect = TemplateError("Test")
+        render.side_effect = TemplateError(jinja2.TemplateError())
 
         hass.states.async_set("switch.not_exist", "off")
         await hass.async_block_till_done()


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update websocket api to use async_track_template_result

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
