### PR TITLE
Allow templates in data & service parameters (making data_template & service_template obsolete)

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -423,12 +423,17 @@ def remove_falsy(value: List[T]) -> List[T]:
     return [v for v in value if v]
 
 
-def service(value: Any) -> str:
+def service(value: Any) -> Union[str, template_helper.Template]:
     """Validate service."""
     # Services use same format as entities so we can use same helper.
     str_value = string(value).lower()
     if valid_entity_id(str_value):
         return str_value
+
+    template_value = template(value)
+    if isinstance(template_value, template_helper.Template):
+        return template_value
+
     raise vol.Invalid(f"Service {value} does not match format <domain>.<name>")
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -527,7 +527,7 @@ def template(value: Optional[Any]) -> Any:
         except TemplateError as ex:
             raise vol.Invalid(f"invalid template ({ex})")
 
-    return value
+    return template_helper.StaticTemplate(value)
 
 
 def template_complex(value: Any) -> Any:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -876,7 +876,7 @@ SERVICE_SCHEMA = vol.All(
         {
             vol.Optional(CONF_ALIAS): string,
             vol.Exclusive(CONF_SERVICE, "service name"): service,
-            vol.Exclusive(CONF_SERVICE_TEMPLATE, "service name"): template,
+            vol.Exclusive(CONF_SERVICE_TEMPLATE, "service name"): service,
             vol.Optional("data"): vol.All(dict, template_complex),
             vol.Optional("data_template"): vol.All(dict, template_complex),
             vol.Optional(CONF_ENTITY_ID): comp_entity_ids,

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -515,7 +515,9 @@ unit_system = vol.All(
 )
 
 
-def template(value: Optional[Any]) -> Any:
+def template(
+    value: Optional[Any],
+) -> Union[template_helper.Template, template_helper.StaticTemplate]:
     """Validate a jinja2 template."""
 
     if value is None:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -441,17 +441,17 @@ class _ScriptRun:
         self._log("Executing step %s", self._script.last_action)
         event_data = {}
         for conf in [CONF_EVENT_DATA, CONF_EVENT_DATA_TEMPLATE]:
-            if conf in self._action:
-                try:
-                    event_data.update(
-                        template.render_complex(self._action[conf], self._variables)
-                    )
-                except exceptions.TemplateError as ex:
-                    self._log(
-                        "Error rendering event data template: %s",
-                        ex,
-                        level=logging.ERROR,
-                    )
+            if conf not in self._action:
+                continue
+
+            try:
+                event_data.update(
+                    template.render_complex(self._action[conf], self._variables)
+                )
+            except exceptions.TemplateError as ex:
+                self._log(
+                    "Error rendering event data template: %s", ex, level=logging.ERROR,
+                )
 
         self._hass.bus.async_fire(
             self._action[CONF_EVENT], event_data, context=self._context

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -439,18 +439,19 @@ class _ScriptRun:
             CONF_ALIAS, self._action[CONF_EVENT]
         )
         self._log("Executing step %s", self._script.last_action)
-        event_data = dict(self._action.get(CONF_EVENT_DATA, {}))
-        if CONF_EVENT_DATA_TEMPLATE in self._action:
-            try:
-                event_data.update(
-                    template.render_complex(
-                        self._action[CONF_EVENT_DATA_TEMPLATE], self._variables
+        event_data = {}
+        for conf in [CONF_EVENT_DATA, CONF_EVENT_DATA_TEMPLATE]:
+            if conf in self._action:
+                try:
+                    event_data.update(
+                        template.render_complex(self._action[conf], self._variables)
                     )
-                )
-            except exceptions.TemplateError as ex:
-                self._log(
-                    "Error rendering event data template: %s", ex, level=logging.ERROR
-                )
+                except exceptions.TemplateError as ex:
+                    self._log(
+                        "Error rendering event data template: %s",
+                        ex,
+                        level=logging.ERROR,
+                    )
 
         self._hass.bus.async_fire(
             self._action[CONF_EVENT], event_data, context=self._context

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -131,12 +131,13 @@ def async_prepare_call_from_config(
 
     service_data = {}
     for conf in [CONF_SERVICE_DATA, CONF_SERVICE_DATA_TEMPLATE]:
-        if conf in config:
-            try:
-                template.attach(hass, config[conf])
-                service_data.update(template.render_complex(config[conf], variables))
-            except TemplateError as ex:
-                raise HomeAssistantError(f"Error rendering data template: {ex}") from ex
+        if conf not in config:
+            continue
+        try:
+            template.attach(hass, config[conf])
+            service_data.update(template.render_complex(config[conf], variables))
+        except TemplateError as ex:
+            raise HomeAssistantError(f"Error rendering data template: {ex}") from ex
 
     if CONF_SERVICE_ENTITY_ID in config:
         service_data[ATTR_ENTITY_ID] = config[CONF_SERVICE_ENTITY_ID]

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -27,7 +27,13 @@ from homeassistant.const import (
     MATCH_ALL,
     STATE_UNKNOWN,
 )
-from homeassistant.core import State, callback, split_entity_id, valid_entity_id
+from homeassistant.core import (
+    HomeAssistant,
+    State,
+    callback,
+    split_entity_id,
+    valid_entity_id,
+)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, location as loc_helper
 from homeassistant.helpers.typing import HomeAssistantType, TemplateVarsType
@@ -352,6 +358,79 @@ class Template:
     def __repr__(self) -> str:
         """Representation of Template."""
         return 'Template("' + self.template + '")'
+
+
+class StaticTemplate:
+    """Class to hold a static template."""
+
+    def __init__(self, template: Any, hass: Optional[HomeAssistant] = None):
+        """Instantiate a static template."""
+        self.template: Any = template
+        self.hass = hass
+
+    def ensure_valid(self):
+        """Return True as a static template is always valid."""
+        return True
+
+    def extract_entities(
+        self, variables: TemplateVarsType = None
+    ) -> Union[str, List[str]]:
+        """Extract all entities for state_changed listener."""
+        return []
+
+    def render(self, variables: TemplateVarsType = None, **kwargs: Any) -> Any:
+        """Render given template."""
+        return self.template
+
+    @callback
+    def async_render(self, variables: TemplateVarsType = None, **kwargs: Any) -> Any:
+        """Render given template.
+
+        This method must be run in the event loop.
+        """
+        return self.template
+
+    @callback
+    def async_render_to_info(
+        self, variables: TemplateVarsType = None, **kwargs: Any
+    ) -> RenderInfo:
+        """Render the template and collect an entity filter."""
+        assert self.hass
+        render_info = self.hass.data[_RENDER_INFO] = RenderInfo(self)
+        # pylint: disable=protected-access
+        render_info._result = self.template
+        render_info._freeze_static()
+        return render_info
+
+    def render_with_possible_json_value(self, value, error_value=_SENTINEL):
+        """Render template with value exposed."""
+        return self.template
+
+    @callback
+    def async_render_with_possible_json_value(
+        self, value, error_value=_SENTINEL, variables=None
+    ):
+        """Render template with value exposed.
+
+        This method must be run in the event loop.
+        """
+        return self.template
+
+    def __eq__(self, other):
+        """Compare template with another."""
+        return (
+            self.__class__ == other.__class__
+            and self.template == other.template
+            and self.hass == other.hass
+        )
+
+    def __hash__(self) -> int:
+        """Hash code for template."""
+        return hash(self.template)
+
+    def __repr__(self) -> str:
+        """Representation of Template."""
+        return 'StaticTemplate("' + self.template + '")'
 
 
 class AllStates:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -368,10 +368,12 @@ class StaticTemplate:
         self.template: Any = template
         self.hass = hass
 
+    # pylint: disable=no-self-use
     def ensure_valid(self):
         """Return True as a static template is always valid."""
         return True
 
+    # pylint: disable=no-self-use
     def extract_entities(
         self, variables: TemplateVarsType = None
     ) -> Union[str, List[str]]:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -71,13 +71,21 @@ async def test_firing_event_template(hass):
     sequence = cv.SCRIPT_SCHEMA(
         {
             "event": event,
-            "event_data_template": {
+            "event_data": {
                 "dict": {
                     1: "{{ is_world }}",
                     2: "{{ is_world }}{{ is_world }}",
                     3: "{{ is_world }}{{ is_world }}{{ is_world }}",
                 },
                 "list": ["{{ is_world }}", "{{ is_world }}{{ is_world }}"],
+            },
+            "event_data_template": {
+                "dict2": {
+                    1: "{{ is_world }}",
+                    2: "{{ is_world }}{{ is_world }}",
+                    3: "{{ is_world }}{{ is_world }}{{ is_world }}",
+                },
+                "list2": ["{{ is_world }}", "{{ is_world }}{{ is_world }}"],
             },
         }
     )
@@ -91,6 +99,8 @@ async def test_firing_event_template(hass):
     assert events[0].data == {
         "dict": {1: "yes", 2: "yesyes", 3: "yesyesyes"},
         "list": ["yes", "yesyes"],
+        "dict2": {1: "yes", 2: "yesyes", 3: "yesyesyes"},
+        "list2": ["yes", "yesyes"],
     }
 
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -149,11 +149,11 @@ class TestServiceHelpers(unittest.TestCase):
         config = {
             "service_template": "{{ 'test_domain.test_service' }}",
             "entity_id": "hello.world",
-            "data_template": {
+            "data": {
                 "hello": "{{ 'goodbye' }}",
                 "data": {"value": "{{ 'complex' }}", "simple": "simple"},
-                "list": ["{{ 'list' }}", "2"],
             },
+            "data_template": {"list": ["{{ 'list' }}", "2"]},
         }
 
         service.call_from_config(self.hass, config)

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -144,10 +144,10 @@ class TestServiceHelpers(unittest.TestCase):
         """Stop down everything that was started."""
         self.hass.stop()
 
-    def test_template_service_call(self):
+    def test_service_call(self):
         """Test service call with templating."""
         config = {
-            "service_template": "{{ 'test_domain.test_service' }}",
+            "service": "{{ 'test_domain.test_service' }}",
             "entity_id": "hello.world",
             "data": {
                 "hello": "{{ 'goodbye' }}",
@@ -163,6 +163,19 @@ class TestServiceHelpers(unittest.TestCase):
         assert self.calls[0].data["data"]["value"] == "complex"
         assert self.calls[0].data["data"]["simple"] == "simple"
         assert self.calls[0].data["list"][0] == "list"
+
+    def test_service_template_service_call(self):
+        """Test legacy service_template call with templating."""
+        config = {
+            "service_template": "{{ 'test_domain.test_service' }}",
+            "entity_id": "hello.world",
+            "data": {"hello": "goodbye"},
+        }
+
+        service.call_from_config(self.hass, config)
+        self.hass.block_till_done()
+
+        assert self.calls[0].data["hello"] == "goodbye"
 
     def test_passing_variables_to_templates(self):
         """Test passing variables to templates."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Based on: <https://community.home-assistant.io/t/stop-requiring-magic-to-enable-templates/219523>

This PR removes the need for `service_template` & `data_template` in service and event actions. Instead, `service` & `data` now accept templates.

If the string passed into `data` and `service` isn't a template, it will be handled normally as before.

This change is backward compatible, as `data_template` & `service_template` are still processed as before (however, they are not needed anymore).

Also fixes a regression introduced in #39008, that allowed `data_template` to be a non-dictionary value.

ℹ️  This PR is in draft until I've adjusted all documentation for this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14292

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
