### PR TITLE
Add description of what caused an automation trigger to fire

### DIFF
--- a/homeassistant/components/arcam_fmj/device_trigger.py
+++ b/homeassistant/components/arcam_fmj/device_trigger.py
@@ -59,11 +59,16 @@ async def async_attach_trigger(
     config = TRIGGER_SCHEMA(config)
 
     if config[CONF_TYPE] == "turn_on":
+        entity_id = config[CONF_ENTITY_ID]
 
         @callback
         def _handle_event(event: Event):
-            if event.data[ATTR_ENTITY_ID] == config[CONF_ENTITY_ID]:
-                hass.async_run_job(action({"trigger": config}, context=event.context))
+            if event.data[ATTR_ENTITY_ID] == entity_id:
+                hass.async_run_job(
+                    action,
+                    {"trigger": {**config, "description": f"{DOMAIN} - {entity_id}"}},
+                    event.context,
+                )
 
         return hass.bus.async_listen(EVENT_TURN_ON, _handle_event)
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -401,7 +401,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             ATTR_NAME: self._name,
             ATTR_ENTITY_ID: self.entity_id,
         }
-        if "description" in variables["trigger"]:
+        if "trigger" in variables and "description" in variables["trigger"]:
             event_data[ATTR_SOURCE] = variables["trigger"]["description"]
         self.hass.bus.async_fire(
             EVENT_AUTOMATION_TRIGGERED, event_data, context=trigger_context

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -1,5 +1,4 @@
 """Allow to set up simple automation rules via the config file."""
-import json
 import logging
 from typing import Any, Awaitable, Callable, List, Optional, Set, cast
 
@@ -34,7 +33,6 @@ from homeassistant.helpers import condition, extract_domain_configs
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.script import (
     ATTR_CUR,
@@ -83,7 +81,7 @@ EVENT_AUTOMATION_RELOADED = "automation_reloaded"
 EVENT_AUTOMATION_TRIGGERED = "automation_triggered"
 
 ATTR_LAST_TRIGGERED = "last_triggered"
-ATTR_TRIGGER = "trigger"
+ATTR_SOURCE = "source"
 ATTR_VARIABLES = "variables"
 SERVICE_TRIGGER = "trigger"
 
@@ -399,22 +397,14 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         self.async_set_context(trigger_context)
         self._last_triggered = utcnow()
         self.async_write_ha_state()
-        trigger = {}
-        for attr, value in variables[ATTR_TRIGGER].items():
-            try:
-                _ = json.dumps(value, cls=JSONEncoder)
-            except TypeError:
-                pass
-            else:
-                trigger[attr] = value
+        event_data = {
+            ATTR_NAME: self._name,
+            ATTR_ENTITY_ID: self.entity_id,
+        }
+        if "description" in variables["trigger"]:
+            event_data[ATTR_SOURCE] = variables["trigger"]["description"]
         self.hass.bus.async_fire(
-            EVENT_AUTOMATION_TRIGGERED,
-            {
-                ATTR_NAME: self._name,
-                ATTR_ENTITY_ID: self.entity_id,
-                ATTR_TRIGGER: trigger,
-            },
-            context=trigger_context,
+            EVENT_AUTOMATION_TRIGGERED, event_data, context=trigger_context
         )
 
         self._logger.info("Executing %s", self._name)

--- a/homeassistant/components/automation/logbook.py
+++ b/homeassistant/components/automation/logbook.py
@@ -2,7 +2,7 @@
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
 from homeassistant.core import callback
 
-from . import DOMAIN, EVENT_AUTOMATION_TRIGGERED
+from . import ATTR_TRIGGER, DOMAIN, EVENT_AUTOMATION_TRIGGERED
 
 
 @callback
@@ -12,9 +12,20 @@ def async_describe_events(hass, async_describe_event):  # type: ignore
     @callback
     def async_describe_logbook_event(event):  # type: ignore
         """Describe a logbook event."""
+        trigger = event.data.get(ATTR_TRIGGER)
+        if not trigger:
+            triggered_by = ""
+        elif ATTR_ENTITY_ID in trigger:
+            triggered_by = f" by {trigger[ATTR_ENTITY_ID]}"
+        elif trigger["platform"] == "sun":
+            triggered_by = f" by {trigger['event']}"
+        elif trigger["platform"] == "event":
+            triggered_by = f" by event: {trigger['event']['event_type']}"
+        else:
+            triggered_by = f" by {trigger['platform']} trigger"
         return {
             "name": event.data.get(ATTR_NAME),
-            "message": "has been triggered",
+            "message": f"has been triggered{triggered_by}",
             "entity_id": event.data.get(ATTR_ENTITY_ID),
         }
 

--- a/homeassistant/components/automation/logbook.py
+++ b/homeassistant/components/automation/logbook.py
@@ -18,6 +18,7 @@ def async_describe_events(hass, async_describe_event):  # type: ignore
         return {
             "name": event.data.get(ATTR_NAME),
             "message": message,
+            "source": event.data.get(ATTR_SOURCE),
             "entity_id": event.data.get(ATTR_ENTITY_ID),
         }
 

--- a/homeassistant/components/automation/logbook.py
+++ b/homeassistant/components/automation/logbook.py
@@ -2,7 +2,7 @@
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
 from homeassistant.core import callback
 
-from . import ATTR_TRIGGER, DOMAIN, EVENT_AUTOMATION_TRIGGERED
+from . import ATTR_SOURCE, DOMAIN, EVENT_AUTOMATION_TRIGGERED
 
 
 @callback
@@ -12,20 +12,12 @@ def async_describe_events(hass, async_describe_event):  # type: ignore
     @callback
     def async_describe_logbook_event(event):  # type: ignore
         """Describe a logbook event."""
-        trigger = event.data.get(ATTR_TRIGGER)
-        if not trigger:
-            triggered_by = ""
-        elif ATTR_ENTITY_ID in trigger:
-            triggered_by = f" by {trigger[ATTR_ENTITY_ID]}"
-        elif trigger["platform"] == "sun":
-            triggered_by = f" by {trigger['event']}"
-        elif trigger["platform"] == "event":
-            triggered_by = f" by event: {trigger['event']['event_type']}"
-        else:
-            triggered_by = f" by {trigger['platform']} trigger"
+        message = "has been triggered"
+        if ATTR_SOURCE in event.data:
+            message = f"{message} by {event.data[ATTR_SOURCE]}"
         return {
             "name": event.data.get(ATTR_NAME),
-            "message": f"has been triggered{triggered_by}",
+            "message": message,
             "entity_id": event.data.get(ATTR_ENTITY_ID),
         }
 

--- a/homeassistant/components/geo_location/trigger.py
+++ b/homeassistant/components/geo_location/trigger.py
@@ -67,20 +67,20 @@ async def async_attach_trigger(hass, config, action, automation_info):
             and not to_match
         ):
             hass.async_run_job(
-                action(
-                    {
-                        "trigger": {
-                            "platform": "geo_location",
-                            "source": source,
-                            "entity_id": event.data.get("entity_id"),
-                            "from_state": from_state,
-                            "to_state": to_state,
-                            "zone": zone_state,
-                            "event": trigger_event,
-                        }
-                    },
-                    context=event.context,
-                )
+                action,
+                {
+                    "trigger": {
+                        "platform": "geo_location",
+                        "source": source,
+                        "entity_id": event.data.get("entity_id"),
+                        "from_state": from_state,
+                        "to_state": to_state,
+                        "zone": zone_state,
+                        "event": trigger_event,
+                        "description": f"geo_location - {source}",
+                    }
+                },
+                event.context,
             )
 
     return hass.bus.async_listen(EVENT_STATE_CHANGED, state_change_listener)

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -48,7 +48,13 @@ async def async_attach_trigger(
 
         hass.async_run_job(
             action,
-            {"trigger": {"platform": platform_type, "event": event}},
+            {
+                "trigger": {
+                    "platform": platform_type,
+                    "event": event,
+                    "description": f"event '{event.event_type}'",
+                }
+            },
             event.context,
         )
 

--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -31,7 +31,13 @@ async def async_attach_trigger(hass, config, action, automation_info):
             """Execute when Home Assistant is shutting down."""
             hass.async_run_job(
                 action,
-                {"trigger": {"platform": "homeassistant", "event": event}},
+                {
+                    "trigger": {
+                        "platform": "homeassistant",
+                        "event": event,
+                        "description": "Home Assistant stopping",
+                    }
+                },
                 event.context,
             )
 
@@ -41,7 +47,14 @@ async def async_attach_trigger(hass, config, action, automation_info):
     # Check state because a config reload shouldn't trigger it.
     if automation_info["home_assistant_start"]:
         hass.async_run_job(
-            action({"trigger": {"platform": "homeassistant", "event": event}})
+            action,
+            {
+                "trigger": {
+                    "platform": "homeassistant",
+                    "event": event,
+                    "description": "Home Assistant starting",
+                }
+            },
         )
 
     return lambda: None

--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -117,6 +117,7 @@ async def async_attach_trigger(
                         "from_state": from_s,
                         "to_state": to_s,
                         "for": time_delta if not time_delta else period[entity],
+                        "description": f"numeric state of {entity}",
                     }
                 },
                 to_s.context,

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -103,6 +103,7 @@ async def async_attach_trigger(
                         "to_state": to_s,
                         "for": time_delta if not time_delta else period[entity],
                         "attribute": attribute,
+                        "description": f"state of {entity}",
                     }
                 },
                 event.context,

--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -1,5 +1,6 @@
 """Offer time listening automation rules."""
 from datetime import datetime
+from functools import partial
 import logging
 
 import voluptuous as vol
@@ -38,9 +39,12 @@ async def async_attach_trigger(hass, config, action, automation_info):
     removes = []
 
     @callback
-    def time_automation_listener(now):
+    def time_automation_listener(description, now):
         """Listen for time changes and calls action."""
-        hass.async_run_job(action, {"trigger": {"platform": "time", "now": now}})
+        hass.async_run_job(
+            action,
+            {"trigger": {"platform": "time", "now": now, "description": description}},
+        )
 
     @callback
     def update_entity_trigger(entity_id, old_state=None, new_state=None):
@@ -75,13 +79,15 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 # Only set up listener if time is now or in the future.
                 if trigger_dt >= dt_util.now():
                     remove = async_track_point_in_time(
-                        hass, time_automation_listener, trigger_dt
+                        hass,
+                        partial(time_automation_listener, f"time set in {entity_id}"),
+                        trigger_dt,
                     )
             elif has_time:
                 # Else if it has time, then track time change.
                 remove = async_track_time_change(
                     hass,
-                    time_automation_listener,
+                    partial(time_automation_listener, f"time set in {entity_id}"),
                     hour=hour,
                     minute=minute,
                     second=second,
@@ -102,7 +108,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
             removes.append(
                 async_track_time_change(
                     hass,
-                    time_automation_listener,
+                    partial(time_automation_listener, "time"),
                     hour=at_time.hour,
                     minute=at_time.minute,
                     second=at_time.second,

--- a/homeassistant/components/homeassistant/triggers/time_pattern.py
+++ b/homeassistant/components/homeassistant/triggers/time_pattern.py
@@ -75,7 +75,14 @@ async def async_attach_trigger(hass, config, action, automation_info):
     def time_automation_listener(now):
         """Listen for time changes and calls action."""
         hass.async_run_job(
-            action, {"trigger": {"platform": "time_pattern", "now": now}}
+            action,
+            {
+                "trigger": {
+                    "platform": "time_pattern",
+                    "now": now,
+                    "description": "time pattern",
+                }
+            },
         )
 
     return async_track_time_change(

--- a/homeassistant/components/kodi/device_trigger.py
+++ b/homeassistant/components/kodi/device_trigger.py
@@ -66,7 +66,11 @@ def _attach_trigger(
     @callback
     def _handle_event(event: Event):
         if event.data[ATTR_ENTITY_ID] == config[CONF_ENTITY_ID]:
-            hass.async_run_job(action({"trigger": config}, context=event.context))
+            hass.async_run_job(
+                action,
+                {"trigger": {**config, "description": event_type}},
+                event.context,
+            )
 
     return hass.bus.async_listen(event_type, _handle_event)
 

--- a/homeassistant/components/litejet/trigger.py
+++ b/homeassistant/components/litejet/trigger.py
@@ -50,6 +50,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     CONF_NUMBER: number,
                     CONF_HELD_MORE_THAN: held_more_than,
                     CONF_HELD_LESS_THAN: held_less_than,
+                    "description": f"litejet switch #{number}",
                 }
             },
         )

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -45,6 +45,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 "topic": mqttmsg.topic,
                 "payload": mqttmsg.payload,
                 "qos": mqttmsg.qos,
+                "description": f"mqtt topic {mqttmsg.topic}",
             }
 
             try:

--- a/homeassistant/components/sun/trigger.py
+++ b/homeassistant/components/sun/trigger.py
@@ -31,12 +31,23 @@ async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for events based on configuration."""
     event = config.get(CONF_EVENT)
     offset = config.get(CONF_OFFSET)
+    description = event
+    if offset:
+        description = f"{description} with offset"
 
     @callback
     def call_action():
         """Call action with right context."""
         hass.async_run_job(
-            action, {"trigger": {"platform": "sun", "event": event, "offset": offset}}
+            action,
+            {
+                "trigger": {
+                    "platform": "sun",
+                    "event": event,
+                    "offset": offset,
+                    "description": description,
+                }
+            },
         )
 
     if event == SUN_EVENT_SUNRISE:

--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -62,6 +62,7 @@ async def async_attach_trigger(
                         "from_state": from_s,
                         "to_state": to_s,
                         "for": time_delta if not time_delta else period,
+                        "description": f"{entity_id} via template",
                     }
                 },
                 (to_s.context if to_s else None),

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -30,6 +30,7 @@ async def _handle_webhook(action, hass, webhook_id, request):
         result["data"] = await request.post()
 
     result["query"] = request.query
+    result["description"] = "webhook"
     hass.async_run_job(action, {"trigger": result})
 
 

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -1,7 +1,13 @@
 """Offer zone automation rules."""
 import voluptuous as vol
 
-from homeassistant.const import CONF_ENTITY_ID, CONF_EVENT, CONF_PLATFORM, CONF_ZONE
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    CONF_ENTITY_ID,
+    CONF_EVENT,
+    CONF_PLATFORM,
+    CONF_ZONE,
+)
 from homeassistant.core import callback
 from homeassistant.helpers import condition, config_validation as cv, location
 from homeassistant.helpers.event import async_track_state_change_event
@@ -11,6 +17,8 @@ from homeassistant.helpers.event import async_track_state_change_event
 EVENT_ENTER = "enter"
 EVENT_LEAVE = "leave"
 DEFAULT_EVENT = EVENT_ENTER
+
+_EVENT_DESCRIPTION = {EVENT_ENTER: "entering", EVENT_LEAVE: "leaving"}
 
 TRIGGER_SCHEMA = vol.Schema(
     {
@@ -56,6 +64,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
             and from_match
             and not to_match
         ):
+            description = f"{entity} {_EVENT_DESCRIPTION[event]} {zone_state.attributes[ATTR_FRIENDLY_NAME]}"
             hass.async_run_job(
                 action,
                 {
@@ -66,6 +75,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                         "to_state": to_s,
                         "zone": zone_state,
                         "event": event,
+                        "description": description,
                     }
                 },
                 to_s.context,

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components import logbook
 import homeassistant.components.automation as automation
 from homeassistant.components.automation import (
+    ATTR_SOURCE,
     DOMAIN,
     EVENT_AUTOMATION_RELOADED,
     EVENT_AUTOMATION_TRIGGERED,
@@ -324,6 +325,7 @@ async def test_shared_context(hass, calls):
     # Ensure event data has all attributes set
     assert args[0].data.get(ATTR_NAME) is not None
     assert args[0].data.get(ATTR_ENTITY_ID) is not None
+    assert args[0].data.get(ATTR_SOURCE) is not None
 
     # Ensure context set correctly for event fired by 'hello' automation
     args, _ = first_automation_listener.call_args
@@ -341,6 +343,7 @@ async def test_shared_context(hass, calls):
     # Ensure event data has all attributes set
     assert args[0].data.get(ATTR_NAME) is not None
     assert args[0].data.get(ATTR_ENTITY_ID) is not None
+    assert args[0].data.get(ATTR_SOURCE) is not None
 
     # Ensure the service call from the second automation
     # shares the same context
@@ -1085,7 +1088,11 @@ async def test_logbook_humanify_automation_triggered_event(hass):
                 ),
                 MockLazyEventPartialState(
                     EVENT_AUTOMATION_TRIGGERED,
-                    {ATTR_ENTITY_ID: "automation.bye", ATTR_NAME: "Bye Automation"},
+                    {
+                        ATTR_ENTITY_ID: "automation.bye",
+                        ATTR_NAME: "Bye Automation",
+                        ATTR_SOURCE: "source of trigger",
+                    },
                 ),
             ],
             entity_attr_cache,
@@ -1100,5 +1107,5 @@ async def test_logbook_humanify_automation_triggered_event(hass):
 
     assert event2["name"] == "Bye Automation"
     assert event2["domain"] == "automation"
-    assert event2["message"] == "has been triggered"
+    assert event2["message"] == "has been triggered by source of trigger"
     assert event2["entity_id"] == "automation.bye"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Suggested in this WTH topic: <https://community.home-assistant.io/t/wth-cant-we-see-which-trigger-fired-an-automation/220888>

Trying to figure out what event triggered an automation, especially when it has multiple triggers and/or multiple entities per trigger, can be difficult. This change adds a mechanism for the trigger code to provide a description of what caused it to fire. That description will be used in the `automation_triggered` event, and the Logbook entry as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
