### PR TITLE
Add api to reload config entries

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -369,5 +369,5 @@ def entry_json(entry: config_entries.ConfigEntry) -> dict:
         "state": entry.state,
         "connection_class": entry.connection_class,
         "supports_options": supports_options,
-        "can_unload": entry.can_unload,
+        "supports_unload": entry.supports_unload,
     }

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.auth.permissions.const import CAT_CONFIG_ENTRIES, POLICY_EDIT
 from homeassistant.components import websocket_api
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.const import HTTP_NOT_FOUND
+from homeassistant.const import HTTP_FORBIDDEN, HTTP_NOT_FOUND
 from homeassistant.core import callback
 from homeassistant.exceptions import Unauthorized
 import homeassistant.helpers.config_validation as cv
@@ -108,6 +108,8 @@ class ConfigManagerEntryResourceReloadView(HomeAssistantView):
 
         try:
             result = await hass.config_entries.async_reload(entry_id)
+        except config_entries.OperationNotAllowed:
+            return self.json_message("Entry cannot be reloaded", HTTP_FORBIDDEN)
         except config_entries.UnknownEntry:
             return self.json_message("Invalid entry specified", HTTP_NOT_FOUND)
 
@@ -367,4 +369,5 @@ def entry_json(entry: config_entries.ConfigEntry) -> dict:
         "state": entry.state,
         "connection_class": entry.connection_class,
         "supports_options": supports_options,
+        "can_unload": entry.can_unload,
     }

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -110,7 +110,7 @@ class ConfigEntry:
         "data",
         "options",
         "unique_id",
-        "can_unload",
+        "supports_unload",
         "system_options",
         "source",
         "connection_class",
@@ -168,8 +168,8 @@ class ConfigEntry:
         # Unique ID of this entry.
         self.unique_id = unique_id
 
-        # Can unload
-        self.can_unload = False
+        # Supports unload
+        self.supports_unload = False
 
         # Listeners to call on update
         self.update_listeners: List[weakref.ReferenceType[UpdateListenerType]] = []
@@ -190,6 +190,8 @@ class ConfigEntry:
 
         if integration is None:
             integration = await loader.async_get_integration(hass, self.domain)
+
+        self.supports_unload = await support_entry_unload(hass, self.domain)
 
         try:
             component = integration.get_component()
@@ -263,7 +265,6 @@ class ConfigEntry:
 
         if result:
             self.state = ENTRY_STATE_LOADED
-            self.can_unload = await support_entry_unload(hass, self.domain)
         else:
             self.state = ENTRY_STATE_SETUP_ERROR
 
@@ -1117,7 +1118,7 @@ class EntityRegistryDisabledHandler:
         )
         assert config_entry is not None
 
-        if config_entry.entry_id not in self.changed and config_entry.can_unload:
+        if config_entry.entry_id not in self.changed and config_entry.supports_unload:
             self.changed.add(config_entry.entry_id)
 
         if not self.changed:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -110,6 +110,7 @@ class ConfigEntry:
         "data",
         "options",
         "unique_id",
+        "can_unload",
         "system_options",
         "source",
         "connection_class",
@@ -166,6 +167,9 @@ class ConfigEntry:
 
         # Unique ID of this entry.
         self.unique_id = unique_id
+
+        # Can unload
+        self.can_unload = False
 
         # Listeners to call on update
         self.update_listeners: List[weakref.ReferenceType[UpdateListenerType]] = []
@@ -259,6 +263,7 @@ class ConfigEntry:
 
         if result:
             self.state = ENTRY_STATE_LOADED
+            self.can_unload = await support_entry_unload(hass, self.domain)
         else:
             self.state = ENTRY_STATE_SETUP_ERROR
 
@@ -1112,9 +1117,7 @@ class EntityRegistryDisabledHandler:
         )
         assert config_entry is not None
 
-        if config_entry.entry_id not in self.changed and await support_entry_unload(
-            self.hass, config_entry.domain
-        ):
+        if config_entry.entry_id not in self.changed and config_entry.can_unload:
             self.changed.add(config_entry.entry_id)
 
         if not self.changed:

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -59,7 +59,7 @@ async def test_get_entries(hass, client):
             source="bla",
             connection_class=core_ce.CONN_CLASS_LOCAL_POLL,
         )
-        entry.can_unload = True
+        entry.supports_unload = True
         entry.add_to_hass(hass)
         MockConfigEntry(
             domain="comp2",
@@ -82,7 +82,7 @@ async def test_get_entries(hass, client):
                 "state": "not_loaded",
                 "connection_class": "local_poll",
                 "supports_options": True,
-                "can_unload": True,
+                "supports_unload": True,
             },
             {
                 "domain": "comp2",
@@ -91,7 +91,7 @@ async def test_get_entries(hass, client):
                 "state": "loaded",
                 "connection_class": "assumed",
                 "supports_options": False,
-                "can_unload": False,
+                "supports_unload": False,
             },
         ]
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -103,12 +103,37 @@ async def test_remove_entry(hass, client):
     assert len(hass.config_entries.async_entries()) == 0
 
 
+async def test_reload_entry(hass, client):
+    """Test reloading an entry via the API."""
+    entry = MockConfigEntry(domain="demo", state=core_ce.ENTRY_STATE_LOADED)
+    entry.add_to_hass(hass)
+    resp = await client.post(
+        f"/api/config/config_entries/entry/{entry.entry_id}/reload"
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {"require_restart": True}
+    assert len(hass.config_entries.async_entries()) == 1
+
+
 async def test_remove_entry_unauth(hass, client, hass_admin_user):
     """Test removing an entry via the API."""
     hass_admin_user.groups = []
     entry = MockConfigEntry(domain="demo", state=core_ce.ENTRY_STATE_LOADED)
     entry.add_to_hass(hass)
     resp = await client.delete(f"/api/config/config_entries/entry/{entry.entry_id}")
+    assert resp.status == 401
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+async def test_reload_entry_unauth(hass, client, hass_admin_user):
+    """Test reloading an entry via the API."""
+    hass_admin_user.groups = []
+    entry = MockConfigEntry(domain="demo", state=core_ce.ENTRY_STATE_LOADED)
+    entry.add_to_hass(hass)
+    resp = await client.post(
+        f"/api/config/config_entries/entry/{entry.entry_id}/reload"
+    )
     assert resp.status == 401
     assert len(hass.config_entries.async_entries()) == 1
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -116,6 +116,12 @@ async def test_reload_entry(hass, client):
     assert len(hass.config_entries.async_entries()) == 1
 
 
+async def test_reload_invalid_entry(hass, client):
+    """Test reloading an invalid entry via the API."""
+    resp = await client.post("/api/config/config_entries/entry/invalid/reload")
+    assert resp.status == 404
+
+
 async def test_remove_entry_unauth(hass, client, hass_admin_user):
     """Test removing an entry via the API."""
     hass_admin_user.groups = []

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -53,7 +53,7 @@ async def test_call_setup_entry(hass):
     """Test we call <component>.setup_entry."""
     entry = MockConfigEntry(domain="comp")
     entry.add_to_hass(hass)
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
     mock_setup_entry = AsyncMock(return_value=True)
     mock_migrate_entry = AsyncMock(return_value=True)
@@ -75,14 +75,14 @@ async def test_call_setup_entry(hass):
     assert len(mock_migrate_entry.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state == config_entries.ENTRY_STATE_LOADED
-    assert entry.can_unload
+    assert entry.supports_unload
 
 
 async def test_call_setup_entry_without_reload_support(hass):
     """Test we call <component>.setup_entry and the <component> does not support unloading."""
     entry = MockConfigEntry(domain="comp")
     entry.add_to_hass(hass)
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
     mock_setup_entry = AsyncMock(return_value=True)
     mock_migrate_entry = AsyncMock(return_value=True)
@@ -104,13 +104,13 @@ async def test_call_setup_entry_without_reload_support(hass):
     assert len(mock_migrate_entry.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state == config_entries.ENTRY_STATE_LOADED
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
 
 async def test_call_async_migrate_entry(hass):
     """Test we call <component>.async_migrate_entry when version mismatch."""
     entry = MockConfigEntry(domain="comp")
-    assert not entry.can_unload
+    assert not entry.supports_unload
     entry.version = 2
     entry.add_to_hass(hass)
 
@@ -134,7 +134,7 @@ async def test_call_async_migrate_entry(hass):
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state == config_entries.ENTRY_STATE_LOADED
-    assert entry.can_unload
+    assert entry.supports_unload
 
 
 async def test_call_async_migrate_entry_failure_false(hass):
@@ -142,7 +142,7 @@ async def test_call_async_migrate_entry_failure_false(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
     mock_migrate_entry = AsyncMock(return_value=False)
     mock_setup_entry = AsyncMock(return_value=True)
@@ -162,7 +162,7 @@ async def test_call_async_migrate_entry_failure_false(hass):
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
 
 async def test_call_async_migrate_entry_failure_exception(hass):
@@ -170,7 +170,7 @@ async def test_call_async_migrate_entry_failure_exception(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
     mock_migrate_entry = AsyncMock(side_effect=Exception)
     mock_setup_entry = AsyncMock(return_value=True)
@@ -190,7 +190,7 @@ async def test_call_async_migrate_entry_failure_exception(hass):
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
 
 async def test_call_async_migrate_entry_failure_not_bool(hass):
@@ -198,7 +198,7 @@ async def test_call_async_migrate_entry_failure_not_bool(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
     mock_migrate_entry = AsyncMock(return_value=None)
     mock_setup_entry = AsyncMock(return_value=True)
@@ -218,7 +218,7 @@ async def test_call_async_migrate_entry_failure_not_bool(hass):
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
 
 async def test_call_async_migrate_entry_failure_not_supported(hass):
@@ -226,7 +226,7 @@ async def test_call_async_migrate_entry_failure_not_supported(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
     mock_setup_entry = AsyncMock(return_value=True)
 
@@ -237,7 +237,7 @@ async def test_call_async_migrate_entry_failure_not_supported(hass):
     assert result
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
-    assert not entry.can_unload
+    assert not entry.supports_unload
 
 
 async def test_remove_entry(hass, manager):
@@ -1036,7 +1036,7 @@ async def test_reload_entry_entity_registry_works(hass):
     config_entry = MockConfigEntry(
         domain="comp", state=config_entries.ENTRY_STATE_LOADED
     )
-    config_entry.can_unload = True
+    config_entry.supports_unload = True
     config_entry.add_to_hass(hass)
     mock_setup_entry = AsyncMock(return_value=True)
     mock_unload_entry = AsyncMock(return_value=True)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -53,6 +53,7 @@ async def test_call_setup_entry(hass):
     """Test we call <component>.setup_entry."""
     entry = MockConfigEntry(domain="comp")
     entry.add_to_hass(hass)
+    assert not entry.can_unload
 
     mock_setup_entry = AsyncMock(return_value=True)
     mock_migrate_entry = AsyncMock(return_value=True)
@@ -67,16 +68,49 @@ async def test_call_setup_entry(hass):
     )
     mock_entity_platform(hass, "config_flow.comp", None)
 
-    result = await async_setup_component(hass, "comp", {})
+    with patch("homeassistant.config_entries.support_entry_unload", return_value=True):
+        result = await async_setup_component(hass, "comp", {})
+        await hass.async_block_till_done()
     assert result
     assert len(mock_migrate_entry.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state == config_entries.ENTRY_STATE_LOADED
+    assert entry.can_unload
+
+
+async def test_call_setup_entry_without_reload_support(hass):
+    """Test we call <component>.setup_entry and the <component> does not support unloading."""
+    entry = MockConfigEntry(domain="comp")
+    entry.add_to_hass(hass)
+    assert not entry.can_unload
+
+    mock_setup_entry = AsyncMock(return_value=True)
+    mock_migrate_entry = AsyncMock(return_value=True)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup_entry=mock_setup_entry,
+            async_migrate_entry=mock_migrate_entry,
+        ),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    with patch("homeassistant.config_entries.support_entry_unload", return_value=False):
+        result = await async_setup_component(hass, "comp", {})
+        await hass.async_block_till_done()
+    assert result
+    assert len(mock_migrate_entry.mock_calls) == 0
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert entry.state == config_entries.ENTRY_STATE_LOADED
+    assert not entry.can_unload
 
 
 async def test_call_async_migrate_entry(hass):
     """Test we call <component>.async_migrate_entry when version mismatch."""
     entry = MockConfigEntry(domain="comp")
+    assert not entry.can_unload
     entry.version = 2
     entry.add_to_hass(hass)
 
@@ -93,11 +127,14 @@ async def test_call_async_migrate_entry(hass):
     )
     mock_entity_platform(hass, "config_flow.comp", None)
 
-    result = await async_setup_component(hass, "comp", {})
+    with patch("homeassistant.config_entries.support_entry_unload", return_value=True):
+        result = await async_setup_component(hass, "comp", {})
+        await hass.async_block_till_done()
     assert result
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state == config_entries.ENTRY_STATE_LOADED
+    assert entry.can_unload
 
 
 async def test_call_async_migrate_entry_failure_false(hass):
@@ -105,6 +142,7 @@ async def test_call_async_migrate_entry_failure_false(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
+    assert not entry.can_unload
 
     mock_migrate_entry = AsyncMock(return_value=False)
     mock_setup_entry = AsyncMock(return_value=True)
@@ -124,6 +162,7 @@ async def test_call_async_migrate_entry_failure_false(hass):
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
+    assert not entry.can_unload
 
 
 async def test_call_async_migrate_entry_failure_exception(hass):
@@ -131,6 +170,7 @@ async def test_call_async_migrate_entry_failure_exception(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
+    assert not entry.can_unload
 
     mock_migrate_entry = AsyncMock(side_effect=Exception)
     mock_setup_entry = AsyncMock(return_value=True)
@@ -150,6 +190,7 @@ async def test_call_async_migrate_entry_failure_exception(hass):
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
+    assert not entry.can_unload
 
 
 async def test_call_async_migrate_entry_failure_not_bool(hass):
@@ -157,6 +198,7 @@ async def test_call_async_migrate_entry_failure_not_bool(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
+    assert not entry.can_unload
 
     mock_migrate_entry = AsyncMock(return_value=None)
     mock_setup_entry = AsyncMock(return_value=True)
@@ -176,6 +218,7 @@ async def test_call_async_migrate_entry_failure_not_bool(hass):
     assert len(mock_migrate_entry.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
+    assert not entry.can_unload
 
 
 async def test_call_async_migrate_entry_failure_not_supported(hass):
@@ -183,6 +226,7 @@ async def test_call_async_migrate_entry_failure_not_supported(hass):
     entry = MockConfigEntry(domain="comp")
     entry.version = 2
     entry.add_to_hass(hass)
+    assert not entry.can_unload
 
     mock_setup_entry = AsyncMock(return_value=True)
 
@@ -193,6 +237,7 @@ async def test_call_async_migrate_entry_failure_not_supported(hass):
     assert result
     assert len(mock_setup_entry.mock_calls) == 0
     assert entry.state == config_entries.ENTRY_STATE_MIGRATION_ERROR
+    assert not entry.can_unload
 
 
 async def test_remove_entry(hass, manager):
@@ -991,6 +1036,7 @@ async def test_reload_entry_entity_registry_works(hass):
     config_entry = MockConfigEntry(
         domain="comp", state=config_entries.ENTRY_STATE_LOADED
     )
+    config_entry.can_unload = True
     config_entry.add_to_hass(hass)
     mock_setup_entry = AsyncMock(return_value=True)
     mock_unload_entry = AsyncMock(return_value=True)


### PR DESCRIPTION
Frontend PR: https://github.com/home-assistant/frontend/pull/6656

https://github.com/home-assistant/core/issues/39033#issuecomment-676479193

https://community.home-assistant.io/t/why-the-heck-is-a-restart-needed-for-each-an-every-change-to-configuration-yaml/219630/6?u=bdraco
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add api to reload config entries

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
