### PR TITLE
Add timestamp option for input_datetime.set_datetime

### DIFF
--- a/homeassistant/components/input_datetime/services.yaml
+++ b/homeassistant/components/input_datetime/services.yaml
@@ -1,18 +1,21 @@
 set_datetime:
-  description: This can be used to dynamically set the date and/or time.
+  description: This can be used to dynamically set the date and/or time. Use date/time, datetime or timestamp.
   fields:
     entity_id:
       description: Entity id of the input datetime to set the new value.
       example: input_datetime.test_date_time
     date:
-      description: The target date the entity should be set to. Do not use with datetime.
+      description: The target date the entity should be set to.
       example: '"2019-04-20"'
     time:
-      description: The target time the entity should be set to. Do not use with datetime.
+      description: The target time the entity should be set to.
       example: '"05:04:20"'
     datetime:
-      description: The target date & time the entity should be set to. Do not use with date or time.
+      description: The target date & time the entity should be set to.
       example: '"2019-04-20 05:04:20"'
+    timestamp:
+      description: The target date & time the entity should be set to as expressed by a UNIX timestamp.
+      example: 1598027400
 
 reload:
   description: Reload the input_datetime configuration.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Building on #38698, make it easier to set an `input_datetime` entity by directly accepting a UNIX timestamp.

Typically setting an `input_datetime` dynamically requires using fairly complex & error prone templates that first convert a string or `datetime` object to a timestamp, then do some math, and then convert back to a string. That last part is error prone because the format has to be just so and probably always requires referring back to the documentation. This change eliminates that last part to not only make it easier, but more importantly, less error prone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
automation:
  - trigger:
      platform: state
      entity_id: binary_sensor.motion
      to: 'on'
    action:
      - service: climate.turn_on
        entity_id: climate.office
      - service: input_datetime.set_datetime
        entity_id: input_datetime.turn_off_ac
        data_template:
          timestamp: "{{ now().timestamp() + 2*60*60 }}"
  - trigger:
      platform: time
      at: input_datetime.turn_off_ac
    action:
      service: climate.turn_off
      entity_id: climate.office
```
Currently the parameter to the `input_datetime.set_datetime` service would have to be something like this:
```yaml
          datetime: >
            {{ (now().timestamp() + 2*60*60)
               | timestamp_custom('%Y-%m-%d %H:%M:%S') }}
```
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#14308

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
