### PR TITLE
Add support for tplink emulation of devices to sense

### DIFF
--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -1,8 +1,8 @@
 """Support for monitoring a Sense energy sensor."""
 import asyncio
 from datetime import timedelta
-from time import time
 import logging
+from time import time
 
 from sense_energy import (
     ASyncSenseable,
@@ -13,6 +13,7 @@ from sense_energy import (
 )
 import voluptuous as vol
 
+import homeassistant.components as comps
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
@@ -22,7 +23,6 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_TIMEOUT,
 )
-import homeassistant.components as comps
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
@@ -112,7 +112,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_IMPORT},
-            data={CONF_EMAIL: conf[CONF_EMAIL], CONF_PASSWORD: conf[CONF_PASSWORD],},
+            data={CONF_EMAIL: conf[CONF_EMAIL], CONF_PASSWORD: conf[CONF_PASSWORD], },
         )
     )
     return True
@@ -189,7 +189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 def get_plug_devices(hass):
-    """Produced list of plug devices from config entities."""
+    """Produce list of plug devices from config entities."""
     entities = hass.data[DOMAIN][CONF_ENTITIES]
     for entity_id in entities:
         state = hass.states.get(entity_id)

--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -112,7 +112,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_IMPORT},
-            data={CONF_EMAIL: conf[CONF_EMAIL], CONF_PASSWORD: conf[CONF_PASSWORD], },
+            data={CONF_EMAIL: conf[CONF_EMAIL], CONF_PASSWORD: conf[CONF_PASSWORD]},
         )
     )
     return True

--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -102,7 +102,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         """Drvices to be emulated."""
         yield from get_plug_devices(hass)
 
-    hass.data[DOMAIN][SENSE_LINK] = SenseLink(devices())
+    hass.data[DOMAIN][SENSE_LINK] = SenseLink(devices)
     if hass.data[DOMAIN][CONF_ENTITIES]:
         await hass.data[DOMAIN][SENSE_LINK].start()
 

--- a/homeassistant/components/sense/const.py
+++ b/homeassistant/components/sense/const.py
@@ -4,6 +4,8 @@ import asyncio
 
 from sense_energy import SenseAPITimeoutException
 
+CONF_POWER = "power"
+
 DOMAIN = "sense"
 DEFAULT_TIMEOUT = 10
 ACTIVE_UPDATE_RATE = 60
@@ -12,6 +14,7 @@ SENSE_DATA = "sense_data"
 SENSE_DEVICE_UPDATE = "sense_devices_update"
 SENSE_DEVICES_DATA = "sense_devices_data"
 SENSE_DISCOVERED_DEVICES_DATA = "sense_discovered_devices"
+SENSE_LINK = "sense_link"
 SENSE_TRENDS_COORDINATOR = "sense_trends_coordinator"
 
 ACTIVE_NAME = "Energy"

--- a/homeassistant/components/sense/manifest.json
+++ b/homeassistant/components/sense/manifest.json
@@ -2,7 +2,7 @@
   "domain": "sense",
   "name": "Sense",
   "documentation": "https://www.home-assistant.io/integrations/sense",
-  "requirements": ["sense_energy==0.7.2"],
+  "requirements": ["sense_energy==0.8.0"],
   "codeowners": ["@kbickar"],
   "config_flow": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1955,7 +1955,7 @@ sendgrid==6.2.1
 sense-hat==2.2.0
 
 # homeassistant.components.sense
-sense_energy==0.7.2
+sense_energy==0.8.0
 
 # homeassistant.components.sentry
 sentry-sdk==0.16.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -888,7 +888,7 @@ samsungctl[websocket]==0.7.1
 samsungtvws[websocket]==1.4.0
 
 # homeassistant.components.sense
-sense_energy==0.7.2
+sense_energy==0.8.0
 
 # homeassistant.components.sentry
 sentry-sdk==0.16.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This update allows HA to emulate TP-Link Kasa HS110 Smart Plugs to help identify up to 20 devices controlled in ways normally unsupported by Sense.  The user configures the devices and the power that are reported to sense via the TP-Link interface

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sense:
  entities:
    light.dining_room:
      name: "Dining Room Lights"
      power: 40.2
    fan.ceiling_fan:
      power: >-
                {% if is_state_attr('fan.ceiling_fan','speed', 'low') %} 2
                {% elif is_state_attr('fan.ceiling_fan','speed', 'medium') %} 12
                {% elif is_state_attr('fan.ceiling_fan','speed', 'high') %} 48
                {% endif %}
    light.wled:
      name: "Strip Lights"
      power: "{{ states('sensor.wled_estimated_current') | float * 5 / 1000  }}"

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14290

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
