### PR TITLE
Add Shelly integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -754,6 +754,8 @@ omit =
     homeassistant/components/seventeentrack/sensor.py
     homeassistant/components/shiftr/*
     homeassistant/components/shodan/sensor.py
+    homeassistant/components/shelly/__init__.py
+    homeassistant/components/shelly/switch.py
     homeassistant/components/sht31/sensor.py
     homeassistant/components/sigfox/sensor.py
     homeassistant/components/simplepush/notify.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -367,6 +367,7 @@ homeassistant/components/serial/* @fabaff
 homeassistant/components/seven_segments/* @fabaff
 homeassistant/components/seventeentrack/* @bachya
 homeassistant/components/shell_command/* @home-assistant/core
+homeassistant/components/shelly/* @balloob
 homeassistant/components/shiftr/* @fabaff
 homeassistant/components/shodan/* @fabaff
 homeassistant/components/sighthound/* @robmarkcole

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -1,0 +1,126 @@
+"""The Shelly integration."""
+import asyncio
+from datetime import timedelta
+import logging
+
+from aiocoap import error as aiocoap_error
+import aioshelly
+import async_timeout
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import aiohttp_client, update_coordinator
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+
+from .const import DOMAIN
+
+PLATFORMS = ["switch"]
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Shelly component."""
+    hass.data[DOMAIN] = {}
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Shelly from a config entry."""
+    try:
+        async with async_timeout.timeout(5):
+            device = await aioshelly.Device.create(
+                entry.data["host"], aiohttp_client.async_get_clientsession(hass)
+            )
+    except asyncio.TimeoutError:
+        raise ConfigEntryNotReady
+
+    wrapper = hass.data[DOMAIN][entry.entry_id] = ShellyDeviceWrapper(
+        hass, entry, device
+    )
+
+    wrapper.async_setup()
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
+    """Wrapper for a Shelly device with Home Assistant specific functions."""
+
+    def __init__(self, hass, entry, device: aioshelly.Device):
+        """Initialize the Shelly device wrapper."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=device.settings["name"] or entry.title,
+            update_interval=timedelta(seconds=5),
+        )
+        self.hass = hass
+        self.entry = entry
+        self.device = device
+        self._unsub_stop = None
+
+    async def _async_update_data(self):
+        """Fetch data."""
+        try:
+            async with async_timeout.timeout(5):
+                return await self.device.update()
+        except aiocoap_error.Error:
+            raise update_coordinator.UpdateFailed("Error fetching data")
+
+    @property
+    def mac(self):
+        """Mac address of the device."""
+        return self.device.settings["device"]["mac"]
+
+    @property
+    def device_info(self):
+        """Entity device info."""
+        return {
+            "name": self.name or self.entry.title,
+            "connections": {(CONNECTION_NETWORK_MAC, self.mac)},
+            "manufacturer": "Shelly",
+            "model": self.device.settings["device"]["type"],
+            "sw_version": self.device.settings["fw"],
+        }
+
+    @callback
+    def async_setup(self):
+        """Set up the wrapper."""
+        self._unsub_stop = self.hass.bus.async_listen(
+            EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop
+        )
+
+    async def shutdown(self):
+        """Shutdown the device wrapper."""
+        await self.device.shutdown()
+        if self._unsub_stop:
+            self._unsub_stop()
+            self._unsub_stop = None
+
+    async def _handle_ha_stop(self, _):
+        """Handle Home Assistant stopping."""
+        self._unsub_stop = None
+        await self.shutdown()
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        await hass.data[DOMAIN].pop(entry.entry_id).shutdown()
+
+    return unload_ok

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -82,6 +82,11 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
             raise update_coordinator.UpdateFailed("Error fetching data")
 
     @property
+    def model(self):
+        """Model of the device."""
+        return self.device.settings["device"]["type"]
+
+    @property
     def mac(self):
         """Mac address of the device."""
         return self.device.settings["device"]["mac"]
@@ -92,6 +97,7 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
             EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop
         )
         dev_reg = await device_registry.async_get_registry(self.hass)
+        model_type = self.device.settings["device"]["type"]
         dev_reg.async_get_or_create(
             config_entry_id=self.entry.entry_id,
             name=self.name,
@@ -99,7 +105,7 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
             # This is duplicate but otherwise via_device can't work
             identifiers={(DOMAIN, self.mac)},
             manufacturer="Shelly",
-            model=self.device.settings["device"]["type"],
+            model=aioshelly.MODEL_NAMES.get(model_type, model_type),
             sw_version=self.device.settings["fw"],
         )
 

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -37,7 +37,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-    info = None
     host = None
 
     async def async_step_user(self, user_input=None):
@@ -70,7 +69,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             aiohttp_client.async_get_clientsession(self.hass), zeroconf_info["host"]
         )
         await self.async_set_unique_id(info["mac"])
-        self.info = info
         self._abort_if_unique_id_configured({"host": zeroconf_info["host"]})
         self.host = zeroconf_info["host"]
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 
+import aiohttp
 import aioshelly
 import async_timeout
 import voluptuous as vol
@@ -14,6 +15,8 @@ from .const import DOMAIN  # pylint:disable=unused-import
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema({"host": str})
+
+HTTP_CONNECT_ERRORS = (asyncio.TimeoutError, aiohttp.ClientError)
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -45,17 +48,27 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             try:
-                device_info = await validate_input(self.hass, user_input)
-            except asyncio.TimeoutError:
+                info = await self._async_get_info(user_input["host"])
+            except HTTP_CONNECT_ERRORS:
                 errors["base"] = "cannot_connect"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+
             else:
-                await self.async_set_unique_id(device_info["mac"])
-                return self.async_create_entry(
-                    title=device_info["title"] or user_input["host"], data=user_input
-                )
+                if info["auth"]:
+                    return self.async_abort(reason="auth_not_supported")
+
+                try:
+                    device_info = await validate_input(self.hass, user_input)
+                except asyncio.TimeoutError:
+                    errors["base"] = "cannot_connect"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected exception")
+                    errors["base"] = "unknown"
+                else:
+                    await self.async_set_unique_id(device_info["mac"])
+                    return self.async_create_entry(
+                        title=device_info["title"] or user_input["host"],
+                        data=user_input,
+                    )
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
@@ -66,9 +79,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not zeroconf_info.get("name", "").startswith("shelly"):
             return self.async_abort(reason="not_shelly")
 
-        info = self.info = await aioshelly.get_info(
-            aiohttp_client.async_get_clientsession(self.hass), zeroconf_info["host"]
-        )
+        try:
+            self.info = info = await self._async_get_info(zeroconf_info["host"])
+        except HTTP_CONNECT_ERRORS:
+            return self.async_abort(reason="cannot_connect")
+
+        if info["auth"]:
+            return self.async_abort(reason="auth_not_supported")
+
         await self.async_set_unique_id(info["mac"])
         self._abort_if_unique_id_configured({"host": zeroconf_info["host"]})
         self.host = zeroconf_info["host"]
@@ -102,3 +120,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
             errors=errors,
         )
+
+    async def _async_get_info(self, host):
+        """Get info from shelly device."""
+        async with async_timeout.timeout(5):
+            return await aioshelly.get_info(
+                aiohttp_client.async_get_clientsession(self.hass), host,
+            )

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Shelly integration."""
+
+DOMAIN = "shelly"

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -4,9 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly2",
   "requirements": ["aioshelly==0.1"],
-  "ssdp": [],
   "zeroconf": ["_http._tcp.local."],
-  "homekit": {},
-  "dependencies": [],
   "codeowners": ["@balloob"]
 }

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "shelly",
+  "name": "Shelly",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/shelly2",
+  "requirements": ["aioshelly==0.1"],
+  "ssdp": [],
+  "zeroconf": ["_http._tcp.local."],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": ["@balloob"]
+}

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly2",
-  "requirements": ["aioshelly==0.1"],
+  "requirements": ["aioshelly==0.1.1"],
   "zeroconf": ["_http._tcp.local."],
   "codeowners": ["@balloob"]
 }

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly2",
-  "requirements": ["aioshelly==0.1.1"],
+  "requirements": ["aioshelly==0.1.2"],
   "zeroconf": ["_http._tcp.local."],
   "codeowners": ["@balloob"]
 }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -1,0 +1,23 @@
+{
+  "title": "Shelly",
+  "config": {
+    "flow_title": "Shelly: {name}",
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      },
+      "confirm_discovery": {
+        "description": "Do you want to set up Shelly?"
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -14,7 +14,8 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "auth_not_supported": "Shelly devices requiring authentication are not currently supported."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -9,7 +9,7 @@
         }
       },
       "confirm_discovery": {
-        "description": "Do you want to set up Shelly?"
+        "description": "Do you want to set up the {model} at {host}?"
       }
     },
     "error": {

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -1,4 +1,5 @@
 """Switch for Shelly."""
+from homeassistant.components.shelly import ShellyBlockEntity
 from homeassistant.components.switch import SwitchEntity
 
 from .const import DOMAIN
@@ -16,42 +17,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         async_add_entities(entities)
 
 
-class RelaySwitch(SwitchEntity):
+class RelaySwitch(ShellyBlockEntity, SwitchEntity):
     """Switch that controls a relay block on Shelly devices."""
-
-    def __init__(self, wrapper, block):
-        """Initialize Shelly entity."""
-        self.wrapper = wrapper
-        self.block = block
 
     @property
     def is_on(self) -> bool:
         """If switch is on."""
         return self.block.output
-
-    @property
-    def name(self):
-        """Name of entity."""
-        return f"{self.wrapper.name} - {self.block.description}"
-
-    @property
-    def should_poll(self):
-        """If device should be polled."""
-        return False
-
-    @property
-    def device_info(self):
-        """Device info."""
-        return self.wrapper.device_info
-
-    @property
-    def unique_id(self):
-        """Return unique ID of entity."""
-        return f"{self.wrapper.mac}-{self.block.index}"
-
-    async def async_added_to_hass(self):
-        """When entity is added to HASS."""
-        self.async_on_remove(self.wrapper.async_add_listener(self.async_write_ha_state))
 
     async def async_turn_on(self, **kwargs):
         """Turn on relay."""
@@ -60,7 +32,3 @@ class RelaySwitch(SwitchEntity):
     async def async_turn_off(self, **kwargs):
         """Turn off relay."""
         await self.block.turn_off()
-
-    async def async_update(self):
-        """Update entity with latest info."""
-        await self.wrapper.async_request_refresh()

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -1,0 +1,66 @@
+"""Switch for Shelly."""
+from homeassistant.components.switch import SwitchEntity
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up switches for device."""
+    wrapper = hass.data[DOMAIN][config_entry.entry_id]
+    entities = [
+        RelaySwitch(wrapper, block)
+        for block in wrapper.device.blocks
+        if block.type == "relay"
+    ]
+    if entities:
+        async_add_entities(entities)
+
+
+class RelaySwitch(SwitchEntity):
+    """Switch that controls a relay block on Shelly devices."""
+
+    def __init__(self, wrapper, block):
+        """Initialize Shelly entity."""
+        self.wrapper = wrapper
+        self.block = block
+
+    @property
+    def is_on(self) -> bool:
+        """If switch is on."""
+        return self.block.output
+
+    @property
+    def name(self):
+        """Name of entity."""
+        return f"{self.wrapper.name} - {self.block.description}"
+
+    @property
+    def should_poll(self):
+        """If device should be polled."""
+        return False
+
+    @property
+    def device_info(self):
+        """Device info."""
+        return self.wrapper.device_info
+
+    @property
+    def unique_id(self):
+        """Return unique ID of entity."""
+        return f"{self.wrapper.mac}-{self.block.index}"
+
+    async def async_added_to_hass(self):
+        """When entity is added to HASS."""
+        self.async_on_remove(self.wrapper.async_add_listener(self.async_write_ha_state))
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on relay."""
+        await self.block.turn_on()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off relay."""
+        await self.block.turn_off()
+
+    async def async_update(self):
+        """Update entity with latest info."""
+        await self.wrapper.async_request_refresh()

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -1,6 +1,7 @@
 """Switch for Shelly."""
 from homeassistant.components.shelly import ShellyBlockEntity
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import callback
 
 from .const import DOMAIN
 
@@ -8,27 +9,59 @@ from .const import DOMAIN
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switches for device."""
     wrapper = hass.data[DOMAIN][config_entry.entry_id]
-    entities = [
-        RelaySwitch(wrapper, block)
-        for block in wrapper.device.blocks
-        if block.type == "relay"
-    ]
-    if entities:
-        async_add_entities(entities)
+    relay_blocks = [block for block in wrapper.device.blocks if block.type == "relay"]
+    if not relay_blocks:
+        return
+
+    multiple_blocks = len(relay_blocks) > 1
+    async_add_entities(
+        RelaySwitch(wrapper, block, multiple_blocks=multiple_blocks)
+        for block in relay_blocks
+    )
 
 
 class RelaySwitch(ShellyBlockEntity, SwitchEntity):
     """Switch that controls a relay block on Shelly devices."""
 
+    def __init__(self, *args, multiple_blocks) -> None:
+        """Initialize relay switch."""
+        super().__init__(*args)
+        self.multiple_blocks = multiple_blocks
+        self.control_result = None
+
     @property
     def is_on(self) -> bool:
         """If switch is on."""
+        if self.control_result:
+            return self.control_result["ison"]
+
         return self.block.output
+
+    @property
+    def device_info(self):
+        """Device info."""
+        if not self.multiple_blocks:
+            return super().device_info
+
+        # If a device has multiple relays, we want to expose as separate device
+        return {
+            "name": self.name,
+            "identifiers": {(DOMAIN, self.wrapper.mac, self.block.index)},
+            "via_device": (DOMAIN, self.wrapper.mac),
+        }
 
     async def async_turn_on(self, **kwargs):
         """Turn on relay."""
-        await self.block.turn_on()
+        self.control_result = await self.block.turn_on()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn off relay."""
-        await self.block.turn_off()
+        self.control_result = await self.block.turn_off()
+        self.async_write_ha_state()
+
+    @callback
+    def _update_callback(self):
+        """When device updates, clear control result that overrides state."""
+        self.control_result = None
+        super()._update_callback()

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -10,7 +10,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switches for device."""
     wrapper = hass.data[DOMAIN][config_entry.entry_id]
     relay_blocks = [block for block in wrapper.device.blocks if block.type == "relay"]
+
     if not relay_blocks:
+        return
+
+    if wrapper.model == "SHSW-25" and wrapper.device.settings["mode"] != "relay":
         return
 
     multiple_blocks = len(relay_blocks) > 1

--- a/homeassistant/components/shelly/translations/en.json
+++ b/homeassistant/components/shelly/translations/en.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        },
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "unknown": "[%key:common::config_flow::error::unknown%]"
+        },
+        "flow_title": "Shelly: {name}",
+        "step": {
+            "confirm_discovery": {
+                "description": "Do you want to set up Shelly?"
+            },
+            "user": {
+                "data": {
+                    "host": "[%key:common::config_flow::data::host%]"
+                }
+            }
+        }
+    },
+    "title": "Shelly"
+}

--- a/homeassistant/components/shelly/translations/en.json
+++ b/homeassistant/components/shelly/translations/en.json
@@ -4,6 +4,7 @@
             "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         },
         "error": {
+            "auth_not_supported": "Authenticated Shelly devices are not currently supported.",
             "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
             "unknown": "[%key:common::config_flow::error::unknown%]"
         },

--- a/homeassistant/components/shelly/translations/en.json
+++ b/homeassistant/components/shelly/translations/en.json
@@ -10,7 +10,7 @@
         "flow_title": "Shelly: {name}",
         "step": {
             "confirm_discovery": {
-                "description": "Do you want to set up Shelly?"
+                "description": "Do you want to set up the {model} at {host}?"
             },
             "user": {
                 "data": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -151,6 +151,7 @@ FLOWS = [
     "samsungtv",
     "sense",
     "sentry",
+    "shelly",
     "shopping_list",
     "simplisafe",
     "smappee",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -37,6 +37,9 @@ ZEROCONF = {
     "_hap._tcp.local.": [
         "homekit_controller"
     ],
+    "_http._tcp.local.": [
+        "shelly"
+    ],
     "_ipp._tcp.local.": [
         "ipp"
     ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -221,6 +221,9 @@ aiopvpc==2.0.2
 # homeassistant.components.webostv
 aiopylgtv==0.3.3
 
+# homeassistant.components.shelly
+aioshelly==0.1
+
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -222,7 +222,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.1
+aioshelly==0.1.1
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -222,7 +222,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.1.1
+aioshelly==0.1.2
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,6 +131,9 @@ aiopvpc==2.0.2
 # homeassistant.components.webostv
 aiopylgtv==0.3.3
 
+# homeassistant.components.shelly
+aioshelly==0.1
+
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -132,7 +132,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.1.1
+aioshelly==0.1.2
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -132,7 +132,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.1
+aioshelly==0.1.1
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.0

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Shelly integration."""

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -1,0 +1,58 @@
+"""Test the Shelly config flow."""
+import asyncio
+
+from homeassistant import config_entries, setup
+from homeassistant.components.shelly.const import DOMAIN
+
+from tests.async_mock import AsyncMock, Mock, patch
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "aioshelly.Device.create",
+        return_value=Mock(
+            shutdown=AsyncMock(),
+            settings={"name": "Test name", "device": {"mac": "test-mac"}},
+        ),
+    ), patch(
+        "homeassistant.components.shelly.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.shelly.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "1.1.1.1"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Test name"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "aioshelly.Device.create", side_effect=asyncio.TimeoutError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "1.1.1.1"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -5,6 +5,7 @@ from homeassistant import config_entries, setup
 from homeassistant.components.shelly.const import DOMAIN
 
 from tests.async_mock import AsyncMock, Mock, patch
+from tests.common import MockConfigEntry
 
 
 async def test_form(hass):
@@ -56,3 +57,63 @@ async def test_form_cannot_connect(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_zeroconf(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "aioshelly.get_info", return_value={"mac": "abcd"},
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+        assert result["type"] == "form"
+        assert result["errors"] == {}
+
+    with patch(
+        "aioshelly.Device.create",
+        return_value=Mock(
+            shutdown=AsyncMock(),
+            settings={"name": "Test name", "device": {"mac": "test-mac"}},
+        ),
+    ), patch(
+        "homeassistant.components.shelly.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.shelly.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {},)
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Test name"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_already_configured(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain="shelly", unique_id="test-mac", data={"host": "0.0.0.0"}
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "aioshelly.get_info", return_value={"mac": "test-mac"},
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+        assert result["type"] == "abort"
+
+    # Test config entry got updated with latest IP
+    assert entry.data["host"] == "1.1.1.1"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1127,6 +1127,7 @@ async def test_unique_id_update_existing_entry_without_reload(hass, manager):
         domain="comp",
         data={"additional": "data", "host": "0.0.0.0"},
         unique_id="mock-unique-id",
+        state=config_entries.ENTRY_STATE_LOADED,
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a basic Shelly integration as a stub to built on top:
 - Can control Shelly devices without a username/password set
 - Supports zeroconf network discovery
 - Limited to relay blocks on Shelly devices (Shelly 1 etc)
 - Only tested with latest firmware
 - Does not support password protected devices

This integration is meant as a foundation on which a full-blown Shelly integration can be built.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
