### PR TITLE
0.114.3

### DIFF
--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==7.2.0"],
+  "requirements": ["pychromecast==7.2.1"],
   "after_dependencies": ["cloud","zeroconf"],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/control4/light.py
+++ b/homeassistant/components/control4/light.py
@@ -73,40 +73,64 @@ async def async_setup_entry(
     await dimmer_coordinator.async_refresh()
 
     items_of_category = await get_items_of_category(hass, entry, CONTROL4_CATEGORY)
+
+    entity_list = []
     for item in items_of_category:
-        if item["type"] == CONTROL4_ENTITY_TYPE:
-            item_name = item["name"]
-            item_id = item["id"]
-            item_parent_id = item["parentId"]
-            item_is_dimmer = item["capabilities"]["dimmer"]
+        try:
+            if item["type"] == CONTROL4_ENTITY_TYPE:
+                item_name = item["name"]
+                item_id = item["id"]
+                item_parent_id = item["parentId"]
 
-            if item_is_dimmer:
-                item_coordinator = dimmer_coordinator
+                item_manufacturer = None
+                item_device_name = None
+                item_model = None
+
+                for parent_item in items_of_category:
+                    if parent_item["id"] == item_parent_id:
+                        item_manufacturer = parent_item["manufacturer"]
+                        item_device_name = parent_item["name"]
+                        item_model = parent_item["model"]
             else:
-                item_coordinator = non_dimmer_coordinator
-
-            for parent_item in items_of_category:
-                if parent_item["id"] == item_parent_id:
-                    item_manufacturer = parent_item["manufacturer"]
-                    item_device_name = parent_item["name"]
-                    item_model = parent_item["model"]
-            async_add_entities(
-                [
-                    Control4Light(
-                        entry_data,
-                        entry,
-                        item_coordinator,
-                        item_name,
-                        item_id,
-                        item_device_name,
-                        item_manufacturer,
-                        item_model,
-                        item_parent_id,
-                        item_is_dimmer,
-                    )
-                ],
-                True,
+                continue
+        except KeyError:
+            _LOGGER.exception(
+                "Unknown device properties received from Control4: %s", item,
             )
+            continue
+
+        if item_id in dimmer_coordinator.data:
+            item_is_dimmer = True
+            item_coordinator = dimmer_coordinator
+        elif item_id in non_dimmer_coordinator.data:
+            item_is_dimmer = False
+            item_coordinator = non_dimmer_coordinator
+        else:
+            director = entry_data[CONF_DIRECTOR]
+            item_variables = await director.getItemVariables(item_id)
+            _LOGGER.warning(
+                "Couldn't get light state data for %s, skipping setup. Available variables from Control4: %s",
+                item_name,
+                item_variables,
+            )
+            continue
+
+        entity_list.append(
+            Control4Light(
+                entry_data,
+                entry,
+                item_coordinator,
+                item_name,
+                item_id,
+                item_device_name,
+                item_manufacturer,
+                item_model,
+                item_parent_id,
+                item_is_dimmer,
+            )
+        )
+
+    async_add_entities(entity_list, True)
 
 
 class Control4Light(Control4Entity, LightEntity):

--- a/homeassistant/components/discovery/manifest.json
+++ b/homeassistant/components/discovery/manifest.json
@@ -2,7 +2,7 @@
   "domain": "discovery",
   "name": "Discovery",
   "documentation": "https://www.home-assistant.io/integrations/discovery",
-  "requirements": ["netdisco==2.8.1"],
+  "requirements": ["netdisco==2.8.2"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],
   "quality_scale": "internal"

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -781,6 +781,7 @@ def entity_to_json(config, entity):
         retval["type"] = "On/Off light"
         retval["productname"] = "On/Off light"
         retval["modelid"] = "HASS321"
+        retval["state"].update({HUE_API_STATE_BRI: HUE_API_STATE_BRI_MAX})
 
     return retval
 

--- a/homeassistant/components/met/manifest.json
+++ b/homeassistant/components/met/manifest.json
@@ -3,6 +3,6 @@
   "name": "Meteorologisk institutt (Met.no)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/met",
-  "requirements": ["pyMetno==0.7.0"],
+  "requirements": ["pyMetno==0.7.1"],
   "codeowners": ["@danielhiversen"]
 }

--- a/homeassistant/components/norway_air/manifest.json
+++ b/homeassistant/components/norway_air/manifest.json
@@ -2,6 +2,6 @@
   "domain": "norway_air",
   "name": "Om Luftkvalitet i Norge (Norway Air)",
   "documentation": "https://www.home-assistant.io/integrations/norway_air",
-  "requirements": ["pyMetno==0.7.0"],
+  "requirements": ["pyMetno==0.7.1"],
   "codeowners": []
 }

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["defusedxml==0.6.0", "netdisco==2.8.1"],
+  "requirements": ["defusedxml==0.6.0", "netdisco==2.8.2"],
   "after_dependencies": ["zeroconf"],
   "codeowners": []
 }

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.28.0"],
+  "requirements": ["zeroconf==0.28.1"],
   "dependencies": ["api"],
   "codeowners": ["@Kane610"],
   "quality_scale": "internal"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 114
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -28,7 +28,7 @@ sqlalchemy==1.3.18
 voluptuous-serialize==2.4.0
 voluptuous==0.11.7
 yarl==1.4.2
-zeroconf==0.28.0
+zeroconf==0.28.1
 
 pycryptodome>=3.6.6
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,7 @@ hass-nabucasa==0.35.0
 home-assistant-frontend==20200811.0
 importlib-metadata==1.6.0;python_version<'3.8'
 jinja2>=2.11.1
-netdisco==2.8.1
+netdisco==2.8.2
 paho-mqtt==1.5.0
 pip>=8.0.3
 python-slugify==4.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -945,7 +945,7 @@ netdata==0.2.0
 
 # homeassistant.components.discovery
 # homeassistant.components.ssdp
-netdisco==2.8.1
+netdisco==2.8.2
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1181,7 +1181,7 @@ pyHS100==0.3.5.1
 
 # homeassistant.components.met
 # homeassistant.components.norway_air
-pyMetno==0.7.0
+pyMetno==0.7.1
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.25

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1256,7 +1256,7 @@ pycfdns==0.0.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==7.2.0
+pychromecast==7.2.1
 
 # homeassistant.components.cmus
 pycmus==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2269,7 +2269,7 @@ youtube_dl==2020.07.28
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.28.0
+zeroconf==0.28.1
 
 # homeassistant.components.zha
 zha-quirks==0.0.43

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -595,7 +595,7 @@ pyblackbird==0.5
 pybotvac==0.0.17
 
 # homeassistant.components.cast
-pychromecast==7.2.0
+pychromecast==7.2.1
 
 # homeassistant.components.coolmaster
 pycoolmasternet==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -443,7 +443,7 @@ nessclient==0.9.15
 
 # homeassistant.components.discovery
 # homeassistant.components.ssdp
-netdisco==2.8.1
+netdisco==2.8.2
 
 # homeassistant.components.nexia
 nexia==0.9.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -559,7 +559,7 @@ pyHS100==0.3.5.1
 
 # homeassistant.components.met
 # homeassistant.components.norway_air
-pyMetno==0.7.0
+pyMetno==0.7.1
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.25

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1005,7 +1005,7 @@ xmltodict==0.12.0
 yeelight==0.5.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.28.0
+zeroconf==0.28.1
 
 # homeassistant.components.zha
 zha-quirks==0.0.43

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -22,6 +22,7 @@ from homeassistant.components import (
 from homeassistant.components.emulated_hue import Config, hue_api
 from homeassistant.components.emulated_hue.hue_api import (
     HUE_API_STATE_BRI,
+    HUE_API_STATE_BRI_MAX,
     HUE_API_STATE_CT,
     HUE_API_STATE_HUE,
     HUE_API_STATE_ON,
@@ -281,6 +282,12 @@ async def test_light_without_brightness_supported(hass_hue, hue_client):
 
     assert light_without_brightness_json["state"][HUE_API_STATE_ON] is True
     assert light_without_brightness_json["type"] == "On/Off light"
+
+    # BRI required for alexa compat
+    assert (
+        light_without_brightness_json["state"][HUE_API_STATE_BRI]
+        == HUE_API_STATE_BRI_MAX
+    )
 
 
 async def test_light_without_brightness_can_be_turned_off(hass_hue, hue_client):


### PR DESCRIPTION
- Update zeroconf to fix ServiceBrowser leak on cancelation ([@bdraco] - [#38933]) ([zeroconf docs])
- Bump netdisco to 2.8.2 to accomodate new zeroconf exception ([@bdraco] - [#38949]) ([discovery docs]) ([ssdp docs])
- Fix Control4 light setup issues ([@lawtancool] - [#38952]) ([control4 docs])
- Bump pychromecast to 7.2.1 ([@emontnemery] - [#39018]) ([cast docs])
- Fix emulated hue on/off devices compatibility with alexa ([@bdraco] - [#39063]) ([emulated_hue docs])
- Update met.no library ([@Danielhiversen] - [#39076]) ([met docs]) ([norway_air docs])

[#38933]: https://github.com/home-assistant/core/pull/38933
[#38949]: https://github.com/home-assistant/core/pull/38949
[#38952]: https://github.com/home-assistant/core/pull/38952
[#39018]: https://github.com/home-assistant/core/pull/39018
[#39063]: https://github.com/home-assistant/core/pull/39063
[#39076]: https://github.com/home-assistant/core/pull/39076
[@Danielhiversen]: https://github.com/Danielhiversen
[@bdraco]: https://github.com/bdraco
[@emontnemery]: https://github.com/emontnemery
[@lawtancool]: https://github.com/lawtancool
[cast docs]: https://www.home-assistant.io/integrations/cast/
[control4 docs]: https://www.home-assistant.io/integrations/control4/
[discovery docs]: https://www.home-assistant.io/integrations/discovery/
[emulated_hue docs]: https://www.home-assistant.io/integrations/emulated_hue/
[met docs]: https://www.home-assistant.io/integrations/met/
[norway_air docs]: https://www.home-assistant.io/integrations/norway_air/
[ssdp docs]: https://www.home-assistant.io/integrations/ssdp/
[zeroconf docs]: https://www.home-assistant.io/integrations/zeroconf/