### PR TITLE
Improve the performance of dt_util.utcnow()

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -52,7 +52,7 @@ def get_time_zone(time_zone_str: str) -> Optional[dt.tzinfo]:
 
 def utcnow() -> dt.datetime:
     """Get now in UTC time."""
-    return dt.datetime.now(UTC)
+    return dt.datetime.utcnow().replace(tzinfo=UTC)
 
 
 def now(time_zone: Optional[dt.tzinfo] = None) -> dt.datetime:

--- a/tests/components/metoffice/__init__.py
+++ b/tests/components/metoffice/__init__.py
@@ -1,1 +1,12 @@
 """Tests for the metoffice component."""
+
+import datetime
+
+
+class NewDateTime(datetime.datetime):
+    """Patch time to a specific point."""
+
+    @classmethod
+    def now(cls, *args, **kwargs):  # pylint: disable=signature-differs
+        """Overload datetime.datetime.now."""
+        return cls(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -1,9 +1,9 @@
 """The tests for the Met Office sensor component."""
-from datetime import datetime, timezone
 import json
 
 from homeassistant.components.metoffice.const import ATTRIBUTION, DOMAIN
 
+from . import NewDateTime
 from .const import (
     DATETIME_FORMAT,
     KINGSLYNN_SENSOR_RESULTS,
@@ -15,13 +15,12 @@ from .const import (
     WAVERTREE_SENSOR_RESULTS,
 )
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry, load_fixture
 
 
 @patch(
-    "datapoint.Forecast.datetime.datetime",
-    Mock(now=Mock(return_value=datetime(2020, 4, 25, 12, tzinfo=timezone.utc))),
+    "datapoint.Forecast.datetime.datetime", NewDateTime,
 )
 async def test_one_sensor_site_running(hass, requests_mock, legacy_patchable_time):
     """Test the Met Office sensor platform."""
@@ -58,8 +57,7 @@ async def test_one_sensor_site_running(hass, requests_mock, legacy_patchable_tim
 
 
 @patch(
-    "datapoint.Forecast.datetime.datetime",
-    Mock(now=Mock(return_value=datetime(2020, 4, 25, 12, tzinfo=timezone.utc))),
+    "datapoint.Forecast.datetime.datetime", NewDateTime,
 )
 async def test_two_sensor_sites_running(hass, requests_mock, legacy_patchable_time):
     """Test we handle two sets of sensors running for two different sites."""

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -1,24 +1,24 @@
 """The tests for the Met Office sensor component."""
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 import json
 
 from homeassistant.components.metoffice.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.util import utcnow
 
+from . import NewDateTime
 from .const import (
     METOFFICE_CONFIG_KINGSLYNN,
     METOFFICE_CONFIG_WAVERTREE,
     WAVERTREE_SENSOR_RESULTS,
 )
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
 @patch(
-    "datapoint.Forecast.datetime.datetime",
-    Mock(now=Mock(return_value=datetime(2020, 4, 25, 12, tzinfo=timezone.utc))),
+    "datapoint.Forecast.datetime.datetime", NewDateTime,
 )
 async def test_site_cannot_connect(hass, requests_mock, legacy_patchable_time):
     """Test we handle cannot connect error."""
@@ -39,8 +39,7 @@ async def test_site_cannot_connect(hass, requests_mock, legacy_patchable_time):
 
 
 @patch(
-    "datapoint.Forecast.datetime.datetime",
-    Mock(now=Mock(return_value=datetime(2020, 4, 25, 12, tzinfo=timezone.utc))),
+    "datapoint.Forecast.datetime.datetime", NewDateTime,
 )
 async def test_site_cannot_update(hass, requests_mock, legacy_patchable_time):
     """Test we handle cannot connect error."""
@@ -74,8 +73,7 @@ async def test_site_cannot_update(hass, requests_mock, legacy_patchable_time):
 
 
 @patch(
-    "datapoint.Forecast.datetime.datetime",
-    Mock(now=Mock(return_value=datetime(2020, 4, 25, 12, tzinfo=timezone.utc))),
+    "datapoint.Forecast.datetime.datetime", NewDateTime,
 )
 async def test_one_weather_site_running(hass, requests_mock, legacy_patchable_time):
     """Test the Met Office weather platform."""
@@ -108,8 +106,7 @@ async def test_one_weather_site_running(hass, requests_mock, legacy_patchable_ti
 
 
 @patch(
-    "datapoint.Forecast.datetime.datetime",
-    Mock(now=Mock(return_value=datetime(2020, 4, 25, 12, tzinfo=timezone.utc))),
+    "datapoint.Forecast.datetime.datetime", NewDateTime,
 )
 async def test_two_weather_sites_running(hass, requests_mock, legacy_patchable_time):
     """Test we handle two different weather sites both running."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We call utcnow() all over the place, and its a particularly time
sensitive function. In order to reduce tracking error, we can call
utcnow() directly and replace the timezone which is equivalent to
what is happening under the hood. This avoids the need to call
python code as these functions are all implemented in C which
gives us a more accurate timestamp because we loose a few less
microseconds fetching the time.

Before:

We can see it jump into pytz `fromutc`, figure out that that tzinfo is None
https://github.com/stub42/pytz/blob/master/src/pytz/__init__.py#L225

Then it jumps to `localize`
https://github.com/stub42/pytz/blob/master/src/pytz/__init__.py#L242

and ultimately ends up calling `dt.replace(tzinfo=self)`
<img width="209" alt="Screen Shot 2020-08-14 at 2 38 53 PM" src="https://user-images.githubusercontent.com/663432/90957612-3cffbc00-e454-11ea-8cd9-3b74251c210e.png">

After:

Everything is happening in compiled c code:
<img width="419" alt="Screen Shot 2020-08-14 at 2 38 42 PM" src="https://user-images.githubusercontent.com/663432/90957671-beefe500-e454-11ea-8f51-417429baa432.png">




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
