### PR TITLE
Upgrade py-cpuinfo to 7.0.0

### DIFF
--- a/homeassistant/components/cpuspeed/manifest.json
+++ b/homeassistant/components/cpuspeed/manifest.json
@@ -2,6 +2,6 @@
   "domain": "cpuspeed",
   "name": "CPU Speed",
   "documentation": "https://www.home-assistant.io/integrations/cpuspeed",
-  "requirements": ["py-cpuinfo==5.0.0"],
+  "requirements": ["py-cpuinfo==7.0.0"],
   "codeowners": ["@fabaff"]
 }

--- a/homeassistant/components/cpuspeed/sensor.py
+++ b/homeassistant/components/cpuspeed/sensor.py
@@ -11,12 +11,12 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_BRAND = "Brand"
-ATTR_HZ = "GHz Advertised"
+ATTR_BRAND = "brand"
+ATTR_HZ = "ghz_advertised"
 ATTR_ARCH = "arch"
 
-HZ_ACTUAL_RAW = "hz_actual_raw"
-HZ_ADVERTISED_RAW = "hz_advertised_raw"
+HZ_ACTUAL = "hz_actual"
+HZ_ADVERTISED = "hz_advertised"
 
 DEFAULT_NAME = "CPU speed"
 
@@ -30,7 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the CPU speed sensor."""
     name = config[CONF_NAME]
-
     add_entities([CpuSpeedSensor(name)], True)
 
 
@@ -38,7 +37,7 @@ class CpuSpeedSensor(Entity):
     """Representation of a CPU sensor."""
 
     def __init__(self, name):
-        """Initialize the sensor."""
+        """Initialize the CPU sensor."""
         self._name = name
         self._state = None
         self.info = None
@@ -62,10 +61,12 @@ class CpuSpeedSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         if self.info is not None:
-            attrs = {ATTR_ARCH: self.info["arch"], ATTR_BRAND: self.info["brand"]}
-
-            if HZ_ADVERTISED_RAW in self.info:
-                attrs[ATTR_HZ] = round(self.info[HZ_ADVERTISED_RAW][0] / 10 ** 9, 2)
+            attrs = {
+                ATTR_ARCH: self.info["arch_string_raw"],
+                ATTR_BRAND: self.info["brand_raw"],
+            }
+            if HZ_ADVERTISED in self.info:
+                attrs[ATTR_HZ] = round(self.info[HZ_ADVERTISED][0] / 10 ** 9, 2)
             return attrs
 
     @property
@@ -75,9 +76,8 @@ class CpuSpeedSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the state."""
-
         self.info = cpuinfo.get_cpu_info()
-        if HZ_ACTUAL_RAW in self.info:
-            self._state = round(float(self.info[HZ_ACTUAL_RAW][0]) / 10 ** 9, 2)
+        if HZ_ACTUAL in self.info:
+            self._state = round(float(self.info[HZ_ACTUAL][0]) / 10 ** 9, 2)
         else:
             self._state = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1157,7 +1157,7 @@ py-august==0.25.0
 py-canary==0.5.0
 
 # homeassistant.components.cpuspeed
-py-cpuinfo==5.0.0
+py-cpuinfo==7.0.0
 
 # homeassistant.components.melissa
 py-melissa-climate==2.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The naming of the attributes was updated to be aligned with the current used standards.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Upgrade py-cpuinfo to 7.0.0 ([Changelog](https://github.com/workhorsy/py-cpuinfo/blob/master/ChangeLog))
- Implement upstream changes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: cpuspeed
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
