### PR TITLE
Add support for attributes in state/numeric state trigger

### DIFF
--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 from homeassistant import exceptions
 from homeassistant.const import (
     CONF_ABOVE,
+    CONF_ATTRIBUTE,
     CONF_BELOW,
     CONF_ENTITY_ID,
     CONF_FOR,
@@ -48,6 +49,7 @@ TRIGGER_SCHEMA = vol.All(
             vol.Optional(CONF_ABOVE): vol.Coerce(float),
             vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_FOR): cv.positive_time_period_template,
+            vol.Optional(CONF_ATTRIBUTE): cv.match_all,
         }
     ),
     cv.has_at_least_one_key(CONF_BELOW, CONF_ABOVE),
@@ -70,6 +72,7 @@ async def async_attach_trigger(
     unsub_track_same = {}
     entities_triggered = set()
     period: dict = {}
+    attribute = config.get(CONF_ATTRIBUTE)
 
     if value_template is not None:
         value_template.hass = hass
@@ -86,10 +89,11 @@ async def async_attach_trigger(
                 "entity_id": entity,
                 "below": below,
                 "above": above,
+                "attribute": attribute,
             }
         }
         return condition.async_numeric_state(
-            hass, to_s, below, above, value_template, variables
+            hass, to_s, below, above, value_template, variables, attribute
         )
 
     @callback

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -66,9 +66,6 @@ async def async_attach_trigger(
     def state_automation_listener(event: Event):
         """Listen for state changes and calls action."""
         entity: str = event.data["entity_id"]
-        if entity not in entity_id:
-            return
-
         from_s: Optional[State] = event.data.get("old_state")
         to_s: Optional[State] = event.data.get("new_state")
 

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -34,7 +34,7 @@ TRIGGER_SCHEMA = vol.All(
             vol.Optional(CONF_FROM): vol.Any(str, [str]),
             vol.Optional(CONF_TO): vol.Any(str, [str]),
             vol.Optional(CONF_FOR): cv.positive_time_period_template,
-            vol.Optional(CONF_ATTRIBUTE): cv.string,
+            vol.Optional(CONF_ATTRIBUTE): cv.match_all,
         }
     ),
     cv.key_dependency(CONF_FOR, CONF_TO),
@@ -105,6 +105,7 @@ async def async_attach_trigger(
                         "from_state": from_s,
                         "to_state": to_s,
                         "for": time_delta if not time_delta else period[entity],
+                        "attribute": attribute,
                     }
                 },
                 event.context,

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -1,13 +1,13 @@
 """Offer state listening automation rules."""
 from datetime import timedelta
 import logging
-from typing import Dict
+from typing import Dict, Optional
 
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.const import CONF_FOR, CONF_PLATFORM, MATCH_ALL
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.const import CONF_ATTRIBUTE, CONF_FOR, CONF_PLATFORM, MATCH_ALL
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.event import (
     Event,
@@ -34,6 +34,7 @@ TRIGGER_SCHEMA = vol.All(
             vol.Optional(CONF_FROM): vol.Any(str, [str]),
             vol.Optional(CONF_TO): vol.Any(str, [str]),
             vol.Optional(CONF_FOR): cv.positive_time_period_template,
+            vol.Optional(CONF_ATTRIBUTE): cv.string,
         }
     ),
     cv.key_dependency(CONF_FOR, CONF_TO),
@@ -59,6 +60,7 @@ async def async_attach_trigger(
     period: Dict[str, timedelta] = {}
     match_from_state = process_state_match(from_state)
     match_to_state = process_state_match(to_state)
+    attribute = config.get(CONF_ATTRIBUTE)
 
     @callback
     def state_automation_listener(event: Event):
@@ -67,15 +69,27 @@ async def async_attach_trigger(
         if entity not in entity_id:
             return
 
-        from_s = event.data.get("old_state")
-        to_s = event.data.get("new_state")
-        old_state = getattr(from_s, "state", None)
-        new_state = getattr(to_s, "state", None)
+        from_s: Optional[State] = event.data.get("old_state")
+        to_s: Optional[State] = event.data.get("new_state")
+
+        if from_s is None:
+            old_value = None
+        elif attribute is None:
+            old_value = from_s.state
+        else:
+            old_value = from_s.attributes.get(attribute)
+
+        if to_s is None:
+            new_value = None
+        elif attribute is None:
+            new_value = to_s.state
+        else:
+            new_value = to_s.attributes.get(attribute)
 
         if (
-            not match_from_state(old_state)
-            or not match_to_state(new_state)
-            or (not match_all and old_state == new_state)
+            not match_from_state(old_value)
+            or not match_to_state(new_value)
+            or (not match_all and old_value == new_value)
         ):
             return
 
@@ -119,10 +133,16 @@ async def async_attach_trigger(
             )
             return
 
-        def _check_same_state(_, _2, new_st):
+        def _check_same_state(_, _2, new_st: State):
             if new_st is None:
                 return False
-            return new_st.state == to_s.state
+
+            if attribute is None:
+                cur_value = new_st.state
+            else:
+                cur_value = new_st.attributes.get(attribute)
+
+            return cur_value == new_value
 
         unsub_track_same[entity] = async_track_same_state(
             hass, period[entity], call_action, _check_same_state, entity_ids=entity,

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -1061,9 +1061,29 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     )
     await hass.async_block_till_done()
 
+    # Test that the for-check works
     hass.states.async_set("test.entity", "bla", {"name": "world"})
     await hass.async_block_till_done()
     assert len(calls) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+    hass.states.async_set("test.entity", "bla", {"name": "world", "something": "else"})
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Now remove state while inside "for"
+    hass.states.async_set("test.entity", "bla", {"name": "hello"})
+    hass.states.async_set("test.entity", "bla", {"name": "world"})
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_remove("test.entity")
+    await hass.async_block_till_done()
+
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
     assert len(calls) == 1

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -1007,3 +1007,63 @@ async def test_if_fires_on_entities_change_overlap_for_template(hass, calls):
         await hass.async_block_till_done()
         assert len(calls) == 2
         assert calls[1].data["some"] == "test.entity_2 - 0:00:10"
+
+
+async def test_attribute_if_fires_on_entity_change_with_both_filters(hass, calls):
+    """Test for firing if both filters are match attribute."""
+    hass.states.async_set("test.entity", "bla", {"name": "hello"})
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "from": "hello",
+                    "to": "world",
+                    "attribute": "name",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("test.entity", "bla", {"name": "world"})
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
+    hass, calls
+):
+    """Test for not firing on entity change with for after stop trigger."""
+    hass.states.async_set("test.entity", "bla", {"name": "hello"})
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "from": "hello",
+                    "to": "world",
+                    "attribute": "name",
+                    "for": 5,
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("test.entity", "bla", {"name": "world"})
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow specifying an attribute for state/numeric state triggers. Same matching rules apply.

CC @bramkragten this could use some frontend support 👍 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
