### PR TITLE
Allow owner users to change password of any user

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -30,6 +30,15 @@ def _disallow_id(conf: Dict[str, Any]) -> Dict[str, Any]:
 CONFIG_SCHEMA = vol.All(AUTH_PROVIDER_SCHEMA, _disallow_id)
 
 
+async def async_get_provider(hass: HomeAssistant) -> "HassAuthProvider":
+    """Get the provider."""
+    for prv in hass.auth.auth_providers:
+        if prv.type == "homeassistant":
+            return cast(HassAuthProvider, prv)
+
+    raise RuntimeError("Provider not found")
+
+
 class InvalidAuth(HomeAssistantError):
     """Raised when we encounter invalid authentication."""
 
@@ -234,6 +243,35 @@ class HassAuthProvider(AuthProvider):
         await self.hass.async_add_executor_job(
             self.data.validate_login, username, password
         )
+
+    async def async_add_auth(self, username: str, password: str) -> None:
+        """Call add_auth on data."""
+        if self.data is None:
+            await self.async_initialize()
+            assert self.data is not None
+
+        await self.hass.async_add_executor_job(self.data.add_auth, username, password)
+        await self.data.async_save()
+
+    async def async_remove_auth(self, username: str) -> None:
+        """Call remove_auth on data."""
+        if self.data is None:
+            await self.async_initialize()
+            assert self.data is not None
+
+        self.data.async_remove_auth(username)
+        await self.data.async_save()
+
+    async def async_change_password(self, username: str, new_password: str) -> None:
+        """Call change_password on data."""
+        if self.data is None:
+            await self.async_initialize()
+            assert self.data is not None
+
+        await self.hass.async_add_executor_job(
+            self.data.change_password, username, new_password
+        )
+        await self.data.async_save()
 
     async def async_get_or_create_credentials(
         self, flow_result: Dict[str, str]

--- a/tests/components/config/test_auth_provider_homeassistant.py
+++ b/tests/components/config/test_auth_provider_homeassistant.py
@@ -16,17 +16,35 @@ def setup_config(hass):
     hass.loop.run_until_complete(auth_ha.async_setup(hass))
 
 
-async def test_create_auth_system_generated_user(
-    hass, hass_access_token, hass_ws_client
-):
+@pytest.fixture
+async def auth_provider(hass):
+    """Hass auth provider."""
+    provider = hass.auth.auth_providers[0]
+    await provider.async_initialize()
+    return provider
+
+
+@pytest.fixture
+async def test_user_credential(hass, auth_provider):
+    """Add a test user."""
+    await hass.async_add_executor_job(
+        auth_provider.data.add_auth, "test-user", "test-pass"
+    )
+
+    return await auth_provider.async_get_or_create_credentials(
+        {"username": "test-user"}
+    )
+
+
+async def test_create_auth_system_generated_user(hass, hass_ws_client):
     """Test we can't add auth to system generated users."""
     system_user = MockUser(system_generated=True).add_to_hass(hass)
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
 
     await client.send_json(
         {
             "id": 5,
-            "type": auth_ha.WS_TYPE_CREATE,
+            "type": "config/auth_provider/homeassistant/create",
             "user_id": system_user.id,
             "username": "test-user",
             "password": "test-pass",
@@ -44,14 +62,14 @@ async def test_create_auth_user_already_credentials():
     # assert False
 
 
-async def test_create_auth_unknown_user(hass_ws_client, hass, hass_access_token):
+async def test_create_auth_unknown_user(hass_ws_client, hass):
     """Test create pointing at unknown user."""
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
 
     await client.send_json(
         {
             "id": 5,
-            "type": auth_ha.WS_TYPE_CREATE,
+            "type": "config/auth_provider/homeassistant/create",
             "user_id": "test-id",
             "username": "test-user",
             "password": "test-pass",
@@ -73,7 +91,7 @@ async def test_create_auth_requires_admin(
     await client.send_json(
         {
             "id": 5,
-            "type": auth_ha.WS_TYPE_CREATE,
+            "type": "config/auth_provider/homeassistant/create",
             "user_id": "test-id",
             "username": "test-user",
             "password": "test-pass",
@@ -85,9 +103,9 @@ async def test_create_auth_requires_admin(
     assert result["error"]["code"] == "unauthorized"
 
 
-async def test_create_auth(hass, hass_ws_client, hass_access_token, hass_storage):
+async def test_create_auth(hass, hass_ws_client, hass_storage):
     """Test create auth command works."""
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
     user = MockUser().add_to_hass(hass)
 
     assert len(user.credentials) == 0
@@ -95,7 +113,7 @@ async def test_create_auth(hass, hass_ws_client, hass_access_token, hass_storage
     await client.send_json(
         {
             "id": 5,
-            "type": auth_ha.WS_TYPE_CREATE,
+            "type": "config/auth_provider/homeassistant/create",
             "user_id": user.id,
             "username": "test-user",
             "password": "test-pass",
@@ -114,11 +132,9 @@ async def test_create_auth(hass, hass_ws_client, hass_access_token, hass_storage
     assert entry["username"] == "test-user"
 
 
-async def test_create_auth_duplicate_username(
-    hass, hass_ws_client, hass_access_token, hass_storage
-):
+async def test_create_auth_duplicate_username(hass, hass_ws_client, hass_storage):
     """Test we can't create auth with a duplicate username."""
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
     user = MockUser().add_to_hass(hass)
 
     hass_storage[prov_ha.STORAGE_KEY] = {
@@ -129,7 +145,7 @@ async def test_create_auth_duplicate_username(
     await client.send_json(
         {
             "id": 5,
-            "type": auth_ha.WS_TYPE_CREATE,
+            "type": "config/auth_provider/homeassistant/create",
             "user_id": user.id,
             "username": "test-user",
             "password": "test-pass",
@@ -141,11 +157,9 @@ async def test_create_auth_duplicate_username(
     assert result["error"]["code"] == "username_exists"
 
 
-async def test_delete_removes_just_auth(
-    hass_ws_client, hass, hass_storage, hass_access_token
-):
+async def test_delete_removes_just_auth(hass_ws_client, hass, hass_storage):
     """Test deleting an auth without being connected to a user."""
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
 
     hass_storage[prov_ha.STORAGE_KEY] = {
         "version": 1,
@@ -153,7 +167,11 @@ async def test_delete_removes_just_auth(
     }
 
     await client.send_json(
-        {"id": 5, "type": auth_ha.WS_TYPE_DELETE, "username": "test-user"}
+        {
+            "id": 5,
+            "type": "config/auth_provider/homeassistant/delete",
+            "username": "test-user",
+        }
     )
 
     result = await client.receive_json()
@@ -161,11 +179,9 @@ async def test_delete_removes_just_auth(
     assert len(hass_storage[prov_ha.STORAGE_KEY]["data"]["users"]) == 0
 
 
-async def test_delete_removes_credential(
-    hass, hass_ws_client, hass_access_token, hass_storage
-):
+async def test_delete_removes_credential(hass, hass_ws_client, hass_storage):
     """Test deleting auth that is connected to a user."""
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
 
     user = MockUser().add_to_hass(hass)
     hass_storage[prov_ha.STORAGE_KEY] = {
@@ -180,7 +196,11 @@ async def test_delete_removes_credential(
     )
 
     await client.send_json(
-        {"id": 5, "type": auth_ha.WS_TYPE_DELETE, "username": "test-user"}
+        {
+            "id": 5,
+            "type": "config/auth_provider/homeassistant/delete",
+            "username": "test-user",
+        }
     )
 
     result = await client.receive_json()
@@ -193,7 +213,11 @@ async def test_delete_requires_admin(hass, hass_ws_client, hass_read_only_access
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
     await client.send_json(
-        {"id": 5, "type": auth_ha.WS_TYPE_DELETE, "username": "test-user"}
+        {
+            "id": 5,
+            "type": "config/auth_provider/homeassistant/delete",
+            "username": "test-user",
+        }
     )
 
     result = await client.receive_json()
@@ -201,12 +225,16 @@ async def test_delete_requires_admin(hass, hass_ws_client, hass_read_only_access
     assert result["error"]["code"] == "unauthorized"
 
 
-async def test_delete_unknown_auth(hass, hass_ws_client, hass_access_token):
+async def test_delete_unknown_auth(hass, hass_ws_client):
     """Test trying to delete an unknown auth username."""
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
 
     await client.send_json(
-        {"id": 5, "type": auth_ha.WS_TYPE_DELETE, "username": "test-user"}
+        {
+            "id": 5,
+            "type": "config/auth_provider/homeassistant/delete",
+            "username": "test-user",
+        }
     )
 
     result = await client.receive_json()
@@ -214,25 +242,17 @@ async def test_delete_unknown_auth(hass, hass_ws_client, hass_access_token):
     assert result["error"]["code"] == "auth_not_found"
 
 
-async def test_change_password(hass, hass_ws_client, hass_access_token):
+async def test_change_password(
+    hass, hass_ws_client, hass_admin_user, auth_provider, test_user_credential
+):
     """Test that change password succeeds with valid password."""
-    provider = hass.auth.auth_providers[0]
-    await provider.async_initialize()
-    await hass.async_add_executor_job(provider.data.add_auth, "test-user", "test-pass")
+    await hass.auth.async_link_user(hass_admin_user, test_user_credential)
 
-    credentials = await provider.async_get_or_create_credentials(
-        {"username": "test-user"}
-    )
-
-    refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
-    user = refresh_token.user
-    await hass.auth.async_link_user(user, credentials)
-
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
     await client.send_json(
         {
             "id": 6,
-            "type": auth_ha.WS_TYPE_CHANGE_PASSWORD,
+            "type": "config/auth_provider/homeassistant/change_password",
             "current_password": "test-pass",
             "new_password": "new-pass",
         }
@@ -240,28 +260,20 @@ async def test_change_password(hass, hass_ws_client, hass_access_token):
 
     result = await client.receive_json()
     assert result["success"], result
-    await provider.async_validate_login("test-user", "new-pass")
+    await auth_provider.async_validate_login("test-user", "new-pass")
 
 
-async def test_change_password_wrong_pw(hass, hass_ws_client, hass_access_token):
+async def test_change_password_wrong_pw(
+    hass, hass_ws_client, hass_admin_user, auth_provider, test_user_credential
+):
     """Test that change password fails with invalid password."""
-    provider = hass.auth.auth_providers[0]
-    await provider.async_initialize()
-    await hass.async_add_executor_job(provider.data.add_auth, "test-user", "test-pass")
+    await hass.auth.async_link_user(hass_admin_user, test_user_credential)
 
-    credentials = await provider.async_get_or_create_credentials(
-        {"username": "test-user"}
-    )
-
-    refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
-    user = refresh_token.user
-    await hass.auth.async_link_user(user, credentials)
-
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
     await client.send_json(
         {
             "id": 6,
-            "type": auth_ha.WS_TYPE_CHANGE_PASSWORD,
+            "type": "config/auth_provider/homeassistant/change_password",
             "current_password": "wrong-pass",
             "new_password": "new-pass",
         }
@@ -271,17 +283,17 @@ async def test_change_password_wrong_pw(hass, hass_ws_client, hass_access_token)
     assert not result["success"], result
     assert result["error"]["code"] == "invalid_password"
     with pytest.raises(prov_ha.InvalidAuth):
-        await provider.async_validate_login("test-user", "new-pass")
+        await auth_provider.async_validate_login("test-user", "new-pass")
 
 
-async def test_change_password_no_creds(hass, hass_ws_client, hass_access_token):
+async def test_change_password_no_creds(hass, hass_ws_client):
     """Test that change password fails with no credentials."""
-    client = await hass_ws_client(hass, hass_access_token)
+    client = await hass_ws_client(hass)
 
     await client.send_json(
         {
             "id": 6,
-            "type": auth_ha.WS_TYPE_CHANGE_PASSWORD,
+            "type": "config/auth_provider/homeassistant/change_password",
             "current_password": "test-pass",
             "new_password": "new-pass",
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new websocket command for owner users to be able to change the password of any user.

Also migrated the websocket command registration to use the modern format.

CC @bramkragten this could use some frontend.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
