### PR TITLE
Implement config and option flow for rfxtrx integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -355,7 +355,7 @@ homeassistant/components/rainmachine/* @bachya
 homeassistant/components/random/* @fabaff
 homeassistant/components/rejseplanen/* @DarkFox
 homeassistant/components/repetier/* @MTrab
-homeassistant/components/rfxtrx/* @danielhiversen @elupus
+homeassistant/components/rfxtrx/* @danielhiversen @elupus @RobBie1221
 homeassistant/components/ring/* @balloob
 homeassistant/components/risco/* @OnFreund
 homeassistant/components/rmvtransport/* @cgtobi

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -38,6 +38,13 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     ATTR_EVENT,
+    CONF_AUTOMATIC_ADD,
+    CONF_DATA_BITS,
+    CONF_DEBUG,
+    CONF_FIRE_EVENT,
+    CONF_OFF_DELAY,
+    CONF_REMOVE_DEVICE,
+    CONF_SIGNAL_REPETITIONS,
     DEVICE_PACKET_TYPE_LIGHTING4,
     EVENT_RFXTRX_EVENT,
     SERVICE_SEND,
@@ -47,12 +54,6 @@ DOMAIN = "rfxtrx"
 
 DEFAULT_SIGNAL_REPETITIONS = 1
 
-CONF_FIRE_EVENT = "fire_event"
-CONF_DATA_BITS = "data_bits"
-CONF_AUTOMATIC_ADD = "automatic_add"
-CONF_SIGNAL_REPETITIONS = "signal_repetitions"
-CONF_DEBUG = "debug"
-CONF_OFF_DELAY = "off_delay"
 SIGNAL_EVENT = f"{DOMAIN}_event"
 
 DATA_TYPES = OrderedDict(
@@ -441,6 +442,12 @@ class RfxtrxEntity(RestoreEntity):
         self.async_on_remove(
             self.hass.helpers.dispatcher.async_dispatcher_connect(
                 SIGNAL_EVENT, self._handle_event
+            )
+        )
+
+        self.async_on_remove(
+            self.hass.helpers.dispatcher.async_dispatcher_connect(
+                f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{self._device_id}", self.async_remove
             )
         )
 

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -61,6 +61,18 @@ DEVICE_TYPE_DEVICE_CLASS = {
 }
 
 
+def supported(event):
+    """Return whether an event supports binary_sensor."""
+    if isinstance(event, rfxtrxmod.ControlEvent):
+        return True
+    if isinstance(event, rfxtrxmod.SensorEvent):
+        return event.values.get("Sensor Status") in [
+            *SENSOR_STATUS_ON,
+            *SENSOR_STATUS_OFF,
+        ]
+    return False
+
+
 async def async_setup_entry(
     hass,
     config_entry,
@@ -73,16 +85,6 @@ async def async_setup_entry(
     pt2262_devices = []
 
     discovery_info = config_entry.data
-
-    def supported(event):
-        if isinstance(event, rfxtrxmod.ControlEvent):
-            return True
-        if isinstance(event, rfxtrxmod.SensorEvent):
-            return event.values.get("Sensor Status") in [
-                *SENSOR_STATUS_ON,
-                *SENSOR_STATUS_OFF,
-            ]
-        return False
 
     for packet_id, entity_info in discovery_info[CONF_DEVICES].items():
         event = get_rfx_object(packet_id)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -412,6 +412,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured(import_config)
             else:
                 self._abort_if_unique_id_configured()
+
+        host = import_config[CONF_HOST]
+        port = import_config[CONF_PORT]
+        device = import_config[CONF_DEVICE]
+
+        try:
+            if host is not None:
+                await self.async_validate_rfx(host=host, port=port)
+            else:
+                await self.async_validate_rfx(device=device)
+        except CannotConnect:
+            return self.async_abort(reason="cannot_connect")
+
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -36,7 +36,6 @@ from .binary_sensor import supported as binary_supported
 from .const import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
-    CONF_DEBUG,
     CONF_FIRE_EVENT,
     CONF_OFF_DELAY,
     CONF_REMOVE_DEVICE,
@@ -85,7 +84,6 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         if user_input is not None:
             self._global_options = {
-                CONF_DEBUG: user_input[CONF_DEBUG],
                 CONF_AUTOMATIC_ADD: user_input[CONF_AUTOMATIC_ADD],
             }
             if CONF_DEVICE in user_input:
@@ -148,7 +146,6 @@ class OptionsFlow(config_entries.OptionsFlow):
         }
 
         options = {
-            vol.Optional(CONF_DEBUG, default=self._config_entry.data[CONF_DEBUG]): bool,
             vol.Optional(
                 CONF_AUTOMATIC_ADD,
                 default=self._config_entry.data[CONF_AUTOMATIC_ADD],
@@ -535,7 +532,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_PORT: port,
             CONF_DEVICE: device,
             CONF_AUTOMATIC_ADD: False,
-            CONF_DEBUG: False,
             CONF_DEVICES: {},
         }
         return data

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -1,9 +1,13 @@
 """Config flow for RFXCOM RFXtrx integration."""
 import logging
+import os
 
+import RFXtrx as rfxtrxmod
+import serial
+import serial.tools.list_ports
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant import config_entries, exceptions
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_COMMAND_OFF,
@@ -11,6 +15,9 @@ from homeassistant.const import (
     CONF_DEVICE,
     CONF_DEVICE_ID,
     CONF_DEVICES,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TYPE,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import (
@@ -37,6 +44,7 @@ from .switch import supported as switch_supported
 _LOGGER = logging.getLogger(__name__)
 
 CONF_EVENT_CODE = "event_code"
+CONF_MANUAL_PATH = "Enter Manually"
 
 
 def none_or_int(value, base):
@@ -293,14 +301,166 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
+    async def async_step_user(self, user_input=None):
+        """Step when user initializes a integration."""
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        errors = {}
+        if user_input is not None:
+            user_selection = user_input[CONF_TYPE]
+            if user_selection == "Serial":
+                return await self.async_step_setup_serial()
+
+            return await self.async_step_setup_network()
+
+        list_of_types = ["Serial", "Network"]
+
+        schema = vol.Schema({vol.Required(CONF_TYPE): vol.In(list_of_types)})
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_setup_network(self, user_input=None):
+        """Step when setting up network configuration."""
+        errors = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            port = user_input[CONF_PORT]
+
+            try:
+                data = await self.async_validate_rfx(host=host, port=port)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(title="RFXTRX", data=data)
+
+        schema = vol.Schema(
+            {vol.Required(CONF_HOST): str, vol.Required(CONF_PORT): int}
+        )
+        return self.async_show_form(
+            step_id="setup_network", data_schema=schema, errors=errors,
+        )
+
+    async def async_step_setup_serial(self, user_input=None):
+        """Step when setting up serial configuration."""
+        errors = {}
+
+        if user_input is not None:
+            user_selection = user_input[CONF_DEVICE]
+            if user_selection == CONF_MANUAL_PATH:
+                return await self.async_step_setup_serial_manual_path()
+
+            dev_path = await self.hass.async_add_executor_job(
+                get_serial_by_id, user_selection
+            )
+
+            try:
+                data = await self.async_validate_rfx(device=dev_path)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(title="RFXTRX", data=data)
+
+        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        list_of_ports = {}
+        for port in ports:
+            list_of_ports[port.device] = (
+                f"{port}, s/n: {port.serial_number or 'n/a'}"
+                + (f" - {port.manufacturer}" if port.manufacturer else "")
+            )
+        list_of_ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
+
+        schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(list_of_ports)})
+        return self.async_show_form(
+            step_id="setup_serial", data_schema=schema, errors=errors,
+        )
+
+    async def async_step_setup_serial_manual_path(self, user_input=None):
+        """Select path manually."""
+        errors = {}
+
+        if user_input is not None:
+            device = user_input[CONF_DEVICE]
+            try:
+                data = await self.async_validate_rfx(device=device)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(title="RFXTRX", data=data)
+
+        schema = vol.Schema({vol.Required(CONF_DEVICE): str})
+        return self.async_show_form(
+            step_id="setup_serial_manual_path", data_schema=schema, errors=errors,
+        )
+
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
+    async def async_validate_rfx(self, host=None, port=None, device=None):
+        """Create data for rfxtrx entry."""
+        success = await self.hass.async_add_executor_job(
+            _test_transport, host, port, device
+        )
+        if not success:
+            raise CannotConnect
+
+        data = {
+            CONF_HOST: host,
+            CONF_PORT: port,
+            CONF_DEVICE: device,
+            CONF_AUTOMATIC_ADD: False,
+            CONF_DEBUG: False,
+            CONF_DEVICES: {},
+        }
+        return data
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Get the options flow for this handler."""
         return OptionsFlow(config_entry)
+
+
+def _test_transport(host, port, device):
+    """Construct a rfx object based on config."""
+    if port is not None:
+        try:
+            conn = rfxtrxmod.PyNetworkTransport((host, port))
+        except OSError:
+            return False
+
+        conn.close()
+    else:
+        try:
+            conn = rfxtrxmod.PySerialTransport(device)
+        except serial.serialutil.SerialException:
+            return False
+
+        if conn.serial is None:
+            return False
+
+        conn.close()
+
+    return True
+
+
+def get_serial_by_id(dev_path: str) -> str:
+    """Return a /dev/serial/by-id match for given device if available."""
+    by_id = "/dev/serial/by-id"
+    if not os.path.isdir(by_id):
+        return dev_path
+
+    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
+        if os.path.realpath(path) == dev_path:
+            return path
+    return dev_path
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -124,6 +124,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                 )
                 if selected_device_object is None:
                     errors[CONF_EVENT_CODE] = "invalid_event_code"
+                elif not self._can_add_device(selected_device_object):
+                    errors[CONF_EVENT_CODE] = "already_configured_device"
                 else:
                     self._selected_device_object = selected_device_object
                     return await self.async_step_set_device_options()
@@ -338,6 +340,17 @@ class OptionsFlow(config_entries.OptionsFlow):
             )
 
         device_registry.async_remove_device(old_device)
+
+    def _can_add_device(self, new_rfx_obj):
+        """Check if device does not already exist."""
+        new_device_id = get_device_id(new_rfx_obj.device)
+        for packet_id, entity_info in self._config_entry.data[CONF_DEVICES].items():
+            rfx_obj = get_rfx_object(packet_id)
+            device_id = get_device_id(rfx_obj.device, entity_info.get(CONF_DATA_BITS))
+            if new_device_id == device_id:
+                return False
+
+        return True
 
     def _can_replace_device(self, entry_id):
         """Check if device can be replaced with selected device."""

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -1,11 +1,290 @@
 """Config flow for RFXCOM RFXtrx integration."""
 import logging
 
-from homeassistant import config_entries
+import voluptuous as vol
 
-from . import DOMAIN
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_COMMAND_OFF,
+    CONF_COMMAND_ON,
+    CONF_DEVICE,
+    CONF_DEVICE_ID,
+    CONF_DEVICES,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import (
+    async_entries_for_config_entry,
+    async_get_registry,
+)
+
+from . import DOMAIN, get_device_id, get_rfx_object
+from .binary_sensor import supported as binary_supported
+from .const import (
+    CONF_AUTOMATIC_ADD,
+    CONF_DATA_BITS,
+    CONF_DEBUG,
+    CONF_FIRE_EVENT,
+    CONF_OFF_DELAY,
+    CONF_REMOVE_DEVICE,
+    CONF_SIGNAL_REPETITIONS,
+    DEVICE_PACKET_TYPE_LIGHTING4,
+)
+from .cover import supported as cover_supported
+from .light import supported as light_supported
+from .switch import supported as switch_supported
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_EVENT_CODE = "event_code"
+
+
+def none_or_int(value, base):
+    """Check if strin is one otherwise convert to int."""
+    if value is None:
+        return None
+    return int(value, base)
+
+
+class OptionsFlow(config_entries.OptionsFlow):
+    """Handle Rfxtrx options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize rfxtrx options flow."""
+        self._config_entry = config_entry
+        self._global_options = None
+        self._selected_device = None
+        self._selected_device_event_code = None
+        self._selected_device_object = None
+        self._device_entries = None
+        self._device_registry = None
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        return await self.async_step_prompt_options()
+
+    async def async_step_prompt_options(self, user_input=None):
+        """Prompt for options."""
+        errors = {}
+
+        if user_input is not None:
+            self._global_options = {
+                CONF_DEBUG: user_input[CONF_DEBUG],
+                CONF_AUTOMATIC_ADD: user_input[CONF_AUTOMATIC_ADD],
+            }
+            if CONF_DEVICE in user_input:
+                device_data = self._get_device_data(user_input[CONF_DEVICE])
+                event_code = device_data[CONF_EVENT_CODE]
+                self._selected_device_event_code = event_code
+                self._selected_device = self._config_entry.data[CONF_DEVICES][
+                    event_code
+                ]
+                self._selected_device_object = get_rfx_object(event_code)
+                return await self.async_step_set_device_options()
+            if CONF_REMOVE_DEVICE in user_input:
+                entry_id = user_input[CONF_REMOVE_DEVICE]
+                device_data = self._get_device_data(entry_id)
+
+                event_code = device_data[CONF_EVENT_CODE]
+                device_id = device_data[CONF_DEVICE_ID]
+                self.hass.helpers.dispatcher.async_dispatcher_send(
+                    f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{device_id}"
+                )
+                self._device_registry.async_remove_device(entry_id)
+                devices = {event_code: None}
+                self.update_config_data(
+                    global_options=self._global_options, devices=devices
+                )
+
+                return self.async_create_entry(title="", data={})
+            if CONF_EVENT_CODE in user_input:
+                self._selected_device_event_code = user_input[CONF_EVENT_CODE]
+                self._selected_device = {}
+                selected_device_object = get_rfx_object(
+                    self._selected_device_event_code
+                )
+                if selected_device_object is None:
+                    errors[CONF_EVENT_CODE] = "invalid_event_code"
+                else:
+                    self._selected_device_object = selected_device_object
+                    return await self.async_step_set_device_options()
+
+            if not errors:
+                self.update_config_data(global_options=self._global_options)
+
+                return self.async_create_entry(title="", data={})
+
+        device_registry = await async_get_registry(self.hass)
+        device_entries = async_entries_for_config_entry(
+            device_registry, self._config_entry.entry_id
+        )
+        self._device_registry = device_registry
+        self._device_entries = device_entries
+
+        devices = {
+            entry.id: entry.name_by_user if entry.name_by_user else entry.name
+            for entry in device_entries
+        }
+
+        options = {
+            vol.Optional(CONF_DEBUG, default=self._config_entry.data[CONF_DEBUG]): bool,
+            vol.Optional(
+                CONF_AUTOMATIC_ADD,
+                default=self._config_entry.data[CONF_AUTOMATIC_ADD],
+            ): bool,
+            vol.Optional(CONF_EVENT_CODE): str,
+            vol.Optional(CONF_DEVICE): vol.In(devices),
+            vol.Optional(CONF_REMOVE_DEVICE): vol.In(devices),
+        }
+
+        return self.async_show_form(
+            step_id="prompt_options", data_schema=vol.Schema(options), errors=errors
+        )
+
+    async def async_step_set_device_options(self, user_input=None):
+        """Manage device options."""
+        errors = {}
+
+        if user_input is not None:
+            device_id = get_device_id(
+                self._selected_device_object.device,
+                data_bits=user_input.get(CONF_DATA_BITS),
+            )
+
+            try:
+                command_on = none_or_int(user_input.get(CONF_COMMAND_ON), 16)
+            except ValueError:
+                errors[CONF_COMMAND_ON] = "invalid_input_2262_on"
+
+            try:
+                command_off = none_or_int(user_input.get(CONF_COMMAND_OFF), 16)
+            except ValueError:
+                errors[CONF_COMMAND_OFF] = "invalid_input_2262_off"
+
+            try:
+                off_delay = none_or_int(user_input.get(CONF_OFF_DELAY), 10)
+            except ValueError:
+                errors[CONF_OFF_DELAY] = "invalid_input_off_delay"
+
+            if not errors:
+                devices = {}
+                device = {
+                    CONF_DEVICE_ID: device_id,
+                    CONF_FIRE_EVENT: user_input.get(CONF_FIRE_EVENT, False),
+                    CONF_SIGNAL_REPETITIONS: user_input.get(CONF_SIGNAL_REPETITIONS, 1),
+                }
+
+                devices[self._selected_device_event_code] = device
+
+                if off_delay:
+                    device[CONF_OFF_DELAY] = off_delay
+                if user_input.get(CONF_DATA_BITS):
+                    device[CONF_DATA_BITS] = user_input[CONF_DATA_BITS]
+                if command_on:
+                    device[CONF_COMMAND_ON] = command_on
+                if command_off:
+                    device[CONF_COMMAND_OFF] = command_off
+
+                self.update_config_data(
+                    global_options=self._global_options, devices=devices
+                )
+
+                return self.async_create_entry(title="", data={})
+
+        device_data = self._selected_device
+
+        data_schema = {
+            vol.Optional(
+                CONF_FIRE_EVENT, default=device_data.get(CONF_FIRE_EVENT, False)
+            ): bool,
+        }
+
+        if binary_supported(self._selected_device_object):
+            if device_data.get(CONF_OFF_DELAY):
+                off_delay_schema = {
+                    vol.Optional(
+                        CONF_OFF_DELAY,
+                        description={"suggested_value": device_data[CONF_OFF_DELAY]},
+                    ): str,
+                }
+            else:
+                off_delay_schema = {
+                    vol.Optional(CONF_OFF_DELAY): str,
+                }
+            data_schema.update(off_delay_schema)
+
+        if (
+            binary_supported(self._selected_device_object)
+            or cover_supported(self._selected_device_object)
+            or light_supported(self._selected_device_object)
+            or switch_supported(self._selected_device_object)
+        ):
+            data_schema.update(
+                {
+                    vol.Optional(
+                        CONF_SIGNAL_REPETITIONS,
+                        default=device_data.get(CONF_SIGNAL_REPETITIONS, 1),
+                    ): int,
+                }
+            )
+
+        if (
+            self._selected_device_object.device.packettype
+            == DEVICE_PACKET_TYPE_LIGHTING4
+        ):
+            data_schema.update(
+                {
+                    vol.Optional(
+                        CONF_DATA_BITS, default=device_data.get(CONF_DATA_BITS, 0)
+                    ): int,
+                    vol.Optional(
+                        CONF_COMMAND_ON,
+                        default=hex(device_data.get(CONF_COMMAND_ON, 0)),
+                    ): str,
+                    vol.Optional(
+                        CONF_COMMAND_OFF,
+                        default=hex(device_data.get(CONF_COMMAND_OFF, 0)),
+                    ): str,
+                }
+            )
+
+        return self.async_show_form(
+            step_id="set_device_options",
+            data_schema=vol.Schema(data_schema),
+            errors=errors,
+        )
+
+    def _get_device_data(self, entry_id):
+        """Get event code based on device identifier."""
+        event_code = None
+        device_id = None
+        entry = self._device_registry.async_get(entry_id)
+        device_id = next(iter(entry.identifiers))[1:]
+        for packet_id, entity_info in self._config_entry.data[CONF_DEVICES].items():
+            if tuple(entity_info.get(CONF_DEVICE_ID)) == device_id:
+                event_code = packet_id
+                break
+
+        data = {CONF_EVENT_CODE: event_code, CONF_DEVICE_ID: device_id}
+
+        return data
+
+    @callback
+    def update_config_data(self, global_options=None, devices=None):
+        """Update data in ConfigEntry."""
+        entry_data = self._config_entry.data.copy()
+        if global_options:
+            entry_data.update(global_options)
+        if devices:
+            for event_code, options in devices.items():
+                if options is None:
+                    entry_data[CONF_DEVICES].pop(event_code)
+                else:
+                    entry_data[CONF_DEVICES][event_code] = options
+        self.hass.config_entries.async_update_entry(self._config_entry, data=entry_data)
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self._config_entry.entry_id)
+        )
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -16,9 +295,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
-        entry = await self.async_set_unique_id(DOMAIN)
-        if entry and import_config.items() != entry.data.items():
-            self.hass.config_entries.async_update_entry(entry, data=import_config)
-            return self.async_abort(reason="already_configured")
+        await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title="RFXTRX", data=import_config)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Get the options flow for this handler."""
+        return OptionsFlow(config_entry)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -339,7 +339,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {vol.Required(CONF_HOST): str, vol.Required(CONF_PORT): int}
         )
         return self.async_show_form(
-            step_id="setup_network", data_schema=schema, errors=errors,
+            step_id="setup_network",
+            data_schema=schema,
+            errors=errors,
         )
 
     async def async_step_setup_serial(self, user_input=None):
@@ -366,15 +368,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
         list_of_ports = {}
         for port in ports:
-            list_of_ports[port.device] = (
-                f"{port}, s/n: {port.serial_number or 'n/a'}"
-                + (f" - {port.manufacturer}" if port.manufacturer else "")
+            list_of_ports[
+                port.device
+            ] = f"{port}, s/n: {port.serial_number or 'n/a'}" + (
+                f" - {port.manufacturer}" if port.manufacturer else ""
             )
         list_of_ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
 
         schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(list_of_ports)})
         return self.async_show_form(
-            step_id="setup_serial", data_schema=schema, errors=errors,
+            step_id="setup_serial",
+            data_schema=schema,
+            errors=errors,
         )
 
     async def async_step_setup_serial_manual_path(self, user_input=None):
@@ -393,13 +398,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema({vol.Required(CONF_DEVICE): str})
         return self.async_show_form(
-            step_id="setup_serial_manual_path", data_schema=schema, errors=errors,
+            step_id="setup_serial_manual_path",
+            data_schema=schema,
+            errors=errors,
         )
 
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured()
+        entry = await self.async_set_unique_id(DOMAIN)
+        if entry:
+            if CONF_DEVICES not in entry.data:
+                # In version 0.113, devices key was not written to config entry. Update the entry with import data
+                self._abort_if_unique_id_configured(import_config)
+            else:
+                self._abort_if_unique_id_configured()
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -1,5 +1,13 @@
 """Constants for RFXtrx integration."""
 
+CONF_FIRE_EVENT = "fire_event"
+CONF_DATA_BITS = "data_bits"
+CONF_AUTOMATIC_ADD = "automatic_add"
+CONF_SIGNAL_REPETITIONS = "signal_repetitions"
+CONF_DEBUG = "debug"
+CONF_OFF_DELAY = "off_delay"
+
+CONF_REMOVE_DEVICE = "remove_device"
 
 COMMAND_ON_LIST = [
     "On",

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -8,6 +8,7 @@ CONF_DEBUG = "debug"
 CONF_OFF_DELAY = "off_delay"
 
 CONF_REMOVE_DEVICE = "remove_device"
+CONF_REPLACE_DEVICE = "replace_device"
 
 COMMAND_ON_LIST = [
     "On",

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -20,6 +20,11 @@ from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 _LOGGER = logging.getLogger(__name__)
 
 
+def supported(event):
+    """Return whether an event supports cover."""
+    return event.device.known_to_be_rollershutter
+
+
 async def async_setup_entry(
     hass,
     config_entry,
@@ -28,9 +33,6 @@ async def async_setup_entry(
     """Set up config entry."""
     discovery_info = config_entry.data
     device_ids = set()
-
-    def supported(event):
-        return event.device.known_to_be_rollershutter
 
     entities = []
     for packet_id, entity_info in discovery_info[CONF_DEVICES].items():

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -28,6 +28,14 @@ _LOGGER = logging.getLogger(__name__)
 SUPPORT_RFXTRX = SUPPORT_BRIGHTNESS
 
 
+def supported(event):
+    """Return whether an event supports light."""
+    return (
+        isinstance(event.device, rfxtrxmod.LightingDevice)
+        and event.device.known_to_be_dimmable
+    )
+
+
 async def async_setup_entry(
     hass,
     config_entry,
@@ -36,12 +44,6 @@ async def async_setup_entry(
     """Set up config entry."""
     discovery_info = config_entry.data
     device_ids = set()
-
-    def supported(event):
-        return (
-            isinstance(event.device, rfxtrxmod.LightingDevice)
-            and event.device.known_to_be_dimmable
-        )
 
     # Add switch from config file
     entities = []

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "requirements": ["pyRFXtrx==0.25"],
   "codeowners": ["@danielhiversen", "@elupus", "@RobBie1221"],
-  "config_flow": false
+  "config_flow": true
 }

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -3,6 +3,6 @@
   "name": "RFXCOM RFXtrx",
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "requirements": ["pyRFXtrx==0.25"],
-  "codeowners": ["@danielhiversen", "@elupus"],
+  "codeowners": ["@danielhiversen", "@elupus", "@RobBie1221"],
   "config_flow": false
 }

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rfxtrx",
   "name": "RFXCOM RFXtrx",
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
-  "requirements": ["pyRFXtrx==0.25"],
+  "requirements": ["pyRFXtrx==0.26"],
   "codeowners": ["@danielhiversen", "@elupus", "@RobBie1221"],
   "config_flow": true
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -1,5 +1,40 @@
 {
   "title": "Rfxtrx",
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "type": "Connection type"
+        },
+        "title": "Select connection type"
+      },
+      "setup_network": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "title": "Select connection address"
+      },
+      "setup_serial": {
+        "data": {
+          "device": "Select device"
+        },
+        "title": "Device"
+      },
+      "setup_serial_manual_path": {
+        "data": {
+          "device": "Select path"
+        },
+        "title": "Path"
+      }
+    }
+  },
   "options": {
     "step": {
       "prompt_options": {

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -2,7 +2,8 @@
   "title": "Rfxtrx",
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -1,9 +1,36 @@
 {
-    "config": {
-        "step": {},
-        "error": {},
-        "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-        }
+  "title": "Rfxtrx",
+  "options": {
+    "step": {
+      "prompt_options": {
+        "data": {
+          "debug": "Enable debugging",
+          "automatic_add": "Enable automatic add",
+          "event_code": "Enter event code to add",
+          "device": "Select device to configure",
+          "remove_device": "Select device to delete"
+        },
+        "title": "Rfxtrx Options"
+      },
+      "set_device_options": {
+        "data": {
+          "fire_event": "Enable device event",
+          "off_delay": "Off delay",
+          "off_delay_enabled": "Enable off delay",
+          "data_bit": "Number of data bits",
+          "command_on": "Data bits value for command on",
+          "command_off": "Data bits value for command off",
+          "signal_repetitions": "Number of signal repetitions"
+        },
+        "title": "Configure device options"
+      }
+    },
+    "error": {
+      "invalid_event_code": "Invalid event code",
+      "invalid_input_2262_on": "Invalid input for command on",
+      "invalid_input_2262_off": "Invalid input for command off",
+      "invalid_input_off_delay": "Invalid input for off delay",
+      "unknown": "Unexpected error"
     }
+  }
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -63,6 +63,7 @@
       }
     },
     "error": {
+      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",
       "invalid_event_code": "Invalid event code",
       "invalid_input_2262_on": "Invalid input for command on",
       "invalid_input_2262_off": "Invalid input for command off",

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -30,7 +30,7 @@
       },
       "setup_serial_manual_path": {
         "data": {
-          "device": "Select path"
+          "device": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Path"
       }
@@ -56,7 +56,8 @@
           "data_bit": "Number of data bits",
           "command_on": "Data bits value for command on",
           "command_off": "Data bits value for command off",
-          "signal_repetitions": "Number of signal repetitions"
+          "signal_repetitions": "Number of signal repetitions",
+          "replace_device": "Select device to replace"
         },
         "title": "Configure device options"
       }
@@ -66,7 +67,7 @@
       "invalid_input_2262_on": "Invalid input for command on",
       "invalid_input_2262_off": "Invalid input for command off",
       "invalid_input_off_delay": "Invalid input for off delay",
-      "unknown": "Unexpected error"
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }
 }

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -25,6 +25,16 @@ DATA_SWITCH = f"{DOMAIN}_switch"
 _LOGGER = logging.getLogger(__name__)
 
 
+def supported(event):
+    """Return whether an event supports switch."""
+    return (
+        isinstance(event.device, rfxtrxmod.LightingDevice)
+        and not event.device.known_to_be_dimmable
+        and not event.device.known_to_be_rollershutter
+        or isinstance(event.device, rfxtrxmod.RfyDevice)
+    )
+
+
 async def async_setup_entry(
     hass,
     config_entry,
@@ -33,14 +43,6 @@ async def async_setup_entry(
     """Set up config entry."""
     discovery_info = config_entry.data
     device_ids = set()
-
-    def supported(event):
-        return (
-            isinstance(event.device, rfxtrxmod.LightingDevice)
-            and not event.device.known_to_be_dimmable
-            and not event.device.known_to_be_rollershutter
-            or isinstance(event.device, rfxtrxmod.RfyDevice)
-        )
 
     # Add switch from config file
     entities = []

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,4 +1,39 @@
 {
+    "config": {
+        "abort": {
+            "already_configured": "Already configured. Only a single configuration possible."
+        },
+        "error": {
+            "cannot_connect": "Failed to connect"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "type": "Connection type"
+                },
+                "title": "Select connection type"
+            },
+            "setup_network": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "title": "Select connection address"
+            },
+            "setup_serial": {
+                "data": {
+                    "device": "Select device"
+                },
+                "title": "Device"
+            },
+            "setup_serial_manual_path": {
+                "data": {
+                    "device": "Select path"
+                },
+                "title": "Path"
+            }
+        }
+    },
     "options": {
         "step": {
             "prompt_options": {

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,7 +1,36 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
+    "options": {
+        "step": {
+            "prompt_options": {
+                "data": {
+                    "debug": "Enable debugging",
+                    "automatic_add": "Enable automatic add",
+                    "event_code": "Enter event code to add",
+                    "device": "Select device to configure",
+                    "remove_device": "Select device to delete"
+                },
+                "title": "Rfxtrx Options"
+            },
+            "set_device_options": {
+                "data": {
+                    "fire_event": "Enable device event",
+                    "off_delay": "Off delay",
+                    "off_delay_enabled": "Enable off delay",
+                    "data_bit": "Number of data bits",
+                    "command_on": "Data bits value for command on",
+                    "command_off": "Data bits value for command off",
+                    "signal_repetitions": "Number of signal repetitions"
+                },
+                "title": "Configure device options"
+            }
+        },
+        "error": {
+            "invalid_event_code": "Invalid event code",
+            "invalid_input_2262_on": "Invalid input for command on",
+            "invalid_input_2262_off": "Invalid input for command off",
+            "invalid_input_off_delay": "Invalid input for off delay",
+            "unknown": "Unexpected error"
         }
-    }
+    },
+    "title": "Rfxtrx"
 }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Already configured. Only a single configuration possible."
+            "already_configured": "Already configured. Only a single configuration possible.",
+            "cannot_connect": "Failed to connect"
         },
         "error": {
             "cannot_connect": "Failed to connect"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -62,6 +62,7 @@
             }
         },
         "error": {
+            "already_configured_device": "Device is already configured",
             "invalid_event_code": "Invalid event code",
             "invalid_input_2262_on": "Invalid input for command on",
             "invalid_input_2262_off": "Invalid input for command off",

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -55,7 +55,8 @@
                     "data_bit": "Number of data bits",
                     "command_on": "Data bits value for command on",
                     "command_off": "Data bits value for command off",
-                    "signal_repetitions": "Number of signal repetitions"
+                    "signal_repetitions": "Number of signal repetitions",
+                    "replace_device": "Select device to replace"
                 },
                 "title": "Configure device options"
             }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -150,6 +150,7 @@ FLOWS = [
     "pvpc_hourly_pricing",
     "rachio",
     "rainmachine",
+    "rfxtrx",
     "ring",
     "risco",
     "roku",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1211,7 +1211,7 @@ pyHS100==0.3.5.1
 pyMetno==0.8.1
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.25
+pyRFXtrx==0.26
 
 # homeassistant.components.switchmate
 # pySwitchmate==0.4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -592,7 +592,7 @@ pyHS100==0.3.5.1
 pyMetno==0.8.1
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.25
+pyRFXtrx==0.26
 
 # homeassistant.components.tibber
 pyTibber==0.15.3

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -4,11 +4,23 @@ from datetime import timedelta
 import pytest
 
 from homeassistant.components import rfxtrx
-from homeassistant.setup import async_setup_component
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.util.dt import utcnow
 
 from tests.async_mock import patch
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def create_rfx_test_cfg(device="abcd", automatic_add=False, devices=None):
+    """Create rfxtrx config entry data."""
+    return {
+        "device": device,
+        "host": None,
+        "port": None,
+        "automatic_add": automatic_add,
+        "debug": False,
+        "devices": devices,
+    }
 
 
 @pytest.fixture(autouse=True, name="rfxtrx")
@@ -37,12 +49,12 @@ async def rfxtrx_fixture(hass):
 @pytest.fixture(name="rfxtrx_automatic")
 async def rfxtrx_automatic_fixture(hass, rfxtrx):
     """Fixture that starts up with automatic additions."""
+    entry_data = create_rfx_test_cfg(automatic_add=True, devices={})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "automatic_add": True}},
-    )
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
     yield rfxtrx

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -1,11 +1,12 @@
 """The tests for the Rfxtrx sensor platform."""
 import pytest
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 EVENT_SMOKE_DETECTOR_PANIC = "08200300a109000670"
 EVENT_SMOKE_DETECTOR_NO_PANIC = "08200300a109000770"
@@ -21,11 +22,12 @@ EVENT_AC_118CDEA_2_ON = "0b1100100118cdea02010f70"
 
 async def test_one(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f230010f71": {}}}},
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f230010f71": {}})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.ac_213c7f2_48")
@@ -36,22 +38,20 @@ async def test_one(hass, rfxtrx):
 
 async def test_one_pt2262(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013970": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    }
-                },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013970": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
             }
-        },
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -71,19 +71,14 @@ async def test_one_pt2262(hass, rfxtrx):
 
 async def test_pt2262_unconfigured(hass, rfxtrx):
     """Test with discovery for PT2262."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013970": {},
-                    "09130000226707013970": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={"0913000022670e013970": {}, "09130000226707013970": {}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -109,11 +104,12 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f230010f71": {}}}},
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f230010f71": {}})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -121,20 +117,18 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
 async def test_several(hass, rfxtrx):
     """Test with 3."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {},
-                    "0b1100100118cdea02010f70": {},
-                    "0b1100101118cdea02010f70": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1100cd0213c7f230010f71": {},
+            "0b1100100118cdea02010f70": {},
+            "0b1100101118cdea02010f70": {},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.ac_213c7f2_48")
@@ -181,16 +175,12 @@ async def test_off_delay_restore(hass, rfxtrx):
         ],
     )
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {EVENT_AC_118CDEA_2_ON: {"off_delay": 5}},
-            }
-        },
-    )
+    entry_data = create_rfx_test_cfg(devices={EVENT_AC_118CDEA_2_ON: {"off_delay": 5}})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -201,16 +191,14 @@ async def test_off_delay_restore(hass, rfxtrx):
 
 async def test_off_delay(hass, rfxtrx, timestep):
     """Test with discovery."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {"0b1100100118cdea02010f70": {"off_delay": 5}},
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100100118cdea02010f70": {"off_delay": 5}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -295,27 +283,25 @@ async def test_light(hass, rfxtrx_automatic):
 
 async def test_pt2262_duplicate_id(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013970": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    },
-                    "09130000226707013970": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    },
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013970": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            },
+            "09130000226707013970": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            },
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -1,12 +1,280 @@
 """Test the Tado config flow."""
+import os
+
+import serial.tools.list_ports
+
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.components.rfxtrx import DOMAIN, config_flow
 from homeassistant.helpers.device_registry import (
     async_entries_for_config_entry,
     async_get_registry,
 )
 
+from tests.async_mock import MagicMock, patch, sentinel
 from tests.common import MockConfigEntry
+
+
+def serial_connect(self):
+    """Mock a serial connection."""
+    self.serial = True
+
+
+def serial_connect_fail(self):
+    """Mock a failed serial connection."""
+    self.serial = None
+
+
+def com_port():
+    """Mock of a serial port."""
+    port = serial.tools.list_ports_common.ListPortInfo()
+    port.serial_number = "1234"
+    port.manufacturer = "Virtual serial port"
+    port.device = "/dev/ttyUSB1234"
+    port.description = "Some serial port"
+
+    return port
+
+
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport.connect",
+    return_value=None,
+)
+async def test_setup_network(connect_mock, hass):
+    """Test we can setup network."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Network"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_network"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "10.10.0.1", "port": 1234}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "RFXTRX"
+    assert result["data"] == {
+        "host": "10.10.0.1",
+        "port": 1234,
+        "device": None,
+        "automatic_add": False,
+        "debug": False,
+        "devices": {},
+    }
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    serial_connect,
+)
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
+    return_value=None,
+)
+async def test_setup_serial(com_mock, connect_mock, hass):
+    """Test we can setup serial."""
+    port = com_port()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"device": port.device}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "RFXTRX"
+    assert result["data"] == {
+        "host": None,
+        "port": None,
+        "device": port.device,
+        "automatic_add": False,
+        "debug": False,
+        "devices": {},
+    }
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    serial_connect,
+)
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
+    return_value=None,
+)
+async def test_setup_serial_manual(com_mock, connect_mock, hass):
+    """Test we can setup serial with manual entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": "Enter Manually"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"device": "/dev/ttyUSB0"}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "RFXTRX"
+    assert result["data"] == {
+        "host": None,
+        "port": None,
+        "device": "/dev/ttyUSB0",
+        "automatic_add": False,
+        "debug": False,
+        "devices": {},
+    }
+
+
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport.connect",
+    side_effect=OSError,
+)
+async def test_setup_network_fail(connect_mock, hass):
+    """Test we can setup network."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Network"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_network"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"host": "10.10.0.1", "port": 1234}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_network"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    side_effect=serial.serialutil.SerialException,
+)
+async def test_setup_serial_fail(com_mock, connect_mock, hass):
+    """Test setup serial failed connection."""
+    port = com_port()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": port.device}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    serial_connect_fail,
+)
+async def test_setup_serial_manual_fail(com_mock, hass):
+    """Test setup serial failed connection."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": "Enter Manually"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": "/dev/ttyUSB0"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_import(hass):
@@ -367,3 +635,50 @@ async def test_options_add_and_configure_device(hass):
     assert entry.data["devices"]["0913000022670e013970"]["fire_event"]
     assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
     assert "delay_off" not in entry.data["devices"]["0913000022670e013970"]
+
+
+def test_get_serial_by_id_no_dir():
+    """Test serial by id conversion if there's no /dev/serial/by-id."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=False))
+    p2 = patch("os.scandir")
+    with p1 as is_dir_mock, p2 as scan_mock:
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 0
+
+
+def test_get_serial_by_id():
+    """Test serial by id conversion."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=True))
+    p2 = patch("os.scandir")
+
+    def _realpath(path):
+        if path is sentinel.matched_link:
+            return sentinel.path
+        return sentinel.serial_link_path
+
+    p3 = patch("os.path.realpath", side_effect=_realpath)
+    with p1 as is_dir_mock, p2 as scan_mock, p3:
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 1
+
+        entry1 = MagicMock(spec_set=os.DirEntry)
+        entry1.is_symlink.return_value = True
+        entry1.path = sentinel.some_path
+
+        entry2 = MagicMock(spec_set=os.DirEntry)
+        entry2.is_symlink.return_value = False
+        entry2.path = sentinel.other_path
+
+        entry3 = MagicMock(spec_set=os.DirEntry)
+        entry3.is_symlink.return_value = True
+        entry3.path = sentinel.matched_link
+
+        scan_mock.return_value = [entry1, entry2, entry3]
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.matched_link
+        assert is_dir_mock.call_count == 2
+        assert scan_mock.call_count == 2

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -1,6 +1,10 @@
 """Test the Tado config flow."""
-from homeassistant import config_entries, setup
+from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.helpers.device_registry import (
+    async_entries_for_config_entry,
+    async_get_registry,
+)
 
 from tests.common import MockConfigEntry
 
@@ -44,4 +48,322 @@ async def test_import_update(hass):
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
+
+
+async def test_options_global(hass):
+    """Test if we can set global options."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {},
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"debug": True, "automatic_add": True}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
     assert entry.data["debug"]
+    assert entry.data["automatic_add"]
+
+
+async def test_options_add_device(hass):
+    """Test we can add a device."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {},
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    # Try with invalid event code
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"debug": True, "automatic_add": True, "event_code": "1234"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+    assert result["errors"]
+    assert result["errors"]["event_code"] == "invalid_event_code"
+
+    # Try with valid event code
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": True,
+            "automatic_add": True,
+            "event_code": "0b1100cd0213c7f230010f71",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"fire_event": True, "signal_repetitions": 5}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    assert entry.data["debug"]
+    assert entry.data["automatic_add"]
+
+    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
+    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["fire_event"]
+    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["signal_repetitions"] == 5
+    assert "delay_off" not in entry.data["devices"]["0b1100cd0213c7f230010f71"]
+
+    state = hass.states.get("binary_sensor.ac_213c7f2_48")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
+
+
+async def test_options_add_remove_device(hass):
+    """Test we can add a device."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {},
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": True,
+            "automatic_add": True,
+            "event_code": "0b1100cd0213c7f230010f71",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"fire_event": True, "signal_repetitions": 5, "off_delay": "4"},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    assert entry.data["debug"]
+    assert entry.data["automatic_add"]
+
+    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
+    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["fire_event"]
+    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["signal_repetitions"] == 5
+    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["off_delay"] == 4
+
+    state = hass.states.get("binary_sensor.ac_213c7f2_48")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
+
+    device_registry = await async_get_registry(hass)
+    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+
+    assert device_entries[0].id
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": False,
+            "automatic_add": False,
+            "remove_device": device_entries[0].id,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    assert not entry.data["debug"]
+    assert not entry.data["automatic_add"]
+
+    assert "0b1100cd0213c7f230010f71" not in entry.data["devices"]
+
+    state = hass.states.get("binary_sensor.ac_213c7f2_48")
+    assert not state
+
+
+async def test_options_add_and_configure_device(hass):
+    """Test we can add a device."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {},
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": True,
+            "automatic_add": True,
+            "event_code": "0913000022670e013970",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "fire_event": False,
+            "signal_repetitions": 5,
+            "data_bits": 4,
+            "off_delay": "abcdef",
+            "command_on": "xyz",
+            "command_off": "xyz",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+    assert result["errors"]
+    assert result["errors"]["off_delay"] == "invalid_input_off_delay"
+    assert result["errors"]["command_on"] == "invalid_input_2262_on"
+    assert result["errors"]["command_off"] == "invalid_input_2262_off"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "fire_event": False,
+            "signal_repetitions": 5,
+            "data_bits": 4,
+            "command_on": "0xE",
+            "command_off": "0x7",
+            "off_delay": "9",
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    assert entry.data["debug"]
+    assert entry.data["automatic_add"]
+
+    assert entry.data["devices"]["0913000022670e013970"]
+    assert not entry.data["devices"]["0913000022670e013970"]["fire_event"]
+    assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
+    assert entry.data["devices"]["0913000022670e013970"]["off_delay"] == 9
+
+    state = hass.states.get("binary_sensor.pt2262_22670e")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+
+    device_registry = await async_get_registry(hass)
+    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+
+    assert device_entries[0].id
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": False,
+            "automatic_add": False,
+            "device": device_entries[0].id,
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "fire_event": True,
+            "signal_repetitions": 5,
+            "data_bits": 4,
+            "command_on": "0xE",
+            "command_off": "0x7",
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    assert entry.data["devices"]["0913000022670e013970"]
+    assert entry.data["devices"]["0913000022670e013970"]["fire_event"]
+    assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
+    assert "delay_off" not in entry.data["devices"]["0913000022670e013970"]

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -50,7 +50,8 @@ async def test_setup_network(connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Network"},
+        result["flow_id"],
+        {"type": "Network"},
     )
 
     assert result["type"] == "form"
@@ -96,7 +97,8 @@ async def test_setup_serial(com_mock, connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -140,7 +142,8 @@ async def test_setup_serial_manual(com_mock, connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -187,7 +190,8 @@ async def test_setup_network_fail(connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Network"},
+        result["flow_id"],
+        {"type": "Network"},
     )
 
     assert result["type"] == "form"
@@ -221,7 +225,8 @@ async def test_setup_serial_fail(com_mock, connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -253,7 +258,8 @@ async def test_setup_serial_manual_fail(com_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -303,7 +309,13 @@ async def test_import_update(hass):
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "devices": {},
+        },
         unique_id=DOMAIN,
     )
     entry.add_to_hass(hass)
@@ -311,11 +323,48 @@ async def test_import_update(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
-        data={"host": None, "port": None, "device": "/dev/tty123", "debug": True},
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": True,
+            "devices": {},
+        },
     )
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
+
+
+async def test_import_migrate(hass):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "host": None,
+                "port": None,
+                "device": "/dev/tty123",
+                "debug": True,
+                "automatic_add": True,
+                "devices": {},
+            },
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+    assert entry.data["devices"] == {}
 
 
 async def test_options_global(hass):

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -73,7 +73,6 @@ async def test_setup_network(connect_mock, hass):
         "port": 1234,
         "device": None,
         "automatic_add": False,
-        "debug": False,
         "devices": {},
     }
 
@@ -120,7 +119,6 @@ async def test_setup_serial(com_mock, connect_mock, hass):
         "port": None,
         "device": port.device,
         "automatic_add": False,
-        "debug": False,
         "devices": {},
     }
 
@@ -173,7 +171,6 @@ async def test_setup_serial_manual(com_mock, connect_mock, hass):
         "port": None,
         "device": "/dev/ttyUSB0",
         "automatic_add": False,
-        "debug": False,
         "devices": {},
     }
 
@@ -433,7 +430,6 @@ async def test_options_global(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "debug": False,
             "automatic_add": False,
             "devices": {},
         },
@@ -447,14 +443,13 @@ async def test_options_global(hass):
     assert result["step_id"] == "prompt_options"
 
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"debug": True, "automatic_add": True}
+        result["flow_id"], user_input={"automatic_add": True}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
 
-    assert entry.data["debug"]
     assert entry.data["automatic_add"]
 
 
@@ -468,7 +463,6 @@ async def test_options_add_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "debug": False,
             "automatic_add": False,
             "devices": {},
         },
@@ -484,7 +478,7 @@ async def test_options_add_device(hass):
     # Try with invalid event code
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={"debug": True, "automatic_add": True, "event_code": "1234"},
+        user_input={"automatic_add": True, "event_code": "1234"},
     )
 
     assert result["type"] == "form"
@@ -496,7 +490,6 @@ async def test_options_add_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": True,
             "automatic_add": True,
             "event_code": "0b1100cd0213c7f230010f71",
         },
@@ -513,7 +506,6 @@ async def test_options_add_device(hass):
 
     await hass.async_block_till_done()
 
-    assert entry.data["debug"]
     assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
@@ -537,7 +529,6 @@ async def test_options_add_remove_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "debug": False,
             "automatic_add": False,
             "devices": {},
         },
@@ -553,7 +544,6 @@ async def test_options_add_remove_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": True,
             "automatic_add": True,
             "event_code": "0b1100cd0213c7f230010f71",
         },
@@ -571,7 +561,6 @@ async def test_options_add_remove_device(hass):
 
     await hass.async_block_till_done()
 
-    assert entry.data["debug"]
     assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
@@ -597,7 +586,6 @@ async def test_options_add_remove_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": False,
             "automatic_add": False,
             "remove_device": [device_entries[0].id],
         },
@@ -607,7 +595,6 @@ async def test_options_add_remove_device(hass):
 
     await hass.async_block_till_done()
 
-    assert not entry.data["debug"]
     assert not entry.data["automatic_add"]
 
     assert "0b1100cd0213c7f230010f71" not in entry.data["devices"]
@@ -626,7 +613,6 @@ async def test_options_replace_sensor_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "debug": False,
             "automatic_add": False,
             "devices": {
                 "0a520101f00400e22d0189": {"device_id": ["52", "1", "f0:04"]},
@@ -709,7 +695,6 @@ async def test_options_replace_sensor_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": False,
             "automatic_add": False,
             "device": old_device,
         },
@@ -789,7 +774,6 @@ async def test_options_replace_control_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "debug": False,
             "automatic_add": False,
             "devices": {
                 "0b1100100118cdea02010f70": {
@@ -850,7 +834,6 @@ async def test_options_replace_control_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": False,
             "automatic_add": False,
             "device": old_device,
         },
@@ -900,7 +883,6 @@ async def test_options_remove_multiple_devices(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "debug": False,
             "automatic_add": False,
             "devices": {
                 "0b1100cd0213c7f230010f71": {"device_id": ["11", "0", "213c7f2:48"]},
@@ -945,7 +927,6 @@ async def test_options_remove_multiple_devices(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": False,
             "automatic_add": False,
             "remove_device": remove_devices,
         },
@@ -973,7 +954,6 @@ async def test_options_add_and_configure_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "debug": False,
             "automatic_add": False,
             "devices": {},
         },
@@ -989,7 +969,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": True,
             "automatic_add": True,
             "event_code": "0913000022670e013970",
         },
@@ -1033,7 +1012,6 @@ async def test_options_add_and_configure_device(hass):
 
     await hass.async_block_till_done()
 
-    assert entry.data["debug"]
     assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0913000022670e013970"]
@@ -1059,7 +1037,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "debug": False,
             "automatic_add": False,
             "device": device_entries[0].id,
         },

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -7,7 +7,10 @@ from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.rfxtrx import DOMAIN, config_flow
 from homeassistant.helpers.device_registry import (
     async_entries_for_config_entry,
-    async_get_registry,
+    async_get_registry as async_get_device_registry,
+)
+from homeassistant.helpers.entity_registry import (
+    async_get_registry as async_get_entity_registry,
 )
 
 from tests.async_mock import MagicMock, patch, sentinel
@@ -581,7 +584,7 @@ async def test_options_add_remove_device(hass):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
-    device_registry = await async_get_registry(hass)
+    device_registry = await async_get_device_registry(hass)
     device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id
@@ -610,6 +613,280 @@ async def test_options_add_remove_device(hass):
     assert "0b1100cd0213c7f230010f71" not in entry.data["devices"]
 
     state = hass.states.get("binary_sensor.ac_213c7f2_48")
+    assert not state
+
+
+async def test_options_replace_sensor_device(hass):
+    """Test we can replace a sensor device."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {
+                "0a520101f00400e22d0189": {"device_id": ["52", "1", "f0:04"]},
+                "0a520105230400c3260279": {"device_id": ["52", "1", "23:04"]},
+            },
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_rssi_numeric"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_battery_numeric"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_humidity"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_humidity_status"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_temperature"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_rssi_numeric"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_battery_numeric"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_humidity"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_humidity_status"
+    )
+    assert state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_temperature"
+    )
+    assert state
+
+    device_registry = await async_get_device_registry(hass)
+    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+
+    old_device = next(
+        (
+            elem.id
+            for elem in device_entries
+            if next(iter(elem.identifiers))[1:] == ("52", "1", "f0:04")
+        ),
+        None,
+    )
+    new_device = next(
+        (
+            elem.id
+            for elem in device_entries
+            if next(iter(elem.identifiers))[1:] == ("52", "1", "23:04")
+        ),
+        None,
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": False,
+            "automatic_add": False,
+            "device": old_device,
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "replace_device": new_device,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    entity_registry = await async_get_entity_registry(hass)
+
+    entry = entity_registry.async_get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_rssi_numeric"
+    )
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_humidity"
+    )
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_humidity_status"
+    )
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_battery_numeric"
+    )
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_temperature"
+    )
+    assert entry
+    assert entry.device_id == new_device
+
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_rssi_numeric"
+    )
+    assert not state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_battery_numeric"
+    )
+    assert not state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_humidity"
+    )
+    assert not state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_humidity_status"
+    )
+    assert not state
+    state = hass.states.get(
+        "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_temperature"
+    )
+    assert not state
+
+
+async def test_options_replace_control_device(hass):
+    """Test we can replace a control device."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {
+                "0b1100100118cdea02010f70": {
+                    "device_id": ["11", "0", "118cdea:2"],
+                    "signal_repetitions": 1,
+                },
+                "0b1100101118cdea02010f70": {
+                    "device_id": ["11", "0", "1118cdea:2"],
+                    "signal_repetitions": 1,
+                },
+            },
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
+    assert state
+    state = hass.states.get("sensor.ac_118cdea_2_rssi_numeric")
+    assert state
+    state = hass.states.get("switch.ac_118cdea_2")
+    assert state
+    state = hass.states.get("binary_sensor.ac_1118cdea_2")
+    assert state
+    state = hass.states.get("sensor.ac_1118cdea_2_rssi_numeric")
+    assert state
+    state = hass.states.get("switch.ac_1118cdea_2")
+    assert state
+
+    device_registry = await async_get_device_registry(hass)
+    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+
+    old_device = next(
+        (
+            elem.id
+            for elem in device_entries
+            if next(iter(elem.identifiers))[1:] == ("11", "0", "118cdea:2")
+        ),
+        None,
+    )
+    new_device = next(
+        (
+            elem.id
+            for elem in device_entries
+            if next(iter(elem.identifiers))[1:] == ("11", "0", "1118cdea:2")
+        ),
+        None,
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": False,
+            "automatic_add": False,
+            "device": old_device,
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "set_device_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "replace_device": new_device,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    entity_registry = await async_get_entity_registry(hass)
+
+    entry = entity_registry.async_get("binary_sensor.ac_118cdea_2")
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get("sensor.ac_118cdea_2_rssi_numeric")
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get("switch.ac_118cdea_2")
+    assert entry
+    assert entry.device_id == new_device
+
+    state = hass.states.get("binary_sensor.ac_1118cdea_2")
+    assert not state
+    state = hass.states.get("sensor.ac_1118cdea_2_rssi_numeric")
+    assert not state
+    state = hass.states.get("switch.ac_1118cdea_2")
     assert not state
 
 
@@ -645,7 +922,7 @@ async def test_options_remove_multiple_devices(hass):
     state = hass.states.get("binary_sensor.ac_1118cdea_2")
     assert state
 
-    device_registry = await async_get_registry(hass)
+    device_registry = await async_get_device_registry(hass)
     device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert len(device_entries) == 3
@@ -769,7 +1046,7 @@ async def test_options_add_and_configure_device(hass):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "PT2262 22670e"
 
-    device_registry = await async_get_registry(hass)
+    device_registry = await async_get_device_registry(hass)
     device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -519,6 +519,43 @@ async def test_options_add_device(hass):
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
 
+async def test_options_add_duplicate_device(hass):
+    """Test we can add a device."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {"0b1100cd0213c7f230010f71": {"signal_repetitions": 1}},
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "automatic_add": True,
+            "event_code": "0b1100cd0213c7f230010f71",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+    assert result["errors"]
+    assert result["errors"]["event_code"] == "already_configured_device"
+
+
 async def test_options_add_remove_device(hass):
     """Test we can add a device."""
     await setup.async_setup_component(hass, "persistent_notification", {})

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -3,19 +3,23 @@ from unittest.mock import call
 
 import pytest
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_one_cover(hass, rfxtrx):
     """Test with 1 cover."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1400cd0213c7f20d010f51": {}}}},
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")
@@ -57,11 +61,14 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1400cd0213c7f20d010f51": {}}}},
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -69,20 +76,18 @@ async def test_state_restore(hass, rfxtrx, state):
 
 async def test_several_covers(hass, rfxtrx):
     """Test with 3 covers."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1400cd0213c7f20d010f51": {},
-                    "0A1400ADF394AB010D0060": {},
-                    "09190000009ba8010100": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
+            "0A1400ADF394AB010D0060": {"signal_repetitions": 1},
+            "09190000009ba8010100": {"signal_repetitions": 1},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")
@@ -118,19 +123,17 @@ async def test_discover_covers(hass, rfxtrx_automatic):
 
 async def test_duplicate_cover(hass, rfxtrx):
     """Test with 2 duplicate covers."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1400cd0213c7f20d010f51": {},
-                    "0b1400cd0213c7f20d010f50": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
+            "0b1400cd0213c7f20d010f50": {"signal_repetitions": 1},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,10 +1,13 @@
 """The tests for the Rfxtrx component."""
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import call
+from tests.common import MockConfigEntry
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_valid_config(hass):
@@ -55,21 +58,19 @@ async def test_invalid_config(hass):
 
 async def test_fire_event(hass, rfxtrx):
     """Test fire event."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "/dev/serial/by-id/usb"
-                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                "automatic_add": True,
-                "devices": {
-                    "0b1100cd0213c7f210010f51": {"fire_event": True},
-                    "0716000100900970": {"fire_event": True},
-                },
-            }
+    entry_data = create_rfx_test_cfg(
+        device="/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
+        automatic_add=True,
+        devices={
+            "0b1100cd0213c7f210010f51": {"fire_event": True},
+            "0716000100900970": {"fire_event": True},
         },
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -108,9 +109,12 @@ async def test_fire_event(hass, rfxtrx):
 
 async def test_send(hass, rfxtrx):
     """Test configuration."""
-    assert await async_setup_component(
-        hass, "rfxtrx", {"rfxtrx": {"device": "/dev/null"}}
-    )
+    entry_data = create_rfx_test_cfg(device="/dev/null", devices={})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -102,7 +102,7 @@ async def test_fire_event(hass, rfxtrx):
             "type_string": "Byron SX",
             "id_string": "00:90",
             "data": "0716000100900970",
-            "values": {"Sound": 9, "Battery numeric": 0, "Rssi numeric": 7},
+            "values": {"Command": "Chime", "Rssi numeric": 7, "Sound": 9},
         },
     ]
 

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -4,19 +4,23 @@ from unittest.mock import call
 import pytest
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_one_light(hass, rfxtrx):
     """Test with 1 light."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210020f51": {}}}},
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("light.ac_213c7f2_16")
@@ -95,11 +99,14 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
         hass, [State(entity_id, state, attributes={ATTR_BRIGHTNESS: brightness})]
     )
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210020f51": {}}}},
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -108,20 +115,18 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
 
 async def test_several_lights(hass, rfxtrx):
     """Test with 3 lights."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230020f71": {},
-                    "0b1100100118cdea02020f70": {},
-                    "0b1100101118cdea02050f70": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1100cd0213c7f230020f71": {"signal_repetitions": 1},
+            "0b1100100118cdea02020f70": {"signal_repetitions": 1},
+            "0b1100101118cdea02050f70": {"signal_repetitions": 1},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -160,18 +165,14 @@ async def test_several_lights(hass, rfxtrx):
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -1,19 +1,23 @@
 """The tests for the Rfxtrx sensor platform."""
 import pytest
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, TEMP_CELSIUS
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_default_config(hass, rfxtrx):
     """Test with 0 sensor."""
-    await async_setup_component(
-        hass, "sensor", {"sensor": {"platform": "rfxtrx", "devices": {}}}
-    )
+    entry_data = create_rfx_test_cfg(devices={})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
@@ -21,11 +25,12 @@ async def test_default_config(hass, rfxtrx):
 
 async def test_one_sensor(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0a52080705020095220269": {}}}},
-    )
+    entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02_temperature")
@@ -49,11 +54,12 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0a520801070100b81b0279": {}}}},
-    )
+    entry_data = create_rfx_test_cfg(devices={"0a520801070100b81b0279": {}})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -61,11 +67,12 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
 async def test_one_sensor_no_datatype(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0a52080705020095220269": {}}}},
-    )
+    entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02"
@@ -104,19 +111,17 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
 
 async def test_several_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0a52080705020095220269": {},
-                    "0a520802060100ff0e0269": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0a52080705020095220269": {},
+            "0a520802060100ff0e0269": {},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -244,19 +249,17 @@ async def test_discover_sensor(hass, rfxtrx_automatic):
 
 async def test_update_of_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0a52080705020095220269": {},
-                    "0a520802060100ff0e0269": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0a52080705020095220269": {},
+            "0a520802060100ff0e0269": {},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -290,23 +293,21 @@ async def test_update_of_sensors(hass, rfxtrx):
 
 async def test_rssi_sensor(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013b70": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    },
-                    "0b1100cd0213c7f230010f71": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013b70": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            },
+            "0b1100cd0213c7f230010f71": {},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -5,9 +5,9 @@ import pytest
 
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 EVENT_RFY_ENABLE_SUN_AUTO = "081a00000301010113"
 EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
@@ -15,11 +15,14 @@ EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
 
 async def test_one_switch(hass, rfxtrx):
     """Test with 1 switch."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210010f51": {}}}},
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.ac_213c7f2_16")
@@ -55,11 +58,14 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210010f51": {}}}},
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -67,20 +73,18 @@ async def test_state_restore(hass, rfxtrx, state):
 
 async def test_several_switches(hass, rfxtrx):
     """Test with 3 switches."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {},
-                    "0b1100100118cdea02010f70": {},
-                    "0b1100101118cdea02010f70": {},
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1100cd0213c7f230010f71": {"signal_repetitions": 1},
+            "0b1100100118cdea02010f70": {"signal_repetitions": 1},
+            "0b1100101118cdea02010f70": {"signal_repetitions": 1},
+        }
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.ac_213c7f2_48")
@@ -102,18 +106,14 @@ async def test_several_switches(hass, rfxtrx):
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}
-                },
-            }
-        },
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}}
     )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -156,16 +156,12 @@ async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
 
 async def test_unknown_event_code(hass, rfxtrx):
     """Test with 3 switches."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {"1234567890": {}},
-            }
-        },
-    )
+    entry_data = create_rfx_test_cfg(devices={"1234567890": {"signal_repetitions": 1}})
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     conf_entries = hass.config_entries.async_entries(DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- yaml support is limited to one-time import
- New users can add the integration through config flow
- Options must be set through the UI once import is done (global options/add device/remove device/change device options)
- For newly added or detected devices, device_class cannot be set. Instead, it should be set by customizing entities:
https://www.home-assistant.io/docs/configuration/customizing-devices/
- The debug key is removed as option for the integration. Instead, log level for the library can be set by configuring the logger (see below). No configuration changes are necessary, to keep existing configs working, the key is still accepted.

```
logger:
  logs:
    RFXtrx: debug
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR brings full support of configuring the rfxtrx integration through UI. This is split into the following PR's:
- [x] Implement option flow: #37982 
- [x] Implement config flow: #39299
- [x] Make migration for older ConfigEntry keys (0.113 version): #39528
- [x] Add device validation to import: #39582
- [x] Allow removal of multiple devices at once: #39625
- [x] Migration function for devices which can change id (e.g. when exchanging batteries of some sensors): #39694
- [x] Bump pyRFXtrx to newest version and deprecate `debug` config key: #40679
- [x] Prevent adding duplicate device identifiers: #40656

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14158

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
