### PR TITLE
WIP: WTH: Support more than 3 fan speeds

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -32,10 +32,12 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 SUPPORT_SET_SPEED = 1
 SUPPORT_OSCILLATE = 2
 SUPPORT_DIRECTION = 4
+SUPPORT_SET_SPEED_PERCENTAGE = 8
 
 SERVICE_SET_SPEED = "set_speed"
 SERVICE_OSCILLATE = "oscillate"
 SERVICE_SET_DIRECTION = "set_direction"
+SERVICE_SET_SPEED_PERCENTAGE = "set_speed_percentage"
 
 SPEED_OFF = "off"
 SPEED_LOW = "low"
@@ -46,6 +48,7 @@ DIRECTION_FORWARD = "forward"
 DIRECTION_REVERSE = "reverse"
 
 ATTR_SPEED = "speed"
+ATTR_SPEED_PERCENTAGE = "speed_percentage"
 ATTR_SPEED_LIST = "speed_list"
 ATTR_OSCILLATING = "oscillating"
 ATTR_DIRECTION = "direction"
@@ -91,6 +94,12 @@ async def async_setup(hass, config: dict):
         "async_set_direction",
         [SUPPORT_DIRECTION],
     )
+    component.async_register_entity_service(
+        SERVICE_SET_SPEED_PERCENTAGE,
+        {vol.Required(ATTR_SPEED): vol.Number()},
+        "async_set_speed_percentage",
+        [SUPPORT_SET_SPEED],
+    )
 
     return True
 
@@ -116,6 +125,21 @@ class FanEntity(ToggleEntity):
         """Set the speed of the fan."""
         if speed == SPEED_OFF:
             await self.async_turn_off()
+        elif self.supported_features & SUPPORT_SET_SPEED_PERCENTAGE:
+            await self.async_set_speed_percentage(self.speed_to_percentage(speed))
+        else:
+            await self.hass.async_add_job(self.set_speed, speed)
+
+    def set_speed_percentage(self, speed: str) -> None:
+        """Set the speed of the fan, as a percentage."""
+        raise NotImplementedError()
+
+    async def async_set_speed_percentage(self, speed: int):
+        """Set the speed of the fan, as a percentage."""
+        if speed == SPEED_OFF:
+            await self.async_turn_off()
+        elif not self.supported_features & SUPPORT_SET_SPEED_PERCENTAGE:
+            await self.async_set_speed(self.percentage_to_speed(speed))
         else:
             await self.hass.async_add_job(self.set_speed, speed)
 
@@ -155,11 +179,22 @@ class FanEntity(ToggleEntity):
     @property
     def speed(self) -> Optional[str]:
         """Return the current speed."""
+        if self.supported_features & SUPPORT_SET_SPEED_PERCENTAGE:
+            return self.percentage_to_speed(self.percentage_speed)
+        return None
+
+    @property
+    def percentage_speed(self):
+        """Return the current speed as a percentage."""
+        if not self.supported_features & SUPPORT_SET_SPEED_PERCENTAGE:
+            return self.speed_to_percentage(self.speed)
         return None
 
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
+        if self.supported_features & SUPPORT_SET_SPEED_PERCENTAGE:
+            return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
         return []
 
     @property
@@ -179,6 +214,61 @@ class FanEntity(ToggleEntity):
             return {ATTR_SPEED_LIST: self.speed_list}
         return {}
 
+    def speed_to_percentage(self, speed: str):
+        """
+        Map a speed to a percentage.
+
+        Officially this should only have to deal with the 4 pre-defined speeds:
+
+        return {
+            SPEED_OFF: 0,
+            SPEED_LOW: 33,
+            SPEED_MEDIUM: 66,
+            SPEED_HIGH: 100,
+        }[speed]
+
+        Unfortunately lots of fans make up their own speeds. So the default
+        mapping is more dynamic.
+        """
+        if speed == SPEED_OFF:
+            return 0
+
+        speeds_len = len(self.speed_list)
+        speed_offset = self.speed_list.index(speed)
+
+        return ((speed_offset) * 100) // ((speeds_len - 1))
+
+    def percentage_to_speed(self, value: int):
+        """
+        Map a percentage onto self.speed_list
+
+        Officially, this should only have to deal with 4 pre-defined speeds.
+
+        if value == 0:
+            return SPEED_OFF
+        elif value <= 33:
+            return SPEED_LOW
+        elif value <= 66:
+            return SPEED_MEDIUM
+        else:
+            return SPEED_HIGH
+
+        Unfortunately there is currently a high degree of non-conformancy.
+        Until fans have been corrected a more complicated and dynamic
+        mapping is used.
+        """
+        if value == 0:
+            return SPEED_OFF
+
+        speeds_len = len(self.speed_list)
+
+        for offset, speed in enumerate(self.speed_list[1:], start=1):
+            upper_bound = (offset * 100) // ((speeds_len - 1))
+            if value <= upper_bound:
+                return speed
+
+        return self.speed_list[-1]
+
     @property
     def state_attributes(self) -> dict:
         """Return optional state attributes."""
@@ -191,8 +281,9 @@ class FanEntity(ToggleEntity):
         if supported_features & SUPPORT_OSCILLATE:
             data[ATTR_OSCILLATING] = self.oscillating
 
-        if supported_features & SUPPORT_SET_SPEED:
+        if supported_features & SUPPORT_SET_SPEED or supported_features & SUPPORT_SET_SPEED_PERCENTAGE:
             data[ATTR_SPEED] = self.speed
+            data[ATTR_SPEED_PERCENTAGE] = self.percentage_speed
 
         return data
 

--- a/homeassistant/components/homekit_controller/fan.py
+++ b/homeassistant/components/homekit_controller/fan.py
@@ -6,13 +6,10 @@ from aiohomekit.model.characteristics import CharacteristicsTypes
 from homeassistant.components.fan import (
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
-    SPEED_HIGH,
-    SPEED_LOW,
-    SPEED_MEDIUM,
-    SPEED_OFF,
     SUPPORT_DIRECTION,
     SUPPORT_OSCILLATE,
     SUPPORT_SET_SPEED,
+    SUPPORT_SET_SPEED_PERCENTAGE,
     FanEntity,
 )
 from homeassistant.core import callback
@@ -28,13 +25,6 @@ DIRECTION_TO_HK = {
     DIRECTION_FORWARD: 0,
 }
 HK_DIRECTION_TO_HA = {v: k for (k, v) in DIRECTION_TO_HK.items()}
-
-SPEED_TO_PCNT = {
-    SPEED_HIGH: 100,
-    SPEED_MEDIUM: 50,
-    SPEED_LOW: 25,
-    SPEED_OFF: 0,
-}
 
 
 class BaseHomeKitFan(HomeKitEntity, FanEntity):
@@ -59,30 +49,12 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         return self.service.value(self.on_characteristic) == 1
 
     @property
-    def speed(self):
+    def percentage_speed(self):
         """Return the current speed."""
         if not self.is_on:
-            return SPEED_OFF
+            return 0
 
-        rotation_speed = self.service.value(CharacteristicsTypes.ROTATION_SPEED)
-
-        if rotation_speed > SPEED_TO_PCNT[SPEED_MEDIUM]:
-            return SPEED_HIGH
-
-        if rotation_speed > SPEED_TO_PCNT[SPEED_LOW]:
-            return SPEED_MEDIUM
-
-        if rotation_speed > SPEED_TO_PCNT[SPEED_OFF]:
-            return SPEED_LOW
-
-        return SPEED_OFF
-
-    @property
-    def speed_list(self):
-        """Get the list of available speeds."""
-        if self.supported_features & SUPPORT_SET_SPEED:
-            return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
-        return []
+        return self.service.value(CharacteristicsTypes.ROTATION_SPEED)
 
     @property
     def current_direction(self):
@@ -105,7 +77,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
             features |= SUPPORT_DIRECTION
 
         if self.service.has(CharacteristicsTypes.ROTATION_SPEED):
-            features |= SUPPORT_SET_SPEED
+            features |= SUPPORT_SET_SPEED | SUPPORT_SET_SPEED_PERCENTAGE
 
         if self.service.has(CharacteristicsTypes.SWING_MODE):
             features |= SUPPORT_OSCILLATE
@@ -118,13 +90,13 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
             {CharacteristicsTypes.ROTATION_DIRECTION: DIRECTION_TO_HK[direction]}
         )
 
-    async def async_set_speed(self, speed):
+    async def async_set_speed_percentage(self, speed):
         """Set the speed of the fan."""
-        if speed == SPEED_OFF:
+        if speed == 0:
             return await self.async_turn_off()
 
         await self.async_put_characteristics(
-            {CharacteristicsTypes.ROTATION_SPEED: SPEED_TO_PCNT[speed]}
+            {CharacteristicsTypes.ROTATION_SPEED: speed}
         )
 
     async def async_oscillate(self, oscillating: bool):
@@ -141,8 +113,10 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         if not self.is_on:
             characteristics[self.on_characteristic] = True
 
-        if self.supported_features & SUPPORT_SET_SPEED and speed:
-            characteristics[CharacteristicsTypes.ROTATION_SPEED] = SPEED_TO_PCNT[speed]
+        if self.supported_features & SUPPORT_SET_SPEED_PERCENTAGE and speed:
+            characteristics[
+                CharacteristicsTypes.ROTATION_SPEED
+            ] = self.speed_to_percentage(speed)
 
         if characteristics:
             await self.async_put_characteristics(characteristics)

--- a/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
@@ -4,6 +4,7 @@ from homeassistant.components.fan import (
     SUPPORT_DIRECTION,
     SUPPORT_OSCILLATE,
     SUPPORT_SET_SPEED,
+    SUPPORT_SET_SPEED_PERCENTAGE,
 )
 
 from tests.components.homekit_controller.common import (
@@ -35,7 +36,10 @@ async def test_homeassistant_bridge_fan_setup(hass):
     assert fan_state.attributes["friendly_name"] == "Living Room Fan"
     assert fan_state.state == "off"
     assert fan_state.attributes["supported_features"] == (
-        SUPPORT_DIRECTION | SUPPORT_SET_SPEED | SUPPORT_OSCILLATE
+        SUPPORT_DIRECTION
+        | SUPPORT_SET_SPEED
+        | SUPPORT_OSCILLATE
+        | SUPPORT_SET_SPEED_PERCENTAGE
     )
 
     device_registry = await hass.helpers.device_registry.async_get_registry()

--- a/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
@@ -4,7 +4,11 @@ Test against characteristics captured from a SIMPLEconnect Fan.
 https://github.com/home-assistant/home-assistant/issues/26180
 """
 
-from homeassistant.components.fan import SUPPORT_DIRECTION, SUPPORT_SET_SPEED
+from homeassistant.components.fan import (
+    SUPPORT_DIRECTION,
+    SUPPORT_SET_SPEED,
+    SUPPORT_SET_SPEED_PERCENTAGE,
+)
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -33,7 +37,7 @@ async def test_simpleconnect_fan_setup(hass):
     assert fan_state.attributes["friendly_name"] == "SIMPLEconnect Fan-06F674"
     assert fan_state.state == "off"
     assert fan_state.attributes["supported_features"] == (
-        SUPPORT_DIRECTION | SUPPORT_SET_SPEED
+        SUPPORT_DIRECTION | SUPPORT_SET_SPEED | SUPPORT_SET_SPEED_PERCENTAGE
     )
 
     device_registry = await hass.helpers.device_registry.async_get_registry()

--- a/tests/components/homekit_controller/test_fan.py
+++ b/tests/components/homekit_controller/test_fan.py
@@ -83,7 +83,7 @@ async def test_turn_on(hass, utcnow):
         blocking=True,
     )
     assert helper.characteristics[V1_ON].value == 1
-    assert helper.characteristics[V1_ROTATION_SPEED].value == 50
+    assert helper.characteristics[V1_ROTATION_SPEED].value == 66.0
 
     await hass.services.async_call(
         "fan",
@@ -92,7 +92,7 @@ async def test_turn_on(hass, utcnow):
         blocking=True,
     )
     assert helper.characteristics[V1_ON].value == 1
-    assert helper.characteristics[V1_ROTATION_SPEED].value == 25
+    assert helper.characteristics[V1_ROTATION_SPEED].value == 33.0
 
 
 async def test_turn_off(hass, utcnow):
@@ -127,7 +127,7 @@ async def test_set_speed(hass, utcnow):
         {"entity_id": "fan.testdevice", "speed": "medium"},
         blocking=True,
     )
-    assert helper.characteristics[V1_ROTATION_SPEED].value == 50
+    assert helper.characteristics[V1_ROTATION_SPEED].value == 66.0
 
     await hass.services.async_call(
         "fan",
@@ -135,12 +135,35 @@ async def test_set_speed(hass, utcnow):
         {"entity_id": "fan.testdevice", "speed": "low"},
         blocking=True,
     )
-    assert helper.characteristics[V1_ROTATION_SPEED].value == 25
+    assert helper.characteristics[V1_ROTATION_SPEED].value == 33.0
 
     await hass.services.async_call(
         "fan",
         "set_speed",
         {"entity_id": "fan.testdevice", "speed": "off"},
+        blocking=True,
+    )
+    assert helper.characteristics[V1_ON].value == 0
+
+
+async def test_set_speed_percentage(hass, utcnow):
+    """Test that we set fan speed by percentage."""
+    helper = await setup_test_component(hass, create_fan_service)
+
+    helper.characteristics[V1_ON].value = 1
+
+    await hass.services.async_call(
+        "fan",
+        "set_speed_percentage",
+        {"entity_id": "fan.testdevice", "speed": 66},
+        blocking=True,
+    )
+    assert helper.characteristics[V1_ROTATION_SPEED].value == 66
+
+    await hass.services.async_call(
+        "fan",
+        "set_speed_percentage",
+        {"entity_id": "fan.testdevice", "speed": 0},
         blocking=True,
     )
     assert helper.characteristics[V1_ON].value == 0
@@ -154,19 +177,23 @@ async def test_speed_read(hass, utcnow):
     helper.characteristics[V1_ROTATION_SPEED].value = 100
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "high"
+    assert state.attributes["speed_percentage"] == 100
 
     helper.characteristics[V1_ROTATION_SPEED].value = 50
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "medium"
+    assert state.attributes["speed_percentage"] == 50
 
     helper.characteristics[V1_ROTATION_SPEED].value = 25
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "low"
+    assert state.attributes["speed_percentage"] == 25
 
     helper.characteristics[V1_ON].value = 0
     helper.characteristics[V1_ROTATION_SPEED].value = 0
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "off"
+    assert state.attributes["speed_percentage"] == 0
 
 
 async def test_set_direction(hass, utcnow):
@@ -236,7 +263,7 @@ async def test_v2_turn_on(hass, utcnow):
         blocking=True,
     )
     assert helper.characteristics[V2_ACTIVE].value == 1
-    assert helper.characteristics[V2_ROTATION_SPEED].value == 50
+    assert helper.characteristics[V2_ROTATION_SPEED].value == 66.0
 
     await hass.services.async_call(
         "fan",
@@ -245,7 +272,7 @@ async def test_v2_turn_on(hass, utcnow):
         blocking=True,
     )
     assert helper.characteristics[V2_ACTIVE].value == 1
-    assert helper.characteristics[V2_ROTATION_SPEED].value == 25
+    assert helper.characteristics[V2_ROTATION_SPEED].value == 33.0
 
 
 async def test_v2_turn_off(hass, utcnow):
@@ -280,7 +307,7 @@ async def test_v2_set_speed(hass, utcnow):
         {"entity_id": "fan.testdevice", "speed": "medium"},
         blocking=True,
     )
-    assert helper.characteristics[V2_ROTATION_SPEED].value == 50
+    assert helper.characteristics[V2_ROTATION_SPEED].value == 66
 
     await hass.services.async_call(
         "fan",
@@ -288,12 +315,35 @@ async def test_v2_set_speed(hass, utcnow):
         {"entity_id": "fan.testdevice", "speed": "low"},
         blocking=True,
     )
-    assert helper.characteristics[V2_ROTATION_SPEED].value == 25
+    assert helper.characteristics[V2_ROTATION_SPEED].value == 33
 
     await hass.services.async_call(
         "fan",
         "set_speed",
         {"entity_id": "fan.testdevice", "speed": "off"},
+        blocking=True,
+    )
+    assert helper.characteristics[V2_ACTIVE].value == 0
+
+
+async def test_v2_set_speed_percentage(hass, utcnow):
+    """Test that we set fan speed by percentage."""
+    helper = await setup_test_component(hass, create_fanv2_service)
+
+    helper.characteristics[V2_ACTIVE].value = 1
+
+    await hass.services.async_call(
+        "fan",
+        "set_speed_percentage",
+        {"entity_id": "fan.testdevice", "speed": 66},
+        blocking=True,
+    )
+    assert helper.characteristics[V2_ROTATION_SPEED].value == 66
+
+    await hass.services.async_call(
+        "fan",
+        "set_speed_percentage",
+        {"entity_id": "fan.testdevice", "speed": 0},
         blocking=True,
     )
     assert helper.characteristics[V2_ACTIVE].value == 0
@@ -307,19 +357,23 @@ async def test_v2_speed_read(hass, utcnow):
     helper.characteristics[V2_ROTATION_SPEED].value = 100
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "high"
+    assert state.attributes["speed_percentage"] == 100
 
     helper.characteristics[V2_ROTATION_SPEED].value = 50
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "medium"
+    assert state.attributes["speed_percentage"] == 50
 
     helper.characteristics[V2_ROTATION_SPEED].value = 25
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "low"
+    assert state.attributes["speed_percentage"] == 25
 
     helper.characteristics[V2_ACTIVE].value = 0
     helper.characteristics[V2_ROTATION_SPEED].value = 0
     state = await helper.poll_and_get_state()
     assert state.attributes["speed"] == "off"
+    assert state.attributes["speed_percentage"] == 0
 
 
 async def test_v2_set_direction(hass, utcnow):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a draft to explore possible solutions to https://github.com/home-assistant/architecture/issues/127. At the moment i'd like if possible any reviews to focus on the high level approach, ideally in that issue.

At the moment the goal is to add a supplemental interface rather than to replace the existing interface as this enables a gradual transition.

At its heart this PR adds support for a new method on fans, `async_set_speed_percentage` (and its sync counterpart).

If a device supports `async_set_speed_percentage` then it doesn't need to implement `async_set_speed` - HA provides a mapping function that converts `medium` into a percentage.

If a device does not support `async_set_speed_percentage` then a mapping fucntion will translate calls to that method into reasonable `async_set_speed` calls.

The `speed` attribute will always be available - using a mapping function if only a percentage is available.

A new `speed_percentage` attribute is added and will also always be available - again using a mapping function where needed - turning `low` into `33%` etc.

The mapping function is dynamic and tries to accomodate fans that don't follow the spec properly (e.g. they have added extra speeds) using a similar mechanism to the one in `homekit`.

The PR ports homekit_controller to the new API to test it out. homekit_controller previously had to map the HomeKit percentage onto Home Assistant's official 3 speeds. So the change deleted more code than it added there.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/issues/127
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
