### PR TITLE
Standardize uuid generation for events/storage/registry

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -4,7 +4,6 @@ import functools
 import logging
 from types import MappingProxyType
 from typing import Any, Callable, Dict, List, Optional, Set, Union, cast
-import uuid
 import weakref
 
 import attr
@@ -16,6 +15,7 @@ from homeassistant.helpers import entity_registry
 from homeassistant.helpers.event import Event
 from homeassistant.setup import async_process_deps_reqs, async_setup_component
 from homeassistant.util.decorator import Registry
+import homeassistant.util.uuid as uuid_util
 
 _LOGGER = logging.getLogger(__name__)
 _UNDEF: dict = {}
@@ -135,7 +135,7 @@ class ConfigEntry:
     ) -> None:
         """Initialize a config entry."""
         # Unique id of the config entry
-        self.entry_id = entry_id or uuid.uuid4().hex
+        self.entry_id = entry_id or uuid_util.uuid_v1mc_hex()
 
         # Version of the configuration.
         self.version = version

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -12,7 +12,6 @@ from ipaddress import ip_address
 import logging
 import os
 import pathlib
-import random
 import re
 import threading
 from time import monotonic
@@ -33,7 +32,6 @@ from typing import (
     Union,
     cast,
 )
-import uuid
 
 import attr
 import voluptuous as vol
@@ -77,6 +75,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.util.thread import fix_threading_exception_logging
 from homeassistant.util.timeout import TimeoutManager
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
+import homeassistant.util.uuid as uuid_util
 
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:
@@ -510,13 +509,7 @@ class Context:
 
     user_id: str = attr.ib(default=None)
     parent_id: Optional[str] = attr.ib(default=None)
-    # The uuid1 uses a random multicast MAC address instead of the real MAC address
-    # of the machine without the overhead of calling the getrandom() system call.
-    #
-    # This is effectively equivalent to PostgreSQL's uuid_generate_v1mc() function
-    id: str = attr.ib(
-        factory=lambda: uuid.uuid1(node=random.getrandbits(48) | (1 << 40)).hex
-    )
+    id: str = attr.ib(factory=uuid_util.uuid_v1mc_hex)
 
     def as_dict(self) -> dict:
         """Return a dictionary representation of the context."""

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -3,10 +3,9 @@ import abc
 import asyncio
 import logging
 from typing import Any, Dict, List, Optional, cast
+import uuid
 
 import voluptuous as vol
-
-import homeassistant.util.uuid as uuid_util
 
 from .core import HomeAssistant, callback
 from .exceptions import HomeAssistantError
@@ -121,7 +120,7 @@ class FlowManager(abc.ABC):
             raise UnknownFlow("Flow was not created")
         flow.hass = self.hass
         flow.handler = handler
-        flow.flow_id = uuid_util.uuid_v1mc_hex()
+        flow.flow_id = uuid.uuid4().hex
         flow.context = context
         self._progress[flow.flow_id] = flow
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -3,9 +3,10 @@ import abc
 import asyncio
 import logging
 from typing import Any, Dict, List, Optional, cast
-import uuid
 
 import voluptuous as vol
+
+import homeassistant.util.uuid as uuid_util
 
 from .core import HomeAssistant, callback
 from .exceptions import HomeAssistantError
@@ -120,7 +121,7 @@ class FlowManager(abc.ABC):
             raise UnknownFlow("Flow was not created")
         flow.hass = self.hass
         flow.handler = handler
-        flow.flow_id = uuid.uuid4().hex
+        flow.flow_id = uuid_util.uuid_v1mc_hex()
         flow.context = context
         self._progress[flow.flow_id] = flow
 

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -3,12 +3,12 @@ from asyncio import Event
 from collections import OrderedDict
 import logging
 from typing import Dict, Iterable, List, MutableMapping, Optional, cast
-import uuid
 
 import attr
 
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
+import homeassistant.util.uuid as uuid_util
 
 from .typing import HomeAssistantType
 
@@ -26,7 +26,7 @@ class AreaEntry:
     """Area Registry Entry."""
 
     name: Optional[str] = attr.ib(default=None)
-    id: str = attr.ib(factory=lambda: uuid.uuid4().hex)
+    id: str = attr.ib(factory=uuid_util.uuid_v1mc_hex)
 
 
 class AreaRegistry:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2,12 +2,12 @@
 from collections import OrderedDict
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
-import uuid
 
 import attr
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import Event, callback
+import homeassistant.util.uuid as uuid_util
 
 from .debounce import Debouncer
 from .singleton import singleton
@@ -73,7 +73,7 @@ class DeviceEntry:
     area_id: str = attr.ib(default=None)
     name_by_user: str = attr.ib(default=None)
     entry_type: str = attr.ib(default=None)
-    id: str = attr.ib(factory=lambda: uuid.uuid4().hex)
+    id: str = attr.ib(factory=uuid_util.uuid_v1mc_hex)
     # This value is not stored, just used to keep track of events to fire.
     is_new: bool = attr.ib(default=False)
 

--- a/homeassistant/util/uuid.py
+++ b/homeassistant/util/uuid.py
@@ -1,0 +1,15 @@
+"""Helpers to generate uuids."""
+
+import random
+import uuid
+
+
+def uuid_v1mc_hex() -> str:
+    """Generate a uuid1 with a random multicast MAC address.
+
+    The uuid1 uses a random multicast MAC address instead of the real MAC address
+    of the machine without the overhead of calling the getrandom() system call.
+
+    This is effectively equivalent to PostgreSQL's uuid_generate_v1mc() function
+    """
+    return uuid.uuid1(node=random.getrandbits(48) | (1 << 40)).hex

--- a/tests/util/test_uuid.py
+++ b/tests/util/test_uuid.py
@@ -1,0 +1,11 @@
+"""Test Home Assistant uuid util methods."""
+
+import uuid
+
+import homeassistant.util.uuid as uuid_util
+
+
+async def test_uuid_v1mc_hex():
+    """Verify we can generate a uuid_v1mc and return hex."""
+    assert len(uuid_util.uuid_v1mc_hex()) == 32
+    assert uuid.UUID(uuid_util.uuid_v1mc_hex())


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Standardize uuid generation for events/storage/registry
on the faster uuid1_mc

These areas do not need cryptographically secure uuids

The frequency of the `getrandom` syscall decreases a bit more with this change.

```
# strace -t -p 26433 -e trace=318
Process 26433 attached
09:21:20 syscall_318(0x7f0b73b1e5b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:20 syscall_318(0x7f0b7398d538, 0x20, 0, 0, 0, 0) = 0x20
09:21:20 syscall_318(0x7f0b737ce480, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:20 syscall_318(0x7f0b77b6a3b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:20 syscall_318(0x7f0b65940538, 0x20, 0, 0, 0, 0) = 0x20
09:21:20 syscall_318(0x7f0b7e6064a0, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:20 syscall_318(0x7f0b658730b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:20 syscall_318(0x7f0b7398f138, 0x20, 0, 0, 0, 0) = 0x20
09:21:20 syscall_318(0x7f0b737cea20, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:22 syscall_318(0x7f0b73ab28b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:22 syscall_318(0x7f0b73aa9538, 0x20, 0, 0, 0, 0) = 0x20
09:21:22 syscall_318(0x7f0b737d56e0, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:22 syscall_318(0x7f0b73994ab8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:22 syscall_318(0x7f0b73aacd38, 0x20, 0, 0, 0, 0) = 0x20
09:21:22 syscall_318(0x7f0b737d7e80, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:22 syscall_318(0x7f0b70f173b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:22 syscall_318(0x7f0b73aced38, 0x20, 0, 0, 0, 0) = 0x20
09:21:22 syscall_318(0x7f0b7397cdc0, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:24 syscall_318(0x7f0b73ab28b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:24 syscall_318(0x7f0b73ad2538, 0x20, 0, 0, 0, 0) = 0x20
09:21:24 syscall_318(0x7f0b737d79a0, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:24 syscall_318(0x7f0b73b1e5b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:24 syscall_318(0x7f0b73aa9538, 0x20, 0, 0, 0, 0) = 0x20
09:21:24 syscall_318(0x7f0b7e606300, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:24 syscall_318(0x7f0b77b6a3b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:24 syscall_318(0x7f0b7398d538, 0x20, 0, 0, 0, 0) = 0x20
09:21:24 syscall_318(0x7f0b74aa7260, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:26 syscall_318(0x7f0b77b6a3b8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:26 syscall_318(0x7f0b7398d538, 0x20, 0, 0, 0, 0) = 0x20
09:21:26 syscall_318(0x7f0b737ce780, 0x20, 0, 0, 0, 0x2) = 0x20
09:21:28 syscall_318(0x7f0b73994ab8, 0x20, 0, 0, 0, 0x20) = 0x20
09:21:28 syscall_318(0x7f0b73aced38, 0x20, 0, 0, 0, 0) = 0x20
09:21:28 syscall_318(0x7f0b7e6061c0, 0x20, 0, 0, 0, 0x2) = 0x20
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
