### PR TITLE
Improve handling of exceptions in Android TV

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -376,6 +376,10 @@ def adb_decorator(override_available=False):
                 await self.aftv.adb_close()
                 self._available = False  # pylint: disable=protected-access
                 return None
+            except Exception:
+                # An unforeseen exception occurred. close the ADB connection so that it doesn't happen over and over again, then raise the exception.
+                await self.aftv.adb_close()
+                raise
 
         return _adb_exception_catcher
 
@@ -421,10 +425,8 @@ class ADBDevice(MediaPlayerEntity):
             # Using "adb_shell" (Python ADB implementation)
             self.exceptions = (
                 AdbTimeoutError,
-                AttributeError,
                 BrokenPipeError,
                 ConnectionResetError,
-                TypeError,
                 ValueError,
                 InvalidChecksumError,
                 InvalidCommandError,

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -377,7 +377,7 @@ def adb_decorator(override_available=False):
                 self._available = False  # pylint: disable=protected-access
                 return None
             except Exception:
-                # An unforeseen exception occurred. close the ADB connection so that
+                # An unforeseen exception occurred. Close the ADB connection so that
                 # it doesn't happen over and over again, then raise the exception.
                 await self.aftv.adb_close()
                 self._available = False  # pylint: disable=protected-access

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -379,6 +379,7 @@ def adb_decorator(override_available=False):
             except Exception:
                 # An unforeseen exception occurred. close the ADB connection so that it doesn't happen over and over again, then raise the exception.
                 await self.aftv.adb_close()
+                self._available = False  # pylint: disable=protected-access
                 raise
 
         return _adb_exception_catcher

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -377,7 +377,8 @@ def adb_decorator(override_available=False):
                 self._available = False  # pylint: disable=protected-access
                 return None
             except Exception:
-                # An unforeseen exception occurred. close the ADB connection so that it doesn't happen over and over again, then raise the exception.
+                # An unforeseen exception occurred. close the ADB connection so that
+                # it doesn't happen over and over again, then raise the exception.
                 await self.aftv.adb_close()
                 self._available = False  # pylint: disable=protected-access
                 raise

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -111,7 +111,7 @@ def patch_shell(response=None, error=False):
     async def shell_fail_python(self, cmd, *args, **kwargs):
         """Mock the `AdbDeviceTcpAsyncFake.shell` method when it fails."""
         self.shell_cmd = cmd
-        raise AttributeError
+        raise ValueError
 
     async def shell_fail_server(self, cmd):
         """Mock the `DeviceAsyncFake.shell` method when it fails."""

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -182,6 +182,9 @@ def patch_androidtv_update(
 
 PATCH_LAUNCH_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.launch_app")
 PATCH_STOP_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.stop_app")
+
+# Cause the update to raise an unexpected type of exception
 PATCH_ANDROIDTV_UPDATE_EXCEPTION = patch(
-    "androidtv.androidtv.androidtv_async.AndroidTVAsync.update", side_effect=Exception
+    "androidtv.androidtv.androidtv_async.AndroidTVAsync.update",
+    side_effect=ZeroDivisionError,
 )

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -182,3 +182,6 @@ def patch_androidtv_update(
 
 PATCH_LAUNCH_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.launch_app")
 PATCH_STOP_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.stop_app")
+PATCH_ANDROIDTV_UPDATE_EXCEPTION = patch(
+    "androidtv.androidtv.androidtv_async.AndroidTVAsync.update", side_effect=Exception
+)

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -1,8 +1,10 @@
 """The tests for the androidtv platform."""
 import base64
+import copy
 import logging
 
 from androidtv.exceptions import LockNotAcquiredException
+import pytest
 
 from homeassistant.components.androidtv.media_player import (
     ANDROIDTV_DOMAIN,
@@ -294,7 +296,7 @@ async def test_adb_shell_returns_none_firetv_adb_server(hass):
 
 async def test_setup_with_adbkey(hass):
     """Test that setup succeeds when using an ADB key."""
-    config = CONFIG_ANDROIDTV_PYTHON_ADB.copy()
+    config = copy.deepcopy(CONFIG_ANDROIDTV_PYTHON_ADB)
     config[DOMAIN][CONF_ADBKEY] = hass.config.path("user_provided_adbkey")
     patch_key, entity_id = _setup(config)
 
@@ -313,7 +315,7 @@ async def test_setup_with_adbkey(hass):
 
 async def _test_sources(hass, config0):
     """Test that sources (i.e., apps) are handled correctly for Android TV and Fire TV devices."""
-    config = config0.copy()
+    config = copy.deepcopy(config0)
     config[DOMAIN][CONF_APPS] = {
         "com.app.test1": "TEST 1",
         "com.app.test3": None,
@@ -394,7 +396,7 @@ async def test_firetv_sources(hass):
 
 async def _test_exclude_sources(hass, config0, expected_sources):
     """Test that sources (i.e., apps) are handled correctly when the `exclude_unnamed_apps` config parameter is provided."""
-    config = config0.copy()
+    config = copy.deepcopy(config0)
     config[DOMAIN][CONF_APPS] = {
         "com.app.test1": "TEST 1",
         "com.app.test3": None,
@@ -453,21 +455,21 @@ async def _test_exclude_sources(hass, config0, expected_sources):
 
 async def test_androidtv_exclude_sources(hass):
     """Test that sources (i.e., apps) are handled correctly for Android TV devices when the `exclude_unnamed_apps` config parameter is provided as true."""
-    config = CONFIG_ANDROIDTV_ADB_SERVER.copy()
+    config = copy.deepcopy(CONFIG_ANDROIDTV_ADB_SERVER)
     config[DOMAIN][CONF_EXCLUDE_UNNAMED_APPS] = True
     assert await _test_exclude_sources(hass, config, ["TEST 1"])
 
 
 async def test_firetv_exclude_sources(hass):
     """Test that sources (i.e., apps) are handled correctly for Fire TV devices when the `exclude_unnamed_apps` config parameter is provided as true."""
-    config = CONFIG_FIRETV_ADB_SERVER.copy()
+    config = copy.deepcopy(CONFIG_FIRETV_ADB_SERVER)
     config[DOMAIN][CONF_EXCLUDE_UNNAMED_APPS] = True
     assert await _test_exclude_sources(hass, config, ["TEST 1"])
 
 
 async def _test_select_source(hass, config0, source, expected_arg, method_patch):
     """Test that the methods for launching and stopping apps are called correctly when selecting a source."""
-    config = config0.copy()
+    config = copy.deepcopy(config0)
     config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1", "com.app.test3": None}
     patch_key, entity_id = _setup(config)
 
@@ -702,7 +704,7 @@ async def test_setup_two_devices(hass):
     config = {
         DOMAIN: [
             CONFIG_ANDROIDTV_ADB_SERVER[DOMAIN],
-            CONFIG_FIRETV_ADB_SERVER[DOMAIN].copy(),
+            copy.deepcopy(CONFIG_FIRETV_ADB_SERVER[DOMAIN]),
         ]
     }
     config[DOMAIN][1][CONF_HOST] = "127.0.0.2"
@@ -1142,7 +1144,7 @@ async def test_services_androidtv(hass):
 async def test_services_firetv(hass):
     """Test media player services for a Fire TV device."""
     patch_key, entity_id = _setup(CONFIG_FIRETV_ADB_SERVER)
-    config = CONFIG_FIRETV_ADB_SERVER.copy()
+    config = copy.deepcopy(CONFIG_FIRETV_ADB_SERVER)
     config[DOMAIN][CONF_TURN_OFF_COMMAND] = "test off"
     config[DOMAIN][CONF_TURN_ON_COMMAND] = "test on"
 
@@ -1174,3 +1176,37 @@ async def test_connection_closed_on_ha_stop(hass):
                 hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
                 await hass.async_block_till_done()
                 assert adb_close.called
+
+
+async def test_exception(hass):
+    """Test that the ADB connection gets closed when there is an unforeseen exception.
+
+    HA will attempt to reconnect on the next update.
+    """
+    patch_key, entity_id = _setup(CONFIG_ANDROIDTV_PYTHON_ADB)
+
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
+        patch_key
+    ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
+        patch_key
+    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
+        assert await async_setup_component(hass, DOMAIN, CONFIG_ANDROIDTV_PYTHON_ADB)
+        await hass.async_block_till_done()
+
+        await hass.helpers.entity_component.async_update_entity(entity_id)
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_OFF
+
+        # When an unforessen exception occurs, we close the ADB connection and raise the exception
+        with patchers.PATCH_ANDROIDTV_UPDATE_EXCEPTION, pytest.raises(Exception):
+            await hass.helpers.entity_component.async_update(entity_id)
+            state = hass.states.get(entity_id)
+            assert state is not None
+            assert state.state == STATE_UNAVAILABLE
+
+        # On the next update, HA will reconnect to the device
+        await hass.helpers.entity_component.async_update_entity(entity_id)
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_OFF

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -1200,7 +1200,7 @@ async def test_exception(hass):
 
         # When an unforessen exception occurs, we close the ADB connection and raise the exception
         with patchers.PATCH_ANDROIDTV_UPDATE_EXCEPTION, pytest.raises(Exception):
-            await hass.helpers.entity_component.async_update(entity_id)
+            await hass.helpers.entity_component.async_update_entity(entity_id)
             state = hass.states.get(entity_id)
             assert state is not None
             assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Whenever there is an ADB-related exception, we should disconnect from the device and reconnect in the next update.  Otherwise, we can run into the same error over and over again, as in https://github.com/home-assistant/core/issues/39203.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/39203
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
