### PR TITLE
Add cache version to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
   pull_request: ~
 
 env:
+  CACHE_VERSION: 1
   DEFAULT_PYTHON: 3.7
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 
@@ -33,14 +34,15 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
           restore-keys: |
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements_test.txt') }}-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements_test.txt') }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -58,9 +60,9 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pre-commit-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-
       - name: Install pre-commit dependencies
         if: steps.cache-precommit.outputs.cache-hit != 'true'
         run: |
@@ -85,8 +87,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -100,7 +103,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -129,8 +132,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -144,7 +148,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -173,8 +177,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -188,7 +193,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -239,8 +244,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -254,7 +260,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -286,8 +292,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -301,7 +308,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -333,8 +340,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -348,7 +356,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -377,8 +385,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -392,7 +401,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -424,8 +433,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -439,7 +449,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -479,8 +489,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -494,7 +505,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: |
-            ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -526,8 +537,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -558,8 +570,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version
-            }}-${{ hashFiles('requirements.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('requirements.txt') }}-${{
             hashFiles('requirements_test.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
@@ -589,14 +602,14 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-${{
-            hashFiles('requirements_test.txt') }}-${{
-            hashFiles('requirements_all.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+            matrix.python-version }}-${{ hashFiles('requirements_test.txt')
+            }}-${{ hashFiles('requirements_all.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
           restore-keys: |
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('requirements_test.txt') }}-${{ hashFiles('requirements_all.txt') }}
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('requirements_test.txt') }}
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('requirements_test.txt') }}-${{ hashFiles('requirements_all.txt') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('requirements_test.txt') }}
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ matrix.python-version }}-
       - name:
           Create full Python ${{ matrix.python-version }} virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -630,9 +643,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-${{
-            hashFiles('requirements_test.txt') }}-${{
-            hashFiles('requirements_all.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+            matrix.python-version }}-${{ hashFiles('requirements_test.txt')
+            }}-${{ hashFiles('requirements_all.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -665,9 +678,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-${{
-            hashFiles('requirements_test.txt') }}-${{
-            hashFiles('requirements_all.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+            matrix.python-version }}-${{ hashFiles('requirements_test.txt')
+            }}-${{ hashFiles('requirements_all.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -702,9 +715,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-${{
-            hashFiles('requirements_test.txt') }}-${{
-            hashFiles('requirements_all.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+            matrix.python-version }}-${{ hashFiles('requirements_test.txt')
+            }}-${{ hashFiles('requirements_all.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -763,9 +776,9 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-${{
-            hashFiles('requirements_test.txt') }}-${{
-            hashFiles('requirements_all.txt') }}-${{
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+            matrix.python-version }}-${{ hashFiles('requirements_test.txt')
+            }}-${{ hashFiles('requirements_all.txt') }}-${{
             hashFiles('homeassistant/package_constraints.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a CACHE_VERSION environment variable to our GitHub actions cache keys.
This allows us to invalidate all existing caches of our CI when this is needed.

While this is a rare action to take, it might be needed (like just now).

Another option is to invalidate the cache fully when any dependency has changed. The downside of that approach is that all dependency bumping PRs will be much slower and intensive. Hence, introducing a variable.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
