### PR TITLE
Ensure the context is passed to group changes

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -347,7 +347,7 @@ class GroupEntity(Entity):
 
     @property
     def should_poll(self) -> bool:
-        """Disable polling for cover group."""
+        """Disable polling for group."""
         return False
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -364,8 +364,7 @@ class GroupEntity(Entity):
         self, force_refresh: bool = False
     ) -> None:
         """Only update once at start."""
-        if not self.hass:
-            return
+        assert self.hass is not None
 
         if self.hass.state != CoreState.running:
             return

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -350,26 +350,23 @@ class GroupEntity(Entity):
         """Disable polling for group."""
         return False
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Register listeners."""
+        assert self.hass is not None
 
-        @callback
-        def _update_at_start(_):
-            self.async_schedule_update_ha_state(True)
+        async def _update_at_start(_):
+            await self.async_update_ha_state(True)
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _update_at_start)
 
-    @callback
-    def async_schedule_or_defer_update_ha_state(
-        self, force_refresh: bool = False
-    ) -> None:
+    async def async_defer_or_update_ha_state(self) -> None:
         """Only update once at start."""
         assert self.hass is not None
 
         if self.hass.state != CoreState.running:
             return
 
-        self.async_schedule_update_ha_state(force_refresh)
+        await self.async_update_ha_state(True)
 
 
 class Group(Entity):

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -159,7 +159,7 @@ class CoverGroup(GroupEntity, CoverEntity):
                 self.hass, self._entities, self._update_supported_features_event
             )
         )
-        super().async_added_to_hass()
+        await super().async_added_to_hass()
 
     @property
     def name(self):

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -43,6 +43,8 @@ from homeassistant.core import State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 
+from . import GroupEntity
+
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs
 
@@ -68,7 +70,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([CoverGroup(config[CONF_NAME], config[CONF_ENTITIES])])
 
 
-class CoverGroup(CoverEntity):
+class CoverGroup(GroupEntity, CoverEntity):
     """Representation of a CoverGroup."""
 
     def __init__(self, name, entities):
@@ -96,6 +98,7 @@ class CoverGroup(CoverEntity):
 
     @callback
     def _update_supported_features_event(self, event):
+        self.async_set_context(event.context)
         self.update_supported_features(
             event.data.get("entity_id"), event.data.get("new_state")
         )
@@ -111,7 +114,7 @@ class CoverGroup(CoverEntity):
             for values in self._tilts.values():
                 values.discard(entity_id)
             if update_state:
-                self.async_schedule_update_ha_state(True)
+                self.async_schedule_or_defer_update_ha_state(True)
             return
 
         features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
@@ -143,17 +146,20 @@ class CoverGroup(CoverEntity):
             self._tilts[KEY_POSITION].discard(entity_id)
 
         if update_state:
-            self.async_schedule_update_ha_state(True)
+            self.async_schedule_or_defer_update_ha_state(True)
 
     async def async_added_to_hass(self):
         """Register listeners."""
         for entity_id in self._entities:
             new_state = self.hass.states.get(entity_id)
             self.update_supported_features(entity_id, new_state, update_state=False)
-        async_track_state_change_event(
-            self.hass, self._entities, self._update_supported_features_event
+        assert self.hass is not None
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, self._entities, self._update_supported_features_event
+            )
         )
-        await self.async_update()
+        super().async_added_to_hass()
 
     @property
     def name(self):
@@ -164,11 +170,6 @@ class CoverGroup(CoverEntity):
     def assumed_state(self):
         """Enable buttons even if at end position."""
         return self._assumed_state
-
-    @property
-    def should_poll(self):
-        """Disable polling for cover group."""
-        return False
 
     @property
     def supported_features(self):

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.core import State, callback
+from homeassistant.core import State
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -96,15 +96,13 @@ class CoverGroup(GroupEntity, CoverEntity):
             KEY_POSITION: set(),
         }
 
-    @callback
-    def _update_supported_features_event(self, event):
+    async def _update_supported_features_event(self, event):
         self.async_set_context(event.context)
-        self.update_supported_features(
+        await self.async_update_supported_features(
             event.data.get("entity_id"), event.data.get("new_state")
         )
 
-    @callback
-    def update_supported_features(
+    async def async_update_supported_features(
         self, entity_id: str, new_state: Optional[State], update_state: bool = True,
     ) -> None:
         """Update dictionaries with supported features."""
@@ -114,7 +112,7 @@ class CoverGroup(GroupEntity, CoverEntity):
             for values in self._tilts.values():
                 values.discard(entity_id)
             if update_state:
-                self.async_schedule_or_defer_update_ha_state(True)
+                await self.async_defer_or_update_ha_state()
             return
 
         features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
@@ -146,13 +144,15 @@ class CoverGroup(GroupEntity, CoverEntity):
             self._tilts[KEY_POSITION].discard(entity_id)
 
         if update_state:
-            self.async_schedule_or_defer_update_ha_state(True)
+            await self.async_defer_or_update_ha_state()
 
     async def async_added_to_hass(self):
         """Register listeners."""
         for entity_id in self._entities:
             new_state = self.hass.states.get(entity_id)
-            self.update_supported_features(entity_id, new_state, update_state=False)
+            await self.async_update_supported_features(
+                entity_id, new_state, update_state=False
+            )
         assert self.hass is not None
         self.async_on_remove(
             async_track_state_change_event(

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -112,7 +112,7 @@ class LightGroup(GroupEntity, light.LightEntity):
                 self.hass, self._entity_ids, async_state_changed_listener
             )
         )
-        super().async_added_to_hass()
+        await super().async_added_to_hass()
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -36,11 +36,13 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import CALLBACK_TYPE, State, callback
+from homeassistant.core import State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util import color as color_util
+
+from . import GroupEntity
 
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs
@@ -76,7 +78,7 @@ async def async_setup_platform(
     )
 
 
-class LightGroup(light.LightEntity):
+class LightGroup(GroupEntity, light.LightEntity):
     """Representation of a light group."""
 
     def __init__(self, name: str, entity_ids: List[str]) -> None:
@@ -94,27 +96,23 @@ class LightGroup(light.LightEntity):
         self._effect_list: Optional[List[str]] = None
         self._effect: Optional[str] = None
         self._supported_features: int = 0
-        self._async_unsub_state_changed: Optional[CALLBACK_TYPE] = None
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
 
         @callback
-        def async_state_changed_listener(*_):
+        def async_state_changed_listener(event):
             """Handle child updates."""
-            self.async_schedule_update_ha_state(True)
+            self.async_set_context(event.context)
+            self.async_schedule_or_defer_update_ha_state(True)
 
-        assert self.hass is not None
-        self._async_unsub_state_changed = async_track_state_change_event(
-            self.hass, self._entity_ids, async_state_changed_listener
+        assert self.hass
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, self._entity_ids, async_state_changed_listener
+            )
         )
-        await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        """Handle removal from Home Assistant."""
-        if self._async_unsub_state_changed is not None:
-            self._async_unsub_state_changed()
-            self._async_unsub_state_changed = None
+        super().async_added_to_hass()
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State, callback
+from homeassistant.core import State
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
@@ -100,11 +100,10 @@ class LightGroup(GroupEntity, light.LightEntity):
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
 
-        @callback
-        def async_state_changed_listener(event):
+        async def async_state_changed_listener(event):
             """Handle child updates."""
             self.async_set_context(event.context)
-            self.async_schedule_or_defer_update_ha_state(True)
+            await self.async_defer_or_update_ha_state()
 
         assert self.hass
         self.async_on_remove(

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -78,6 +78,8 @@ async def setup_comp(hass, config_count):
     with assert_setup_component(count, DOMAIN):
         await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -47,6 +47,8 @@ async def test_default_state(hass):
         },
     )
     await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     state = hass.states.get("light.bedroom_group")
     assert state is not None
@@ -73,6 +75,9 @@ async def test_state_reporting(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set("light.test1", STATE_ON)
     hass.states.async_set("light.test2", STATE_UNAVAILABLE)
@@ -107,6 +112,9 @@ async def test_brightness(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set(
         "light.test1", STATE_ON, {ATTR_BRIGHTNESS: 255, ATTR_SUPPORTED_FEATURES: 1}
@@ -147,6 +155,9 @@ async def test_color(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set(
         "light.test1", STATE_ON, {ATTR_HS_COLOR: (0, 100), ATTR_SUPPORTED_FEATURES: 16}
@@ -184,6 +195,9 @@ async def test_white_value(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set(
         "light.test1", STATE_ON, {ATTR_WHITE_VALUE: 255, ATTR_SUPPORTED_FEATURES: 128}
@@ -219,6 +233,9 @@ async def test_color_temp(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set(
         "light.test1", STATE_ON, {"color_temp": 2, ATTR_SUPPORTED_FEATURES: 2}
@@ -261,6 +278,8 @@ async def test_emulated_color_temp_group(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
     await hass.async_block_till_done()
 
     hass.states.async_set("light.bed_light", STATE_ON, {ATTR_SUPPORTED_FEATURES: 2})
@@ -306,6 +325,9 @@ async def test_min_max_mireds(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set(
         "light.test1",
@@ -350,6 +372,9 @@ async def test_effect_list(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set(
         "light.test1",
@@ -402,6 +427,9 @@ async def test_effect(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set(
         "light.test1", STATE_ON, {ATTR_EFFECT: "None", ATTR_SUPPORTED_FEATURES: 6}
@@ -447,6 +475,9 @@ async def test_supported_features(hass):
             }
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set("light.test1", STATE_ON, {ATTR_SUPPORTED_FEATURES: 0})
     await hass.async_block_till_done()
@@ -488,6 +519,8 @@ async def test_service_calls(hass):
             ]
         },
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
     await hass.async_block_till_done()
 
     assert hass.states.get("light.light_group").state == STATE_ON
@@ -559,6 +592,9 @@ async def test_invalid_service_calls(hass):
     await group.async_setup_platform(
         hass, {"entities": ["light.test1", "light.test2"]}, add_entities
     )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
     assert add_entities.call_count == 1
     grouped_light = add_entities.call_args[0][0][0]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure the context is passed to group changes

Defer group state updates until the start event
    to avoid multiple state updates on startup

<img width="515" alt="Screen Shot 2020-08-24 at 2 02 22 PM" src="https://user-images.githubusercontent.com/663432/91085177-a7f6f180-e612-11ea-8e0a-a483de76bb69.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
