### PR TITLE
Fix Geo location for generate config

### DIFF
--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -113,9 +113,7 @@ async def test_detect_location_info_ip_api(aioclient_mock, session):
 
 async def test_detect_location_info_queries_fail(session):
     """Ensure we return None if both queries fail."""
-    with patch(
-        "homeassistant.util.location._get_ip_api", return_value=None
-    ):
+    with patch("homeassistant.util.location._get_ip_api", return_value=None):
         info = await location_util.async_detect_location_info(session, _test_real=True)
     assert info is None
 

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -91,25 +91,11 @@ async def test_detect_location_info_ipapi(aioclient_mock, session):
     assert info.use_metric
 
 
-async def test_detect_location_info_ipapi_exhaust(aioclient_mock, session):
-    """Test detect location info using ipapi.co."""
-    aioclient_mock.get(location_util.IPAPI, json={"latitude": "Sign up to access"})
-    aioclient_mock.get(location_util.IP_API, text=load_fixture("ip-api.com.json"))
-
-    info = await location_util.async_detect_location_info(session, _test_real=True)
-
-    assert info is not None
-    # ip_api result because ipapi got skipped
-    assert info.country_code == "US"
-    assert len(aioclient_mock.mock_calls) == 2
-
-
 async def test_detect_location_info_ip_api(aioclient_mock, session):
     """Test detect location info using ip-api.com."""
     aioclient_mock.get(location_util.IP_API, text=load_fixture("ip-api.com.json"))
 
-    with patch("homeassistant.util.location._get_ipapi", return_value=None):
-        info = await location_util.async_detect_location_info(session, _test_real=True)
+    info = await location_util.async_detect_location_info(session, _test_real=True)
 
     assert info is not None
     assert info.ip == "1.2.3.4"
@@ -125,18 +111,12 @@ async def test_detect_location_info_ip_api(aioclient_mock, session):
     assert not info.use_metric
 
 
-async def test_detect_location_info_both_queries_fail(session):
+async def test_detect_location_info_queries_fail(session):
     """Ensure we return None if both queries fail."""
-    with patch("homeassistant.util.location._get_ipapi", return_value=None), patch(
+    with patch(
         "homeassistant.util.location._get_ip_api", return_value=None
     ):
         info = await location_util.async_detect_location_info(session, _test_real=True)
-    assert info is None
-
-
-async def test_freegeoip_query_raises(raising_session):
-    """Test ipapi.co query when the request to API fails."""
-    info = await location_util._get_ipapi(raising_session)
     assert info is None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

We use http://ip-api.com/json also on for the Supervisor and had never an issue. Today somethings on the response with ipapi.co break the location detection. Let's stick with one service which also work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
