### PR TITLE
Fix for exception when checking if fan without speed is on

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import voluptuous as vol
 
-from homeassistant.const import SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -50,7 +50,9 @@ ATTR_DIRECTION = "direction"
 def is_on(hass, entity_id: str) -> bool:
     """Return if the fans are on based on the statemachine."""
     state = hass.states.get(entity_id)
-    return state.attributes[ATTR_SPEED] not in [SPEED_OFF, None]
+    if ATTR_SPEED in state.attributes:
+        return state.attributes[ATTR_SPEED] not in [SPEED_OFF, None]
+    return state.state == STATE_ON
 
 
 async def async_setup(hass, config: dict):

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -6,7 +6,12 @@ from typing import Optional
 
 import voluptuous as vol
 
-from homeassistant.const import SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON
+from homeassistant.const import (
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -22,6 +22,8 @@ from homeassistant.const import (
     CONF_PAYLOAD_ON,
     CONF_STATE,
     CONF_UNIQUE_ID,
+    STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -106,7 +108,7 @@ PLATFORM_SCHEMA = (
     .extend(mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 )
 
-
+ 
 async def async_setup_platform(
     hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
 ):
@@ -153,7 +155,7 @@ class MqttFan(
     def __init__(self, config, config_entry, discovery_data):
         """Initialize the MQTT fan."""
         self._unique_id = config.get(CONF_UNIQUE_ID)
-        self._state = False
+        self._state = STATE_OFF
         self._speed = None
         self._oscillation = None
         self._supported_features = 0
@@ -255,9 +257,9 @@ class MqttFan(
             """Handle new received MQTT message."""
             payload = templates[CONF_STATE](msg.payload)
             if payload == self._payload["STATE_ON"]:
-                self._state = True
+                self._state = STATE_ON
             elif payload == self._payload["STATE_OFF"]:
-                self._state = False
+                self._state = STATE_OFF
             self.async_write_ha_state()
 
         if self._topic[CONF_STATE_TOPIC] is not None:
@@ -335,7 +337,7 @@ class MqttFan(
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state
+        return self._state == STATE_ON
 
     @property
     def name(self) -> str:
@@ -377,7 +379,7 @@ class MqttFan(
         if speed:
             await self.async_set_speed(speed)
         if self._optimistic:
-            self._state = True
+            self._state = STATE_ON
             self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -393,7 +395,7 @@ class MqttFan(
             self._config[CONF_RETAIN],
         )
         if self._optimistic:
-            self._state = False
+            self._state = STATE_OFF
             self.async_write_ha_state()
 
     async def async_set_speed(self, speed: str) -> None:

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -108,7 +108,7 @@ PLATFORM_SCHEMA = (
     .extend(mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 )
 
- 
+
 async def async_setup_platform(
     hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `is_on` function was generating an exception for fans without a speed such as an MQTT fan

This change updates that to first check if there's a speed attribute and if it can't find one it uses the state instead.

The MQTT fan component has also been standardized from using a boolean state to using STATE_ON/STATE_OFF

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
