### PR TITLE
Refactor KNX integration to centralize configuration yaml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -223,7 +223,7 @@ homeassistant/components/keba/* @dannerph
 homeassistant/components/keenetic_ndms2/* @foxel
 homeassistant/components/kef/* @basnijholt
 homeassistant/components/keyboard_remote/* @bendavid
-homeassistant/components/knx/* @Julius2342
+homeassistant/components/knx/* @Julius2342 @farmio @marvin-w
 homeassistant/components/kodi/* @armills @OnFreund
 homeassistant/components/konnected/* @heythisisnate @kit-klein
 homeassistant/components/lametric/* @robbiet480

--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -1,60 +1,16 @@
 """Support for KNX/IP binary sensors."""
-import voluptuous as vol
-from xknx.devices import BinarySensor
+from xknx.devices import BinarySensor as XknxBinarySensor
 
-from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
-from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
 
-from . import ATTR_DISCOVER_DEVICES, DATA_KNX, KNXAutomation
-
-CONF_STATE_ADDRESS = "state_address"
-CONF_SIGNIFICANT_BIT = "significant_bit"
-CONF_DEFAULT_SIGNIFICANT_BIT = 1
-CONF_SYNC_STATE = "sync_state"
-CONF_AUTOMATION = "automation"
-CONF_HOOK = "hook"
-CONF_DEFAULT_HOOK = "on"
-CONF_COUNTER = "counter"
-CONF_DEFAULT_COUNTER = 1
-CONF_ACTION = "action"
-CONF_RESET_AFTER = "reset_after"
-
-CONF__ACTION = "turn_off_action"
-
-DEFAULT_NAME = "KNX Binary Sensor"
-AUTOMATION_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_HOOK, default=CONF_DEFAULT_HOOK): cv.string,
-        vol.Optional(CONF_COUNTER, default=CONF_DEFAULT_COUNTER): cv.port,
-        vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
-    }
-)
-
-AUTOMATIONS_SCHEMA = vol.All(cv.ensure_list, [AUTOMATION_SCHEMA])
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(
-            CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT
-        ): cv.positive_int,
-        vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
-        vol.Required(CONF_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_DEVICE_CLASS): cv.string,
-        vol.Optional(CONF_RESET_AFTER): cv.positive_int,
-        vol.Optional(CONF_AUTOMATION): AUTOMATIONS_SCHEMA,
-    }
-)
+from . import ATTR_DISCOVER_DEVICES, DATA_KNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up binary sensor(s) for KNX platform."""
     if discovery_info is not None:
         async_add_entities_discovery(hass, discovery_info, async_add_entities)
-    else:
-        async_add_entities_config(hass, config, async_add_entities)
 
 
 @callback
@@ -67,48 +23,12 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     async_add_entities(entities)
 
 
-@callback
-def async_add_entities_config(hass, config, async_add_entities):
-    """Set up binary senor for KNX platform configured within platform."""
-    name = config[CONF_NAME]
-
-    binary_sensor = BinarySensor(
-        hass.data[DATA_KNX].xknx,
-        name=name,
-        group_address_state=config[CONF_STATE_ADDRESS],
-        sync_state=config[CONF_SYNC_STATE],
-        device_class=config.get(CONF_DEVICE_CLASS),
-        significant_bit=config[CONF_SIGNIFICANT_BIT],
-        reset_after=config.get(CONF_RESET_AFTER),
-    )
-    hass.data[DATA_KNX].xknx.devices.add(binary_sensor)
-
-    entity = KNXBinarySensor(binary_sensor)
-    automations = config.get(CONF_AUTOMATION)
-    if automations is not None:
-        for automation in automations:
-            counter = automation[CONF_COUNTER]
-            hook = automation[CONF_HOOK]
-            action = automation[CONF_ACTION]
-            entity.automations.append(
-                KNXAutomation(
-                    hass=hass,
-                    device=binary_sensor,
-                    hook=hook,
-                    action=action,
-                    counter=counter,
-                )
-            )
-    async_add_entities([entity])
-
-
 class KNXBinarySensor(BinarySensorEntity):
     """Representation of a KNX binary sensor."""
 
-    def __init__(self, device):
+    def __init__(self, device: XknxBinarySensor):
         """Initialize of KNX binary sensor."""
         self.device = device
-        self.automations = []
 
     @callback
     def async_register_callbacks(self):

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -1,127 +1,31 @@
 """Support for KNX/IP climate devices."""
 from typing import List, Optional
 
-import voluptuous as vol
-from xknx.devices import Climate as XknxClimate, ClimateMode as XknxClimateMode
+from xknx.devices import Climate as XknxClimate
 from xknx.dpt import HVACOperationMode
 
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
+from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     PRESET_AWAY,
-    PRESET_COMFORT,
-    PRESET_ECO,
-    PRESET_SLEEP,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
-from homeassistant.const import ATTR_TEMPERATURE, CONF_NAME, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
 
 from . import ATTR_DISCOVER_DEVICES, DATA_KNX
-
-CONF_SETPOINT_SHIFT_ADDRESS = "setpoint_shift_address"
-CONF_SETPOINT_SHIFT_STATE_ADDRESS = "setpoint_shift_state_address"
-CONF_SETPOINT_SHIFT_STEP = "setpoint_shift_step"
-CONF_SETPOINT_SHIFT_MAX = "setpoint_shift_max"
-CONF_SETPOINT_SHIFT_MIN = "setpoint_shift_min"
-CONF_TEMPERATURE_ADDRESS = "temperature_address"
-CONF_TARGET_TEMPERATURE_ADDRESS = "target_temperature_address"
-CONF_TARGET_TEMPERATURE_STATE_ADDRESS = "target_temperature_state_address"
-CONF_OPERATION_MODE_ADDRESS = "operation_mode_address"
-CONF_OPERATION_MODE_STATE_ADDRESS = "operation_mode_state_address"
-CONF_CONTROLLER_STATUS_ADDRESS = "controller_status_address"
-CONF_CONTROLLER_STATUS_STATE_ADDRESS = "controller_status_state_address"
-CONF_CONTROLLER_MODE_ADDRESS = "controller_mode_address"
-CONF_CONTROLLER_MODE_STATE_ADDRESS = "controller_mode_state_address"
-CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS = "operation_mode_frost_protection_address"
-CONF_OPERATION_MODE_NIGHT_ADDRESS = "operation_mode_night_address"
-CONF_OPERATION_MODE_COMFORT_ADDRESS = "operation_mode_comfort_address"
-CONF_OPERATION_MODES = "operation_modes"
-CONF_ON_OFF_ADDRESS = "on_off_address"
-CONF_ON_OFF_STATE_ADDRESS = "on_off_state_address"
-CONF_ON_OFF_INVERT = "on_off_invert"
-CONF_MIN_TEMP = "min_temp"
-CONF_MAX_TEMP = "max_temp"
-
-DEFAULT_NAME = "KNX Climate"
-DEFAULT_SETPOINT_SHIFT_STEP = 0.5
-DEFAULT_SETPOINT_SHIFT_MAX = 6
-DEFAULT_SETPOINT_SHIFT_MIN = -6
-DEFAULT_ON_OFF_INVERT = False
-# Map KNX operation modes to HA modes. This list might not be full.
-OPERATION_MODES = {
-    # Map DPT 201.105 HVAC control modes
-    "Auto": HVAC_MODE_AUTO,
-    "Heat": HVAC_MODE_HEAT,
-    "Cool": HVAC_MODE_COOL,
-    "Off": HVAC_MODE_OFF,
-    "Fan only": HVAC_MODE_FAN_ONLY,
-    "Dry": HVAC_MODE_DRY,
-}
+from .const import OPERATION_MODES, PRESET_MODES
 
 OPERATION_MODES_INV = dict(reversed(item) for item in OPERATION_MODES.items())
-
-PRESET_MODES = {
-    # Map DPT 201.100 HVAC operating modes to HA presets
-    "Frost Protection": PRESET_ECO,
-    "Night": PRESET_SLEEP,
-    "Standby": PRESET_AWAY,
-    "Comfort": PRESET_COMFORT,
-}
-
 PRESET_MODES_INV = dict(reversed(item) for item in PRESET_MODES.items())
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(
-            CONF_SETPOINT_SHIFT_STEP, default=DEFAULT_SETPOINT_SHIFT_STEP
-        ): vol.All(float, vol.Range(min=0, max=2)),
-        vol.Optional(
-            CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX
-        ): vol.All(int, vol.Range(min=0, max=32)),
-        vol.Optional(
-            CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN
-        ): vol.All(int, vol.Range(min=-32, max=0)),
-        vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
-        vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
-        vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
-        vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_STATUS_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_STATUS_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_MODE_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_MODE_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_NIGHT_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_COMFORT_ADDRESS): cv.string,
-        vol.Optional(CONF_ON_OFF_ADDRESS): cv.string,
-        vol.Optional(CONF_ON_OFF_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_ON_OFF_INVERT, default=DEFAULT_ON_OFF_INVERT): cv.boolean,
-        vol.Optional(CONF_OPERATION_MODES): vol.All(
-            cv.ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
-        ),
-        vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
-        vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
-    }
-)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up climate(s) for KNX platform."""
     if discovery_info is not None:
         async_add_entities_discovery(hass, discovery_info, async_add_entities)
-    else:
-        async_add_entities_config(hass, config, async_add_entities)
 
 
 @callback
@@ -134,68 +38,10 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     async_add_entities(entities)
 
 
-@callback
-def async_add_entities_config(hass, config, async_add_entities):
-    """Set up climate for KNX platform configured within platform."""
-    climate_mode = XknxClimateMode(
-        hass.data[DATA_KNX].xknx,
-        name=f"{config[CONF_NAME]} Mode",
-        group_address_operation_mode=config.get(CONF_OPERATION_MODE_ADDRESS),
-        group_address_operation_mode_state=config.get(
-            CONF_OPERATION_MODE_STATE_ADDRESS
-        ),
-        group_address_controller_status=config.get(CONF_CONTROLLER_STATUS_ADDRESS),
-        group_address_controller_status_state=config.get(
-            CONF_CONTROLLER_STATUS_STATE_ADDRESS
-        ),
-        group_address_controller_mode=config.get(CONF_CONTROLLER_MODE_ADDRESS),
-        group_address_controller_mode_state=config.get(
-            CONF_CONTROLLER_MODE_STATE_ADDRESS
-        ),
-        group_address_operation_mode_protection=config.get(
-            CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS
-        ),
-        group_address_operation_mode_night=config.get(
-            CONF_OPERATION_MODE_NIGHT_ADDRESS
-        ),
-        group_address_operation_mode_comfort=config.get(
-            CONF_OPERATION_MODE_COMFORT_ADDRESS
-        ),
-        operation_modes=config.get(CONF_OPERATION_MODES),
-    )
-    hass.data[DATA_KNX].xknx.devices.add(climate_mode)
-
-    climate = XknxClimate(
-        hass.data[DATA_KNX].xknx,
-        name=config[CONF_NAME],
-        group_address_temperature=config[CONF_TEMPERATURE_ADDRESS],
-        group_address_target_temperature=config.get(CONF_TARGET_TEMPERATURE_ADDRESS),
-        group_address_target_temperature_state=config[
-            CONF_TARGET_TEMPERATURE_STATE_ADDRESS
-        ],
-        group_address_setpoint_shift=config.get(CONF_SETPOINT_SHIFT_ADDRESS),
-        group_address_setpoint_shift_state=config.get(
-            CONF_SETPOINT_SHIFT_STATE_ADDRESS
-        ),
-        setpoint_shift_step=config[CONF_SETPOINT_SHIFT_STEP],
-        setpoint_shift_max=config[CONF_SETPOINT_SHIFT_MAX],
-        setpoint_shift_min=config[CONF_SETPOINT_SHIFT_MIN],
-        group_address_on_off=config.get(CONF_ON_OFF_ADDRESS),
-        group_address_on_off_state=config.get(CONF_ON_OFF_STATE_ADDRESS),
-        min_temp=config.get(CONF_MIN_TEMP),
-        max_temp=config.get(CONF_MAX_TEMP),
-        mode=climate_mode,
-        on_off_invert=config[CONF_ON_OFF_INVERT],
-    )
-    hass.data[DATA_KNX].xknx.devices.add(climate)
-
-    async_add_entities([KNXClimate(climate)])
-
-
 class KNXClimate(ClimateEntity):
     """Representation of a KNX climate device."""
 
-    def __init__(self, device):
+    def __init__(self, device: XknxClimate):
         """Initialize of a KNX climate device."""
         self.device = device
         self._unit_of_measurement = TEMP_CELSIUS

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -17,6 +17,9 @@ from homeassistant.components.climate.const import (
 DOMAIN = "knx"
 DATA_KNX = "data_knx"
 
+CONF_STATE_ADDRESS = "state_address"
+CONF_SYNC_STATE = "sync_state"
+
 
 class ColorTempModes(Enum):
     """Color temperature modes for config validation."""

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -1,0 +1,58 @@
+"""Constants for the KNX integration."""
+from enum import Enum
+
+from homeassistant.components.climate.const import (
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    PRESET_AWAY,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_SLEEP,
+)
+
+DOMAIN = "knx"
+DATA_KNX = "data_knx"
+
+
+class ColorTempModes(Enum):
+    """Color temperature modes for config validation."""
+
+    absolute = "DPT-7.600"
+    relative = "DPT-5.001"
+
+
+class DeviceTypes(Enum):
+    """KNX device types."""
+
+    cover = "cover"
+    light = "light"
+    binary_sensor = "binary_sensor"
+    climate = "climate"
+    switch = "switch"
+    notify = "notify"
+    scene = "scene"
+    sensor = "sensor"
+
+
+# Map KNX operation modes to HA modes. This list might not be complete.
+OPERATION_MODES = {
+    # Map DPT 20.105 HVAC control modes
+    "Auto": HVAC_MODE_AUTO,
+    "Heat": HVAC_MODE_HEAT,
+    "Cool": HVAC_MODE_COOL,
+    "Off": HVAC_MODE_OFF,
+    "Fan only": HVAC_MODE_FAN_ONLY,
+    "Dry": HVAC_MODE_DRY,
+}
+
+PRESET_MODES = {
+    # Map DPT 20.102 HVAC operating modes to HA presets
+    "Frost Protection": PRESET_ECO,
+    "Night": PRESET_SLEEP,
+    "Standby": PRESET_AWAY,
+    "Comfort": PRESET_COMFORT,
+}

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -1,11 +1,9 @@
 """Support for KNX/IP covers."""
-import voluptuous as vol
 from xknx.devices import Cover as XknxCover
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
-    PLATFORM_SCHEMA,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
@@ -13,53 +11,16 @@ from homeassistant.components.cover import (
     SUPPORT_STOP,
     CoverEntity,
 )
-from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_utc_time_change
 
 from . import ATTR_DISCOVER_DEVICES, DATA_KNX
-
-CONF_MOVE_LONG_ADDRESS = "move_long_address"
-CONF_MOVE_SHORT_ADDRESS = "move_short_address"
-CONF_POSITION_ADDRESS = "position_address"
-CONF_POSITION_STATE_ADDRESS = "position_state_address"
-CONF_ANGLE_ADDRESS = "angle_address"
-CONF_ANGLE_STATE_ADDRESS = "angle_state_address"
-CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
-CONF_TRAVELLING_TIME_UP = "travelling_time_up"
-CONF_INVERT_POSITION = "invert_position"
-CONF_INVERT_ANGLE = "invert_angle"
-
-DEFAULT_TRAVEL_TIME = 25
-DEFAULT_NAME = "KNX Cover"
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_MOVE_LONG_ADDRESS): cv.string,
-        vol.Optional(CONF_MOVE_SHORT_ADDRESS): cv.string,
-        vol.Optional(CONF_POSITION_ADDRESS): cv.string,
-        vol.Optional(CONF_POSITION_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_ANGLE_ADDRESS): cv.string,
-        vol.Optional(CONF_ANGLE_STATE_ADDRESS): cv.string,
-        vol.Optional(
-            CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
-        ): cv.positive_int,
-        vol.Optional(
-            CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME
-        ): cv.positive_int,
-        vol.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
-        vol.Optional(CONF_INVERT_ANGLE, default=False): cv.boolean,
-    }
-)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up cover(s) for KNX platform."""
     if discovery_info is not None:
         async_add_entities_discovery(hass, discovery_info, async_add_entities)
-    else:
-        async_add_entities_config(hass, config, async_add_entities)
 
 
 @callback
@@ -72,32 +33,10 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     async_add_entities(entities)
 
 
-@callback
-def async_add_entities_config(hass, config, async_add_entities):
-    """Set up cover for KNX platform configured within platform."""
-    cover = XknxCover(
-        hass.data[DATA_KNX].xknx,
-        name=config[CONF_NAME],
-        group_address_long=config.get(CONF_MOVE_LONG_ADDRESS),
-        group_address_short=config.get(CONF_MOVE_SHORT_ADDRESS),
-        group_address_position_state=config.get(CONF_POSITION_STATE_ADDRESS),
-        group_address_angle=config.get(CONF_ANGLE_ADDRESS),
-        group_address_angle_state=config.get(CONF_ANGLE_STATE_ADDRESS),
-        group_address_position=config.get(CONF_POSITION_ADDRESS),
-        travel_time_down=config[CONF_TRAVELLING_TIME_DOWN],
-        travel_time_up=config[CONF_TRAVELLING_TIME_UP],
-        invert_position=config[CONF_INVERT_POSITION],
-        invert_angle=config[CONF_INVERT_ANGLE],
-    )
-
-    hass.data[DATA_KNX].xknx.devices.add(cover)
-    async_add_entities([KNXCover(cover)])
-
-
 class KNXCover(CoverEntity):
     """Representation of a KNX cover."""
 
-    def __init__(self, device):
+    def __init__(self, device: XknxCover):
         """Initialize the cover."""
         self.device = device
         self._unsubscribe_auto_updater = None

--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -36,31 +36,31 @@ def create_knx_device(
 ) -> XknxDevice:
     """Return the requested XKNX device."""
     if device_type is DeviceTypes.light:
-        return __create_light(knx_module, config)
+        return _create_light(knx_module, config)
 
     if device_type is DeviceTypes.cover:
-        return __create_cover(knx_module, config)
+        return _create_cover(knx_module, config)
 
     if device_type is DeviceTypes.climate:
-        return __create_climate(hass, knx_module, config)
+        return _create_climate(hass, knx_module, config)
 
     if device_type is DeviceTypes.switch:
-        return __create_switch(knx_module, config)
+        return _create_switch(knx_module, config)
 
     if device_type is DeviceTypes.sensor:
-        return __create_sensor(knx_module, config)
+        return _create_sensor(knx_module, config)
 
     if device_type is DeviceTypes.notify:
-        return __create_notify(knx_module, config)
+        return _create_notify(knx_module, config)
 
     if device_type is DeviceTypes.scene:
-        return __create_scene(knx_module, config)
+        return _create_scene(knx_module, config)
 
     if device_type is DeviceTypes.binary_sensor:
-        return __create_binary_sensor(hass, knx_module, config)
+        return _create_binary_sensor(hass, knx_module, config)
 
 
-def __create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
+def _create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
     """Return a KNX Cover device to be used within XKNX."""
     return XknxCover(
         knx_module,
@@ -80,7 +80,7 @@ def __create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
     )
 
 
-def __create_light(knx_module: XKNX, config: ConfigType) -> XknxLight:
+def _create_light(knx_module: XKNX, config: ConfigType) -> XknxLight:
     """Return a KNX Light device to be used within XKNX."""
     group_address_tunable_white = None
     group_address_tunable_white_state = None
@@ -119,7 +119,7 @@ def __create_light(knx_module: XKNX, config: ConfigType) -> XknxLight:
     )
 
 
-def __create_climate(
+def _create_climate(
     hass: HomeAssistant, knx_module: XKNX, config: ConfigType
 ) -> XknxClimate:
     """Return a KNX Climate device to be used within XKNX."""
@@ -185,7 +185,7 @@ def __create_climate(
     )
 
 
-def __create_switch(knx_module: XKNX, config: ConfigType) -> XknxSwitch:
+def _create_switch(knx_module: XKNX, config: ConfigType) -> XknxSwitch:
     """Return a KNX switch to be used within XKNX."""
     return XknxSwitch(
         knx_module,
@@ -195,7 +195,7 @@ def __create_switch(knx_module: XKNX, config: ConfigType) -> XknxSwitch:
     )
 
 
-def __create_sensor(knx_module: XKNX, config: ConfigType) -> XknxSensor:
+def _create_sensor(knx_module: XKNX, config: ConfigType) -> XknxSensor:
     """Return a KNX sensor to be used within XKNX."""
     return XknxSensor(
         knx_module,
@@ -206,14 +206,14 @@ def __create_sensor(knx_module: XKNX, config: ConfigType) -> XknxSensor:
     )
 
 
-def __create_notify(knx_module: XKNX, config: ConfigType) -> XknxNotification:
+def _create_notify(knx_module: XKNX, config: ConfigType) -> XknxNotification:
     """Return a KNX notification to be used within XKNX."""
     return XknxNotification(
         knx_module, name=config[CONF_NAME], group_address=config[CONF_ADDRESS],
     )
 
 
-def __create_scene(knx_module: XKNX, config: ConfigType) -> XknxScene:
+def _create_scene(knx_module: XKNX, config: ConfigType) -> XknxScene:
     """Return a KNX scene to be used within XKNX."""
     return XknxScene(
         knx_module,
@@ -223,7 +223,7 @@ def __create_scene(knx_module: XKNX, config: ConfigType) -> XknxScene:
     )
 
 
-def __create_binary_sensor(
+def _create_binary_sensor(
     hass: HomeAssistant, knx_module: XKNX, config: ConfigType
 ) -> XknxBinarySensor:
     """Return a KNX binary sensor to be used within XKNX."""

--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -1,0 +1,254 @@
+"""Factory function to initialize KNX devices from config."""
+from xknx import XKNX
+from xknx.devices import (
+    ActionCallback as XknxActionCallback,
+    BinarySensor as XknxBinarySensor,
+    Climate as XknxClimate,
+    ClimateMode as XknxClimateMode,
+    Cover as XknxCover,
+    Device as XknxDevice,
+    Light as XknxLight,
+    Notification as XknxNotification,
+    Scene as XknxScene,
+    Sensor as XknxSensor,
+    Switch as XknxSwitch,
+)
+
+from homeassistant.const import CONF_ADDRESS, CONF_DEVICE_CLASS, CONF_NAME, CONF_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.script import Script
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DATA_KNX, DOMAIN, ColorTempModes, DeviceTypes
+from .schema import (
+    BinarySensorSchema,
+    ClimateSchema,
+    CoverSchema,
+    LightSchema,
+    SceneSchema,
+    SensorSchema,
+    SwitchSchema,
+)
+
+
+def create_knx_device(
+    hass: HomeAssistant, device_type: DeviceTypes, knx_module: XKNX, config: ConfigType
+) -> XknxDevice:
+    """Return the requested XKNX device."""
+    if device_type is DeviceTypes.light:
+        return __create_light(knx_module, config)
+
+    if device_type is DeviceTypes.cover:
+        return __create_cover(knx_module, config)
+
+    if device_type is DeviceTypes.climate:
+        return __create_climate(hass, knx_module, config)
+
+    if device_type is DeviceTypes.switch:
+        return __create_switch(knx_module, config)
+
+    if device_type is DeviceTypes.sensor:
+        return __create_sensor(knx_module, config)
+
+    if device_type is DeviceTypes.notify:
+        return __create_notify(knx_module, config)
+
+    if device_type is DeviceTypes.scene:
+        return __create_scene(knx_module, config)
+
+    if device_type is DeviceTypes.binary_sensor:
+        return __create_binary_sensor(hass, knx_module, config)
+
+
+def __create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
+    """Return a KNX Cover device to be used within XKNX."""
+    return XknxCover(
+        knx_module,
+        name=config[CONF_NAME],
+        group_address_long=config.get(CoverSchema.CONF_MOVE_LONG_ADDRESS),
+        group_address_short=config.get(CoverSchema.CONF_MOVE_SHORT_ADDRESS),
+        group_address_position_state=config.get(
+            CoverSchema.CONF_POSITION_STATE_ADDRESS
+        ),
+        group_address_angle=config.get(CoverSchema.CONF_ANGLE_ADDRESS),
+        group_address_angle_state=config.get(CoverSchema.CONF_ANGLE_STATE_ADDRESS),
+        group_address_position=config.get(CoverSchema.CONF_POSITION_ADDRESS),
+        travel_time_down=config[CoverSchema.CONF_TRAVELLING_TIME_DOWN],
+        travel_time_up=config[CoverSchema.CONF_TRAVELLING_TIME_UP],
+        invert_position=config[CoverSchema.CONF_INVERT_POSITION],
+        invert_angle=config[CoverSchema.CONF_INVERT_ANGLE],
+    )
+
+
+def __create_light(knx_module: XKNX, config: ConfigType) -> XknxLight:
+    """Return a KNX Light device to be used within XKNX."""
+    group_address_tunable_white = None
+    group_address_tunable_white_state = None
+    group_address_color_temp = None
+    group_address_color_temp_state = None
+    if config[LightSchema.CONF_COLOR_TEMP_MODE] == ColorTempModes.absolute:
+        group_address_color_temp = config.get(LightSchema.CONF_COLOR_TEMP_ADDRESS)
+        group_address_color_temp_state = config.get(
+            LightSchema.CONF_COLOR_TEMP_STATE_ADDRESS
+        )
+    elif config[LightSchema.CONF_COLOR_TEMP_MODE] == ColorTempModes.relative:
+        group_address_tunable_white = config.get(LightSchema.CONF_COLOR_TEMP_ADDRESS)
+        group_address_tunable_white_state = config.get(
+            LightSchema.CONF_COLOR_TEMP_STATE_ADDRESS
+        )
+
+    return XknxLight(
+        knx_module,
+        name=config[CONF_NAME],
+        group_address_switch=config[CONF_ADDRESS],
+        group_address_switch_state=config.get(LightSchema.CONF_STATE_ADDRESS),
+        group_address_brightness=config.get(LightSchema.CONF_BRIGHTNESS_ADDRESS),
+        group_address_brightness_state=config.get(
+            LightSchema.CONF_BRIGHTNESS_STATE_ADDRESS
+        ),
+        group_address_color=config.get(LightSchema.CONF_COLOR_ADDRESS),
+        group_address_color_state=config.get(LightSchema.CONF_COLOR_STATE_ADDRESS),
+        group_address_rgbw=config.get(LightSchema.CONF_RGBW_ADDRESS),
+        group_address_rgbw_state=config.get(LightSchema.CONF_RGBW_STATE_ADDRESS),
+        group_address_tunable_white=group_address_tunable_white,
+        group_address_tunable_white_state=group_address_tunable_white_state,
+        group_address_color_temperature=group_address_color_temp,
+        group_address_color_temperature_state=group_address_color_temp_state,
+        min_kelvin=config[LightSchema.CONF_MIN_KELVIN],
+        max_kelvin=config[LightSchema.CONF_MAX_KELVIN],
+    )
+
+
+def __create_climate(
+    hass: HomeAssistant, knx_module: XKNX, config: ConfigType
+) -> XknxClimate:
+    """Return a KNX Climate device to be used within XKNX."""
+    climate_mode = XknxClimateMode(
+        knx_module,
+        name=f"{config[CONF_NAME]} Mode",
+        group_address_operation_mode=config.get(
+            ClimateSchema.CONF_OPERATION_MODE_ADDRESS
+        ),
+        group_address_operation_mode_state=config.get(
+            ClimateSchema.CONF_OPERATION_MODE_STATE_ADDRESS
+        ),
+        group_address_controller_status=config.get(
+            ClimateSchema.CONF_CONTROLLER_STATUS_ADDRESS
+        ),
+        group_address_controller_status_state=config.get(
+            ClimateSchema.CONF_CONTROLLER_STATUS_STATE_ADDRESS
+        ),
+        group_address_controller_mode=config.get(
+            ClimateSchema.CONF_CONTROLLER_MODE_ADDRESS
+        ),
+        group_address_controller_mode_state=config.get(
+            ClimateSchema.CONF_CONTROLLER_MODE_STATE_ADDRESS
+        ),
+        group_address_operation_mode_protection=config.get(
+            ClimateSchema.CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS
+        ),
+        group_address_operation_mode_night=config.get(
+            ClimateSchema.CONF_OPERATION_MODE_NIGHT_ADDRESS
+        ),
+        group_address_operation_mode_comfort=config.get(
+            ClimateSchema.CONF_OPERATION_MODE_COMFORT_ADDRESS
+        ),
+        operation_modes=config.get(ClimateSchema.CONF_OPERATION_MODES),
+    )
+    hass.data[DATA_KNX].xknx.devices.add(climate_mode)
+
+    return XknxClimate(
+        knx_module,
+        name=config[CONF_NAME],
+        group_address_temperature=config[ClimateSchema.CONF_TEMPERATURE_ADDRESS],
+        group_address_target_temperature=config.get(
+            ClimateSchema.CONF_TARGET_TEMPERATURE_ADDRESS
+        ),
+        group_address_target_temperature_state=config[
+            ClimateSchema.CONF_TARGET_TEMPERATURE_STATE_ADDRESS
+        ],
+        group_address_setpoint_shift=config.get(
+            ClimateSchema.CONF_SETPOINT_SHIFT_ADDRESS
+        ),
+        group_address_setpoint_shift_state=config.get(
+            ClimateSchema.CONF_SETPOINT_SHIFT_STATE_ADDRESS
+        ),
+        setpoint_shift_step=config[ClimateSchema.CONF_SETPOINT_SHIFT_STEP],
+        setpoint_shift_max=config[ClimateSchema.CONF_SETPOINT_SHIFT_MAX],
+        setpoint_shift_min=config[ClimateSchema.CONF_SETPOINT_SHIFT_MIN],
+        group_address_on_off=config.get(ClimateSchema.CONF_ON_OFF_ADDRESS),
+        group_address_on_off_state=config.get(ClimateSchema.CONF_ON_OFF_STATE_ADDRESS),
+        min_temp=config.get(ClimateSchema.CONF_MIN_TEMP),
+        max_temp=config.get(ClimateSchema.CONF_MAX_TEMP),
+        mode=climate_mode,
+        on_off_invert=config[ClimateSchema.CONF_ON_OFF_INVERT],
+    )
+
+
+def __create_switch(knx_module: XKNX, config: ConfigType) -> XknxSwitch:
+    """Return a KNX switch to be used within XKNX."""
+    return XknxSwitch(
+        knx_module,
+        name=config[CONF_NAME],
+        group_address=config[CONF_ADDRESS],
+        group_address_state=config.get(SwitchSchema.CONF_STATE_ADDRESS),
+    )
+
+
+def __create_sensor(knx_module: XKNX, config: ConfigType) -> XknxSensor:
+    """Return a KNX sensor to be used within XKNX."""
+    return XknxSensor(
+        knx_module,
+        name=config[CONF_NAME],
+        group_address_state=config[SensorSchema.CONF_STATE_ADDRESS],
+        sync_state=config[SensorSchema.CONF_SYNC_STATE],
+        value_type=config[CONF_TYPE],
+    )
+
+
+def __create_notify(knx_module: XKNX, config: ConfigType) -> XknxNotification:
+    """Return a KNX notification to be used within XKNX."""
+    return XknxNotification(
+        knx_module, name=config[CONF_NAME], group_address=config[CONF_ADDRESS],
+    )
+
+
+def __create_scene(knx_module: XKNX, config: ConfigType) -> XknxScene:
+    """Return a KNX scene to be used within XKNX."""
+    return XknxScene(
+        knx_module,
+        name=config[CONF_NAME],
+        group_address=config[CONF_ADDRESS],
+        scene_number=config[SceneSchema.CONF_SCENE_NUMBER],
+    )
+
+
+def __create_binary_sensor(
+    hass: HomeAssistant, knx_module: XKNX, config: ConfigType
+) -> XknxBinarySensor:
+    """Return a KNX binary sensor to be used within XKNX."""
+    device_name = config[CONF_NAME]
+    actions = []
+    automations = config.get(BinarySensorSchema.CONF_AUTOMATION)
+    if automations is not None:
+        for automation in automations:
+            counter = automation[BinarySensorSchema.CONF_COUNTER]
+            hook = automation[BinarySensorSchema.CONF_HOOK]
+            action = automation[BinarySensorSchema.CONF_ACTION]
+            script_name = f"{device_name} turn ON script"
+            script = Script(hass, action, script_name, DOMAIN)
+            action = XknxActionCallback(
+                knx_module, script.async_run, hook=hook, counter=counter
+            )
+            actions.append(action)
+
+    return XknxBinarySensor(
+        knx_module,
+        name=device_name,
+        group_address_state=config[BinarySensorSchema.CONF_STATE_ADDRESS],
+        sync_state=config[BinarySensorSchema.CONF_SYNC_STATE],
+        device_class=config.get(CONF_DEVICE_CLASS),
+        significant_bit=config[BinarySensorSchema.CONF_SIGNIFICANT_BIT],
+        reset_after=config.get(BinarySensorSchema.CONF_RESET_AFTER),
+        actions=actions,
+    )

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -3,5 +3,5 @@
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
   "requirements": ["xknx==0.11.3"],
-  "codeowners": ["@Julius2342"]
+  "codeowners": ["@Julius2342", "@farmio", "@marvin-w"]
 }

--- a/homeassistant/components/knx/notify.py
+++ b/homeassistant/components/knx/notify.py
@@ -1,31 +1,16 @@
 """Support for KNX/IP notification services."""
-import voluptuous as vol
 from xknx.devices import Notification as XknxNotification
 
-from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService
-from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.components.notify import BaseNotificationService
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
 
 from . import ATTR_DISCOVER_DEVICES, DATA_KNX
-
-DEFAULT_NAME = "KNX Notify"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_ADDRESS): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
 
 
 async def async_get_service(hass, config, discovery_info=None):
     """Get the KNX notification service."""
-    return (
+    if discovery_info is not None:
         async_get_service_discovery(hass, discovery_info)
-        if discovery_info is not None
-        else async_get_service_config(hass, config)
-    )
 
 
 @callback
@@ -40,22 +25,10 @@ def async_get_service_discovery(hass, discovery_info):
     )
 
 
-@callback
-def async_get_service_config(hass, config):
-    """Set up notification for KNX platform configured within platform."""
-    notification = XknxNotification(
-        hass.data[DATA_KNX].xknx,
-        name=config[CONF_NAME],
-        group_address=config[CONF_ADDRESS],
-    )
-    hass.data[DATA_KNX].xknx.devices.add(notification)
-    return KNXNotificationService([notification])
-
-
 class KNXNotificationService(BaseNotificationService):
     """Implement demo notification service."""
 
-    def __init__(self, devices):
+    def __init__(self, devices: XknxNotification):
         """Initialize the service."""
         self.devices = devices
 

--- a/homeassistant/components/knx/scene.py
+++ b/homeassistant/components/knx/scene.py
@@ -1,35 +1,18 @@
 """Support for KNX scenes."""
 from typing import Any
 
-import voluptuous as vol
 from xknx.devices import Scene as XknxScene
 
-from homeassistant.components.scene import CONF_PLATFORM, Scene
-from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.components.scene import Scene
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
 
 from . import ATTR_DISCOVER_DEVICES, DATA_KNX
-
-CONF_SCENE_NUMBER = "scene_number"
-
-DEFAULT_NAME = "KNX SCENE"
-PLATFORM_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_PLATFORM): "knx",
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Required(CONF_ADDRESS): cv.string,
-        vol.Required(CONF_SCENE_NUMBER): cv.positive_int,
-    }
-)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the scenes for KNX platform."""
     if discovery_info is not None:
         async_add_entities_discovery(hass, discovery_info, async_add_entities)
-    else:
-        async_add_entities_config(hass, config, async_add_entities)
 
 
 @callback
@@ -42,23 +25,10 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     async_add_entities(entities)
 
 
-@callback
-def async_add_entities_config(hass, config, async_add_entities):
-    """Set up scene for KNX platform configured within platform."""
-    scene = XknxScene(
-        hass.data[DATA_KNX].xknx,
-        name=config[CONF_NAME],
-        group_address=config[CONF_ADDRESS],
-        scene_number=config[CONF_SCENE_NUMBER],
-    )
-    hass.data[DATA_KNX].xknx.devices.add(scene)
-    async_add_entities([KNXScene(scene)])
-
-
 class KNXScene(Scene):
     """Representation of a KNX scene."""
 
-    def __init__(self, scene):
+    def __init__(self, scene: XknxScene):
         """Init KNX scene."""
         self.scene = scene
 

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -12,7 +12,13 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
-from .const import OPERATION_MODES, PRESET_MODES, ColorTempModes
+from .const import (
+    CONF_STATE_ADDRESS,
+    CONF_SYNC_STATE,
+    OPERATION_MODES,
+    PRESET_MODES,
+    ColorTempModes,
+)
 
 
 class ConnectionSchema:
@@ -72,10 +78,10 @@ class CoverSchema:
 class BinarySensorSchema:
     """Voluptuous schema for KNX binary sensors."""
 
-    CONF_STATE_ADDRESS = "state_address"
+    CONF_STATE_ADDRESS = CONF_STATE_ADDRESS
     CONF_SIGNIFICANT_BIT = "significant_bit"
     CONF_DEFAULT_SIGNIFICANT_BIT = 1
-    CONF_SYNC_STATE = "sync_state"
+    CONF_SYNC_STATE = CONF_SYNC_STATE
     CONF_AUTOMATION = "automation"
     CONF_HOOK = "hook"
     CONF_DEFAULT_HOOK = "on"
@@ -113,7 +119,7 @@ class BinarySensorSchema:
 class LightSchema:
     """Voluptuous schema for KNX lights."""
 
-    CONF_STATE_ADDRESS = "state_address"
+    CONF_STATE_ADDRESS = CONF_STATE_ADDRESS
     CONF_BRIGHTNESS_ADDRESS = "brightness_address"
     CONF_BRIGHTNESS_STATE_ADDRESS = "brightness_state_address"
     CONF_COLOR_ADDRESS = "color_address"
@@ -233,7 +239,7 @@ class ClimateSchema:
 class SwitchSchema:
     """Voluptuous schema for KNX switches."""
 
-    CONF_STATE_ADDRESS = "state_address"
+    CONF_STATE_ADDRESS = CONF_STATE_ADDRESS
 
     DEFAULT_NAME = "KNX Switch"
     SCHEMA = vol.Schema(
@@ -248,10 +254,10 @@ class SwitchSchema:
 class ExposeSchema:
     """Voluptuous schema for KNX exposures."""
 
-    CONF_KNX_EXPOSE_TYPE = "type"
+    CONF_KNX_EXPOSE_TYPE = CONF_TYPE
     CONF_KNX_EXPOSE_ATTRIBUTE = "attribute"
     CONF_KNX_EXPOSE_DEFAULT = "default"
-    CONF_KNX_EXPOSE_ADDRESS = "address"
+    CONF_KNX_EXPOSE_ADDRESS = CONF_ADDRESS
 
     SCHEMA = vol.Schema(
         {
@@ -280,8 +286,8 @@ class NotifySchema:
 class SensorSchema:
     """Voluptuous schema for KNX sensors."""
 
-    CONF_STATE_ADDRESS = "state_address"
-    CONF_SYNC_STATE = "sync_state"
+    CONF_STATE_ADDRESS = CONF_STATE_ADDRESS
+    CONF_SYNC_STATE = CONF_SYNC_STATE
     DEFAULT_NAME = "KNX Sensor"
 
     SCHEMA = vol.Schema(

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -1,0 +1,309 @@
+"""Voluptuous schemas for the KNX integration."""
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_ADDRESS,
+    CONF_DEVICE_CLASS,
+    CONF_ENTITY_ID,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TYPE,
+)
+import homeassistant.helpers.config_validation as cv
+
+from .const import OPERATION_MODES, PRESET_MODES, ColorTempModes
+
+
+class ConnectionSchema:
+    """Voluptuous schema for KNX connection."""
+
+    CONF_KNX_LOCAL_IP = "local_ip"
+
+    TUNNELING_SCHEMA = vol.Schema(
+        {
+            vol.Required(CONF_HOST): cv.string,
+            vol.Optional(CONF_KNX_LOCAL_IP): cv.string,
+            vol.Optional(CONF_PORT): cv.port,
+        }
+    )
+
+    ROUTING_SCHEMA = vol.Schema({vol.Optional(CONF_KNX_LOCAL_IP): cv.string})
+
+
+class CoverSchema:
+    """Voluptuous schema for KNX covers."""
+
+    CONF_MOVE_LONG_ADDRESS = "move_long_address"
+    CONF_MOVE_SHORT_ADDRESS = "move_short_address"
+    CONF_POSITION_ADDRESS = "position_address"
+    CONF_POSITION_STATE_ADDRESS = "position_state_address"
+    CONF_ANGLE_ADDRESS = "angle_address"
+    CONF_ANGLE_STATE_ADDRESS = "angle_state_address"
+    CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
+    CONF_TRAVELLING_TIME_UP = "travelling_time_up"
+    CONF_INVERT_POSITION = "invert_position"
+    CONF_INVERT_ANGLE = "invert_angle"
+
+    DEFAULT_TRAVEL_TIME = 25
+    DEFAULT_NAME = "KNX Cover"
+
+    SCHEMA = vol.Schema(
+        {
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_MOVE_LONG_ADDRESS): cv.string,
+            vol.Optional(CONF_MOVE_SHORT_ADDRESS): cv.string,
+            vol.Optional(CONF_POSITION_ADDRESS): cv.string,
+            vol.Optional(CONF_POSITION_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_ANGLE_ADDRESS): cv.string,
+            vol.Optional(CONF_ANGLE_STATE_ADDRESS): cv.string,
+            vol.Optional(
+                CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
+            ): cv.positive_int,
+            vol.Optional(
+                CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME
+            ): cv.positive_int,
+            vol.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
+            vol.Optional(CONF_INVERT_ANGLE, default=False): cv.boolean,
+        }
+    )
+
+
+class BinarySensorSchema:
+    """Voluptuous schema for KNX binary sensors."""
+
+    CONF_STATE_ADDRESS = "state_address"
+    CONF_SIGNIFICANT_BIT = "significant_bit"
+    CONF_DEFAULT_SIGNIFICANT_BIT = 1
+    CONF_SYNC_STATE = "sync_state"
+    CONF_AUTOMATION = "automation"
+    CONF_HOOK = "hook"
+    CONF_DEFAULT_HOOK = "on"
+    CONF_COUNTER = "counter"
+    CONF_DEFAULT_COUNTER = 1
+    CONF_ACTION = "action"
+    CONF_RESET_AFTER = "reset_after"
+
+    DEFAULT_NAME = "KNX Binary Sensor"
+    AUTOMATION_SCHEMA = vol.Schema(
+        {
+            vol.Optional(CONF_HOOK, default=CONF_DEFAULT_HOOK): cv.string,
+            vol.Optional(CONF_COUNTER, default=CONF_DEFAULT_COUNTER): cv.port,
+            vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
+        }
+    )
+
+    AUTOMATIONS_SCHEMA = vol.All(cv.ensure_list, [AUTOMATION_SCHEMA])
+
+    SCHEMA = vol.Schema(
+        {
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(
+                CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT
+            ): cv.positive_int,
+            vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
+            vol.Required(CONF_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_DEVICE_CLASS): cv.string,
+            vol.Optional(CONF_RESET_AFTER): cv.positive_int,
+            vol.Optional(CONF_AUTOMATION): AUTOMATIONS_SCHEMA,
+        }
+    )
+
+
+class LightSchema:
+    """Voluptuous schema for KNX lights."""
+
+    CONF_STATE_ADDRESS = "state_address"
+    CONF_BRIGHTNESS_ADDRESS = "brightness_address"
+    CONF_BRIGHTNESS_STATE_ADDRESS = "brightness_state_address"
+    CONF_COLOR_ADDRESS = "color_address"
+    CONF_COLOR_STATE_ADDRESS = "color_state_address"
+    CONF_COLOR_TEMP_ADDRESS = "color_temperature_address"
+    CONF_COLOR_TEMP_STATE_ADDRESS = "color_temperature_state_address"
+    CONF_COLOR_TEMP_MODE = "color_temperature_mode"
+    CONF_RGBW_ADDRESS = "rgbw_address"
+    CONF_RGBW_STATE_ADDRESS = "rgbw_state_address"
+    CONF_MIN_KELVIN = "min_kelvin"
+    CONF_MAX_KELVIN = "max_kelvin"
+
+    DEFAULT_NAME = "KNX Light"
+    DEFAULT_COLOR_TEMP_MODE = "absolute"
+    DEFAULT_MIN_KELVIN = 2700  # 370 mireds
+    DEFAULT_MAX_KELVIN = 6000  # 166 mireds
+
+    SCHEMA = vol.Schema(
+        {
+            vol.Required(CONF_ADDRESS): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_BRIGHTNESS_ADDRESS): cv.string,
+            vol.Optional(CONF_BRIGHTNESS_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_COLOR_ADDRESS): cv.string,
+            vol.Optional(CONF_COLOR_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_COLOR_TEMP_ADDRESS): cv.string,
+            vol.Optional(CONF_COLOR_TEMP_STATE_ADDRESS): cv.string,
+            vol.Optional(
+                CONF_COLOR_TEMP_MODE, default=DEFAULT_COLOR_TEMP_MODE
+            ): cv.enum(ColorTempModes),
+            vol.Optional(CONF_RGBW_ADDRESS): cv.string,
+            vol.Optional(CONF_RGBW_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_MIN_KELVIN, default=DEFAULT_MIN_KELVIN): vol.All(
+                vol.Coerce(int), vol.Range(min=1)
+            ),
+            vol.Optional(CONF_MAX_KELVIN, default=DEFAULT_MAX_KELVIN): vol.All(
+                vol.Coerce(int), vol.Range(min=1)
+            ),
+        }
+    )
+
+
+class ClimateSchema:
+    """Voluptuous schema for KNX climate devices."""
+
+    CONF_SETPOINT_SHIFT_ADDRESS = "setpoint_shift_address"
+    CONF_SETPOINT_SHIFT_STATE_ADDRESS = "setpoint_shift_state_address"
+    CONF_SETPOINT_SHIFT_STEP = "setpoint_shift_step"
+    CONF_SETPOINT_SHIFT_MAX = "setpoint_shift_max"
+    CONF_SETPOINT_SHIFT_MIN = "setpoint_shift_min"
+    CONF_TEMPERATURE_ADDRESS = "temperature_address"
+    CONF_TARGET_TEMPERATURE_ADDRESS = "target_temperature_address"
+    CONF_TARGET_TEMPERATURE_STATE_ADDRESS = "target_temperature_state_address"
+    CONF_OPERATION_MODE_ADDRESS = "operation_mode_address"
+    CONF_OPERATION_MODE_STATE_ADDRESS = "operation_mode_state_address"
+    CONF_CONTROLLER_STATUS_ADDRESS = "controller_status_address"
+    CONF_CONTROLLER_STATUS_STATE_ADDRESS = "controller_status_state_address"
+    CONF_CONTROLLER_MODE_ADDRESS = "controller_mode_address"
+    CONF_CONTROLLER_MODE_STATE_ADDRESS = "controller_mode_state_address"
+    CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS = (
+        "operation_mode_frost_protection_address"
+    )
+    CONF_OPERATION_MODE_NIGHT_ADDRESS = "operation_mode_night_address"
+    CONF_OPERATION_MODE_COMFORT_ADDRESS = "operation_mode_comfort_address"
+    CONF_OPERATION_MODES = "operation_modes"
+    CONF_ON_OFF_ADDRESS = "on_off_address"
+    CONF_ON_OFF_STATE_ADDRESS = "on_off_state_address"
+    CONF_ON_OFF_INVERT = "on_off_invert"
+    CONF_MIN_TEMP = "min_temp"
+    CONF_MAX_TEMP = "max_temp"
+
+    DEFAULT_NAME = "KNX Climate"
+    DEFAULT_SETPOINT_SHIFT_STEP = 0.5
+    DEFAULT_SETPOINT_SHIFT_MAX = 6
+    DEFAULT_SETPOINT_SHIFT_MIN = -6
+    DEFAULT_ON_OFF_INVERT = False
+
+    SCHEMA = vol.Schema(
+        {
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(
+                CONF_SETPOINT_SHIFT_STEP, default=DEFAULT_SETPOINT_SHIFT_STEP
+            ): vol.All(float, vol.Range(min=0, max=2)),
+            vol.Optional(
+                CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX
+            ): vol.All(int, vol.Range(min=0, max=32)),
+            vol.Optional(
+                CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN
+            ): vol.All(int, vol.Range(min=-32, max=0)),
+            vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
+            vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
+            vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
+            vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_STATUS_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_STATUS_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_MODE_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_MODE_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_NIGHT_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_COMFORT_ADDRESS): cv.string,
+            vol.Optional(CONF_ON_OFF_ADDRESS): cv.string,
+            vol.Optional(CONF_ON_OFF_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_ON_OFF_INVERT, default=DEFAULT_ON_OFF_INVERT): cv.boolean,
+            vol.Optional(CONF_OPERATION_MODES): vol.All(
+                cv.ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
+            ),
+            vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
+            vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
+        }
+    )
+
+
+class SwitchSchema:
+    """Voluptuous schema for KNX switches."""
+
+    CONF_STATE_ADDRESS = "state_address"
+
+    DEFAULT_NAME = "KNX Switch"
+    SCHEMA = vol.Schema(
+        {
+            vol.Required(CONF_ADDRESS): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_STATE_ADDRESS): cv.string,
+        }
+    )
+
+
+class ExposeSchema:
+    """Voluptuous schema for KNX exposures."""
+
+    CONF_KNX_EXPOSE_TYPE = "type"
+    CONF_KNX_EXPOSE_ATTRIBUTE = "attribute"
+    CONF_KNX_EXPOSE_DEFAULT = "default"
+    CONF_KNX_EXPOSE_ADDRESS = "address"
+
+    SCHEMA = vol.Schema(
+        {
+            vol.Required(CONF_KNX_EXPOSE_TYPE): vol.Any(int, float, str),
+            vol.Optional(CONF_ENTITY_ID): cv.entity_id,
+            vol.Optional(CONF_KNX_EXPOSE_ATTRIBUTE): cv.string,
+            vol.Optional(CONF_KNX_EXPOSE_DEFAULT): cv.match_all,
+            vol.Required(CONF_KNX_EXPOSE_ADDRESS): cv.string,
+        }
+    )
+
+
+class NotifySchema:
+    """Voluptuous schema for KNX notifications."""
+
+    DEFAULT_NAME = "KNX Notify"
+
+    SCHEMA = vol.Schema(
+        {
+            vol.Required(CONF_ADDRESS): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        }
+    )
+
+
+class SensorSchema:
+    """Voluptuous schema for KNX sensors."""
+
+    CONF_STATE_ADDRESS = "state_address"
+    CONF_SYNC_STATE = "sync_state"
+    DEFAULT_NAME = "KNX Sensor"
+
+    SCHEMA = vol.Schema(
+        {
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
+            vol.Required(CONF_STATE_ADDRESS): cv.string,
+            vol.Required(CONF_TYPE): cv.string,
+        }
+    )
+
+
+class SceneSchema:
+    """Voluptuous schema for KNX scenes."""
+
+    CONF_SCENE_NUMBER = "scene_number"
+
+    DEFAULT_NAME = "KNX SCENE"
+    SCHEMA = vol.Schema(
+        {
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Required(CONF_ADDRESS): cv.string,
+            vol.Required(CONF_SCENE_NUMBER): cv.positive_int,
+        }
+    )

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -1,35 +1,16 @@
 """Support for KNX/IP sensors."""
-import voluptuous as vol
 from xknx.devices import Sensor as XknxSensor
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_TYPE
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 from . import ATTR_DISCOVER_DEVICES, DATA_KNX
-
-CONF_STATE_ADDRESS = "state_address"
-CONF_SYNC_STATE = "sync_state"
-DEFAULT_NAME = "KNX Sensor"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
-        vol.Required(CONF_STATE_ADDRESS): cv.string,
-        vol.Required(CONF_TYPE): cv.string,
-    }
-)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up sensor(s) for KNX platform."""
     if discovery_info is not None:
         async_add_entities_discovery(hass, discovery_info, async_add_entities)
-    else:
-        async_add_entities_config(hass, config, async_add_entities)
 
 
 @callback
@@ -42,24 +23,10 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     async_add_entities(entities)
 
 
-@callback
-def async_add_entities_config(hass, config, async_add_entities):
-    """Set up sensor for KNX platform configured within platform."""
-    sensor = XknxSensor(
-        hass.data[DATA_KNX].xknx,
-        name=config[CONF_NAME],
-        group_address_state=config[CONF_STATE_ADDRESS],
-        sync_state=config[CONF_SYNC_STATE],
-        value_type=config[CONF_TYPE],
-    )
-    hass.data[DATA_KNX].xknx.devices.add(sensor)
-    async_add_entities([KNXSensor(sensor)])
-
-
 class KNXSensor(Entity):
     """Representation of a KNX sensor."""
 
-    def __init__(self, device):
+    def __init__(self, device: XknxSensor):
         """Initialize of a KNX sensor."""
         self.device = device
 

--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -1,32 +1,16 @@
 """Support for KNX/IP switches."""
-import voluptuous as vol
 from xknx.devices import Switch as XknxSwitch
 
-from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
-from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
 
 from . import ATTR_DISCOVER_DEVICES, DATA_KNX
-
-CONF_STATE_ADDRESS = "state_address"
-
-DEFAULT_NAME = "KNX Switch"
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_ADDRESS): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_STATE_ADDRESS): cv.string,
-    }
-)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up switch(es) for KNX platform."""
     if discovery_info is not None:
         async_add_entities_discovery(hass, discovery_info, async_add_entities)
-    else:
-        async_add_entities_config(hass, config, async_add_entities)
 
 
 @callback
@@ -39,23 +23,10 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     async_add_entities(entities)
 
 
-@callback
-def async_add_entities_config(hass, config, async_add_entities):
-    """Set up switch for KNX platform configured within platform."""
-    switch = XknxSwitch(
-        hass.data[DATA_KNX].xknx,
-        name=config[CONF_NAME],
-        group_address=config[CONF_ADDRESS],
-        group_address_state=config.get(CONF_STATE_ADDRESS),
-    )
-    hass.data[DATA_KNX].xknx.devices.add(switch)
-    async_add_entities([KNXSwitch(switch)])
-
-
 class KNXSwitch(SwitchEntity):
     """Representation of a KNX switch."""
 
-    def __init__(self, device):
+    def __init__(self, device: XknxSwitch):
         """Initialize of KNX switch."""
         self.device = device
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


The KNX integration has been completely refactored to no longer rely on dedicated platform config but instead use the integration domain key as the base configuration.

Let's say you've previously used the following configuration:

```yaml

knx:
  tunneling: 
    host: '192.168.0.1'

switch:
  - platform: knx
    name: Switch
    address: '2/0/1'
    state_address: '2/0/2'

```
you will need to migrate it as follows:

```yaml

knx:
  tunneling: 
    host: '192.168.0.1'
  switch:
    - name: Switch
      address: '2/0/1'
      state_address: '2/0/2'

```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
knx:
  tunneling: 
    host: '192.168.0.1'
  cover: !include knx_cover.yaml
  climate: !include knx_climate.yaml
  light: !include knx_light.yaml
  binary_sensor: !include knx_binary_sensor.yaml
  switch: !include switch.yaml
  sensor: !include sensor.yaml
  notify: !include notify.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # -
- This PR is related to issue: -
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/14299

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
