### PR TITLE
Bump python-broadlink to 0.15.0

### DIFF
--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -7,7 +7,7 @@ import broadlink as blk
 from broadlink.exceptions import (
     AuthenticationError,
     BroadlinkException,
-    DeviceOfflineError,
+    NetworkTimeoutError,
 )
 import voluptuous as vol
 
@@ -139,7 +139,7 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(device.mac.hex())
             return await self.async_step_reset(errors=errors)
 
-        except DeviceOfflineError as err:
+        except NetworkTimeoutError as err:
             errors["base"] = "cannot_connect"
             err_msg = str(err)
 
@@ -207,7 +207,7 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await self.hass.async_add_executor_job(device.set_lock, False)
 
-            except DeviceOfflineError as err:
+            except NetworkTimeoutError as err:
                 errors["base"] = "cannot_connect"
                 err_msg = str(err)
 

--- a/homeassistant/components/broadlink/device.py
+++ b/homeassistant/components/broadlink/device.py
@@ -9,7 +9,7 @@ from broadlink.exceptions import (
     AuthorizationError,
     BroadlinkException,
     ConnectionClosedError,
-    DeviceOfflineError,
+    NetworkTimeoutError,
 )
 
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_TIMEOUT, CONF_TYPE
@@ -82,7 +82,7 @@ class BroadlinkDevice:
             await self._async_handle_auth_error()
             return False
 
-        except (DeviceOfflineError, OSError) as err:
+        except (NetworkTimeoutError, OSError) as err:
             raise ConfigEntryNotReady from err
 
         except BroadlinkException as err:

--- a/homeassistant/components/broadlink/manifest.json
+++ b/homeassistant/components/broadlink/manifest.json
@@ -2,7 +2,7 @@
   "domain": "broadlink",
   "name": "Broadlink",
   "documentation": "https://www.home-assistant.io/integrations/broadlink",
-  "requirements": ["broadlink==0.14.1"],
+  "requirements": ["broadlink==0.15.0"],
   "codeowners": ["@danielhiversen", "@felipediel"],
   "config_flow": true
 }

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -9,7 +9,7 @@ import logging
 from broadlink.exceptions import (
     AuthorizationError,
     BroadlinkException,
-    DeviceOfflineError,
+    NetworkTimeoutError,
     ReadError,
     StorageError,
 )
@@ -262,7 +262,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
             try:
                 await self._device.async_request(self._device.api.send_data, code)
 
-            except (AuthorizationError, DeviceOfflineError, OSError) as err:
+            except (AuthorizationError, NetworkTimeoutError, OSError) as err:
                 _LOGGER.error("Failed to send '%s': %s", command, err)
                 break
 
@@ -295,7 +295,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 if toggle:
                     code = [code, await self._async_learn_command(command)]
 
-            except (AuthorizationError, DeviceOfflineError, OSError) as err:
+            except (AuthorizationError, NetworkTimeoutError, OSError) as err:
                 _LOGGER.error("Failed to learn '%s': %s", command, err)
                 break
 

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -9,7 +9,7 @@ from broadlink.exceptions import (
     AuthorizationError,
     BroadlinkException,
     CommandNotSupportedError,
-    DeviceOfflineError,
+    NetworkTimeoutError,
     StorageError,
 )
 
@@ -113,7 +113,7 @@ class BroadlinkRMMini3UpdateManager(BroadlinkUpdateManager):
         )
         devices = await self.device.hass.async_add_executor_job(hello)
         if not devices:
-            raise DeviceOfflineError("The device is offline")
+            raise NetworkTimeoutError("The device is offline")
         return {}
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -383,7 +383,7 @@ boto3==1.9.252
 bravia-tv==1.0.6
 
 # homeassistant.components.broadlink
-broadlink==0.14.1
+broadlink==0.15.0
 
 # homeassistant.components.brother
 brother==0.1.17

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -204,7 +204,7 @@ bond-api==0.1.8
 bravia-tv==1.0.6
 
 # homeassistant.components.broadlink
-broadlink==0.14.1
+broadlink==0.15.0
 
 # homeassistant.components.brother
 brother==0.1.17

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -249,11 +249,11 @@ async def test_flow_auth_authentication_error(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_flow_auth_device_offline(hass):
-    """Test we handle a device offline in the auth step."""
+async def test_flow_auth_network_timeout(hass):
+    """Test we handle a network timeout in the auth step."""
     device = get_device("Living Room")
     mock_api = device.get_mock_api()
-    mock_api.auth.side_effect = blke.DeviceOfflineError()
+    mock_api.auth.side_effect = blke.NetworkTimeoutError()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -403,12 +403,12 @@ async def test_flow_unlock_works(hass):
     assert mock_api.set_lock.call_count == 1
 
 
-async def test_flow_unlock_device_offline(hass):
-    """Test we handle a device offline in the unlock step."""
+async def test_flow_unlock_network_timeout(hass):
+    """Test we handle a network timeout in the unlock step."""
     device = get_device("Living Room")
     mock_api = device.get_mock_api()
     mock_api.is_locked = True
-    mock_api.set_lock.side_effect = blke.DeviceOfflineError
+    mock_api.set_lock.side_effect = blke.NetworkTimeoutError()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/broadlink/test_device.py
+++ b/tests/components/broadlink/test_device.py
@@ -62,11 +62,11 @@ async def test_device_setup_authentication_error(hass):
     }
 
 
-async def test_device_setup_device_offline(hass):
-    """Test we handle a device offline."""
+async def test_device_setup_network_timeout(hass):
+    """Test we handle a network timeout."""
     device = get_device("Office")
     mock_api = device.get_mock_api()
-    mock_api.auth.side_effect = blke.DeviceOfflineError()
+    mock_api.auth.side_effect = blke.NetworkTimeoutError()
 
     with patch.object(
         hass.config_entries, "async_forward_entry_setup"
@@ -119,11 +119,11 @@ async def test_device_setup_broadlink_exception(hass):
     assert mock_init.call_count == 0
 
 
-async def test_device_setup_update_device_offline(hass):
-    """Test we handle a device offline in the update step."""
+async def test_device_setup_update_network_timeout(hass):
+    """Test we handle a network timeout in the update step."""
     device = get_device("Office")
     mock_api = device.get_mock_api()
-    mock_api.check_sensors.side_effect = blke.DeviceOfflineError()
+    mock_api.check_sensors.side_effect = blke.NetworkTimeoutError()
 
     with patch.object(
         hass.config_entries, "async_forward_entry_setup"
@@ -308,7 +308,7 @@ async def test_device_unload_update_failed(hass):
     """Test we unload a device that failed the update step."""
     device = get_device("Office")
     mock_api = device.get_mock_api()
-    mock_api.check_sensors.side_effect = blke.DeviceOfflineError()
+    mock_api.check_sensors.side_effect = blke.NetworkTimeoutError()
 
     with patch.object(hass.config_entries, "async_forward_entry_setup"):
         _, mock_entry = await device.setup_entry(hass, mock_api=mock_api)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Rename DeviceOfflineError to NetworkTimeoutError. This keeps the Broadlink integration in sync with the python-broadlink library after https://github.com/mjg59/python-broadlink/pull/410 (breaking changes).
- Bump python-broadlink to 0.15.0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/40077 https://github.com/home-assistant/core/issues/40286 https://github.com/home-assistant/core/issues/40287 https://github.com/home-assistant/core/issues/40745 https://github.com/home-assistant/core/issues/40267
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
