### PR TITLE
Improve tests and config flow for Smart Meter Texas

### DIFF
--- a/homeassistant/components/smart_meter_texas/__init__.py
+++ b/homeassistant/components/smart_meter_texas/__init__.py
@@ -45,21 +45,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     password = entry.data[CONF_PASSWORD]
 
     account = Account(username, password)
-    smartmetertexas = SmartMeterTexasData(hass, entry, account)
+    smart_meter_texas_data = SmartMeterTexasData(hass, entry, account)
     try:
-        await smartmetertexas.client.authenticate()
+        await smart_meter_texas_data.client.authenticate()
     except SmartMeterTexasAuthError:
         _LOGGER.error("Username or password was not accepted")
         return False
     except asyncio.TimeoutError:
         raise ConfigEntryNotReady
 
-    await smartmetertexas.setup()
+    await smart_meter_texas_data.setup()
 
     async def async_update_data():
         _LOGGER.debug("Fetching latest data")
-        await smartmetertexas.read_meters()
-        return smartmetertexas
+        await smart_meter_texas_data.read_meters()
+        return smart_meter_texas_data
 
     # Use a DataUpdateCoordinator to manage the updates. This is due to the
     # Smart Meter Texas API which takes around 30 seconds to read a meter.
@@ -78,7 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_COORDINATOR: coordinator,
-        DATA_SMART_METER: smartmetertexas,
+        DATA_SMART_METER: smart_meter_texas_data,
     }
 
     asyncio.create_task(coordinator.async_refresh())

--- a/tests/components/smart_meter_texas/conftest.py
+++ b/tests/components/smart_meter_texas/conftest.py
@@ -32,9 +32,9 @@ def load_smt_fixture(name):
     return json.loads(json_fixture)
 
 
-async def setup_integration(hass, config_entry, aioclient_mock):
+async def setup_integration(hass, config_entry, aioclient_mock, **kwargs):
     """Initialize the Smart Meter Texas integration for testing."""
-    mock_connection(aioclient_mock)
+    mock_connection(aioclient_mock, **kwargs)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/smart_meter_texas/test_init.py
+++ b/tests/components/smart_meter_texas/test_init.py
@@ -5,11 +5,11 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.smart_meter_texas import async_setup_entry
 from homeassistant.components.smart_meter_texas.const import DOMAIN
 from homeassistant.config_entries import (
     ENTRY_STATE_LOADED,
     ENTRY_STATE_NOT_LOADED,
+    ENTRY_STATE_SETUP_ERROR,
     ENTRY_STATE_SETUP_RETRY,
 )
 from homeassistant.const import ATTR_ENTITY_ID
@@ -33,16 +33,13 @@ async def test_setup_with_no_config(hass):
 async def test_auth_failure(hass, config_entry, aioclient_mock):
     """Test if user's username or password is not accepted."""
     await setup_integration(hass, config_entry, aioclient_mock, auth_fail=True)
-    result = await async_setup_entry(hass, config_entry)
 
-    assert result is False
+    assert config_entry.state == ENTRY_STATE_SETUP_ERROR
 
 
 async def test_api_timeout(hass, config_entry, aioclient_mock):
     """Test that a timeout results in ConfigEntryNotReady."""
     await setup_integration(hass, config_entry, aioclient_mock, auth_timeout=True)
-    with pytest.raises(ConfigEntryNotReady):
-        await async_setup_entry(hass, config_entry)
 
     assert config_entry.state == ENTRY_STATE_SETUP_RETRY
 

--- a/tests/components/smart_meter_texas/test_init.py
+++ b/tests/components/smart_meter_texas/test_init.py
@@ -1,6 +1,4 @@
 """Test the Smart Meter Texas module."""
-import pytest
-
 from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
@@ -13,7 +11,6 @@ from homeassistant.config_entries import (
     ENTRY_STATE_SETUP_RETRY,
 )
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_ID, setup_integration

--- a/tests/components/smart_meter_texas/test_init.py
+++ b/tests/components/smart_meter_texas/test_init.py
@@ -7,7 +7,11 @@ from homeassistant.components.homeassistant import (
 )
 from homeassistant.components.smart_meter_texas import async_setup_entry
 from homeassistant.components.smart_meter_texas.const import DOMAIN
-from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
+from homeassistant.config_entries import (
+    ENTRY_STATE_LOADED,
+    ENTRY_STATE_NOT_LOADED,
+    ENTRY_STATE_SETUP_RETRY,
+)
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
@@ -28,7 +32,7 @@ async def test_setup_with_no_config(hass):
 
 async def test_auth_failure(hass, config_entry, aioclient_mock):
     """Test if user's username or password is not accepted."""
-    mock_connection(aioclient_mock, auth_fail=True)
+    await setup_integration(hass, config_entry, aioclient_mock, auth_fail=True)
     result = await async_setup_entry(hass, config_entry)
 
     assert result is False
@@ -36,11 +40,11 @@ async def test_auth_failure(hass, config_entry, aioclient_mock):
 
 async def test_api_timeout(hass, config_entry, aioclient_mock):
     """Test that a timeout results in ConfigEntryNotReady."""
-    mock_connection(aioclient_mock, auth_timeout=True)
+    await setup_integration(hass, config_entry, aioclient_mock, auth_timeout=True)
     with pytest.raises(ConfigEntryNotReady):
         await async_setup_entry(hass, config_entry)
 
-    assert config_entry.state == ENTRY_STATE_NOT_LOADED
+    assert config_entry.state == ENTRY_STATE_SETUP_RETRY
 
 
 async def test_update_failure(hass, config_entry, aioclient_mock):

--- a/tests/components/smart_meter_texas/test_init.py
+++ b/tests/components/smart_meter_texas/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
 
-from .conftest import TEST_ENTITY_ID, mock_connection, setup_integration
+from .conftest import TEST_ENTITY_ID, setup_integration
 
 from tests.async_mock import patch
 
@@ -49,8 +49,7 @@ async def test_api_timeout(hass, config_entry, aioclient_mock):
 
 async def test_update_failure(hass, config_entry, aioclient_mock):
     """Test that the coordinator handles a bad response."""
-    mock_connection(aioclient_mock, bad_reading=True)
-    await setup_integration(hass, config_entry, aioclient_mock)
+    await setup_integration(hass, config_entry, aioclient_mock, bad_reading=True)
     await async_setup_component(hass, HA_DOMAIN, {})
     with patch("smart_meter_texas.Meter.read_meter") as updater:
         await hass.services.async_call(

--- a/tests/components/smart_meter_texas/test_sensor.py
+++ b/tests/components/smart_meter_texas/test_sensor.py
@@ -11,14 +11,13 @@ from homeassistant.components.smart_meter_texas.const import (
 from homeassistant.const import ATTR_ENTITY_ID, CONF_ADDRESS
 from homeassistant.setup import async_setup_component
 
-from .conftest import TEST_ENTITY_ID, mock_connection, refresh_data, setup_integration
+from .conftest import TEST_ENTITY_ID, refresh_data, setup_integration
 
 from tests.async_mock import patch
 
 
 async def test_sensor(hass, config_entry, aioclient_mock):
     """Test that the sensor is setup."""
-    mock_connection(aioclient_mock)
     await setup_integration(hass, config_entry, aioclient_mock)
     await refresh_data(hass, config_entry, aioclient_mock)
     meter = hass.states.get(TEST_ENTITY_ID)
@@ -29,7 +28,6 @@ async def test_sensor(hass, config_entry, aioclient_mock):
 
 async def test_name(hass, config_entry, aioclient_mock):
     """Test sensor name property."""
-    mock_connection(aioclient_mock)
     await setup_integration(hass, config_entry, aioclient_mock)
     await refresh_data(hass, config_entry, aioclient_mock)
     meter = hass.states.get(TEST_ENTITY_ID)
@@ -39,7 +37,6 @@ async def test_name(hass, config_entry, aioclient_mock):
 
 async def test_attributes(hass, config_entry, aioclient_mock):
     """Test meter attributes."""
-    mock_connection(aioclient_mock)
     await setup_integration(hass, config_entry, aioclient_mock)
     await refresh_data(hass, config_entry, aioclient_mock)
     meter = hass.states.get(TEST_ENTITY_ID)
@@ -51,7 +48,6 @@ async def test_attributes(hass, config_entry, aioclient_mock):
 
 async def test_generic_entity_update_service(hass, config_entry, aioclient_mock):
     """Test generic update entity service homeasasistant/update_entity."""
-    mock_connection(aioclient_mock)
     await setup_integration(hass, config_entry, aioclient_mock)
     await async_setup_component(hass, HA_DOMAIN, {})
     with patch("smart_meter_texas.Meter.read_meter") as updater:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes comments/changes requested from @MartinHjelmare in https://github.com/home-assistant/core/pull/37966

- Update a variable name to use underscores / snake case (PEP 8)
- In the config flow use the username as unique id to prevent a duplicate account from being setup
- Several tests needed to be updated to start the test with `hass.config_entries.async_setup`
- Updated the `test_api_timeout` test to use the proper state assertion

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/pull/37966
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
