### PR TITLE
Bump brother library to version 0.1.15

### DIFF
--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -1,5 +1,5 @@
 """Constants for Brother integration."""
-from homeassistant.const import TIME_DAYS, UNIT_PERCENTAGE
+from homeassistant.const import UNIT_PERCENTAGE
 
 ATTR_BELT_UNIT_REMAINING_LIFE = "belt_unit_remaining_life"
 ATTR_BLACK_DRUM_COUNTER = "black_drum_counter"
@@ -165,6 +165,6 @@ SENSOR_TYPES = {
     ATTR_UPTIME: {
         ATTR_ICON: "mdi:timer-outline",
         ATTR_LABEL: ATTR_UPTIME.title(),
-        ATTR_UNIT: TIME_DAYS,
+        ATTR_UNIT: None,
     },
 }

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -162,9 +162,5 @@ SENSOR_TYPES = {
         ATTR_LABEL: ATTR_YELLOW_INK_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: UNIT_PERCENTAGE,
     },
-    ATTR_UPTIME: {
-        ATTR_ICON: "mdi:timer-outline",
-        ATTR_LABEL: ATTR_UPTIME.title(),
-        ATTR_UNIT: None,
-    },
+    ATTR_UPTIME: {ATTR_ICON: None, ATTR_LABEL: ATTR_UPTIME.title(), ATTR_UNIT: None},
 }

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brother Printer",
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
-  "requirements": ["brother==0.1.14"],
+  "requirements": ["brother==0.1.15"],
   "zeroconf": ["_printer._tcp.local."],
   "config_flow": true,
   "quality_scale": "platinum"

--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -1,7 +1,10 @@
 """Support for the Brother service."""
+from datetime import timedelta
 import logging
 
+from homeassistant.const import DEVICE_CLASS_TIMESTAMP
 from homeassistant.helpers.entity import Entity
+from homeassistant.util.dt import utcnow
 
 from .const import (
     ATTR_BLACK_DRUM_COUNTER,
@@ -20,6 +23,7 @@ from .const import (
     ATTR_MAGENTA_DRUM_REMAINING_PAGES,
     ATTR_MANUFACTURER,
     ATTR_UNIT,
+    ATTR_UPTIME,
     ATTR_YELLOW_DRUM_COUNTER,
     ATTR_YELLOW_DRUM_REMAINING_LIFE,
     ATTR_YELLOW_DRUM_REMAINING_PAGES,
@@ -76,7 +80,17 @@ class BrotherPrinterSensor(Entity):
     @property
     def state(self):
         """Return the state."""
+        if self.kind == ATTR_UPTIME:
+            uptime = utcnow() - timedelta(seconds=self.coordinator.data.get(self.kind))
+            return uptime.replace(microsecond=0).isoformat()
         return self.coordinator.data.get(self.kind)
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor."""
+        if self.kind == ATTR_UPTIME:
+            return DEVICE_CLASS_TIMESTAMP
+        return None
 
     @property
     def device_state_attributes(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -384,7 +384,7 @@ bravia-tv==1.0.6
 broadlink==0.14.1
 
 # homeassistant.components.brother
-brother==0.1.14
+brother==0.1.15
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -205,7 +205,7 @@ bravia-tv==1.0.6
 broadlink==0.14.1
 
 # homeassistant.components.brother
-brother==0.1.14
+brother==0.1.15
 
 # homeassistant.components.bsblan
 bsblan==0.3.7

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -214,7 +214,7 @@ async def test_sensors(hass):
 
     state = hass.states.get("sensor.hl_l2340dw_uptime")
     assert state
-    assert state.attributes.get(ATTR_ICON) == "mdi:timer-outline"
+    assert state.attributes.get(ATTR_ICON) is None
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TIMESTAMP
     assert state.state == "2019-09-24T12:14:56+00:00"

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -1,5 +1,5 @@
 """Test sensor of Brother integration."""
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import json
 
 from homeassistant.components.brother.const import UNIT_PAGES
@@ -13,7 +13,7 @@ from homeassistant.const import (
     UNIT_PERCENTAGE,
 )
 from homeassistant.setup import async_setup_component
-from homeassistant.util.dt import utcnow
+from homeassistant.util.dt import UTC, utcnow
 
 from tests.async_mock import patch
 from tests.common import async_fire_time_changed, load_fixture
@@ -25,7 +25,7 @@ ATTR_COUNTER = "counter"
 
 async def test_sensors(hass):
     """Test states of the sensors."""
-    test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=timezone.utc)
+    test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=UTC)
     with patch(
         "homeassistant.components.brother.sensor.utcnow", return_value=test_time
     ):

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -1,14 +1,15 @@
 """Test sensor of Brother integration."""
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 import json
 
 from homeassistant.components.brother.const import UNIT_PAGES
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
+    DEVICE_CLASS_TIMESTAMP,
     STATE_UNAVAILABLE,
-    TIME_DAYS,
     UNIT_PERCENTAGE,
 )
 from homeassistant.setup import async_setup_component
@@ -24,7 +25,12 @@ ATTR_COUNTER = "counter"
 
 async def test_sensors(hass):
     """Test states of the sensors."""
-    await init_integration(hass)
+    test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=timezone.utc)
+    with patch(
+        "homeassistant.components.brother.sensor.utcnow", return_value=test_time
+    ):
+        await init_integration(hass)
+
     registry = await hass.helpers.entity_registry.async_get_registry()
 
     state = hass.states.get("sensor.hl_l2340dw_status")
@@ -209,8 +215,9 @@ async def test_sensors(hass):
     state = hass.states.get("sensor.hl_l2340dw_uptime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:timer-outline"
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TIME_DAYS
-    assert state.state == "48"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TIMESTAMP
+    assert state.state == "2019-09-24T12:14:56+00:00"
 
     entry = registry.async_get("sensor.hl_l2340dw_uptime")
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This change may be a breaking change as the `uptime` sensor state format and unit will be different.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps the brother library to version 0.1.15 to change the state of `uptime` sensor to a DateTime object with `device_class` `timestamp`.

Changelog: https://github.com/bieniu/brother/compare/0.1.14...0.1.15

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
