### PR TITLE
Clean up more netgear_lte resources on shutdown

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -306,17 +306,19 @@ async def _login(hass, modem_data, password):
     await modem_data.async_update()
     hass.data[DATA_KEY].modem_data[modem_data.host] = modem_data
 
-    async def cleanup(event):
-        """Clean up resources."""
-        await modem_data.modem.logout()
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
-
     async def _update(now):
         """Periodic update."""
         await modem_data.async_update()
 
-    async_track_time_interval(hass, _update, SCAN_INTERVAL)
+    update_unsub = async_track_time_interval(hass, _update, SCAN_INTERVAL)
+
+    async def cleanup(event):
+        """Clean up resources."""
+        update_unsub()
+        await modem_data.modem.logout()
+        del hass.data[DATA_KEY].modem_data[modem_data.host]
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
 
 
 async def _retry_login(hass, modem_data, password):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Clean up more resources, avoiding a traceback when actions race with shutdown, like this example:
```
Traceback (most recent call last):
  File "/Users/am/home-assistant/homeassistant/helpers/script.py", line 192, in _async_step
    self, f"_async_{cv.determine_script_action(self._action)}_step"
  File "/Users/am/home-assistant/homeassistant/helpers/script.py", line 398, in _async_call_service_step
    await service_task
  File "/Users/am/home-assistant/homeassistant/core.py", line 1309, in async_call
    task.result()
  File "/Users/am/home-assistant/homeassistant/core.py", line 1344, in _execute_service
    await handler.func(service_call)
  File "/Users/am/home-assistant/homeassistant/components/notify/__init__.py", line 119, in async_notify_message
    await notify_service.async_send_message(**kwargs)
  File "/Users/am/home-assistant/homeassistant/components/netgear_lte/notify.py", line 47, in async_send_message
    await modem_data.modem.sms(target, message)
  File "/Users/am/home-assistant/venv/lib/python3.7/site-packages/eternalegypt/eternalegypt.py", line 62, in wrapper
    return await function(self, *args, **kwargs)
  File "/Users/am/home-assistant/venv/lib/python3.7/site-packages/eternalegypt/eternalegypt.py", line 160, in sms
    async with self.websession.post(url, data=data) as response:
AttributeError: 'NoneType' object has no attribute 'post'
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
