### PR TITLE
Bump isort to v5.4.2, pylint to v2.6.0 and use isort main repo as pre-commit hook source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
           - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script|tests)/.+\.py$
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.3.2
+    rev: 5.4.2
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,8 @@ repos:
           - --format=custom
           - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script|tests)/.+\.py$
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.3.2
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -195,7 +195,7 @@ def closefds_osx(min_fd: int, max_fd: int) -> None:
     get rid of.
     """
     # pylint: disable=import-outside-toplevel
-    from fcntl import fcntl, F_GETFD, F_SETFD, FD_CLOEXEC
+    from fcntl import F_GETFD, F_SETFD, FD_CLOEXEC, fcntl
 
     for _fd in range(min_fd, max_fd):
         try:

--- a/homeassistant/auth/permissions/models.py
+++ b/homeassistant/auth/permissions/models.py
@@ -5,8 +5,10 @@ import attr
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from homeassistant.helpers import entity_registry as ent_reg  # noqa: F401
-    from homeassistant.helpers import device_registry as dev_reg  # noqa: F401
+    from homeassistant.helpers import (  # noqa: F401
+        device_registry as dev_reg,
+        entity_registry as ent_reg,
+    )
 
 
 @attr.s(slots=True)

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -562,6 +562,7 @@ class HomeKit:
             type_cameras,
             type_covers,
             type_fans,
+            type_humidifiers,
             type_lights,
             type_locks,
             type_media_players,
@@ -569,7 +570,6 @@ class HomeKit:
             type_sensors,
             type_switches,
             type_thermostats,
-            type_humidifiers,
         )
 
         for state in bridged_states:

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -30,8 +30,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 
-# see https://github.com/PyCQA/pylint/issues/3202 about the DOMAIN's pylint issue
 from .const import CONNECTION_TIMEOUT, DEFAULT_DEVICE_NAME, DEFAULT_NOTIFY_SERVICE_NAME
+# see https://github.com/PyCQA/pylint/issues/3202 about the DOMAIN's pylint issue
 from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 
 from .const import CONNECTION_TIMEOUT, DEFAULT_DEVICE_NAME, DEFAULT_NOTIFY_SERVICE_NAME
+
 # see https://github.com/PyCQA/pylint/issues/3202 about the DOMAIN's pylint issue
 from .const import DOMAIN  # pylint: disable=unused-import
 

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -27,8 +27,8 @@ from . import (
 
 # pylint: disable=ungrouped-imports
 if TYPE_CHECKING:
-    from aioswitcher.devices import SwitcherV2Device
     from aioswitcher.api.messages import SwitcherV2ControlResponseMSG
+    from aioswitcher.devices import SwitcherV2Device
 
 
 _LOGGER = getLogger(__name__)

--- a/homeassistant/components/tensorflow/image_processing.py
+++ b/homeassistant/components/tensorflow/image_processing.py
@@ -125,8 +125,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         # (The model_dir is created during the manual setup process. See integration docs.)
 
         # pylint: disable=import-outside-toplevel
-        from object_detection.utils import config_util, label_map_util
         from object_detection.builders import model_builder
+        from object_detection.utils import config_util, label_map_util
     except ImportError:
         _LOGGER.error(
             "No TensorFlow Object Detection library found! Install or compile "

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -26,13 +26,13 @@ ZigpyGroupType = zigpy.group.Group
 ZigpyZdoType = zigpy.zdo.ZDO
 
 if TYPE_CHECKING:
+    import homeassistant.components.zha.core.channels
     import homeassistant.components.zha.core.channels as channels
     import homeassistant.components.zha.core.channels.base as base_channels
     import homeassistant.components.zha.core.device
     import homeassistant.components.zha.core.gateway
     import homeassistant.components.zha.core.group
     import homeassistant.components.zha.entity
-    import homeassistant.components.zha.core.channels
 
     ChannelType = base_channels.ZigbeeChannel
     ChannelsType = channels.Channels

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -335,12 +335,11 @@ async def async_setup_entry(hass, config_entry):
 
     Will automatically load components to support devices found on the network.
     """
-    from pydispatch import dispatcher
-
+    from openzwave.group import ZWaveGroup
+    from openzwave.network import ZWaveNetwork
     # pylint: disable=import-error
     from openzwave.option import ZWaveOption
-    from openzwave.network import ZWaveNetwork
-    from openzwave.group import ZWaveGroup
+    from pydispatch import dispatcher
 
     # Merge config entry and yaml config
     config = config_entry.data

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -337,6 +337,7 @@ async def async_setup_entry(hass, config_entry):
     """
     from openzwave.group import ZWaveGroup
     from openzwave.network import ZWaveNetwork
+
     # pylint: disable=import-error
     from openzwave.option import ZWaveOption
     from pydispatch import dispatcher

--- a/homeassistant/components/zwave/config_flow.py
+++ b/homeassistant/components/zwave/config_flow.py
@@ -43,8 +43,8 @@ class ZwaveFlowHandler(config_entries.ConfigFlow):
 
         if user_input is not None:
             # Check if USB path is valid
-            from openzwave.option import ZWaveOption
             from openzwave.object import ZWaveException
+            from openzwave.option import ZWaveOption
 
             try:
                 from functools import partial

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -81,8 +81,8 @@ from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitS
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:
     from homeassistant.auth import AuthManager
-    from homeassistant.config_entries import ConfigEntries
     from homeassistant.components.http import HomeAssistantHTTP
+    from homeassistant.config_entries import ConfigEntries
 
 
 block_async_io.enable()

--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -27,7 +27,6 @@ def run(args):
     parser.add_argument("name", help="Name of the secret", nargs="?", default=None)
 
     import keyring  # pylint: disable=import-outside-toplevel
-
     # pylint: disable=import-outside-toplevel
     from keyring.util import platform_ as platform
 

--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -27,6 +27,7 @@ def run(args):
     parser.add_argument("name", help="Name of the secret", nargs="?", default=None)
 
     import keyring  # pylint: disable=import-outside-toplevel
+
     # pylint: disable=import-outside-toplevel
     from keyring.util import platform_ as platform
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,7 +10,7 @@ coverage==5.2.1
 mock-open==1.4.0
 mypy==0.780
 pre-commit==2.6.0
-pylint==2.4.4
+pylint==2.6.0
 astroid==2.3.3
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -5,7 +5,7 @@ black==19.10b0
 codespell==1.17.1
 flake8-docstrings==1.5.0
 flake8==3.8.3
-isort==5.3.2
+isort==5.4.2
 pydocstyle==5.0.2
 pyupgrade==2.7.2
 yamllint==1.24.2

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -5,7 +5,7 @@ black==19.10b0
 codespell==1.17.1
 flake8-docstrings==1.5.0
 flake8==3.8.3
-isort==4.3.21
+isort==5.3.2
 pydocstyle==5.0.2
 pyupgrade==2.7.2
 yamllint==1.24.2

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -8,9 +8,8 @@ import pkgutil
 import re
 import sys
 
-from script.hassfest.model import Integration
-
 from homeassistant.util.yaml.loader import load_yaml
+from script.hassfest.model import Integration
 
 COMMENT_REQUIREMENTS = (
     "Adafruit_BBIO",

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -6,12 +6,12 @@ import logging
 import re
 from typing import Dict
 
-from script.translations import upload
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import slugify
+from script.translations import upload
 
 from .model import Config, Integration
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,6 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 indent = "    "
-# by default isort don't check module indexes
-not_skip = __init__.py
 # will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
 sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,20 +38,14 @@ ignore =
 [isort]
 # https://github.com/timothycrosley/isort
 # https://github.com/timothycrosley/isort/wiki/isort-Settings
-# splits long import on multiple lines indented by 4 spaces
-multi_line_output = 3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-indent = "    "
+# make isort compatible with black
+profile = black
 # will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
-sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-default_section = THIRDPARTY
 known_first_party = homeassistant,tests
 forced_separate = tests
 combine_as_imports = true
+honor_noqa = true
 
 [mypy]
 python_version = 3.7

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -3,6 +3,6 @@ import sys
 
 if sys.version_info[:2] < (3, 8):
     from asynctest.mock import *  # noqa
-    from asynctest.mock import CoroutineMock as AsyncMock
+    from asynctest.mock import CoroutineMock as AsyncMock  # noqa
 else:
     from unittest.mock import *  # noqa

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -3,6 +3,6 @@ import sys
 
 if sys.version_info[:2] < (3, 8):
     from asynctest.mock import *  # noqa
-    from asynctest.mock import CoroutineMock as AsyncMock  # noqa
+    from asynctest.mock import CoroutineMock as AsyncMock
 else:
     from unittest.mock import *  # noqa

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,8 +14,6 @@ import threading
 import time
 import uuid
 
-from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa
-
 from homeassistant import auth, config_entries, core as ha, loader
 from homeassistant.auth import (
     auth_store,
@@ -61,6 +59,10 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 import homeassistant.util.yaml.loader as yaml_loader
 
 from tests.async_mock import AsyncMock, Mock, patch
+
+from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa
+
+
 
 _LOGGER = logging.getLogger(__name__)
 INSTANCES = []

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -153,8 +153,8 @@ async def test_v4_meter(hass, mock_connection_factory):
     (connection_factory, transport, protocol) = mock_connection_factory
 
     from dsmr_parser.obis_references import (
-        HOURLY_GAS_METER_READING,
         ELECTRICITY_ACTIVE_TARIFF,
+        HOURLY_GAS_METER_READING,
     )
     from dsmr_parser.objects import CosemObject, MBusObject
 
@@ -198,8 +198,8 @@ async def test_v5_meter(hass, mock_connection_factory):
     (connection_factory, transport, protocol) = mock_connection_factory
 
     from dsmr_parser.obis_references import (
-        HOURLY_GAS_METER_READING,
         ELECTRICITY_ACTIVE_TARIFF,
+        HOURLY_GAS_METER_READING,
     )
     from dsmr_parser.objects import CosemObject, MBusObject
 

--- a/tests/components/mobile_app/test_http_api.py
+++ b/tests/components/mobile_app/test_http_api.py
@@ -59,8 +59,8 @@ async def test_registration(hass, hass_client, hass_admin_user):
 async def test_registration_encryption(hass, hass_client):
     """Test that registrations happen."""
     try:
-        from nacl.secret import SecretBox
         from nacl.encoding import Base64Encoder
+        from nacl.secret import SecretBox
     except (ImportError, OSError):
         pytest.skip("libnacl/libsodium is not installed")
         return

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -22,8 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 def encrypt_payload(secret_key, payload):
     """Return a encrypted payload given a key and dictionary of data."""
     try:
-        from nacl.secret import SecretBox
         from nacl.encoding import Base64Encoder
+        from nacl.secret import SecretBox
     except (ImportError, OSError):
         pytest.skip("libnacl/libsodium is not installed")
         return
@@ -45,8 +45,8 @@ def encrypt_payload(secret_key, payload):
 def decrypt_payload(secret_key, encrypted_data):
     """Return a decrypted payload given a key and a string of encrypted data."""
     try:
-        from nacl.secret import SecretBox
         from nacl.encoding import Base64Encoder
+        from nacl.secret import SecretBox
     except (ImportError, OSError):
         pytest.skip("libnacl/libsodium is not installed")
         return

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -1318,12 +1318,12 @@ def generate_ciphers(secret):
     # PyNaCl ciphertext generation will fail if the module
     # cannot be imported. However, the test for decryption
     # also relies on this library and won't be run without it.
-    import pickle
     import base64
+    import pickle
 
     try:
-        from nacl.secret import SecretBox
         from nacl.encoding import Base64Encoder
+        from nacl.secret import SecretBox
 
         keylen = SecretBox.KEY_SIZE
         key = secret.encode("utf-8")
@@ -1369,8 +1369,8 @@ def mock_cipher():
 
     def mock_decrypt(ciphertext, key):
         """Decrypt/unpickle."""
-        import pickle
         import base64
+        import pickle
 
         (mkey, plaintext) = pickle.loads(base64.b64decode(ciphertext))
         if key != mkey:

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -337,6 +337,7 @@ async def test_race_condition(hass, monkeypatch):
 async def test_not_connected(hass, monkeypatch):
     """Test Error when sending commands to a disconnected device."""
     import pytest
+
     from homeassistant.core import HomeAssistantError
 
     test_device = RflinkCommand("DUMMY_DEVICE")

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -39,8 +39,9 @@ from .consts import (
 from tests.common import async_fire_time_changed, async_mock_service
 
 if TYPE_CHECKING:
-    from tests.common import MockUser
     from aioswitcher.devices import SwitcherV2Device
+
+    from tests.common import MockUser
 
 
 async def test_failed_config(

--- a/tests/hassfest/test_dependencies.py
+++ b/tests/hassfest/test_dependencies.py
@@ -2,6 +2,7 @@
 import ast
 
 import pytest
+
 from script.hassfest.dependencies import ImportCollector
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update isort and hook source because https://github.com/pre-commit/mirrors-isort/pull/13.

Revamped #38632 because pylint is now compatible with isort 5.

Pylint changes: https://github.com/PyCQA/pylint/compare/pylint-2.6.0...pylint-2.4.4
isort changes from v4.3.21 to v5.4.2: [commits](https://github.com/timothycrosley/isort/compare/4.3.21...5.4.2) and [release notes](https://github.com/timothycrosley/isort/releases)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
