### PR TITLE
Add Sentry tracing support

### DIFF
--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -1,5 +1,6 @@
 """The sentry integration."""
 import re
+from typing import Dict, Union
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -10,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.loader import async_get_custom_components
+from homeassistant.loader import Integration, async_get_custom_components
 
 from .const import (
     CONF_DSN,
@@ -35,12 +36,12 @@ CONFIG_SCHEMA = cv.deprecated(DOMAIN, invalidation_version="0.117")
 LOGGER_INFO_REGEX = re.compile(r"^(\w+)\.?(\w+)?\.?(\w+)?\.?(\w+)?(?:\..*)?$")
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Sentry component."""
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Sentry from a config entry."""
 
     # Migrate environment from config entry data to config entry options
@@ -98,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-def get_channel(version) -> str:
+def get_channel(version: str) -> str:
     """Find channel based on version number."""
     if "dev0" in version:
         return "dev"
@@ -110,7 +111,14 @@ def get_channel(version) -> str:
 
 
 def process_before_send(
-    hass, options, channel, huuid, system_info, custom_components, event, hint
+    hass: HomeAssistant,
+    options,
+    channel: str,
+    huuid: str,
+    system_info: Dict[str, Union[bool, str]],
+    custom_components: Dict[str, Integration],
+    event,
+    hint,
 ):
     """Process a Sentry event before sending it to Sentry."""
     # Filter out handled events by default

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -20,8 +20,11 @@ from .const import (
     CONF_EVENT_THIRD_PARTY_PACKAGES,
     CONF_LOGGING_EVENT_LEVEL,
     CONF_LOGGING_LEVEL,
+    CONF_TRACING,
+    CONF_TRACING_SAMPLE_RATE,
     DEFAULT_LOGGING_EVENT_LEVEL,
     DEFAULT_LOGGING_LEVEL,
+    DEFAULT_TRACING_SAMPLE_RATE,
     DOMAIN,
     ENTITY_COMPONENTS,
 )
@@ -65,6 +68,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     system_info = await hass.helpers.system_info.async_get_system_info()
     custom_components = await async_get_custom_components(hass)
 
+    tracing = {}
+    if entry.options.get(CONF_TRACING):
+        tracing = {
+            "traceparent_v2": True,
+            "traces_sample_rate": entry.options.get(
+                CONF_TRACING_SAMPLE_RATE, DEFAULT_TRACING_SAMPLE_RATE
+            ),
+        }
+
     sentry_sdk.init(
         dsn=entry.data[CONF_DSN],
         environment=entry.options.get(CONF_ENVIRONMENT),
@@ -80,6 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             event,
             hint,
         ),
+        **tracing,
     )
 
     return True

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow for sentry integration."""
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict, Optional
 
@@ -38,7 +40,9 @@ class SentryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> SentryOptionsFlow:
         """Get the options flow for this handler."""
         return SentryOptionsFlow(config_entry)
 
@@ -69,7 +73,7 @@ class SentryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class SentryOptionsFlow(config_entries.OptionsFlow):
     """Handle Sentry options."""
 
-    def __init__(self, config_entry):
+    def __init__(self, config_entry: config_entries.ConfigEntry):
         """Initialize Sentry options flow."""
         self.config_entry = config_entry
 

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -16,8 +16,11 @@ from .const import (  # pylint: disable=unused-import
     CONF_EVENT_THIRD_PARTY_PACKAGES,
     CONF_LOGGING_EVENT_LEVEL,
     CONF_LOGGING_LEVEL,
+    CONF_TRACING,
+    CONF_TRACING_SAMPLE_RATE,
     DEFAULT_LOGGING_EVENT_LEVEL,
     DEFAULT_LOGGING_LEVEL,
+    DEFAULT_TRACING_SAMPLE_RATE,
     DOMAIN,
     LOGGING_LEVELS,
 )
@@ -115,6 +118,16 @@ class SentryOptionsFlow(config_entries.OptionsFlow):
                             CONF_EVENT_THIRD_PARTY_PACKAGES, False
                         ),
                     ): bool,
+                    vol.Optional(
+                        CONF_TRACING,
+                        default=self.config_entry.options.get(CONF_TRACING, False),
+                    ): bool,
+                    vol.Optional(
+                        CONF_TRACING_SAMPLE_RATE,
+                        default=self.config_entry.options.get(
+                            CONF_TRACING_SAMPLE_RATE, DEFAULT_TRACING_SAMPLE_RATE
+                        ),
+                    ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0)),
                 }
             ),
         )

--- a/homeassistant/components/sentry/const.py
+++ b/homeassistant/components/sentry/const.py
@@ -11,9 +11,12 @@ CONF_EVENT_HANDLED = "event_handled"
 CONF_EVENT_THIRD_PARTY_PACKAGES = "event_third_party_packages"
 CONF_LOGGING_EVENT_LEVEL = "logging_event_level"
 CONF_LOGGING_LEVEL = "logging_level"
+CONF_TRACING = "tracing"
+CONF_TRACING_SAMPLE_RATE = "tracing_sample_rate"
 
 DEFAULT_LOGGING_EVENT_LEVEL = logging.ERROR
 DEFAULT_LOGGING_LEVEL = logging.WARNING
+DEFAULT_TRACING_SAMPLE_RATE = 1.0
 
 LOGGING_LEVELS = {
     logging.DEBUG: "debug",

--- a/homeassistant/components/sentry/strings.json
+++ b/homeassistant/components/sentry/strings.json
@@ -21,7 +21,9 @@
           "event_handled": "Send handled events",
           "event_third_party_packages": "Send events from third-party packages",
           "logging_event_level": "The log level Sentry will register an event for",
-          "logging_level": "The log level Sentry will record logs as breadcrums for"
+          "logging_level": "The log level Sentry will record logs as breadcrums for",
+          "tracing": "Enable performance tracing",
+          "tracing_sample_rate": "Tracing sample rate; between 0.0 and 1.0 (1.0 = 100%)"
         }
       }
     }

--- a/tests/components/sentry/test_config_flow.py
+++ b/tests/components/sentry/test_config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.components.sentry.const import (
     CONF_EVENT_THIRD_PARTY_PACKAGES,
     CONF_LOGGING_EVENT_LEVEL,
     CONF_LOGGING_LEVEL,
+    CONF_TRACING,
+    CONF_TRACING_SAMPLE_RATE,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
@@ -119,6 +121,8 @@ async def test_options_flow(hass):
             CONF_EVENT_THIRD_PARTY_PACKAGES: True,
             CONF_LOGGING_EVENT_LEVEL: logging.DEBUG,
             CONF_LOGGING_LEVEL: logging.DEBUG,
+            CONF_TRACING: True,
+            CONF_TRACING_SAMPLE_RATE: 0.5,
         },
     )
 
@@ -130,4 +134,6 @@ async def test_options_flow(hass):
         CONF_EVENT_THIRD_PARTY_PACKAGES: True,
         CONF_LOGGING_EVENT_LEVEL: logging.DEBUG,
         CONF_LOGGING_LEVEL: logging.DEBUG,
+        CONF_TRACING: True,
+        CONF_TRACING_SAMPLE_RATE: 0.5,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

⚠️ This PR builds on top of #38833 and targets the branch of that PR.

Adds performance tracing support to the Sentry integration.
Additionally, some minor type hint improvements to finishing things up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
