### PR TITLE
Allow exposing domains in cloud

### DIFF
--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -19,8 +19,8 @@ from homeassistant.helpers import entity_registry
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.dt import utcnow
 
-from . import prefs
 from .const import CONF_ENTITY_CONFIG, CONF_FILTER, PREF_SHOULD_EXPOSE, RequireRelink
+from .prefs import CloudPreferences
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ SYNC_DELAY = 1
 class AlexaConfig(alexa_config.AbstractConfig):
     """Alexa Configuration."""
 
-    def __init__(self, hass, config, prefs: prefs.CloudPreferences, cloud):
+    def __init__(self, hass, config, prefs: CloudPreferences, cloud):
         """Initialize the Alexa config."""
         super().__init__(hass)
         self._config = config

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -14,18 +14,13 @@ from homeassistant.components.alexa import (
     state_report as alexa_state_report,
 )
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES, HTTP_BAD_REQUEST
-from homeassistant.core import callback
+from homeassistant.core import callback, split_entity_id
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.dt import utcnow
 
-from .const import (
-    CONF_ENTITY_CONFIG,
-    CONF_FILTER,
-    DEFAULT_SHOULD_EXPOSE,
-    PREF_SHOULD_EXPOSE,
-    RequireRelink,
-)
+from . import prefs
+from .const import CONF_ENTITY_CONFIG, CONF_FILTER, PREF_SHOULD_EXPOSE, RequireRelink
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +32,7 @@ SYNC_DELAY = 1
 class AlexaConfig(alexa_config.AbstractConfig):
     """Alexa Configuration."""
 
-    def __init__(self, hass, config, prefs, cloud):
+    def __init__(self, hass, config, prefs: prefs.CloudPreferences, cloud):
         """Initialize the Alexa config."""
         super().__init__(hass)
         self._config = config
@@ -46,6 +41,7 @@ class AlexaConfig(alexa_config.AbstractConfig):
         self._token = None
         self._token_valid = None
         self._cur_entity_prefs = prefs.alexa_entity_configs
+        self._cur_default_expose = prefs.alexa_default_expose
         self._alexa_sync_unsub = None
         self._endpoint = None
 
@@ -99,7 +95,17 @@ class AlexaConfig(alexa_config.AbstractConfig):
 
         entity_configs = self._prefs.alexa_entity_configs
         entity_config = entity_configs.get(entity_id, {})
-        return entity_config.get(PREF_SHOULD_EXPOSE, DEFAULT_SHOULD_EXPOSE)
+        entity_expose = entity_config.get(PREF_SHOULD_EXPOSE)
+        if entity_expose is not None:
+            return entity_expose
+
+        default_expose = self._prefs.alexa_default_expose
+
+        # Backwards compat
+        if default_expose is None:
+            return True
+
+        return split_entity_id(entity_id)[0] in default_expose
 
     @callback
     def async_invalidate_access_token(self):
@@ -147,16 +153,24 @@ class AlexaConfig(alexa_config.AbstractConfig):
             await self.async_sync_entities()
             return
 
-        # If entity prefs are the same or we have filter in config.yaml,
-        # don't sync.
+        # If user has filter in config.yaml, don't sync.
+        if not self._config[CONF_FILTER].empty_filter:
+            return
+
+        # If entity prefs are the same, don't sync.
         if (
             self._cur_entity_prefs is prefs.alexa_entity_configs
-            or not self._config[CONF_FILTER].empty_filter
+            and self._cur_default_expose is prefs.alexa_default_expose
         ):
             return
 
         if self._alexa_sync_unsub:
             self._alexa_sync_unsub()
+            self._alexa_sync_unsub = None
+
+        if self._cur_default_expose is not prefs.alexa_default_expose:
+            await self.async_sync_entities()
+            return
 
         self._alexa_sync_unsub = async_call_later(
             self.hass, SYNC_DELAY, self._sync_prefs

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -18,10 +18,22 @@ PREF_ALIASES = "aliases"
 PREF_SHOULD_EXPOSE = "should_expose"
 PREF_GOOGLE_LOCAL_WEBHOOK_ID = "google_local_webhook_id"
 PREF_USERNAME = "username"
-DEFAULT_SHOULD_EXPOSE = True
+PREF_ALEXA_DEFAULT_EXPOSE = "alexa_default_expose"
+PREF_GOOGLE_DEFAULT_EXPOSE = "google_default_expose"
 DEFAULT_DISABLE_2FA = False
 DEFAULT_ALEXA_REPORT_STATE = False
 DEFAULT_GOOGLE_REPORT_STATE = False
+DEFAULT_EXPOSED_DOMAINS = [
+    "climate",
+    "cover",
+    "light",
+    "lock",
+    "scene",
+    "script",
+    "sensor",
+    "switch",
+    "vacuum",
+]
 
 CONF_ALEXA = "alexa"
 CONF_ALIASES = "aliases"

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -26,6 +26,8 @@ DEFAULT_GOOGLE_REPORT_STATE = False
 DEFAULT_EXPOSED_DOMAINS = [
     "climate",
     "cover",
+    "fan",
+    "humidifier",
     "light",
     "lock",
     "scene",
@@ -33,6 +35,7 @@ DEFAULT_EXPOSED_DOMAINS = [
     "sensor",
     "switch",
     "vacuum",
+    "water_heater",
 ]
 
 CONF_ALEXA = "alexa"

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -14,13 +14,13 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, callback, split_entity_id
 from homeassistant.helpers import entity_registry
 
-from . import prefs
 from .const import (
     CONF_ENTITY_CONFIG,
     DEFAULT_DISABLE_2FA,
     PREF_DISABLE_2FA,
     PREF_SHOULD_EXPOSE,
 )
+from .prefs import CloudPreferences
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 class CloudGoogleConfig(AbstractConfig):
     """HA Cloud Configuration for Google Assistant."""
 
-    def __init__(self, hass, config, cloud_user, prefs: prefs.CloudPreferences, cloud):
+    def __init__(self, hass, config, cloud_user, prefs: CloudPreferences, cloud):
         """Initialize the Google config."""
         super().__init__(hass)
         self._config = config

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -11,13 +11,13 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     HTTP_OK,
 )
-from homeassistant.core import CoreState, callback
+from homeassistant.core import CoreState, callback, split_entity_id
 from homeassistant.helpers import entity_registry
 
+from . import prefs
 from .const import (
     CONF_ENTITY_CONFIG,
     DEFAULT_DISABLE_2FA,
-    DEFAULT_SHOULD_EXPOSE,
     PREF_DISABLE_2FA,
     PREF_SHOULD_EXPOSE,
 )
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 class CloudGoogleConfig(AbstractConfig):
     """HA Cloud Configuration for Google Assistant."""
 
-    def __init__(self, hass, config, cloud_user, prefs, cloud):
+    def __init__(self, hass, config, cloud_user, prefs: prefs.CloudPreferences, cloud):
         """Initialize the Google config."""
         super().__init__(hass)
         self._config = config
@@ -36,6 +36,7 @@ class CloudGoogleConfig(AbstractConfig):
         self._prefs = prefs
         self._cloud = cloud
         self._cur_entity_prefs = self._prefs.google_entity_configs
+        self._cur_default_expose = self._prefs.google_default_expose
         self._sync_entities_lock = asyncio.Lock()
         self._sync_on_started = False
 
@@ -104,7 +105,17 @@ class CloudGoogleConfig(AbstractConfig):
 
         entity_configs = self._prefs.google_entity_configs
         entity_config = entity_configs.get(entity_id, {})
-        return entity_config.get(PREF_SHOULD_EXPOSE, DEFAULT_SHOULD_EXPOSE)
+        entity_expose = entity_config.get(PREF_SHOULD_EXPOSE)
+        if entity_expose is not None:
+            return entity_expose
+
+        default_expose = self._prefs.google_default_expose
+
+        # Backwards compat
+        if default_expose is None:
+            return True
+
+        return split_entity_id(entity_id)[0] in default_expose
 
     @property
     def agent_user_id(self):
@@ -153,14 +164,17 @@ class CloudGoogleConfig(AbstractConfig):
         # don't sync.
         elif (
             self._cur_entity_prefs is not prefs.google_entity_configs
-            and self._config["filter"].empty_filter
-        ):
+            or self._cur_default_expose is not prefs.google_default_expose
+        ) and self._config["filter"].empty_filter:
             self.async_schedule_google_sync_all()
 
         if self.enabled and not self.is_local_sdk_active:
             self.async_enable_local_sdk()
         elif not self.enabled and self.is_local_sdk_active:
             self.async_disable_local_sdk()
+
+        self._cur_entity_prefs = prefs.google_entity_configs
+        self._cur_default_expose = prefs.google_default_expose
 
     async def _handle_entity_registry_updated(self, event):
         """Handle when entity registry updated."""

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -24,9 +24,11 @@ from homeassistant.core import callback
 
 from .const import (
     DOMAIN,
+    PREF_ALEXA_DEFAULT_EXPOSE,
     PREF_ALEXA_REPORT_STATE,
     PREF_ENABLE_ALEXA,
     PREF_ENABLE_GOOGLE,
+    PREF_GOOGLE_DEFAULT_EXPOSE,
     PREF_GOOGLE_REPORT_STATE,
     PREF_GOOGLE_SECURE_DEVICES_PIN,
     REQUEST_TIMEOUT,
@@ -368,6 +370,8 @@ async def websocket_subscription(hass, connection, msg):
         vol.Optional(PREF_ENABLE_ALEXA): bool,
         vol.Optional(PREF_ALEXA_REPORT_STATE): bool,
         vol.Optional(PREF_GOOGLE_REPORT_STATE): bool,
+        vol.Optional(PREF_ALEXA_DEFAULT_EXPOSE): [str],
+        vol.Optional(PREF_GOOGLE_DEFAULT_EXPOSE): [str],
         vol.Optional(PREF_GOOGLE_SECURE_DEVICES_PIN): vol.Any(None, str),
     }
 )
@@ -511,7 +515,7 @@ async def google_assistant_list(hass, connection, msg):
     {
         "type": "cloud/google_assistant/entities/update",
         "entity_id": str,
-        vol.Optional("should_expose"): bool,
+        vol.Optional("should_expose"): vol.Any(None, bool),
         vol.Optional("override_name"): str,
         vol.Optional("aliases"): [str],
         vol.Optional("disable_2fa"): bool,
@@ -563,7 +567,7 @@ async def alexa_list(hass, connection, msg):
     {
         "type": "cloud/alexa/entities/update",
         "entity_id": str,
-        vol.Optional("should_expose"): bool,
+        vol.Optional("should_expose"): vol.Any(None, bool),
     }
 )
 async def alexa_update(hass, connection, msg):

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -12,12 +12,21 @@ from tests.common import async_fire_time_changed
 async def test_alexa_config_expose_entity_prefs(hass, cloud_prefs):
     """Test Alexa config should expose using prefs."""
     entity_conf = {"should_expose": False}
-    await cloud_prefs.async_update(alexa_entity_configs={"light.kitchen": entity_conf})
+    await cloud_prefs.async_update(
+        alexa_entity_configs={"light.kitchen": entity_conf},
+        alexa_default_expose=["light"],
+    )
     conf = alexa_config.AlexaConfig(hass, ALEXA_SCHEMA({}), cloud_prefs, None)
 
     assert not conf.should_expose("light.kitchen")
     entity_conf["should_expose"] = True
     assert conf.should_expose("light.kitchen")
+
+    entity_conf["should_expose"] = None
+    assert conf.should_expose("light.kitchen")
+
+    await cloud_prefs.async_update(alexa_default_expose=["sensor"],)
+    assert not conf.should_expose("light.kitchen")
 
 
 async def test_alexa_config_report_state(hass, cloud_prefs):

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -1,9 +1,11 @@
 """Test the Cloud Google Config."""
+import pytest
+
 from homeassistant.components.cloud import GACTIONS_SCHEMA
 from homeassistant.components.cloud.google_config import CloudGoogleConfig
 from homeassistant.components.google_assistant import helpers as ga_helpers
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, HTTP_NOT_FOUND
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, State
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
 from homeassistant.util.dt import utcnow
 
@@ -11,19 +13,24 @@ from tests.async_mock import AsyncMock, Mock, patch
 from tests.common import async_fire_time_changed
 
 
-async def test_google_update_report_state(hass, cloud_prefs):
-    """Test Google config responds to updating preference."""
-    config = CloudGoogleConfig(
+@pytest.fixture
+def mock_conf(hass, cloud_prefs):
+    """Mock Google conf."""
+    return CloudGoogleConfig(
         hass,
         GACTIONS_SCHEMA({}),
         "mock-user-id",
         cloud_prefs,
         Mock(claims={"cognito:username": "abcdefghjkl"}),
     )
-    await config.async_initialize()
-    await config.async_connect_agent_user("mock-user-id")
 
-    with patch.object(config, "async_sync_entities") as mock_sync, patch(
+
+async def test_google_update_report_state(mock_conf, hass, cloud_prefs):
+    """Test Google config responds to updating preference."""
+    await mock_conf.async_initialize()
+    await mock_conf.async_connect_agent_user("mock-user-id")
+
+    with patch.object(mock_conf, "async_sync_entities") as mock_sync, patch(
         "homeassistant.components.google_assistant.report_state.async_enable_report_state"
     ) as mock_report_state:
         await cloud_prefs.async_update(google_report_state=True)
@@ -161,3 +168,24 @@ async def test_google_entity_registry_sync(hass, mock_cloud_login, cloud_prefs):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
         assert len(mock_sync.mock_calls) == 1
+
+
+async def test_google_config_expose_entity_prefs(mock_conf, cloud_prefs):
+    """Test Google config should expose using prefs."""
+    entity_conf = {"should_expose": False}
+    await cloud_prefs.async_update(
+        google_entity_configs={"light.kitchen": entity_conf},
+        google_default_expose=["light"],
+    )
+
+    state = State("light.kitchen", "on")
+
+    assert not mock_conf.should_expose(state)
+    entity_conf["should_expose"] = True
+    assert mock_conf.should_expose(state)
+
+    entity_conf["should_expose"] = None
+    assert mock_conf.should_expose(state)
+
+    await cloud_prefs.async_update(google_default_expose=["sensor"],)
+    assert not mock_conf.should_expose(state)

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -355,6 +355,8 @@ async def test_websocket_status(
             "google_enabled": True,
             "google_entity_configs": {},
             "google_secure_devices_pin": None,
+            "google_default_expose": None,
+            "alexa_default_expose": None,
             "alexa_entity_configs": {},
             "alexa_report_state": False,
             "google_report_state": False,
@@ -486,6 +488,8 @@ async def test_websocket_update_preferences(
             "alexa_enabled": False,
             "google_enabled": False,
             "google_secure_devices_pin": "1234",
+            "google_default_expose": ["light", "switch"],
+            "alexa_default_expose": ["sensor", "media_player"],
         }
     )
     response = await client.receive_json()
@@ -494,6 +498,8 @@ async def test_websocket_update_preferences(
     assert not setup_api.google_enabled
     assert not setup_api.alexa_enabled
     assert setup_api.google_secure_devices_pin == "1234"
+    assert setup_api.google_default_expose == ["light", "switch"]
+    assert setup_api.alexa_default_expose == ["sensor", "media_player"]
 
 
 async def test_websocket_update_preferences_require_relink(
@@ -745,6 +751,25 @@ async def test_update_google_entity(hass, hass_ws_client, setup_api, mock_cloud_
         "disable_2fa": False,
     }
 
+    await client.send_json(
+        {
+            "id": 6,
+            "type": "cloud/google_assistant/entities/update",
+            "entity_id": "light.kitchen",
+            "should_expose": None,
+        }
+    )
+    response = await client.receive_json()
+
+    assert response["success"]
+    prefs = hass.data[DOMAIN].client.prefs
+    assert prefs.google_entity_configs["light.kitchen"] == {
+        "should_expose": None,
+        "override_name": "updated name",
+        "aliases": ["lefty", "righty"],
+        "disable_2fa": False,
+    }
+
 
 async def test_enabling_remote_trusted_proxies_local4(
     hass, hass_ws_client, setup_api, mock_cloud_login
@@ -832,6 +857,20 @@ async def test_update_alexa_entity(hass, hass_ws_client, setup_api, mock_cloud_l
     assert response["success"]
     prefs = hass.data[DOMAIN].client.prefs
     assert prefs.alexa_entity_configs["light.kitchen"] == {"should_expose": False}
+
+    await client.send_json(
+        {
+            "id": 6,
+            "type": "cloud/alexa/entities/update",
+            "entity_id": "light.kitchen",
+            "should_expose": None,
+        }
+    )
+    response = await client.receive_json()
+
+    assert response["success"]
+    prefs = hass.data[DOMAIN].client.prefs
+    assert prefs.alexa_entity_configs["light.kitchen"] == {"should_expose": None}
 
 
 async def test_sync_alexa_entities_timeout(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add option to Nabu Casa to allow picking domains of entities that need to be exposed to Google/Alexa.

Should not be merged untill frontend PR is ready.

CC @bramkragten 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
