### PR TITLE
Ensure template tracking can recover after the template generates an exception

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -568,6 +568,11 @@ class _TrackTemplateResultInfo:
         entities = set(self._info.entities)
         for entity_id in self.hass.states.async_entity_ids(self._info.domains):
             entities.add(entity_id)
+
+        # Entities has changed to none
+        if not entities:
+            return
+
         self._entities_listener = async_track_state_change_event(
             self.hass, entities, self._refresh
         )
@@ -575,6 +580,10 @@ class _TrackTemplateResultInfo:
     @callback
     def _setup_domains_listener(self) -> None:
         assert self._info
+
+        # Domains has changed to none
+        if not self._info.domains:
+            return
 
         self._domains_listener = async_track_state_added_domain(
             self.hass, self._info.domains, self._refresh

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -549,6 +549,33 @@ async def test_track_template_error(hass, caplog):
     assert "TemplateAssertionError" in caplog.text
 
 
+async def test_track_template_error_can_recover(hass, caplog):
+    """Test tracking template with error."""
+    hass.states.async_set("switch.data_system", "cow", {"opmode": 0})
+    template_error = Template(
+        "{{ states.sensor.data_system.attributes['opmode'] == '0' }}", hass
+    )
+    error_calls = []
+
+    @ha.callback
+    def error_callback(entity_id, old_state, new_state):
+        error_calls.append((entity_id, old_state, new_state))
+
+    async_track_template(hass, template_error, error_callback)
+    await hass.async_block_till_done()
+    assert not error_calls
+
+    hass.states.async_remove("switch.data_system")
+
+    assert "UndefinedError" in caplog.text
+
+    hass.states.async_set("switch.data_system", "cow", {"opmode": 0})
+
+    caplog.clear()
+
+    assert "UndefinedError" not in caplog.text
+
+
 async def test_track_template_result(hass):
     """Test tracking template."""
     specific_runs = []


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When moving to tracking no entities or no domains because
of a template error a listener for an empty set would
be created which would fail on unsubscribe.

Fixes

```
2020-08-25 18:41:40 ERROR (MainThread) [homeassistant.helpers.event] Error while processing state changed for sensor.pool_data_system
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 185, in _async_state_change_dispatcher
    hass.async_run_job(action, event)
  File "/usr/src/homeassistant/homeassistant/core.py", line 386, in async_run_job
    target(*args)
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 600, in _refresh
    self._update_listeners()
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 535, in _update_listeners
    self._cancel_domains_listener()
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 510, in _cancel_domains_listener
    self._domains_listener()
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 343, in remove_listener
    _async_remove_indexed_listeners(
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 235, in _async_remove_indexed_listeners
    hass.data[listener_key]()
KeyError: 'track_state_added_domain_listener'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
