### PR TITLE
Add service to scan for new Plex clients

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -39,6 +39,7 @@ from .const import (
     PLEX_UPDATE_PLATFORMS_SIGNAL,
     SERVERS,
     SERVICE_PLAY_ON_SONOS,
+    SERVICE_SCAN_CLIENTS,
     WEBSOCKETS,
 )
 from .errors import ShouldUpdateConfigEntry

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -39,7 +39,6 @@ from .const import (
     PLEX_UPDATE_PLATFORMS_SIGNAL,
     SERVERS,
     SERVICE_PLAY_ON_SONOS,
-    SERVICE_SCAN_CLIENTS,
     WEBSOCKETS,
 )
 from .errors import ShouldUpdateConfigEntry

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -46,3 +46,4 @@ MANUAL_SETUP_STRING = "Configure Plex server manually"
 
 SERVICE_PLAY_ON_SONOS = "play_on_sonos"
 SERVICE_REFRESH_LIBRARY = "refresh_library"
+SERVICE_SCAN_CLIENTS = "scan_for_clients"

--- a/homeassistant/components/plex/services.yaml
+++ b/homeassistant/components/plex/services.yaml
@@ -21,3 +21,6 @@ refresh_library:
     library_name:
       description: Name of the Plex library to refresh.
       example: "TV Shows"
+
+scan_for_clients:
+  description: Scan for available clients from the Plex server(s), local network, and plex.tv.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a service to trigger an immediate scan for available Plex clients.

**Background**:
Plex clients are software clients that run on various types of devices (TVs, set-top boxes, mobile devices, browsers, etc). A Plex client being "available" means that the underlying device is turned on and the Plex application is running and actively reporting its presence. This can be done in a variety of ways such as network broadcast discovery (GDM), using the plex.tv cloud service, or if the client is actively playing some type of media from the Plex server. If none of these work (or haven't had time to trigger) then we have no way to know how to reach the Plex client. Additionally, the state of the `media_player` entity will be "Unavailable" and cannot accept service calls (which is why this can't be done from within `media_player.play_media` on a restored entity).

One of the classic automation use cases for the `media_player.play_media` service is for the following to occur:
1. Turn on the device that runs Plex
2. Launch / switch to the Plex client
3. Play something

Unfortunately there has always been an indeterminate amount of time between steps 2 and 3 before the Plex `media_player` entity becomes available to the Plex integration. This PR proposes adding a service to manually trigger a scan for newly available clients. It's not guaranteed to work, but it will give automations that rely on this workflow a better chance to succeed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14380

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
