### PR TITLE
Ensure unique ids are generated for surepetcare

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -812,7 +812,8 @@ omit =
     homeassistant/components/streamlabswater/*
     homeassistant/components/suez_water/*
     homeassistant/components/supervisord/sensor.py
-    homeassistant/components/surepetcare/*.py
+    homeassistant/components/surepetcare/__init__.py
+    homeassistant/components/surepetcare/sensor.py
     homeassistant/components/swiss_hydrological_data/sensor.py
     homeassistant/components/swiss_public_transport/sensor.py
     homeassistant/components/swisscom/device_tracker.py

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -104,7 +104,7 @@ async def async_setup(hass, config) -> bool:
     )
 
     # discover hubs the flaps/feeders are connected to
-    hub_ids = {}
+    hub_ids = set()
     for device in things:
         device_data = await surepy.device(device[CONF_ID])
         if (

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -104,12 +104,13 @@ async def async_setup(hass, config) -> bool:
     )
 
     # discover hubs the flaps/feeders are connected to
-    for device in things.copy():
+    hub_ids = {}
+    for device in things:
         device_data = await surepy.device(device[CONF_ID])
         if (
             CONF_PARENT in device_data
             and device_data[CONF_PARENT][CONF_PRODUCT_ID] == SureProductID.HUB
-            and device_data[CONF_PARENT][CONF_ID] not in things
+            and device_data[CONF_PARENT][CONF_ID] not in hub_ids
         ):
             things.append(
                 {
@@ -117,6 +118,7 @@ async def async_setup(hass, config) -> bool:
                     CONF_TYPE: SureProductID.HUB,
                 }
             )
+            hub_ids.add(device_data[CONF_PARENT][CONF_ID])
 
     # add pets
     things.extend(

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -105,7 +105,7 @@ async def async_setup(hass, config) -> bool:
 
     # discover hubs the flaps/feeders are connected to
     hub_ids = set()
-    for device in things:
+    for device in things.copy():
         device_data = await surepy.device(device[CONF_ID])
         if (
             CONF_PARENT in device_data

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -63,14 +63,12 @@ class SurePetcareBinarySensor(BinarySensorEntity):
         _id: int,
         spc: SurePetcareAPI,
         device_class: str,
-        sensor_type: str,
         sure_type: SureProductID,
     ):
         """Initialize a Sure Petcare binary sensor."""
         self._id = _id
         self._sure_type = sure_type
         self._device_class = device_class
-        self._sensor_type = sensor_type
 
         self._spc: SurePetcareAPI = spc
         self._spc_data: Dict[str, Any] = self._spc.states[self._sure_type].get(self._id)
@@ -109,7 +107,7 @@ class SurePetcareBinarySensor(BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         """Return an unique ID."""
-        return f"{self._spc_data['household_id']}-{self._id}-{self._sensor_type}"
+        return f"{self._spc_data['household_id']}-{self._id}"
 
     async def async_update(self) -> None:
         """Get the latest data and update the state."""
@@ -140,7 +138,7 @@ class Hub(SurePetcareBinarySensor):
 
     def __init__(self, _id: int, spc: SurePetcareAPI) -> None:
         """Initialize a Sure Petcare Hub."""
-        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, "hub", SureProductID.HUB)
+        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, SureProductID.HUB)
 
     @property
     def available(self) -> bool:
@@ -170,7 +168,7 @@ class Pet(SurePetcareBinarySensor):
 
     def __init__(self, _id: int, spc: SurePetcareAPI) -> None:
         """Initialize a Sure Petcare Pet."""
-        super().__init__(_id, spc, DEVICE_CLASS_PRESENCE, "pet", SureProductID.PET)
+        super().__init__(_id, spc, DEVICE_CLASS_PRESENCE, SureProductID.PET)
 
     @property
     def is_on(self) -> bool:
@@ -208,12 +206,17 @@ class DeviceConnectivity(SurePetcareBinarySensor):
         self, _id: int, sure_type: SureProductID, spc: SurePetcareAPI,
     ) -> None:
         """Initialize a Sure Petcare Device."""
-        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, "connectivity", sure_type)
+        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, sure_type)
 
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
         return f"{self._name}_connectivity"
+
+    @property
+    def unique_id(self) -> str:
+        """Return an unique ID."""
+        return f"{self._spc_data['household_id']}-{self._id}-connectivity"
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -63,12 +63,14 @@ class SurePetcareBinarySensor(BinarySensorEntity):
         _id: int,
         spc: SurePetcareAPI,
         device_class: str,
+        sensor_type: str,
         sure_type: SureProductID,
     ):
         """Initialize a Sure Petcare binary sensor."""
         self._id = _id
         self._sure_type = sure_type
         self._device_class = device_class
+        self._sensor_type = sensor_type
 
         self._spc: SurePetcareAPI = spc
         self._spc_data: Dict[str, Any] = self._spc.states[self._sure_type].get(self._id)
@@ -107,7 +109,7 @@ class SurePetcareBinarySensor(BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         """Return an unique ID."""
-        return f"{self._spc_data['household_id']}-{self._id}"
+        return f"{self._spc_data['household_id']}-{self._id}-{self._sensor_type}"
 
     async def async_update(self) -> None:
         """Get the latest data and update the state."""
@@ -138,7 +140,7 @@ class Hub(SurePetcareBinarySensor):
 
     def __init__(self, _id: int, spc: SurePetcareAPI) -> None:
         """Initialize a Sure Petcare Hub."""
-        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, SureProductID.HUB)
+        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, "hub", SureProductID.HUB)
 
     @property
     def available(self) -> bool:
@@ -168,7 +170,7 @@ class Pet(SurePetcareBinarySensor):
 
     def __init__(self, _id: int, spc: SurePetcareAPI) -> None:
         """Initialize a Sure Petcare Pet."""
-        super().__init__(_id, spc, DEVICE_CLASS_PRESENCE, SureProductID.PET)
+        super().__init__(_id, spc, DEVICE_CLASS_PRESENCE, "pet", SureProductID.PET)
 
     @property
     def is_on(self) -> bool:
@@ -206,17 +208,12 @@ class DeviceConnectivity(SurePetcareBinarySensor):
         self, _id: int, sure_type: SureProductID, spc: SurePetcareAPI,
     ) -> None:
         """Initialize a Sure Petcare Device."""
-        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, sure_type)
+        super().__init__(_id, spc, DEVICE_CLASS_CONNECTIVITY, "connectivity", sure_type)
 
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
         return f"{self._name}_connectivity"
-
-    @property
-    def unique_id(self) -> str:
-        """Return an unique ID."""
-        return f"{self._spc_data['household_id']}-{self._id}-connectivity"
 
     @property
     def available(self) -> bool:

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -954,6 +954,9 @@ stringcase==1.2.0
 # homeassistant.components.solarlog
 sunwatcher==0.2.1
 
+# homeassistant.components.surepetcare
+surepy==0.2.5
+
 # homeassistant.components.tellduslive
 tellduslive==0.10.11
 

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -1,0 +1,88 @@
+"""Tests for Sure Petcare integration."""
+from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from tests.async_mock import patch
+
+HOUSEHOLD_ID = "household-id"
+HUB_ID = "hub-id"
+
+MOCK_HUB = {
+    "id": HUB_ID,
+    "product_id": 1,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Hub",
+    "status": {"online": True, "led_mode": 0, "pairing_mode": 0},
+}
+
+MOCK_FEEDER = {
+    "id": 12345,
+    "product_id": 4,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Feeder",
+    "parent": {"product_id": 1, "id": HUB_ID},
+    "status": {
+        "battery": 6.4,
+        "locking": {"mode": 0},
+        "learn_mode": 0,
+        "signal": {"device_rssi": 60, "hub_rssi": 65},
+    },
+}
+
+MOCK_CAT_FLAP = {
+    "id": 13579,
+    "product_id": 6,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Cat Flap",
+    "parent": {"product_id": 1, "id": HUB_ID},
+    "status": {
+        "battery": 6.4,
+        "locking": {"mode": 0},
+        "learn_mode": 0,
+        "signal": {"device_rssi": 65, "hub_rssi": 64},
+    },
+}
+
+MOCK_PET_FLAP = {
+    "id": 13576,
+    "product_id": 3,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Pet Flap",
+    "parent": {"product_id": 1, "id": HUB_ID},
+    "status": {
+        "battery": 6.4,
+        "locking": {"mode": 0},
+        "learn_mode": 0,
+        "signal": {"device_rssi": 70, "hub_rssi": 65},
+    },
+}
+
+MOCK_PET = {
+    "id": 24680,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Pet",
+    "position": {"since": "2020-08-23T23:10:50", "where": 1},
+    "status": {},
+}
+
+MOCK_API_DATA = {
+    "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER],
+    "pets": [MOCK_PET],
+}
+
+MOCK_CONFIG = {
+    DOMAIN: {
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+        "feeders": [12345],
+        "flaps": [13579, 13576],
+        "pets": [24680],
+    },
+}
+
+
+def _patch_sensor_setup():
+    return patch(
+        "homeassistant.components.surepetcare.sensor.async_setup_platform",
+        return_value=True,
+    )

--- a/tests/components/surepetcare/conftest.py
+++ b/tests/components/surepetcare/conftest.py
@@ -1,0 +1,23 @@
+"""Define fixtures available for all tests."""
+from pytest import fixture
+from surepy import SurePetcare
+
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from tests.async_mock import AsyncMock, patch
+
+
+@fixture()
+def surepetcare(hass):
+    """Mock the SurePetcare for easier testing."""
+    with patch("homeassistant.components.surepetcare.SurePetcare") as mock_surepetcare:
+        instance = mock_surepetcare.return_value = SurePetcare(
+            "test-username",
+            "test-password",
+            hass.loop,
+            async_get_clientsession(hass),
+            api_timeout=1,
+        )
+        instance.get_data = AsyncMock(return_value=None)
+
+        yield mock_surepetcare

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -18,36 +18,36 @@ async def test_unique_ids(hass, surepetcare) -> None:
 
     assert hass.states.get("binary_sensor.hub_hub")
     hub = entity_registry.async_get("binary_sensor.hub_hub")
-    assert hub.unique_id == ""
-
-    assert hass.states.get("binary_sensor.cat_flap_cat_flap")
-    cat_flap = entity_registry.async_get("binary_sensor.cat_flap_cat_flap")
-    assert cat_flap.unique_id == ""
-
-    assert hass.states.get("binary_sensor.cat_flap_cat_flap_connectivity")
-    cat_flap_conn = entity_registry.async_get(
-        "binary_sensor.cat_flap_cat_flap_connectivity"
-    )
-    assert cat_flap_conn.unique_id == ""
+    assert hub.unique_id == "household-id-hub-id"
 
     assert hass.states.get("binary_sensor.pet_flap_pet_flap")
     pet_flap = entity_registry.async_get("binary_sensor.pet_flap_pet_flap")
-    assert pet_flap.unique_id == ""
+    assert pet_flap.unique_id == "household-id-13576"
 
     assert hass.states.get("binary_sensor.pet_flap_pet_flap_connectivity")
     pet_flap_conn = entity_registry.async_get(
         "binary_sensor.pet_flap_pet_flap_connectivity"
     )
-    assert pet_flap_conn.unique_id == ""
+    assert pet_flap_conn.unique_id == "household-id-13576-connectivity"
+
+    assert hass.states.get("binary_sensor.pet_flap_cat_flap")
+    cat_flap = entity_registry.async_get("binary_sensor.pet_flap_cat_flap")
+    assert cat_flap.unique_id == "household-id-13579"
+
+    assert hass.states.get("binary_sensor.pet_flap_cat_flap_connectivity")
+    cat_flap_conn = entity_registry.async_get(
+        "binary_sensor.pet_flap_cat_flap_connectivity"
+    )
+    assert cat_flap_conn.unique_id == "household-id-13579-connectivity"
 
     assert hass.states.get("binary_sensor.feeder_feeder")
     feeder = entity_registry.async_get("binary_sensor.feeder_feeder")
-    assert feeder.unique_id == ""
+    assert feeder.unique_id == "household-id-12345"
 
     assert hass.states.get("binary_sensor.feeder_feeder_connectivity")
     feeder_conn = entity_registry.async_get("binary_sensor.feeder_feeder_connectivity")
-    assert feeder_conn.unique_id == ""
+    assert feeder_conn.unique_id == "household-id-12345-connectivity"
 
     assert hass.states.get("binary_sensor.pet_pet")
     pet = entity_registry.async_get("binary_sensor.pet_pet")
-    assert pet.unique_id == ""
+    assert pet.unique_id == "household-id-24680"

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -5,11 +5,8 @@ from homeassistant.setup import async_setup_component
 from . import MOCK_API_DATA, MOCK_CONFIG, _patch_sensor_setup
 
 EXPECTED_ENTITY_IDS = {
-    "binary_sensor.pet_flap_pet_flap": "household-id-13576",
     "binary_sensor.pet_flap_pet_flap_connectivity": "household-id-13576-connectivity",
-    "binary_sensor.pet_flap_cat_flap": "household-id-13579",
     "binary_sensor.pet_flap_cat_flap_connectivity": "household-id-13579-connectivity",
-    "binary_sensor.feeder_feeder": "household-id-12345",
     "binary_sensor.feeder_feeder_connectivity": "household-id-12345-connectivity",
     "binary_sensor.pet_pet": "household-id-24680",
     "binary_sensor.hub_hub": "household-id-hub-id",

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -1,46 +1,53 @@
-"""The tests for the surepetcare binary sensor platform."""
-from typing import Any, Dict, Optional
-
-from homeassistant.components.binary_sensor import DOMAIN as BS_DOMAIN
+"""The tests for the Sure Petcare binary sensor platform."""
 from homeassistant.components.surepetcare.const import DOMAIN
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import patch
-
-CONFIG = {
-    DOMAIN: {
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
-    },
-}
-
-HOUSEHOLD_ID = "household-id"
+from . import MOCK_API_DATA, MOCK_CONFIG, _patch_sensor_setup
 
 
-MOCK_API_DATA = {
-}
-
-
-async def test_unique_ids(hass) -> None:
+async def test_unique_ids(hass, surepetcare) -> None:
     """Test the generation of unique ids."""
-    with _patch_api_get_data(MOCK_API_DATA), _patch_sensor_setup():
-        assert await async_setup_component(hass, DOMAIN, CONFIG)
+    instance = surepetcare.return_value
+    instance.data = MOCK_API_DATA
+    instance.get_data.return_value = MOCK_API_DATA
 
-    assert hass.states.get("binary_sensor.hub")
-    assert hass.states.get("binary_sensor.connectivity")
-    assert hass.states.get("binary_sensor.pet")
+    with _patch_sensor_setup():
+        assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
 
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
-def _patch_api_get_data(return_value: Optional[Dict[str, Any]] = None):
-    return patch(
-        "homeassistant.components.surepetcare.SurePetcare.get_data",
-        return_value=return_value,
+    assert hass.states.get("binary_sensor.hub_hub")
+    hub = entity_registry.async_get("binary_sensor.hub_hub")
+    assert hub.unique_id == ""
+
+    assert hass.states.get("binary_sensor.cat_flap_cat_flap")
+    cat_flap = entity_registry.async_get("binary_sensor.cat_flap_cat_flap")
+    assert cat_flap.unique_id == ""
+
+    assert hass.states.get("binary_sensor.cat_flap_cat_flap_connectivity")
+    cat_flap_conn = entity_registry.async_get(
+        "binary_sensor.cat_flap_cat_flap_connectivity"
     )
+    assert cat_flap_conn.unique_id == ""
 
+    assert hass.states.get("binary_sensor.pet_flap_pet_flap")
+    pet_flap = entity_registry.async_get("binary_sensor.pet_flap_pet_flap")
+    assert pet_flap.unique_id == ""
 
-def _patch_sensor_setup():
-    return patch(
-        "homeassistant.components.surepetcare.sensor.async_setup_platform",
-        return_value=True,
+    assert hass.states.get("binary_sensor.pet_flap_pet_flap_connectivity")
+    pet_flap_conn = entity_registry.async_get(
+        "binary_sensor.pet_flap_pet_flap_connectivity"
     )
+    assert pet_flap_conn.unique_id == ""
+
+    assert hass.states.get("binary_sensor.feeder_feeder")
+    feeder = entity_registry.async_get("binary_sensor.feeder_feeder")
+    assert feeder.unique_id == ""
+
+    assert hass.states.get("binary_sensor.feeder_feeder_connectivity")
+    feeder_conn = entity_registry.async_get("binary_sensor.feeder_feeder_connectivity")
+    assert feeder_conn.unique_id == ""
+
+    assert hass.states.get("binary_sensor.pet_pet")
+    pet = entity_registry.async_get("binary_sensor.pet_pet")
+    assert pet.unique_id == ""

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -13,6 +13,7 @@ async def test_binary_sensors(hass, surepetcare) -> None:
 
     with _patch_sensor_setup():
         assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
+        await hass.async_block_till_done()
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.setup import async_setup_component
 from . import MOCK_API_DATA, MOCK_CONFIG, _patch_sensor_setup
 
 
-async def test_unique_ids(hass, surepetcare) -> None:
+async def test_binary_sensors(hass, surepetcare) -> None:
     """Test the generation of unique ids."""
     instance = surepetcare.return_value
     instance.data = MOCK_API_DATA
@@ -15,10 +15,6 @@ async def test_unique_ids(hass, surepetcare) -> None:
         assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
-
-    assert hass.states.get("binary_sensor.hub_hub")
-    hub = entity_registry.async_get("binary_sensor.hub_hub")
-    assert hub.unique_id == "household-id-hub-id"
 
     assert hass.states.get("binary_sensor.pet_flap_pet_flap")
     pet_flap = entity_registry.async_get("binary_sensor.pet_flap_pet_flap")
@@ -51,3 +47,7 @@ async def test_unique_ids(hass, surepetcare) -> None:
     assert hass.states.get("binary_sensor.pet_pet")
     pet = entity_registry.async_get("binary_sensor.pet_pet")
     assert pet.unique_id == "household-id-24680"
+
+    assert hass.states.get("binary_sensor.hub_hub")
+    hub = entity_registry.async_get("binary_sensor.hub_hub")
+    assert hub.unique_id == "household-id-hub-id"

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -8,7 +8,7 @@ EXPECTED_ENTITY_IDS = {
     "binary_sensor.pet_flap_pet_flap": "household-id-13576",
     "binary_sensor.pet_flap_pet_flap_connectivity": "household-id-13576-connectivity",
     "binary_sensor.pet_flap_cat_flap": "household-id-13579",
-    "binary_sensor.pet_flap_cat_flap_connectivity": "household-id-13579-connectivity:,
+    "binary_sensor.pet_flap_cat_flap_connectivity": "household-id-13579-connectivity",
     "binary_sensor.feeder_feeder": "household-id-12345",
     "binary_sensor.feeder_feeder_connectivity": "household-id-12345-connectivity",
     "binary_sensor.pet_pet": "household-id-24680",

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -4,6 +4,17 @@ from homeassistant.setup import async_setup_component
 
 from . import MOCK_API_DATA, MOCK_CONFIG, _patch_sensor_setup
 
+EXPECTED_ENTITY_IDS = {
+    "binary_sensor.pet_flap_pet_flap": "household-id-13576",
+    "binary_sensor.pet_flap_pet_flap_connectivity": "household-id-13576-connectivity",
+    "binary_sensor.pet_flap_cat_flap": "household-id-13579",
+    "binary_sensor.pet_flap_cat_flap_connectivity": "household-id-13579-connectivity:,
+    "binary_sensor.feeder_feeder": "household-id-12345",
+    "binary_sensor.feeder_feeder_connectivity": "household-id-12345-connectivity",
+    "binary_sensor.pet_pet": "household-id-24680",
+    "binary_sensor.hub_hub": "household-id-hub-id",
+}
+
 
 async def test_binary_sensors(hass, surepetcare) -> None:
     """Test the generation of unique ids."""
@@ -16,39 +27,9 @@ async def test_binary_sensors(hass, surepetcare) -> None:
         await hass.async_block_till_done()
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    state_entity_ids = hass.states.async_entity_ids()
 
-    assert hass.states.get("binary_sensor.pet_flap_pet_flap")
-    pet_flap = entity_registry.async_get("binary_sensor.pet_flap_pet_flap")
-    assert pet_flap.unique_id == "household-id-13576"
-
-    assert hass.states.get("binary_sensor.pet_flap_pet_flap_connectivity")
-    pet_flap_conn = entity_registry.async_get(
-        "binary_sensor.pet_flap_pet_flap_connectivity"
-    )
-    assert pet_flap_conn.unique_id == "household-id-13576-connectivity"
-
-    assert hass.states.get("binary_sensor.pet_flap_cat_flap")
-    cat_flap = entity_registry.async_get("binary_sensor.pet_flap_cat_flap")
-    assert cat_flap.unique_id == "household-id-13579"
-
-    assert hass.states.get("binary_sensor.pet_flap_cat_flap_connectivity")
-    cat_flap_conn = entity_registry.async_get(
-        "binary_sensor.pet_flap_cat_flap_connectivity"
-    )
-    assert cat_flap_conn.unique_id == "household-id-13579-connectivity"
-
-    assert hass.states.get("binary_sensor.feeder_feeder")
-    feeder = entity_registry.async_get("binary_sensor.feeder_feeder")
-    assert feeder.unique_id == "household-id-12345"
-
-    assert hass.states.get("binary_sensor.feeder_feeder_connectivity")
-    feeder_conn = entity_registry.async_get("binary_sensor.feeder_feeder_connectivity")
-    assert feeder_conn.unique_id == "household-id-12345-connectivity"
-
-    assert hass.states.get("binary_sensor.pet_pet")
-    pet = entity_registry.async_get("binary_sensor.pet_pet")
-    assert pet.unique_id == "household-id-24680"
-
-    assert hass.states.get("binary_sensor.hub_hub")
-    hub = entity_registry.async_get("binary_sensor.hub_hub")
-    assert hub.unique_id == "household-id-hub-id"
+    for entity_id, unique_id in EXPECTED_ENTITY_IDS:
+        assert entity_id in state_entity_ids
+        entity = entity_registry.async_get(entity_id)
+        assert entity.unique_id == unique_id

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -29,7 +29,7 @@ async def test_binary_sensors(hass, surepetcare) -> None:
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
     state_entity_ids = hass.states.async_entity_ids()
 
-    for entity_id, unique_id in EXPECTED_ENTITY_IDS:
+    for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():
         assert entity_id in state_entity_ids
         entity = entity_registry.async_get(entity_id)
         assert entity.unique_id == unique_id

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -1,0 +1,46 @@
+"""The tests for the surepetcare binary sensor platform."""
+from typing import Any, Dict, Optional
+
+from homeassistant.components.binary_sensor import DOMAIN as BS_DOMAIN
+from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import patch
+
+CONFIG = {
+    DOMAIN: {
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+    },
+}
+
+HOUSEHOLD_ID = "household-id"
+
+
+MOCK_API_DATA = {
+}
+
+
+async def test_unique_ids(hass) -> None:
+    """Test the generation of unique ids."""
+    with _patch_api_get_data(MOCK_API_DATA), _patch_sensor_setup():
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
+
+    assert hass.states.get("binary_sensor.hub")
+    assert hass.states.get("binary_sensor.connectivity")
+    assert hass.states.get("binary_sensor.pet")
+
+
+def _patch_api_get_data(return_value: Optional[Dict[str, Any]] = None):
+    return patch(
+        "homeassistant.components.surepetcare.SurePetcare.get_data",
+        return_value=return_value,
+    )
+
+
+def _patch_sensor_setup():
+    return patch(
+        "homeassistant.components.surepetcare.sensor.async_setup_platform",
+        return_value=True,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

It turns out the "in" check for hub ids wasnt actually working and youd get as many hubs as you have devices. added initial binary sensor tests to uncover this

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39099
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
