### PR TITLE
Tweak OZW Websocket Instance/Network Responses

### DIFF
--- a/homeassistant/components/ozw/websocket_api.py
+++ b/homeassistant/components/ozw/websocket_api.py
@@ -36,7 +36,7 @@ def websocket_get_instances(hass, connection, msg):
     instances = []
 
     for instance in manager.collections["instance"]:
-        instances.append(dict(instance.get_status().data, OZW_INSTANCE=instance.id))
+        instances.append(dict(instance.get_status().data, ozw_instance=instance.id))
 
     connection.send_result(
         msg[ID], instances,
@@ -53,9 +53,9 @@ def websocket_network_status(hass, connection, msg):
     """Get Z-Wave network status."""
 
     manager = hass.data[DOMAIN][MANAGER]
-    status = manager.get_instance(msg[OZW_INSTANCE]).get_status().status
+    status = manager.get_instance(msg[OZW_INSTANCE]).get_status().data
     connection.send_result(
-        msg[ID], {dict(status, OZW_INSTANCE=msg[OZW_INSTANCE])},
+        msg[ID], dict(status, ozw_instance=msg[OZW_INSTANCE]),
     )
 
 

--- a/homeassistant/components/ozw/websocket_api.py
+++ b/homeassistant/components/ozw/websocket_api.py
@@ -36,7 +36,7 @@ def websocket_get_instances(hass, connection, msg):
     instances = []
 
     for instance in manager.collections["instance"]:
-        instances.append(dict(instance.get_status().data, id=instance.id))
+        instances.append(dict(instance.get_status().data, OZW_INSTANCE=instance.id))
 
     connection.send_result(
         msg[ID], instances,
@@ -53,12 +53,9 @@ def websocket_network_status(hass, connection, msg):
     """Get Z-Wave network status."""
 
     manager = hass.data[DOMAIN][MANAGER]
+    status = manager.get_instance(msg[OZW_INSTANCE]).get_status().status
     connection.send_result(
-        msg[ID],
-        {
-            "state": manager.get_instance(msg[OZW_INSTANCE]).get_status().status,
-            OZW_INSTANCE: msg[OZW_INSTANCE],
-        },
+        msg[ID], {dict(status, OZW_INSTANCE=msg[OZW_INSTANCE])},
     )
 
 

--- a/tests/components/ozw/test_websocket_api.py
+++ b/tests/components/ozw/test_websocket_api.py
@@ -17,7 +17,7 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     msg = await client.receive_json()
     assert len(msg["result"]) == 1
     result = msg["result"][0]
-    assert result["id"] == 1
+    assert result[OZW_INSTANCE] == 1
     assert result["Status"] == "driverAllNodesQueried"
     assert result["OpenZWave_Version"] == "1.6.1008"
 
@@ -26,7 +26,7 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     msg = await client.receive_json()
     result = msg["result"]
 
-    assert result["state"] == "driverAllNodesQueried"
+    assert result["Status"] == "driverAllNodesQueried"
     assert result[OZW_INSTANCE] == 1
 
     # Test node status


### PR DESCRIPTION
## Proposed change
This tweaks the output of the OZW `get_network_status` and `get_instances` websocket responses, namely making the instance ID be the same `OZW_INSTANCE` constant for each.

These websocket commands are not actively used by the frontend yet. Frontend PRs that will use them are still in progress.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.