### PR TITLE
Add websocket trigger/condition commands

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -377,7 +377,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         else:
             await self.async_disable()
 
-    async def async_trigger(self, variables, skip_condition=False, context=None):
+    async def async_trigger(self, variables, context=None, skip_condition=False):
         """Trigger automation.
 
         This method is a coroutine.

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -47,10 +47,9 @@ async def async_attach_trigger(
                 return
 
         hass.async_run_job(
-            action(
-                {"trigger": {"platform": platform_type, "event": event}},
-                context=event.context,
-            )
+            action,
+            {"trigger": {"platform": platform_type, "event": event}},
+            event.context,
         )
 
     return hass.bus.async_listen(event_type, handle_event)

--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -30,10 +30,9 @@ async def async_attach_trigger(hass, config, action, automation_info):
         def hass_shutdown(event):
             """Execute when Home Assistant is shutting down."""
             hass.async_run_job(
-                action(
-                    {"trigger": {"platform": "homeassistant", "event": event}},
-                    context=event.context,
-                )
+                action,
+                {"trigger": {"platform": "homeassistant", "event": event}},
+                event.context,
             )
 
         return hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, hass_shutdown)

--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -103,6 +103,7 @@ async def async_attach_trigger(
         def call_action():
             """Call action with right context."""
             hass.async_run_job(
+                action,
                 {
                     "trigger": {
                         "platform": platform_type,

--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -103,20 +103,18 @@ async def async_attach_trigger(
         def call_action():
             """Call action with right context."""
             hass.async_run_job(
-                action(
-                    {
-                        "trigger": {
-                            "platform": platform_type,
-                            "entity_id": entity,
-                            "below": below,
-                            "above": above,
-                            "from_state": from_s,
-                            "to_state": to_s,
-                            "for": time_delta if not time_delta else period[entity],
-                        }
-                    },
-                    context=to_s.context,
-                )
+                {
+                    "trigger": {
+                        "platform": platform_type,
+                        "entity_id": entity,
+                        "below": below,
+                        "above": above,
+                        "from_state": from_s,
+                        "to_state": to_s,
+                        "for": time_delta if not time_delta else period[entity],
+                    }
+                },
+                to_s.context,
             )
 
         matching = check_numeric_state(entity, from_s, to_s)

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -83,6 +83,7 @@ async def async_attach_trigger(
         def call_action():
             """Call action with right context."""
             hass.async_run_job(
+                action,
                 {
                     "trigger": {
                         "platform": platform_type,

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -83,18 +83,16 @@ async def async_attach_trigger(
         def call_action():
             """Call action with right context."""
             hass.async_run_job(
-                action(
-                    {
-                        "trigger": {
-                            "platform": platform_type,
-                            "entity_id": entity,
-                            "from_state": from_s,
-                            "to_state": to_s,
-                            "for": time_delta if not time_delta else period[entity],
-                        }
-                    },
-                    context=event.context,
-                )
+                {
+                    "trigger": {
+                        "platform": platform_type,
+                        "entity_id": entity,
+                        "from_state": from_s,
+                        "to_state": to_s,
+                        "for": time_delta if not time_delta else period[entity],
+                    }
+                },
+                event.context,
             )
 
         if not time_delta:

--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -54,18 +54,17 @@ async def async_attach_trigger(
         def call_action(*_):
             """Call action with right context."""
             hass.async_run_job(
-                action(
-                    {
-                        "trigger": {
-                            "platform": "template",
-                            "entity_id": entity_id,
-                            "from_state": from_s,
-                            "to_state": to_s,
-                            "for": time_delta if not time_delta else period,
-                        }
-                    },
-                    context=(to_s.context if to_s else None),
-                )
+                action,
+                {
+                    "trigger": {
+                        "platform": "template",
+                        "entity_id": entity_id,
+                        "from_state": from_s,
+                        "to_state": to_s,
+                        "for": time_delta if not time_delta else period,
+                    }
+                },
+                (to_s.context if to_s else None),
             )
 
         if not time_delta:

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import (
     TemplateError,
     Unauthorized,
 )
-from homeassistant.helpers import config_validation as cv, entity, typing
+from homeassistant.helpers import config_validation as cv, entity
 from homeassistant.helpers.event import async_track_template_result
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.loader import IntegrationNotFound, async_get_integration
@@ -324,7 +324,7 @@ def handle_entity_source(hass, connection, msg):
     {
         vol.Required("type"): "subscribe_trigger",
         vol.Required("trigger"): cv.TRIGGER_SCHEMA,
-        vol.Optional("variables"): typing.TemplateVarsType,
+        vol.Optional("variables"): dict,
     }
 )
 @decorators.require_admin
@@ -368,7 +368,7 @@ async def handle_subscribe_trigger(hass, connection, msg):
     {
         vol.Required("type"): "test_condition",
         vol.Required("condition"): cv.CONDITION_SCHEMA,
-        vol.Optional("variables"): typing.TemplateVarsType,
+        vol.Optional("variables"): dict,
     }
 )
 @decorators.require_admin

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import (
     TemplateError,
     Unauthorized,
 )
-from homeassistant.helpers import config_validation as cv, entity
+from homeassistant.helpers import config_validation as cv, entity, typing
 from homeassistant.helpers.event import async_track_template_result
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.loader import IntegrationNotFound, async_get_integration
@@ -40,6 +40,8 @@ def async_register_commands(hass, async_reg):
     async_reg(hass, handle_manifest_list)
     async_reg(hass, handle_manifest_get)
     async_reg(hass, handle_entity_source)
+    async_reg(hass, handle_subscribe_trigger)
+    async_reg(hass, handle_test_condition)
 
 
 def pong_message(iden):
@@ -315,3 +317,69 @@ def handle_entity_source(hass, connection, msg):
         sources[entity_id] = source
 
     connection.send_result(msg["id"], sources)
+
+
+@callback
+@decorators.websocket_command(
+    {
+        vol.Required("type"): "subscribe_trigger",
+        vol.Required("trigger"): cv.TRIGGER_SCHEMA,
+        vol.Optional("variables"): typing.TemplateVarsType,
+    }
+)
+@decorators.require_admin
+@decorators.async_response
+async def handle_subscribe_trigger(hass, connection, msg):
+    """Handle subscribe trigger command."""
+    # Circular dep
+    # pylint: disable=import-outside-toplevel
+    from homeassistant.helpers import trigger
+
+    trigger_config = await trigger.async_validate_trigger_config(hass, msg["trigger"])
+
+    @callback
+    def forward_triggers(variables, context=None):
+        """Forward events to websocket."""
+        connection.send_message(
+            messages.event_message(
+                msg["id"], {"variables": variables, "context": context}
+            )
+        )
+
+    connection.subscriptions[msg["id"]] = (
+        await trigger.async_initialize_triggers(
+            hass,
+            trigger_config,
+            forward_triggers,
+            const.DOMAIN,
+            const.DOMAIN,
+            connection.logger.log,
+            variables=msg.get("variables"),
+        )
+    ) or (
+        # Some triggers won't return an unsub function. Since the caller expects
+        # a subscription, we're going to fake one.
+        lambda: None
+    )
+    connection.send_result(msg["id"])
+
+
+@decorators.websocket_command(
+    {
+        vol.Required("type"): "test_condition",
+        vol.Required("condition"): cv.CONDITION_SCHEMA,
+        vol.Optional("variables"): typing.TemplateVarsType,
+    }
+)
+@decorators.require_admin
+@decorators.async_response
+async def handle_test_condition(hass, connection, msg):
+    """Handle test condition command."""
+    # Circular dep
+    # pylint: disable=import-outside-toplevel
+    from homeassistant.helpers import condition
+
+    check_condition = await condition.async_from_config(hass, msg["condition"])
+    connection.send_result(
+        msg["id"], {"result": check_condition(hass, msg.get("variables"))}
+    )

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -57,19 +57,18 @@ async def async_attach_trigger(hass, config, action, automation_info):
             and not to_match
         ):
             hass.async_run_job(
-                action(
-                    {
-                        "trigger": {
-                            "platform": "zone",
-                            "entity_id": entity,
-                            "from_state": from_s,
-                            "to_state": to_s,
-                            "zone": zone_state,
-                            "event": event,
-                        }
-                    },
-                    context=to_s.context,
-                )
+                action,
+                {
+                    "trigger": {
+                        "platform": "zone",
+                        "entity_id": entity,
+                        "from_state": from_s,
+                        "to_state": to_s,
+                        "zone": zone_state,
+                        "event": event,
+                    }
+                },
+                to_s.context,
             )
 
     return async_track_state_change_event(hass, entity_id, zone_automation_listener)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -303,6 +303,9 @@ class HomeAssistant:
         target: target to call.
         args: parameters for method to call.
         """
+        if target is None:
+            raise ValueError("Don't call async_add_job with None")
+
         task = None
 
         # Check for partials to properly determine if coroutine function

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -665,6 +665,7 @@ async def test_subscribe_trigger(hass, websocket_client):
             "id": 5,
             "type": "subscribe_trigger",
             "trigger": {"platform": "event", "event_type": "test_event"},
+            "variables": {"hello": "world"},
         }
     )
 
@@ -722,6 +723,7 @@ async def test_test_condition(hass, websocket_client):
                 "entity_id": "hello.world",
                 "state": "paulus",
             },
+            "variables": {"hello": "world"},
         }
     )
 

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -8,7 +8,7 @@ from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH_REQUIRED,
 )
 from homeassistant.components.websocket_api.const import URL
-from homeassistant.core import callback
+from homeassistant.core import Context, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity
 from homeassistant.loader import async_get_integration
@@ -654,3 +654,79 @@ async def test_entity_source_admin(hass, websocket_client, hass_admin_user):
     assert msg["type"] == const.TYPE_RESULT
     assert not msg["success"]
     assert msg["error"]["code"] == const.ERR_UNAUTHORIZED
+
+
+async def test_subscribe_trigger(hass, websocket_client):
+    """Test subscribing to a trigger."""
+    init_count = sum(hass.bus.async_listeners().values())
+
+    await websocket_client.send_json(
+        {
+            "id": 5,
+            "type": "subscribe_trigger",
+            "trigger": {"platform": "event", "event_type": "test_event"},
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    # Verify we have a new listener
+    assert sum(hass.bus.async_listeners().values()) == init_count + 1
+
+    context = Context()
+
+    hass.bus.async_fire("ignore_event")
+    hass.bus.async_fire("test_event", {"hello": "world"}, context=context)
+    hass.bus.async_fire("ignore_event")
+
+    with timeout(3):
+        msg = await websocket_client.receive_json()
+
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    assert msg["event"]["context"]["id"] == context.id
+    assert msg["event"]["variables"]["trigger"]["platform"] == "event"
+
+    event = msg["event"]["variables"]["trigger"]["event"]
+
+    assert event["event_type"] == "test_event"
+    assert event["data"] == {"hello": "world"}
+    assert event["origin"] == "LOCAL"
+
+    await websocket_client.send_json(
+        {"id": 6, "type": "unsubscribe_events", "subscription": 5}
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 6
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    # Check our listener got unsubscribed
+    assert sum(hass.bus.async_listeners().values()) == init_count
+
+
+async def test_test_condition(hass, websocket_client):
+    """Test testing a condition."""
+    hass.states.async_set("hello.world", "paulus")
+
+    await websocket_client.send_json(
+        {
+            "id": 5,
+            "type": "test_condition",
+            "condition": {
+                "condition": "state",
+                "entity_id": "hello.world",
+                "state": "paulus",
+            },
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+    assert msg["result"]["result"] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add two websocket commands:
 - `subscribe_trigger` will subscribe to a trigger config and forward variables/context when they happen. We can use this to show in automation editor when triggers are happening.
 - `test_condition` will test if a condition config is valid. We can use this in the automation editor to show if the current configured conditions would currently pass or not.

I realized that some triggers were expecting the action to be an awaitable. I have changed this assumption.

I also added a check to `async_add_job` to make sure that `target` is not None.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
