### PR TITLE
Make emulated_hue upnp responder async

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -220,7 +220,6 @@ omit =
     homeassistant/components/emby/media_player.py
     homeassistant/components/emoncms/sensor.py
     homeassistant/components/emoncms_history/*
-    homeassistant/components/emulated_hue/upnp.py
     homeassistant/components/enigma2/media_player.py
     homeassistant/components/enocean/__init__.py
     homeassistant/components/enocean/binary_sensor.py

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -21,7 +21,7 @@ from .hue_api import (
     HueUnauthorizedUser,
     HueUsernameView,
 )
-from .upnp import DescriptionXmlView, UPNPResponderThread
+from .upnp import DescriptionXmlView, create_upnp_datagram_endpoint
 
 DOMAIN = "emulated_hue"
 
@@ -120,17 +120,22 @@ async def async_setup(hass, yaml_config):
     HueGroupView(config).register(app, app.router)
     HueFullStateView(config).register(app, app.router)
 
-    upnp_listener = UPNPResponderThread(
+    listen = create_upnp_datagram_endpoint(
         config.host_ip_addr,
-        config.listen_port,
         config.upnp_bind_multicast,
         config.advertise_ip,
-        config.advertise_port,
+        config.advertise_port or config.listen_port,
     )
+    protocol = None
 
     async def stop_emulated_hue_bridge(event):
         """Stop the emulated hue bridge."""
-        upnp_listener.stop()
+        nonlocal protocol
+        nonlocal site
+        nonlocal runner
+
+        if protocol:
+            protocol.close()
         if site:
             await site.stop()
         if runner:
@@ -138,9 +143,11 @@ async def async_setup(hass, yaml_config):
 
     async def start_emulated_hue_bridge(event):
         """Start the emulated hue bridge."""
-        upnp_listener.start()
+        nonlocal protocol
         nonlocal site
         nonlocal runner
+
+        _, protocol = await listen
 
         runner = web.AppRunner(app)
         await runner.setup()
@@ -153,6 +160,8 @@ async def async_setup(hass, yaml_config):
             _LOGGER.error(
                 "Failed to create HTTP server at port %d: %s", config.listen_port, error
             )
+            if protocol:
+                protocol.close()
         else:
             hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_STOP, stop_emulated_hue_bridge

--- a/homeassistant/components/emulated_hue/upnp.py
+++ b/homeassistant/components/emulated_hue/upnp.py
@@ -1,8 +1,7 @@
 """Support UPNP discovery method that mimics Hue hubs."""
+import asyncio
 import logging
-import select
 import socket
-import threading
 
 from aiohttp import web
 
@@ -12,6 +11,9 @@ from homeassistant.components.http import HomeAssistantView
 from .const import HUE_SERIAL_NUMBER, HUE_UUID
 
 _LOGGER = logging.getLogger(__name__)
+
+BROADCAST_PORT = 1900
+BROADCAST_ADDR = "239.255.255.250"
 
 
 class DescriptionXmlView(HomeAssistantView):
@@ -53,105 +55,94 @@ class DescriptionXmlView(HomeAssistantView):
         return web.Response(text=resp_text, content_type="text/xml")
 
 
-class UPNPResponderThread(threading.Thread):
+@core.callback
+def create_upnp_datagram_endpoint(
+    host_ip_addr, upnp_bind_multicast, advertise_ip, advertise_port,
+):
+    """Create the UPNP socket and protocol."""
+
+    # Listen for UDP port 1900 packets sent to SSDP multicast address
+    ssdp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    ssdp_socket.setblocking(False)
+
+    # Required for receiving multicast
+    ssdp_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+    ssdp_socket.setsockopt(
+        socket.SOL_IP, socket.IP_MULTICAST_IF, socket.inet_aton(host_ip_addr)
+    )
+
+    ssdp_socket.setsockopt(
+        socket.SOL_IP,
+        socket.IP_ADD_MEMBERSHIP,
+        socket.inet_aton(BROADCAST_ADDR) + socket.inet_aton(host_ip_addr),
+    )
+
+    ssdp_socket.bind(("" if upnp_bind_multicast else host_ip_addr, BROADCAST_PORT))
+
+    loop = asyncio.get_event_loop()
+
+    return loop.create_datagram_endpoint(
+        lambda: UPNPResponderProtocol(loop, ssdp_socket, advertise_ip, advertise_port),
+        sock=ssdp_socket,
+    )
+
+
+class UPNPResponderProtocol:
     """Handle responding to UPNP/SSDP discovery requests."""
 
-    _interrupted = False
-
-    def __init__(
-        self,
-        host_ip_addr,
-        listen_port,
-        upnp_bind_multicast,
-        advertise_ip,
-        advertise_port,
-    ):
+    def __init__(self, loop, ssdp_socket, advertise_ip, advertise_port):
         """Initialize the class."""
-        threading.Thread.__init__(self)
-
-        self.host_ip_addr = host_ip_addr
-        self.listen_port = listen_port
-        self.upnp_bind_multicast = upnp_bind_multicast
+        self.transport = None
+        self._loop = loop
+        self._sock = ssdp_socket
         self.advertise_ip = advertise_ip
         self.advertise_port = advertise_port
-        self._ssdp_socket = None
-
-    def run(self):
-        """Run the server."""
-        # Listen for UDP port 1900 packets sent to SSDP multicast address
-        self._ssdp_socket = ssdp_socket = socket.socket(
-            socket.AF_INET, socket.SOCK_DGRAM
+        self._upnp_root_response = self._prepare_response(
+            "upnp:rootdevice", f"uuid:{HUE_UUID}::upnp:rootdevice"
         )
-        ssdp_socket.setblocking(False)
-
-        # Required for receiving multicast
-        ssdp_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-        ssdp_socket.setsockopt(
-            socket.SOL_IP, socket.IP_MULTICAST_IF, socket.inet_aton(self.host_ip_addr)
-        )
-
-        ssdp_socket.setsockopt(
-            socket.SOL_IP,
-            socket.IP_ADD_MEMBERSHIP,
-            socket.inet_aton("239.255.255.250") + socket.inet_aton(self.host_ip_addr),
-        )
-
-        if self.upnp_bind_multicast:
-            ssdp_socket.bind(("", 1900))
-        else:
-            ssdp_socket.bind((self.host_ip_addr, 1900))
-
-        while True:
-            if self._interrupted:
-                return
-
-            try:
-                read, _, _ = select.select([ssdp_socket], [], [ssdp_socket], 2)
-
-                if ssdp_socket in read:
-                    data, addr = ssdp_socket.recvfrom(1024)
-                else:
-                    # most likely the timeout, so check for interrupt
-                    continue
-            except OSError as ex:
-                if self._interrupted:
-                    return
-
-                _LOGGER.error(
-                    "UPNP Responder socket exception occurred: %s", ex.__str__
-                )
-                # without the following continue, a second exception occurs
-                # because the data object has not been initialized
-                continue
-
-            if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
-                _LOGGER.debug("UPNP Responder M-SEARCH method received: %s", data)
-                # SSDP M-SEARCH method received, respond to it with our info
-                response = self._handle_request(data)
-
-                resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                resp_socket.sendto(response, addr)
-                _LOGGER.debug("UPNP Responder responding with: %s", response)
-                resp_socket.close()
-
-    def stop(self):
-        """Stop the server."""
-        # Request for server
-        self._interrupted = True
-        if self._ssdp_socket:
-            clean_socket_close(self._ssdp_socket)
-        self.join()
-
-    def _handle_request(self, data):
-        if "upnp:rootdevice" in data.decode("utf-8", errors="ignore"):
-            return self._prepare_response(
-                "upnp:rootdevice", f"uuid:{HUE_UUID}::upnp:rootdevice"
-            )
-
-        return self._prepare_response(
+        self._upnp_device_response = self._prepare_response(
             "urn:schemas-upnp-org:device:basic:1", f"uuid:{HUE_UUID}"
         )
+
+    def connection_made(self, transport):
+        """Set the transport."""
+        self.transport = transport
+
+    def connection_lost(self, exc):
+        """Handle connection lost."""
+
+    def datagram_received(self, data, addr):
+        """Respond to msearch packets."""
+        decoded_data = data.decode("utf-8", errors="ignore")
+
+        if "M-SEARCH" not in decoded_data:
+            return
+
+        _LOGGER.debug("UPNP Responder M-SEARCH method received: %s", data)
+        # SSDP M-SEARCH method received, respond to it with our info
+        response = self._handle_request(decoded_data)
+        _LOGGER.debug("UPNP Responder responding with: %s", response)
+        self.transport.sendto(response, addr)
+
+    def error_received(self, exc):  # pylint: disable=no-self-use
+        """Log UPNP errors."""
+        _LOGGER.error("UPNP Error received: %s", exc)
+
+    def close(self):
+        """Stop the server."""
+        _LOGGER.info("UPNP responder shutting down")
+        if self.transport:
+            self.transport.close()
+        self._loop.remove_writer(self._sock.fileno())
+        self._loop.remove_reader(self._sock.fileno())
+        self._sock.close()
+
+    def _handle_request(self, decoded_data):
+        if "upnp:rootdevice" in decoded_data:
+            return self._upnp_root_response
+
+        return self._upnp_device_response
 
     def _prepare_response(self, search_target, unique_service_name):
         # Note that the double newline at the end of
@@ -167,10 +158,3 @@ USN: {unique_service_name}
 
 """
         return response.replace("\n", "\r\n").encode("utf-8")
-
-
-def clean_socket_close(sock):
-    """Close a socket connection and logs its closure."""
-    _LOGGER.info("UPNP responder shutting down")
-
-    sock.close()

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -96,7 +96,7 @@ def hass_hue(loop, hass):
         )
     )
 
-    with patch("homeassistant.components.emulated_hue.UPNPResponderThread"):
+    with patch("homeassistant.components.emulated_hue.create_upnp_datagram_endpoint"):
         loop.run_until_complete(
             setup.async_setup_component(
                 hass,


### PR DESCRIPTION
https://community.home-assistant.io/t/wth-stopping-service-is-too-slow/220507/6

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make emulated_hue upnp responder async.  We no longer need another
thread for the upnp responder.  We also no longer have to wait for shutdown.

Also removes `upnp.py` from `.covereagerc` as we have coverage now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
