### PR TITLE
Include the first seen context data in the logbook api

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
     UNIT_PERCENTAGE,
     __version__,
 )
-from homeassistant.core import callback as ha_callback, split_entity_id
+from homeassistant.core import Context, callback as ha_callback, split_entity_id
 from homeassistant.helpers.event import (
     async_track_state_change_event,
     track_point_in_utc_time,
@@ -490,9 +490,12 @@ class HomeAccessory(Accessory):
             ATTR_SERVICE: service,
             ATTR_VALUE: value,
         }
+        context = Context()
 
-        self.hass.bus.async_fire(EVENT_HOMEKIT_CHANGED, event_data)
-        await self.hass.services.async_call(domain, service, service_data)
+        self.hass.bus.async_fire(EVENT_HOMEKIT_CHANGED, event_data, context=context)
+        await self.hass.services.async_call(
+            domain, service, service_data, context=context
+        )
 
     @ha_callback
     def async_stop(self):

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -284,6 +284,7 @@ def humanify(hass, events, entity_attr_cache, context_lookup):
                         event,
                         context_event,
                         entity_attr_cache,
+                        external_events,
                     )
                 yield data
 
@@ -316,7 +317,12 @@ def humanify(hass, events, entity_attr_cache, context_lookup):
                 context_event = context_lookup.get(event.context_id)
                 if context_event and context_event != event:
                     _augment_data_with_context(
-                        data, entity_id, event, context_event, entity_attr_cache
+                        data,
+                        entity_id,
+                        event,
+                        context_event,
+                        entity_attr_cache,
+                        external_events,
                     )
 
                 yield data
@@ -368,7 +374,12 @@ def humanify(hass, events, entity_attr_cache, context_lookup):
                 context_event = context_lookup.get(event.context_id)
                 if context_event and context_event != event:
                     _augment_data_with_context(
-                        data, entity_id, event, context_event, entity_attr_cache
+                        data,
+                        entity_id,
+                        event,
+                        context_event,
+                        entity_attr_cache,
+                        external_events,
                     )
 
                 yield data
@@ -584,12 +595,13 @@ def _entry_message_from_event(entity_id, domain, event, entity_attr_cache):
 
 
 def _augment_data_with_context(
-    data, entity_id, event, context_event, entity_attr_cache
+    data, entity_id, event, context_event, entity_attr_cache, external_events
 ):
     event_type = context_event.event_type
 
     # State change
     context_entity_id = context_event.entity_id
+
     if entity_id and context_entity_id == entity_id:
         return
 
@@ -628,6 +640,13 @@ def _augment_data_with_context(
         attr_entity_id, context_event, entity_attr_cache
     )
     data["context_event_type"] = event_type
+
+    if event_type in external_events:
+        domain, describe_event = external_events[event_type]
+        data["context_domain"] = domain
+        name = describe_event(context_event).get(ATTR_NAME)
+        if name:
+            data["context_name"] = name
 
 
 def _entity_name_from_event(entity_id, event, entity_attr_cache):

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import aliased
 import voluptuous as vol
 
 from homeassistant.components import sun
+from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.history import sqlalchemy_filter_from_include_exclude_conf
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.recorder.models import (
@@ -18,6 +19,7 @@ from homeassistant.components.recorder.models import (
     process_timestamp_to_utc_isoformat,
 )
 from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_DOMAIN,
@@ -78,6 +80,9 @@ ALL_EVENT_TYPES = [
     EVENT_CALL_SERVICE,
     *HOMEASSISTANT_EVENTS,
 ]
+
+SCRIPT_AUTOMATION_EVENTS = [EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED]
+
 
 LOG_MESSAGE_SCHEMA = vol.Schema(
     {
@@ -274,7 +279,11 @@ def humanify(hass, events, entity_attr_cache, context_lookup):
                 context_event = context_lookup.get(event.context_id)
                 if context_event:
                     _augment_data_with_context(
-                        data, data.get(ATTR_ENTITY_ID), context_event, entity_attr_cache
+                        data,
+                        data.get(ATTR_ENTITY_ID),
+                        event,
+                        context_event,
+                        entity_attr_cache,
                     )
                 yield data
 
@@ -305,9 +314,9 @@ def humanify(hass, events, entity_attr_cache, context_lookup):
                     data["context_user_id"] = event.context_user_id
 
                 context_event = context_lookup.get(event.context_id)
-                if context_event:
+                if context_event and context_event != event:
                     _augment_data_with_context(
-                        data, entity_id, context_event, entity_attr_cache
+                        data, entity_id, event, context_event, entity_attr_cache
                     )
 
                 yield data
@@ -357,9 +366,9 @@ def humanify(hass, events, entity_attr_cache, context_lookup):
                     data["context_user_id"] = event.context_user_id
 
                 context_event = context_lookup.get(event.context_id)
-                if context_event:
+                if context_event and context_event != event:
                     _augment_data_with_context(
-                        data, entity_id, context_event, entity_attr_cache
+                        data, entity_id, event, context_event, entity_attr_cache
                     )
 
                 yield data
@@ -574,7 +583,9 @@ def _entry_message_from_event(entity_id, domain, event, entity_attr_cache):
     return f"changed to {state_state}"
 
 
-def _augment_data_with_context(data, entity_id, context_event, entity_attr_cache):
+def _augment_data_with_context(
+    data, entity_id, event, context_event, entity_attr_cache
+):
     event_type = context_event.event_type
 
     # State change
@@ -600,9 +611,16 @@ def _augment_data_with_context(data, entity_id, context_event, entity_attr_cache
         data["context_event_type"] = event_type
         return
 
-    # Script started or automation triggered
+    if not entity_id:
+        return
+
     attr_entity_id = event_data.get(ATTR_ENTITY_ID)
-    if not attr_entity_id or (entity_id and attr_entity_id == entity_id):
+    if not attr_entity_id or (
+        event_type in SCRIPT_AUTOMATION_EVENTS and attr_entity_id == entity_id
+    ):
+        return
+
+    if context_event == event:
         return
 
     data["context_entity_id"] = attr_entity_id
@@ -610,7 +628,6 @@ def _augment_data_with_context(data, entity_id, context_event, entity_attr_cache
         attr_entity_id, context_event, entity_attr_cache
     )
     data["context_event_type"] = event_type
-    return
 
 
 def _entity_name_from_event(entity_id, event, entity_attr_cache):

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -269,6 +269,9 @@ def humanify(hass, events, entity_attr_cache, context_entity_id_map):
                     context_entity_id = context_entity_id_map.get(event.context_id)
                     if context_entity_id and context_entity_id != data["entity_id"]:
                         data["context_entity_id"] = context_entity_id
+                        data["context_entity_id_name"] = _entity_id_name(
+                            hass, context_entity_id
+                        )
                 yield data
 
             if event.event_type == EVENT_STATE_CHANGED:
@@ -299,6 +302,9 @@ def humanify(hass, events, entity_attr_cache, context_entity_id_map):
                 context_entity_id = context_entity_id_map.get(event.context_id)
                 if context_entity_id and context_entity_id != entity_id:
                     data["context_entity_id"] = context_entity_id
+                    data["context_entity_id_name"] = _entity_id_name(
+                        hass, context_entity_id
+                    )
 
                 yield data
 
@@ -349,6 +355,9 @@ def humanify(hass, events, entity_attr_cache, context_entity_id_map):
                     context_entity_id = context_entity_id_map.get(event.context_id)
                     if context_entity_id and context_entity_id != entity_id:
                         data["context_entity_id"] = context_entity_id
+                        data["context_entity_id_name"] = _entity_id_name(
+                            hass, context_entity_id
+                        )
                 yield data
 
 
@@ -561,6 +570,16 @@ def _entry_message_from_event(entity_id, domain, event, entity_attr_cache):
         return "turned off"
 
     return f"changed to {state_state}"
+
+
+def _entity_id_name(hass, entity_id):
+    """Name of the entity id."""
+    state = hass.states.get(entity_id)
+    return (
+        state
+        and state.attributes.get(ATTR_FRIENDLY_NAME)
+        or split_entity_id(entity_id)[1].replace("_", " ")
+    )
 
 
 class LazyEventPartialState:

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -83,13 +83,13 @@ LOG_MESSAGE_SCHEMA = vol.Schema(
 
 
 @bind_hass
-def log_entry(hass, name, message, domain=None, entity_id=None):
+def log_entry(hass, name, message, domain=None, entity_id=None, context=None):
     """Add an entry to the logbook."""
-    hass.add_job(async_log_entry, hass, name, message, domain, entity_id)
+    hass.add_job(async_log_entry, hass, name, message, domain, entity_id, context)
 
 
 @bind_hass
-def async_log_entry(hass, name, message, domain=None, entity_id=None):
+def async_log_entry(hass, name, message, domain=None, entity_id=None, context=None):
     """Add an entry to the logbook."""
     data = {ATTR_NAME: name, ATTR_MESSAGE: message}
 
@@ -97,7 +97,7 @@ def async_log_entry(hass, name, message, domain=None, entity_id=None):
         data[ATTR_DOMAIN] = domain
     if entity_id is not None:
         data[ATTR_ENTITY_ID] = entity_id
-    hass.bus.async_fire(EVENT_LOGBOOK_ENTRY, data)
+    hass.bus.async_fire(EVENT_LOGBOOK_ENTRY, data, context=context)
 
 
 async def async_setup(hass, config):
@@ -215,7 +215,7 @@ class LogbookView(HomeAssistantView):
         return await hass.async_add_executor_job(json_events)
 
 
-def humanify(hass, events, entity_attr_cache):
+def humanify(hass, events, entity_attr_cache, context_entity_id_map):
     """Generate a converted list of events into Entry objects.
 
     Will try to group events if possible:
@@ -263,7 +263,12 @@ def humanify(hass, events, entity_attr_cache):
                 data = describe_event(event)
                 data["when"] = event.time_fired_isoformat
                 data["domain"] = domain
-                data["context_user_id"] = event.context_user_id
+                if event.context_user_id:
+                    data["context_user_id"] = event.context_user_id
+                if "entity_id" in data:
+                    context_entity_id = context_entity_id_map.get(event.context_id)
+                    if context_entity_id and context_entity_id != data["entity_id"]:
+                        data["context_entity_id"] = context_entity_id
                 yield data
 
             if event.event_type == EVENT_STATE_CHANGED:
@@ -277,20 +282,25 @@ def humanify(hass, events, entity_attr_cache):
                     # Skip all but the last sensor state
                     continue
 
-                name = entity_attr_cache.get(
-                    entity_id, ATTR_FRIENDLY_NAME, event
-                ) or split_entity_id(entity_id)[1].replace("_", " ")
-
-                yield {
+                data = {
                     "when": event.time_fired_isoformat,
-                    "name": name,
+                    "name": entity_attr_cache.get(entity_id, ATTR_FRIENDLY_NAME, event)
+                    or split_entity_id(entity_id)[1].replace("_", " "),
                     "message": _entry_message_from_event(
-                        hass, entity_id, domain, event, entity_attr_cache
+                        entity_id, domain, event, entity_attr_cache
                     ),
                     "domain": domain,
                     "entity_id": entity_id,
-                    "context_user_id": event.context_user_id,
                 }
+
+                if event.context_user_id:
+                    data["context_user_id"] = event.context_user_id
+
+                context_entity_id = context_entity_id_map.get(event.context_id)
+                if context_entity_id and context_entity_id != entity_id:
+                    data["context_entity_id"] = context_entity_id
+
+                yield data
 
             elif event.event_type == EVENT_HOMEASSISTANT_START:
                 if start_stop_events.get(event.time_fired_minute) == 2:
@@ -301,7 +311,6 @@ def humanify(hass, events, entity_attr_cache):
                     "name": "Home Assistant",
                     "message": "started",
                     "domain": HA_DOMAIN,
-                    "context_user_id": event.context_user_id,
                 }
 
             elif event.event_type == EVENT_HOMEASSISTANT_STOP:
@@ -315,7 +324,6 @@ def humanify(hass, events, entity_attr_cache):
                     "name": "Home Assistant",
                     "message": action,
                     "domain": HA_DOMAIN,
-                    "context_user_id": event.context_user_id,
                 }
 
             elif event.event_type == EVENT_LOGBOOK_ENTRY:
@@ -328,13 +336,20 @@ def humanify(hass, events, entity_attr_cache):
                     except IndexError:
                         pass
 
-                yield {
+                data = {
                     "when": event.time_fired_isoformat,
                     "name": event_data.get(ATTR_NAME),
                     "message": event_data.get(ATTR_MESSAGE),
                     "domain": domain,
                     "entity_id": entity_id,
                 }
+                if event.context_user_id:
+                    data["context_user_id"] = event.context_user_id
+                if entity_id:
+                    context_entity_id = context_entity_id_map.get(event.context_id)
+                    if context_entity_id and context_entity_id != entity_id:
+                        data["context_entity_id"] = context_entity_id
+                yield data
 
 
 def _get_events(
@@ -342,12 +357,13 @@ def _get_events(
 ):
     """Get events for a period of time."""
     entity_attr_cache = EntityAttributeCache(hass)
+    context_entity_id_map = {None: None}
 
     def yield_events(query):
         """Yield Events that are not filtered away."""
         for row in query.yield_per(1000):
             event = LazyEventPartialState(row)
-            if _keep_event(hass, event, entities_filter):
+            if _keep_event(hass, event, entities_filter, context_entity_id_map):
                 yield event
 
     with session_scope(hass=hass) as session:
@@ -366,6 +382,7 @@ def _get_events(
                 Events.event_type,
                 Events.event_data,
                 Events.time_fired,
+                Events.context_id,
                 Events.context_user_id,
                 States.state,
                 States.entity_id,
@@ -424,12 +441,17 @@ def _get_events(
                     entity_filter | (Events.event_type != EVENT_STATE_CHANGED)
                 )
 
-        return list(humanify(hass, yield_events(query), entity_attr_cache))
+        return list(
+            humanify(
+                hass, yield_events(query), entity_attr_cache, context_entity_id_map
+            )
+        )
 
 
-def _keep_event(hass, event, entities_filter):
+def _keep_event(hass, event, entities_filter, context_entity_id_map):
     if event.event_type == EVENT_STATE_CHANGED:
         entity_id = event.entity_id
+        context_entity_id_map.setdefault(event.context_id, entity_id)
     elif event.event_type in HOMEASSISTANT_EVENTS:
         entity_id = f"{HA_DOMAIN}."
     elif event.event_type in hass.data[DOMAIN] and ATTR_ENTITY_ID not in event.data:
@@ -442,7 +464,9 @@ def _keep_event(hass, event, entities_filter):
     else:
         event_data = event.data
         entity_id = event_data.get(ATTR_ENTITY_ID)
-        if entity_id is None:
+        if entity_id:
+            context_entity_id_map.setdefault(event.context_id, entity_id)
+        else:
             domain = event_data.get(ATTR_DOMAIN)
             if domain is None:
                 return False
@@ -451,7 +475,7 @@ def _keep_event(hass, event, entities_filter):
     return entities_filter is None or entities_filter(entity_id)
 
 
-def _entry_message_from_event(hass, entity_id, domain, event, entity_attr_cache):
+def _entry_message_from_event(entity_id, domain, event, entity_attr_cache):
     """Convert a state to a message for the logbook."""
     # We pass domain in so we don't have to split entity_id again
     state_state = event.state
@@ -552,6 +576,9 @@ class LazyEventPartialState:
         "entity_id",
         "state",
         "domain",
+        "context_id",
+        "context_user_id",
+        "time_fired_minute",
     ]
 
     def __init__(self, row):
@@ -565,11 +592,9 @@ class LazyEventPartialState:
         self.entity_id = self._row.entity_id
         self.state = self._row.state
         self.domain = self._row.domain
-
-    @property
-    def context_user_id(self):
-        """Context user id of event."""
-        return self._row.context_user_id
+        self.context_id = self._row.context_id
+        self.context_user_id = self._row.context_user_id
+        self.time_fired_minute = self._row.time_fired.minute
 
     @property
     def attributes(self):
@@ -593,11 +618,6 @@ class LazyEventPartialState:
             else:
                 self._event_data = json.loads(self._row.event_data)
         return self._event_data
-
-    @property
-    def time_fired_minute(self):
-        """Minute the event was fired not converted."""
-        return self._row.time_fired.minute
 
     @property
     def time_fired(self):

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -576,9 +576,9 @@ def _entity_id_name(hass, entity_id):
     """Name of the entity id."""
     state = hass.states.get(entity_id)
     return (
-        state
-        and state.attributes.get(ATTR_FRIENDLY_NAME)
-        or split_entity_id(entity_id)[1].replace("_", " ")
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        if state
+        else split_entity_id(entity_id)[1].replace("_", " ")
     )
 
 

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -66,6 +66,9 @@ class _TemplateAttribute:
         last_result: Optional[str],
         result: Union[str, TemplateError],
     ) -> None:
+        if event:
+            self._entity.async_set_context(event.context)
+
         if isinstance(result, TemplateError):
             _LOGGER.error(
                 "TemplateError('%s') "

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -226,7 +226,7 @@ async def _logbook_filtering(hass, last_changed, last_updated):
     def yield_events(event):
         for _ in range(10 ** 5):
             # pylint: disable=protected-access
-            if logbook._keep_event(hass, event, entities_filter, {}):
+            if logbook._keep_event(hass, event, entities_filter):
                 yield event
 
     start = timer()

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -226,12 +226,12 @@ async def _logbook_filtering(hass, last_changed, last_updated):
     def yield_events(event):
         for _ in range(10 ** 5):
             # pylint: disable=protected-access
-            if logbook._keep_event(hass, event, entities_filter):
+            if logbook._keep_event(hass, event, entities_filter, {}):
                 yield event
 
     start = timer()
 
-    list(logbook.humanify(hass, yield_events(event), entity_attr_cache))
+    list(logbook.humanify(hass, yield_events(event), entity_attr_cache, {}))
 
     return timer() - start
 

--- a/tests/components/alexa/test_init.py
+++ b/tests/components/alexa/test_init.py
@@ -44,6 +44,7 @@ async def test_humanify_alexa_event(hass):
                 ),
             ],
             entity_attr_cache,
+            {},
         )
     )
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1089,6 +1089,7 @@ async def test_logbook_humanify_automation_triggered_event(hass):
                 ),
             ],
             entity_attr_cache,
+            {},
         )
     )
 

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -44,6 +44,7 @@ async def test_humanify_homekit_changed_event(hass, hk_driver):
                 ),
             ],
             entity_attr_cache,
+            {},
         )
     )
 

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -192,7 +192,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
@@ -230,7 +230,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
@@ -277,7 +277,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB,
                 eventC,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
@@ -319,7 +319,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
@@ -365,7 +365,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
@@ -419,7 +419,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB,
                 eventC,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
@@ -476,7 +476,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB1,
                 eventB2,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
@@ -550,7 +550,7 @@ class TestComponentLogbook(unittest.TestCase):
                 eventC2,
                 eventC3,
             )
-            if logbook._keep_event(self.hass, e, entities_filter, {})
+            if logbook._keep_event(self.hass, e, entities_filter)
         ]
         entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -15,13 +15,16 @@ from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.recorder.models import process_timestamp_to_utc_isoformat
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
+    ATTR_DOMAIN,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_NAME,
+    ATTR_SERVICE,
     CONF_DOMAINS,
     CONF_ENTITIES,
     CONF_EXCLUDE,
     CONF_INCLUDE,
+    EVENT_CALL_SERVICE,
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
     EVENT_STATE_CHANGED,
@@ -97,7 +100,6 @@ class TestComponentLogbook(unittest.TestCase):
         events = list(
             logbook._get_events(
                 self.hass,
-                {},
                 dt_util.utcnow() - timedelta(hours=1),
                 dt_util.utcnow() + timedelta(hours=1),
             )
@@ -1854,6 +1856,7 @@ async def test_logbook_entity_context_id(hass, hass_client):
         user_id="b400facee45711eaa9308bfd3d19e474",
     )
 
+    # An Automation
     automation_entity_id_test = "automation.alarm"
     hass.bus.async_fire(
         EVENT_AUTOMATION_TRIGGERED,
@@ -1874,12 +1877,18 @@ async def test_logbook_entity_context_id(hass, hass_client):
 
     entity_id_test = "alarm_control_panel.area_001"
     hass.states.async_set(entity_id_test, STATE_OFF, context=context)
+    await hass.async_block_till_done()
     hass.states.async_set(entity_id_test, STATE_ON, context=context)
+    await hass.async_block_till_done()
     entity_id_second = "alarm_control_panel.area_002"
     hass.states.async_set(entity_id_second, STATE_OFF, context=context)
+    await hass.async_block_till_done()
     hass.states.async_set(entity_id_second, STATE_ON, context=context)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
     await hass.async_add_job(
         logbook.log_entry,
         hass,
@@ -1889,6 +1898,8 @@ async def test_logbook_entity_context_id(hass, hass_client):
         "alarm_control_panel.area_003",
         context,
     )
+    await hass.async_block_till_done()
+
     await hass.async_add_job(
         logbook.log_entry,
         hass,
@@ -1898,6 +1909,31 @@ async def test_logbook_entity_context_id(hass, hass_client):
         None,
         context,
     )
+    await hass.async_block_till_done()
+
+    # A service call
+    light_turn_off_service_context = ha.Context(
+        id="9c5bd62de45711eaaeb351041eec8dd9",
+        user_id="9400facee45711eaa9308bfd3d19e474",
+    )
+    hass.states.async_set("light.switch", STATE_ON)
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(
+        EVENT_CALL_SERVICE,
+        {
+            ATTR_DOMAIN: "light",
+            ATTR_SERVICE: "turn_off",
+            ATTR_ENTITY_ID: "light.switch",
+        },
+        context=light_turn_off_service_context,
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "light.switch", STATE_OFF, context=light_turn_off_service_context
+    )
+    await hass.async_block_till_done()
 
     await hass.async_add_job(trigger_db_commit, hass)
     await hass.async_block_till_done()
@@ -1922,16 +1958,19 @@ async def test_logbook_entity_context_id(hass, hass_client):
     assert json_dict[0]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
 
     assert json_dict[1]["entity_id"] == "script.mock_script"
+    assert json_dict[1]["context_event_type"] == "automation_triggered"
     assert json_dict[1]["context_entity_id"] == "automation.alarm"
     assert json_dict[1]["context_entity_id_name"] == "Alarm Automation"
     assert json_dict[1]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
 
     assert json_dict[2]["entity_id"] == entity_id_test
+    assert json_dict[2]["context_event_type"] == "automation_triggered"
     assert json_dict[2]["context_entity_id"] == "automation.alarm"
     assert json_dict[2]["context_entity_id_name"] == "Alarm Automation"
     assert json_dict[2]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
 
     assert json_dict[3]["entity_id"] == entity_id_second
+    assert json_dict[3]["context_event_type"] == "automation_triggered"
     assert json_dict[3]["context_entity_id"] == "automation.alarm"
     assert json_dict[3]["context_entity_id_name"] == "Alarm Automation"
     assert json_dict[3]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
@@ -1939,6 +1978,7 @@ async def test_logbook_entity_context_id(hass, hass_client):
     assert json_dict[4]["domain"] == "homeassistant"
 
     assert json_dict[5]["entity_id"] == "alarm_control_panel.area_003"
+    assert json_dict[5]["context_event_type"] == "automation_triggered"
     assert json_dict[5]["context_entity_id"] == "automation.alarm"
     assert json_dict[5]["domain"] == "alarm_control_panel"
     assert json_dict[5]["context_entity_id_name"] == "Alarm Automation"
@@ -1946,6 +1986,99 @@ async def test_logbook_entity_context_id(hass, hass_client):
 
     assert json_dict[6]["domain"] == "homeassistant"
     assert json_dict[6]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+
+    assert json_dict[7]["entity_id"] == "light.switch"
+    assert json_dict[7]["context_event_type"] == "call_service"
+    assert json_dict[7]["context_domain"] == "light"
+    assert json_dict[7]["context_service"] == "turn_off"
+    assert json_dict[7]["domain"] == "light"
+    assert json_dict[7]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
+
+
+async def test_logbook_context_from_template(hass, hass_client):
+    """Test the logbook view with end_time and entity with automations and scripts."""
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", {})
+    assert await async_setup_component(
+        hass,
+        "switch",
+        {
+            "switch": {
+                "platform": "template",
+                "switches": {
+                    "test_template_switch": {
+                        "value_template": "{{ states.switch.test_state.state }}",
+                        "turn_on": {
+                            "service": "switch.turn_on",
+                            "entity_id": "switch.test_state",
+                        },
+                        "turn_off": {
+                            "service": "switch.turn_off",
+                            "entity_id": "switch.test_state",
+                        },
+                    }
+                },
+            }
+        },
+    )
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # Entity added (should not be logged)
+    hass.states.async_set("switch.test_state", STATE_ON)
+    await hass.async_block_till_done()
+
+    # First state change (should be logged)
+    hass.states.async_set("switch.test_state", STATE_OFF)
+    await hass.async_block_till_done()
+
+    switch_turn_off_context = ha.Context(
+        id="9c5bd62de45711eaaeb351041eec8dd9",
+        user_id="9400facee45711eaa9308bfd3d19e474",
+    )
+    hass.states.async_set(
+        "switch.test_state", STATE_ON, context=switch_turn_off_context
+    )
+    await hass.async_block_till_done()
+
+    await hass.async_add_job(trigger_db_commit, hass)
+    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    client = await hass_client()
+
+    # Today time 00:00:00
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day)
+
+    # Test today entries with filter by end_time
+    end_time = start + timedelta(hours=24)
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}"
+    )
+    assert response.status == 200
+    json_dict = await response.json()
+
+    assert json_dict[0]["domain"] == "homeassistant"
+    assert "context_entity_id" not in json_dict[0]
+
+    assert json_dict[1]["entity_id"] == "switch.test_template_switch"
+
+    assert json_dict[2]["entity_id"] == "switch.test_state"
+
+    assert json_dict[3]["entity_id"] == "switch.test_template_switch"
+    assert json_dict[3]["context_entity_id"] == "switch.test_state"
+    assert json_dict[3]["context_entity_id_name"] == "test state"
+
+    assert json_dict[4]["entity_id"] == "switch.test_state"
+    assert json_dict[4]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
+
+    assert json_dict[5]["entity_id"] == "switch.test_template_switch"
+    assert json_dict[5]["context_entity_id"] == "switch.test_state"
+    assert json_dict[5]["context_entity_id_name"] == "test state"
+    assert json_dict[5]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
 
 
 class MockLazyEventPartialState(ha.Event):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -152,7 +152,7 @@ class TestComponentLogbook(unittest.TestCase):
         eventC = self.create_state_changed_event(pointC, entity_id, 30)
 
         entries = list(
-            logbook.humanify(self.hass, (eventA, eventB, eventC), entity_attr_cache)
+            logbook.humanify(self.hass, (eventA, eventB, eventC), entity_attr_cache, {})
         )
 
         assert len(entries) == 2
@@ -189,9 +189,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 2
         self.assert_entry(
@@ -227,9 +227,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 2
         self.assert_entry(
@@ -274,9 +274,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB,
                 eventC,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 2
         self.assert_entry(
@@ -316,9 +316,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 2
         self.assert_entry(
@@ -362,9 +362,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventA,
                 eventB,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 3
         self.assert_entry(
@@ -416,9 +416,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB,
                 eventC,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 4
         self.assert_entry(
@@ -473,9 +473,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventB1,
                 eventB2,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 5
         self.assert_entry(
@@ -547,9 +547,9 @@ class TestComponentLogbook(unittest.TestCase):
                 eventC2,
                 eventC3,
             )
-            if logbook._keep_event(self.hass, e, entities_filter)
+            if logbook._keep_event(self.hass, e, entities_filter, {})
         ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache))
+        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
 
         assert len(entries) == 6
         self.assert_entry(
@@ -585,6 +585,7 @@ class TestComponentLogbook(unittest.TestCase):
                     MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
                 ),
                 entity_attr_cache,
+                {},
             ),
         )
 
@@ -607,6 +608,7 @@ class TestComponentLogbook(unittest.TestCase):
                     self.create_state_changed_event(pointA, entity_id, 10),
                 ),
                 entity_attr_cache,
+                {},
             )
         )
 
@@ -628,21 +630,21 @@ class TestComponentLogbook(unittest.TestCase):
         # message for a device state change
         eventA = self.create_state_changed_event(pointA, "switch.bla", 10)
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "changed to 10"
 
         # message for a switch turned on
         eventA = self.create_state_changed_event(pointA, "switch.bla", STATE_ON)
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "turned on"
 
         # message for a switch turned off
         eventA = self.create_state_changed_event(pointA, "switch.bla", STATE_OFF)
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "turned off"
 
@@ -656,14 +658,14 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "device_tracker.john", STATE_NOT_HOME
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is away"
 
         # message for a device tracker "home" state
         eventA = self.create_state_changed_event(pointA, "device_tracker.john", "work")
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is at work"
 
@@ -675,14 +677,14 @@ class TestComponentLogbook(unittest.TestCase):
         # message for a device tracker "not home" state
         eventA = self.create_state_changed_event(pointA, "person.john", STATE_NOT_HOME)
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is away"
 
         # message for a device tracker "home" state
         eventA = self.create_state_changed_event(pointA, "person.john", "work")
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is at work"
 
@@ -696,7 +698,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "sun.sun", sun.STATE_ABOVE_HORIZON
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "has risen"
 
@@ -705,7 +707,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "sun.sun", sun.STATE_BELOW_HORIZON
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "has set"
 
@@ -720,7 +722,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.battery", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is low"
 
@@ -729,7 +731,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.battery", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is normal"
 
@@ -744,7 +746,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.connectivity", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is connected"
 
@@ -753,7 +755,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.connectivity", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is disconnected"
 
@@ -768,7 +770,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.door", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is opened"
 
@@ -777,7 +779,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.door", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is closed"
 
@@ -792,7 +794,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.garage_door", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is opened"
 
@@ -801,7 +803,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.garage_door", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is closed"
 
@@ -816,7 +818,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.opening", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is opened"
 
@@ -825,7 +827,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.opening", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is closed"
 
@@ -840,7 +842,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.window", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is opened"
 
@@ -849,7 +851,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.window", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is closed"
 
@@ -864,7 +866,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.lock", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is unlocked"
 
@@ -873,7 +875,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.lock", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is locked"
 
@@ -888,7 +890,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.plug", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is plugged in"
 
@@ -897,7 +899,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.plug", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is unplugged"
 
@@ -912,7 +914,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.presence", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is at home"
 
@@ -921,7 +923,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.presence", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is away"
 
@@ -936,7 +938,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.safety", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is unsafe"
 
@@ -945,7 +947,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.safety", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "is safe"
 
@@ -960,7 +962,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.cold", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected cold"
 
@@ -969,7 +971,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.cold", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no cold detected)"
 
@@ -984,7 +986,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.gas", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected gas"
 
@@ -993,7 +995,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.gas", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no gas detected)"
 
@@ -1008,7 +1010,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.heat", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected heat"
 
@@ -1017,7 +1019,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.heat", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no heat detected)"
 
@@ -1032,7 +1034,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.light", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected light"
 
@@ -1041,7 +1043,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.light", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no light detected)"
 
@@ -1056,7 +1058,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.moisture", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected moisture"
 
@@ -1065,7 +1067,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.moisture", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no moisture detected)"
 
@@ -1080,7 +1082,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.motion", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected motion"
 
@@ -1089,7 +1091,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.motion", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no motion detected)"
 
@@ -1104,7 +1106,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.occupancy", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected occupancy"
 
@@ -1113,7 +1115,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.occupancy", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no occupancy detected)"
 
@@ -1128,7 +1130,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.power", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected power"
 
@@ -1137,7 +1139,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.power", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no power detected)"
 
@@ -1152,7 +1154,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.problem", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected problem"
 
@@ -1161,7 +1163,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.problem", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no problem detected)"
 
@@ -1176,7 +1178,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.smoke", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected smoke"
 
@@ -1185,7 +1187,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.smoke", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no smoke detected)"
 
@@ -1200,7 +1202,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.sound", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected sound"
 
@@ -1209,7 +1211,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.sound", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no sound detected)"
 
@@ -1224,7 +1226,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.vibration", STATE_ON, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "detected vibration"
 
@@ -1233,7 +1235,7 @@ class TestComponentLogbook(unittest.TestCase):
             pointA, "binary_sensor.vibration", STATE_OFF, attributes
         )
         message = logbook._entry_message_from_event(
-            self.hass, eventA.entity_id, eventA.domain, eventA, entity_attr_cache
+            eventA.entity_id, eventA.domain, eventA, entity_attr_cache
         )
         assert message == "cleared (no vibration detected)"
 
@@ -1258,6 +1260,7 @@ class TestComponentLogbook(unittest.TestCase):
                     ),
                 ),
                 entity_attr_cache,
+                {},
             )
         )
 
@@ -1652,7 +1655,6 @@ async def test_logbook_entity_filter_with_automations(hass, hass_client):
     assert response.status == 200
     json_dict = await response.json()
 
-    assert len(json_dict) == 5
     assert json_dict[0]["entity_id"] == entity_id_test
     assert json_dict[1]["entity_id"] == entity_id_second
     assert json_dict[2]["entity_id"] == "automation.mock_automation"
@@ -1837,6 +1839,105 @@ async def test_exclude_attribute_changes(hass, hass_client):
     assert response_json[2]["entity_id"] == "light.kitchen"
 
 
+async def test_logbook_entity_context_id(hass, hass_client):
+    """Test the logbook view with end_time and entity with automations and scripts."""
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", {})
+    await async_setup_component(hass, "automation", {})
+    await async_setup_component(hass, "script", {})
+
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    context = ha.Context(
+        id="ac5bd62de45711eaaeb351041eec8dd9",
+        user_id="b400facee45711eaa9308bfd3d19e474",
+    )
+
+    automation_entity_id_test = "automation.alarm"
+    hass.bus.async_fire(
+        EVENT_AUTOMATION_TRIGGERED,
+        {ATTR_NAME: "Mock automation", ATTR_ENTITY_ID: automation_entity_id_test},
+        context=context,
+    )
+    hass.bus.async_fire(
+        EVENT_SCRIPT_STARTED,
+        {ATTR_NAME: "Mock script", ATTR_ENTITY_ID: "script.mock_script"},
+        context=context,
+    )
+    hass.states.async_set(automation_entity_id_test, STATE_ON, context=context)
+
+    entity_id_test = "alarm_control_panel.area_001"
+    hass.states.async_set(entity_id_test, STATE_OFF, context=context)
+    hass.states.async_set(entity_id_test, STATE_ON, context=context)
+    entity_id_second = "alarm_control_panel.area_002"
+    hass.states.async_set(entity_id_second, STATE_OFF, context=context)
+    hass.states.async_set(entity_id_second, STATE_ON, context=context)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_add_job(
+        logbook.log_entry,
+        hass,
+        "mock_name",
+        "mock_message",
+        "alarm_control_panel",
+        "alarm_control_panel.area_003",
+        context,
+    )
+    await hass.async_add_job(
+        logbook.log_entry,
+        hass,
+        "mock_name",
+        "mock_message",
+        "homeassistant",
+        None,
+        context,
+    )
+
+    await hass.async_add_job(trigger_db_commit, hass)
+    await hass.async_block_till_done()
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    client = await hass_client()
+
+    # Today time 00:00:00
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day)
+
+    # Test today entries with filter by end_time
+    end_time = start + timedelta(hours=24)
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}"
+    )
+    assert response.status == 200
+    json_dict = await response.json()
+
+    assert json_dict[0]["entity_id"] == "automation.alarm"
+    assert "context_entity_id" not in json_dict[0]
+    assert json_dict[0]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+
+    assert json_dict[1]["entity_id"] == "script.mock_script"
+    assert json_dict[1]["context_entity_id"] == "automation.alarm"
+    assert json_dict[1]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+
+    assert json_dict[2]["entity_id"] == entity_id_test
+    assert json_dict[2]["context_entity_id"] == "automation.alarm"
+    assert json_dict[2]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+
+    assert json_dict[3]["entity_id"] == entity_id_second
+    assert json_dict[3]["context_entity_id"] == "automation.alarm"
+    assert json_dict[3]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+
+    assert json_dict[4]["domain"] == "homeassistant"
+
+    assert json_dict[5]["entity_id"] == "alarm_control_panel.area_003"
+    assert json_dict[5]["context_entity_id"] == "automation.alarm"
+    assert json_dict[5]["domain"] == "alarm_control_panel"
+    assert json_dict[5]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+
+    assert json_dict[6]["domain"] == "homeassistant"
+    assert json_dict[6]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
+
+
 class MockLazyEventPartialState(ha.Event):
     """Minimal mock of a Lazy event."""
 
@@ -1849,6 +1950,11 @@ class MockLazyEventPartialState(ha.Event):
     def context_user_id(self):
         """Context user id of event."""
         return self.context.user_id
+
+    @property
+    def context_id(self):
+        """Context id of event."""
+        return self.context.id
 
     @property
     def time_fired_isoformat(self):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.components.recorder.models import process_timestamp_to_utc_is
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
     ATTR_NAME,
     CONF_DOMAINS,
     CONF_ENTITIES,
@@ -1864,7 +1865,12 @@ async def test_logbook_entity_context_id(hass, hass_client):
         {ATTR_NAME: "Mock script", ATTR_ENTITY_ID: "script.mock_script"},
         context=context,
     )
-    hass.states.async_set(automation_entity_id_test, STATE_ON, context=context)
+    hass.states.async_set(
+        automation_entity_id_test,
+        STATE_ON,
+        {ATTR_FRIENDLY_NAME: "Alarm Automation"},
+        context=context,
+    )
 
     entity_id_test = "alarm_control_panel.area_001"
     hass.states.async_set(entity_id_test, STATE_OFF, context=context)
@@ -1917,14 +1923,17 @@ async def test_logbook_entity_context_id(hass, hass_client):
 
     assert json_dict[1]["entity_id"] == "script.mock_script"
     assert json_dict[1]["context_entity_id"] == "automation.alarm"
+    assert json_dict[1]["context_entity_id_name"] == "Alarm Automation"
     assert json_dict[1]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
 
     assert json_dict[2]["entity_id"] == entity_id_test
     assert json_dict[2]["context_entity_id"] == "automation.alarm"
+    assert json_dict[2]["context_entity_id_name"] == "Alarm Automation"
     assert json_dict[2]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
 
     assert json_dict[3]["entity_id"] == entity_id_second
     assert json_dict[3]["context_entity_id"] == "automation.alarm"
+    assert json_dict[3]["context_entity_id_name"] == "Alarm Automation"
     assert json_dict[3]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
 
     assert json_dict[4]["domain"] == "homeassistant"
@@ -1932,6 +1941,7 @@ async def test_logbook_entity_context_id(hass, hass_client):
     assert json_dict[5]["entity_id"] == "alarm_control_panel.area_003"
     assert json_dict[5]["context_entity_id"] == "automation.alarm"
     assert json_dict[5]["domain"] == "alarm_control_panel"
+    assert json_dict[5]["context_entity_id_name"] == "Alarm Automation"
     assert json_dict[5]["context_user_id"] == "b400facee45711eaa9308bfd3d19e474"
 
     assert json_dict[6]["domain"] == "homeassistant"

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -516,6 +516,7 @@ async def test_logbook_humanify_script_started_event(hass):
                 ),
             ],
             entity_attr_cache,
+            {},
         )
     )
 


### PR DESCRIPTION
WTH: https://community.home-assistant.io/t/what-the-heck-turned-my-light-on/219488

Frontend change: https://github.com/home-assistant/frontend/pull/6682

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include the context_entity_id in the logbook api

context_entity_id is the first entity seen during
a time period that includes the context

Limitations:
- If the entity that triggered the change happened outside the selected logbook time window, it won't be shown.



Service Call:
```
{
	"context_domain": "switch",
	"context_event_type": "call_service",
	"context_service": "turn_off",
	"context_user_id": "659270f2e98640cd823cbbdb6bf01d19",
	"domain": "switch",
	"entity_id": "switch.bar_dog_water",
	"message": "turned off",
	"name": "Bar Dog Water",
	"when": "2020-08-24T15:10:24.818600+00:00"
}
```

Automation
```
{
	"context_entity_id": "automation.turn_on_rack_at_8am_if_house_occupied",
	"context_entity_id_name": "Turn on Rack at 8am if House Occupied",
	"context_event_type": "automation_triggered",
	"domain": "switch",
	"entity_id": "switch.tech_room_rack_night_away_swi",
	"message": "turned on",
	"name": "Tech Room Rack Night Away Swi",
	"when": "2020-08-24T13:00:00.023137+00:00"
}
```

State change (show which entity triggered the template entity to change)
```
{
	"context_entity_id": "switch.pool_pump",
	"context_entity_id_name": "Pool",
	"context_event_type": "state_changed",
	"domain": "sensor",
	"entity_id": "sensor.poolspa_mode",
	"message": "changed to pool",
	"name": "Pool Mode",
	"when": "2020-08-24T15:07:20.372892+00:00"
}
```

HomeKit

```
{
	"context_entity_id": "light.nick_office_lights",
	"context_entity_id_name": "Nick Office Lights",
	"context_event_type": "homekit_state_change",
	"domain": "light",
	"entity_id": "light.nick_office_lights",
	"message": "turned off",
	"name": "Nick Office Lights",
	"when": "2020-08-24T15:52:23.251478+00:00"
}
```

<img width="853" alt="Screen Shot 2020-08-23 at 1 15 40 PM" src="https://user-images.githubusercontent.com/663432/90987611-dbbe1280-e551-11ea-9530-20e27ade5741.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
