### PR TITLE
Subscribe to state change events only if the template has entities

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -484,12 +484,6 @@ class _TrackTemplateResultInfo:
         if self._info.exception:
             return True
 
-        # There are no entities in the template
-        # to track so this template will
-        # re-render on EVERY state change
-        if not self._info.domains and not self._info.entities:
-            return True
-
         return False
 
     @callback

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -39,7 +39,10 @@ async def test_if_fires_on_change_bool(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": "{{ true }}"},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": "{{ states.test.entity.state and true }}",
+                },
                 "action": {"service": "test.automation"},
             }
         },
@@ -64,7 +67,10 @@ async def test_if_fires_on_change_str(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": '{{ "true" }}'},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": '{{ states.test.entity.state and "true" }}',
+                },
                 "action": {"service": "test.automation"},
             }
         },
@@ -82,7 +88,10 @@ async def test_if_fires_on_change_str_crazy(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": '{{ "TrUE" }}'},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": '{{ states.test.entity.state and "TrUE" }}',
+                },
                 "action": {"service": "test.automation"},
             }
         },
@@ -100,7 +109,10 @@ async def test_if_not_fires_on_change_bool(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": "{{ false }}"},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": "{{ states.test.entity.state and false }}",
+                },
                 "action": {"service": "test.automation"},
             }
         },
@@ -178,7 +190,10 @@ async def test_if_fires_on_two_change(hass, calls):
         automation.DOMAIN,
         {
             automation.DOMAIN: {
-                "trigger": {"platform": "template", "value_template": "{{ true }}"},
+                "trigger": {
+                    "platform": "template",
+                    "value_template": "{{ states.test.entity.state and true }}",
+                },
                 "action": {"service": "test.automation"},
             }
         },

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -542,12 +542,6 @@ async def test_track_template_error(hass, caplog):
     assert "lunch" not in caplog.text
     assert "TemplateAssertionError" not in caplog.text
 
-    hass.states.async_set("switch.not_exist", "on")
-    await hass.async_block_till_done()
-
-    assert "lunch" in caplog.text
-    assert "TemplateAssertionError" in caplog.text
-
 
 async def test_track_template_result(hass):
     """Test tracking template."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Templates that do not reference any entities are no longer evaluated
every state change event as this could lead to an infinite loop
if the template always evaluated to different value and was used
in a template entity since it would fire another state change event.

This restores the 0.114 behavior

![ticker](https://user-images.githubusercontent.com/663432/90982727-a7852a80-e52e-11ea-8968-4220c3ae3a42.gif)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: template
    sensors:
      ticker:
        value_template: "{{ as_timestamp(now()) }}"
        unit_of_measurement: "ms"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
