### PR TITLE
Fix slower tests in sonarr

### DIFF
--- a/tests/components/sonarr/__init__.py
+++ b/tests/components/sonarr/__init__.py
@@ -196,6 +196,10 @@ async def setup_integration(
             CONF_UPCOMING_DAYS: DEFAULT_UPCOMING_DAYS,
             CONF_WANTED_MAX_ITEMS: DEFAULT_WANTED_MAX_ITEMS,
         },
+        options={
+            CONF_UPCOMING_DAYS: DEFAULT_UPCOMING_DAYS,
+            CONF_WANTED_MAX_ITEMS: DEFAULT_WANTED_MAX_ITEMS,
+        },
     )
 
     entry.add_to_hass(hass)

--- a/tests/components/sonarr/__init__.py
+++ b/tests/components/sonarr/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
+from tests.async_mock import patch
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 

--- a/tests/components/sonarr/__init__.py
+++ b/tests/components/sonarr/__init__.py
@@ -219,3 +219,17 @@ async def setup_integration(
         await hass.async_block_till_done()
 
     return entry
+
+
+def _patch_async_setup(return_value=True):
+    """Patch the async setup of sonarr."""
+    return patch(
+        "homeassistant.components.sonarr.async_setup", return_value=return_value
+    )
+
+
+def _patch_async_setup_entry(return_value=True):
+    """Patch the async entry setup of sonarr."""
+    return patch(
+        "homeassistant.components.sonarr.async_setup_entry", return_value=return_value,
+    )

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -27,30 +27,6 @@ from tests.components.sonarr import (
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_options(hass, aioclient_mock: AiohttpClientMocker):
-    """Test updating options."""
-    entry = await setup_integration(hass, aioclient_mock)
-    assert entry.options[CONF_UPCOMING_DAYS] == DEFAULT_UPCOMING_DAYS
-    assert entry.options[CONF_WANTED_MAX_ITEMS] == DEFAULT_WANTED_MAX_ITEMS
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
-
-    with patch(
-        "homeassistant.components.sonarr.async_setup_entry", return_value=True
-    ), patch("homeassistant.components.sonarr.async_setup", return_value=True):
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={CONF_UPCOMING_DAYS: 2, CONF_WANTED_MAX_ITEMS: 100},
-        )
-
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["data"][CONF_UPCOMING_DAYS] == 2
-    assert result["data"][CONF_WANTED_MAX_ITEMS] == 100
-
-
 async def test_show_user_form(hass: HomeAssistantType) -> None:
     """Test that the user set up form is served."""
     result = await hass.config_entries.flow.async_init(
@@ -192,3 +168,27 @@ async def test_full_user_flow_advanced_options(
     assert result["data"]
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_VERIFY_SSL]
+
+
+async def test_options_flow(hass, aioclient_mock: AiohttpClientMocker):
+    """Test updating options."""
+    entry = await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
+    assert entry.options[CONF_UPCOMING_DAYS] == DEFAULT_UPCOMING_DAYS
+    assert entry.options[CONF_WANTED_MAX_ITEMS] == DEFAULT_WANTED_MAX_ITEMS
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    with patch(
+        "homeassistant.components.sonarr.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.sonarr.async_setup", return_value=True):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_UPCOMING_DAYS: 2, CONF_WANTED_MAX_ITEMS: 100},
+        )
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["data"][CONF_UPCOMING_DAYS] == 2
+    assert result["data"][CONF_WANTED_MAX_ITEMS] == 100

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -107,10 +107,6 @@ async def test_full_import_flow_implementation(
     assert result["data"]
     assert result["data"][CONF_HOST] == HOST
 
-    assert result["result"]
-    assert result["result"].options[CONF_UPCOMING_DAYS] == DEFAULT_UPCOMING_DAYS
-    assert result["result"].options[CONF_WANTED_MAX_ITEMS] == DEFAULT_WANTED_MAX_ITEMS
-
 
 async def test_full_user_flow_implementation(
     hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -19,6 +19,8 @@ from tests.async_mock import patch
 from tests.components.sonarr import (
     HOST,
     MOCK_USER_INPUT,
+    _patch_async_setup,
+    _patch_async_setup_entry,
     mock_connection,
     mock_connection_error,
     mock_connection_invalid_auth,
@@ -94,9 +96,10 @@ async def test_full_import_flow_implementation(
 
     user_input = MOCK_USER_INPUT.copy()
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: SOURCE_IMPORT}, data=user_input,
-    )
+    with _patch_async_setup, _patch_async_setup_entry():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={CONF_SOURCE: SOURCE_IMPORT}, data=user_input,
+        )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == HOST
@@ -123,9 +126,8 @@ async def test_full_user_flow_implementation(
     assert result["step_id"] == "user"
 
     user_input = MOCK_USER_INPUT.copy()
-    with patch(
-        "homeassistant.components.sonarr.async_setup_entry", return_value=True
-    ), patch("homeassistant.components.sonarr.async_setup", return_value=True):
+
+    with _patch_async_setup, _patch_async_setup_entry():
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=user_input,
         )
@@ -155,9 +157,7 @@ async def test_full_user_flow_advanced_options(
         CONF_VERIFY_SSL: True,
     }
 
-    with patch(
-        "homeassistant.components.sonarr.async_setup_entry", return_value=True
-    ), patch("homeassistant.components.sonarr.async_setup", return_value=True):
+    with with _patch_async_setup, _patch_async_setup_entry():
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=user_input,
         )
@@ -181,9 +181,7 @@ async def test_options_flow(hass, aioclient_mock: AiohttpClientMocker):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
-    with patch(
-        "homeassistant.components.sonarr.async_setup_entry", return_value=True
-    ), patch("homeassistant.components.sonarr.async_setup", return_value=True):
+    with _patch_async_setup, _patch_async_setup_entry():
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={CONF_UPCOMING_DAYS: 2, CONF_WANTED_MAX_ITEMS: 100},

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -157,7 +157,7 @@ async def test_full_user_flow_advanced_options(
         CONF_VERIFY_SSL: True,
     }
 
-    with with _patch_async_setup(), _patch_async_setup_entry():
+    with _patch_async_setup(), _patch_async_setup_entry():
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=user_input,
         )

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -96,7 +96,7 @@ async def test_full_import_flow_implementation(
 
     user_input = MOCK_USER_INPUT.copy()
 
-    with _patch_async_setup, _patch_async_setup_entry():
+    with _patch_async_setup(), _patch_async_setup_entry():
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_IMPORT}, data=user_input,
         )
@@ -127,7 +127,7 @@ async def test_full_user_flow_implementation(
 
     user_input = MOCK_USER_INPUT.copy()
 
-    with _patch_async_setup, _patch_async_setup_entry():
+    with _patch_async_setup(), _patch_async_setup_entry():
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=user_input,
         )
@@ -157,7 +157,7 @@ async def test_full_user_flow_advanced_options(
         CONF_VERIFY_SSL: True,
     }
 
-    with with _patch_async_setup, _patch_async_setup_entry():
+    with with _patch_async_setup(), _patch_async_setup_entry():
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=user_input,
         )
@@ -181,7 +181,7 @@ async def test_options_flow(hass, aioclient_mock: AiohttpClientMocker):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
-    with _patch_async_setup, _patch_async_setup_entry():
+    with _patch_async_setup(), _patch_async_setup_entry():
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={CONF_UPCOMING_DAYS: 2, CONF_WANTED_MAX_ITEMS: 100},

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -23,7 +23,11 @@ async def test_unload_config_entry(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the configuration entry unloading."""
-    entry = await setup_integration(hass, aioclient_mock)
+    with patch(
+        "homeassistant.components.sonarr.sensor.async_setup_entry",
+        return_value=True,
+    ):
+        entry = await setup_integration(hass, aioclient_mock)
 
     assert hass.data[DOMAIN]
     assert entry.entry_id in hass.data[DOMAIN]

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -25,8 +25,7 @@ async def test_unload_config_entry(
 ) -> None:
     """Test the configuration entry unloading."""
     with patch(
-        "homeassistant.components.sonarr.sensor.async_setup_entry",
-        return_value=True,
+        "homeassistant.components.sonarr.sensor.async_setup_entry", return_value=True,
     ):
         entry = await setup_integration(hass, aioclient_mock)
 

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -7,6 +7,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.core import HomeAssistant
 
+from tests.async_mock import patch
 from tests.components.sonarr import setup_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Before:

```
========================== slowest 10 test durations ===========================
1.84s call     tests/components/sonarr/test_config_flow.py::test_options[pyloop]
1.79s call     tests/components/sonarr/test_init.py::test_unload_config_entry[pyloop]
```

After:

```
========================== slowest 10 test durations ===========================
1.69s call     tests/components/sonarr/test_init.py::test_unload_config_entry[pyloop]
0.69s teardown tests/components/sonarr/test_sensor.py::test_disabled_by_default_sensors[pyloop-sensor.sonarr_wanted]
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
