### PR TITLE
Add Plex service to refresh a library

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -43,6 +43,7 @@ from .const import (
 )
 from .errors import ShouldUpdateConfigEntry
 from .server import PlexServer
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -53,6 +54,8 @@ async def async_setup(hass, config):
         PLEX_DOMAIN,
         {SERVERS: {}, DISPATCHERS: {}, WEBSOCKETS: {}, PLATFORMS_COMPLETED: {}},
     )
+
+    await async_setup_services(hass)
 
     return True
 

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -45,3 +45,4 @@ AUTOMATIC_SETUP_STRING = "Obtain a new token from plex.tv"
 MANUAL_SETUP_STRING = "Configure Plex server manually"
 
 SERVICE_PLAY_ON_SONOS = "play_on_sonos"
+SERVICE_REFRESH_LIBRARY = "refresh_library"

--- a/homeassistant/components/plex/services.py
+++ b/homeassistant/components/plex/services.py
@@ -1,0 +1,75 @@
+"""Services for the Plex integration."""
+import logging
+
+from plexapi.exceptions import NotFound
+import voluptuous as vol
+
+from .const import DOMAIN, SERVERS, SERVICE_REFRESH_LIBRARY
+
+REFRESH_LIBRARY_SCHEMA = vol.Schema(
+    {vol.Optional("server_name"): str, vol.Required("library_name"): str}
+)
+
+_LOGGER = logging.getLogger(__package__)
+
+
+async def async_setup_services(hass):
+    """Set up the Plex component."""
+
+    async def async_refresh_library_service(service_call):
+        await hass.async_add_executor_job(refresh_library, hass, service_call)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_LIBRARY,
+        async_refresh_library_service,
+        schema=REFRESH_LIBRARY_SCHEMA,
+    )
+
+    return True
+
+
+def refresh_library(hass, service_call):
+    """Scan a Plex library for new and updated media."""
+    plex_server_name = service_call.data.get("server_name")
+    library_name = service_call.data.get("library_name")
+
+    plex_server = get_plex_server(hass, plex_server_name)
+    if not plex_server:
+        return
+
+    try:
+        library = plex_server.library.section(title=library_name)
+    except NotFound:
+        _LOGGER.error(
+            "Library with name '%s' not found in %s",
+            library_name,
+            list(map(lambda x: x.title, plex_server.library.sections())),
+        )
+        return
+
+    _LOGGER.info("Scanning %s for new and updated media", library_name)
+    library.update()
+
+
+def get_plex_server(hass, plex_server_name=None):
+    """Retrieve a configured Plex server by name."""
+    plex_servers = hass.data[DOMAIN][SERVERS].values()
+
+    if plex_server_name:
+        plex_server = [x for x in plex_servers if x.friendly_name == plex_server_name]
+        if not plex_server:
+            _LOGGER.error(
+                "Requested Plex server '%s' not found in %s",
+                plex_server_name,
+                list(map(lambda x: x.friendly_name, plex_servers)),
+            )
+            return None
+    elif len(plex_servers) == 1:
+        return next(iter(plex_servers))
+
+    _LOGGER.error(
+        "Multiple Plex servers configured and no selection made: %s",
+        list(map(lambda x: x.friendly_name, plex_servers)),
+    )
+    return None

--- a/homeassistant/components/plex/services.py
+++ b/homeassistant/components/plex/services.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__package__)
 
 
 async def async_setup_services(hass):
-    """Set up the Plex component."""
+    """Set up services for the Plex component."""
 
     async def async_refresh_library_service(service_call):
         await hass.async_add_executor_job(refresh_library, hass, service_call)

--- a/homeassistant/components/plex/services.yaml
+++ b/homeassistant/components/plex/services.yaml
@@ -11,3 +11,13 @@ play_on_sonos:
     media_content_type:
       description: The type of content to play. Must be "music".
       example: "music"
+
+refresh_library:
+  description: Refresh a Plex library to scan for new and updated media.
+  fields:
+    server_name:
+      description: Name of a Plex server if multiple Plex servers configured.
+      example: "My Plex Server"
+    library_name:
+      description: Name of the Plex library to refresh.
+      example: "TV Shows"

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -121,11 +121,8 @@ class MockPlexServer:
 
         self._systemAccounts = list(map(MockPlexSystemAccount, range(num_users)))
 
-        self._library = None
-
         self._clients = []
         self._sessions = []
-        self._library = MockPlexLibrary()
         self.set_clients(num_users)
         self.set_sessions(num_users, session_type)
 

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -125,6 +125,7 @@ class MockPlexServer:
 
         self._clients = []
         self._sessions = []
+        self._library = MockPlexLibrary()
         self.set_clients(num_users)
         self.set_sessions(num_users, session_type)
 
@@ -399,6 +400,10 @@ class MockPlexLibrarySection:
     def key(self):
         """Mock the key identifier property."""
         return str(id(self.title))
+
+    def update(self):
+        """Mock the update call."""
+        pass
 
 
 class MockPlexMediaItem:

--- a/tests/components/plex/test_services.py
+++ b/tests/components/plex/test_services.py
@@ -1,0 +1,93 @@
+"""Tests for various Plex services."""
+from homeassistant.components.plex.const import (
+    CONF_SERVER,
+    CONF_SERVER_IDENTIFIER,
+    DOMAIN,
+    PLEX_SERVER_CONFIG,
+    SERVICE_REFRESH_LIBRARY,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TOKEN,
+    CONF_URL,
+    CONF_VERIFY_SSL,
+)
+
+from .const import DEFAULT_DATA, DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN
+from .mock_classes import MockPlexAccount, MockPlexLibrarySection, MockPlexServer
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_refresh_library(hass):
+    """Test refresh_library service call."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=DEFAULT_DATA,
+        options=DEFAULT_OPTIONS,
+        unique_id=DEFAULT_DATA["server_id"],
+    )
+
+    mock_plex_server = MockPlexServer(config_entry=entry)
+
+    with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket", autospec=True):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Test with non-existent server
+    with patch.object(MockPlexLibrarySection, "update") as mock_update:
+        assert await hass.services.async_call(
+            DOMAIN,
+            SERVICE_REFRESH_LIBRARY,
+            {"server_name": "Not a Server", "library_name": "Movies"},
+            True,
+        )
+        assert not mock_update.called
+
+    # Test with non-existent library
+    with patch.object(MockPlexLibrarySection, "update") as mock_update:
+        assert await hass.services.async_call(
+            DOMAIN, SERVICE_REFRESH_LIBRARY, {"library_name": "Not a Library"}, True,
+        )
+        assert not mock_update.called
+
+    # Test with valid library
+    with patch.object(MockPlexLibrarySection, "update") as mock_update:
+        assert await hass.services.async_call(
+            DOMAIN, SERVICE_REFRESH_LIBRARY, {"library_name": "Movies"}, True,
+        )
+        assert mock_update.called
+
+    # Add a second configured server
+    entry_2 = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SERVER: MOCK_SERVERS[1][CONF_SERVER],
+            PLEX_SERVER_CONFIG: {
+                CONF_TOKEN: MOCK_TOKEN,
+                CONF_URL: f"https://{MOCK_SERVERS[1][CONF_HOST]}:{MOCK_SERVERS[1][CONF_PORT]}",
+                CONF_VERIFY_SSL: True,
+            },
+            CONF_SERVER_IDENTIFIER: MOCK_SERVERS[1][CONF_SERVER_IDENTIFIER],
+        },
+    )
+
+    mock_plex_server_2 = MockPlexServer(config_entry=entry_2)
+    with patch("plexapi.server.PlexServer", return_value=mock_plex_server_2), patch(
+        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
+    ), patch("homeassistant.components.plex.PlexWebsocket", autospec=True):
+        entry_2.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry_2.entry_id)
+        await hass.async_block_till_done()
+
+    # Test multiple servers available but none specified
+    with patch.object(MockPlexLibrarySection, "update") as mock_update:
+        assert await hass.services.async_call(
+            DOMAIN, SERVICE_REFRESH_LIBRARY, {"library_name": "Movies"}, True,
+        )
+        assert not mock_update.called

--- a/tests/components/plex/test_services.py
+++ b/tests/components/plex/test_services.py
@@ -52,14 +52,20 @@ async def test_refresh_library(hass):
     # Test with non-existent library
     with patch.object(MockPlexLibrarySection, "update") as mock_update:
         assert await hass.services.async_call(
-            DOMAIN, SERVICE_REFRESH_LIBRARY, {"library_name": "Not a Library"}, True,
+            DOMAIN,
+            SERVICE_REFRESH_LIBRARY,
+            {"library_name": "Not a Library"},
+            True,
         )
         assert not mock_update.called
 
     # Test with valid library
     with patch.object(MockPlexLibrarySection, "update") as mock_update:
         assert await hass.services.async_call(
-            DOMAIN, SERVICE_REFRESH_LIBRARY, {"library_name": "Movies"}, True,
+            DOMAIN,
+            SERVICE_REFRESH_LIBRARY,
+            {"library_name": "Movies"},
+            True,
         )
         assert mock_update.called
 
@@ -88,6 +94,9 @@ async def test_refresh_library(hass):
     # Test multiple servers available but none specified
     with patch.object(MockPlexLibrarySection, "update") as mock_update:
         assert await hass.services.async_call(
-            DOMAIN, SERVICE_REFRESH_LIBRARY, {"library_name": "Movies"}, True,
+            DOMAIN,
+            SERVICE_REFRESH_LIBRARY,
+            {"library_name": "Movies"},
+            True,
         )
         assert not mock_update.called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new service to trigger a library refresh on the Plex server(s). Updated tests to work with new library calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14349

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
