### PR TITLE
Use icmplib for ping when available

### DIFF
--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -6,6 +6,7 @@ import re
 import sys
 from typing import Any, Dict
 
+from icmplib import SocketPermissionError, ping as icmp_ping
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
@@ -59,7 +60,17 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
     count = config[CONF_PING_COUNT]
     name = config.get(CONF_NAME, f"{DEFAULT_NAME} {host}")
 
-    add_entities([PingBinarySensor(name, PingData(host, count))], True)
+    try:
+        # Verify we can create a raw socket, or
+        # fallback to using a subprocess
+        icmp_ping("127.0.0.1", count=0, timeout=0)
+        ping_cls = PingDataICMPLib
+    except SocketPermissionError:
+        ping_cls = PingDataSubProcess
+
+    ping_data = ping_cls(hass, host, count)
+
+    add_entities([PingBinarySensor(name, ping_data)], True)
 
 
 class PingBinarySensor(BinarySensorEntity):
@@ -102,14 +113,42 @@ class PingBinarySensor(BinarySensorEntity):
 
 
 class PingData:
-    """The Class for handling the data retrieval."""
+    """The base class for handling the data retrieval."""
 
-    def __init__(self, host, count) -> None:
+    def __init__(self, hass, host, count) -> None:
         """Initialize the data object."""
+        self.hass = hass
         self._ip_address = host
         self._count = count
         self.data = {}
         self.available = False
+
+
+class PingDataICMPLib(PingData):
+    """The Class for handling the data retrieval using icmplib."""
+
+    def ping(self):
+        """Send ICMP echo request and return details."""
+        return icmp_ping(self._ip_address, count=self._count)
+
+    async def async_update(self) -> None:
+        """Retrieve the latest details from the host."""
+        data = await self.hass.async_add_executor_job(self.ping)
+        self.data = {
+            "min": data.min_rtt,
+            "max": data.max_rtt,
+            "avg": data.avg_rtt,
+            "mdev": "",
+        }
+        self.available = data.is_alive
+
+
+class PingDataSubProcess(PingData):
+    """The Class for handling the data retrieval using the ping binary."""
+
+    def __init__(self, hass, host, count) -> None:
+        """Initialize the data object."""
+        super().__init__(hass, host, count)
 
         if sys.platform == "win32":
             self._ping_cmd = [

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -149,7 +149,6 @@ class PingDataSubProcess(PingData):
     def __init__(self, hass, host, count) -> None:
         """Initialize the data object."""
         super().__init__(hass, host, count)
-
         if sys.platform == "win32":
             self._ping_cmd = [
                 "ping",

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -146,6 +146,10 @@ class PingDataICMPLib(PingData):
 class PingDataSubProcess(PingData):
     """The Class for handling the data retrieval using the ping binary."""
 
+    def __init__(self, hass, host, count) -> None:
+        """Initialize the data object."""
+        super().__init__(hass, host, count)
+
         if sys.platform == "win32":
             self._ping_cmd = [
                 "ping",

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -146,10 +146,6 @@ class PingDataICMPLib(PingData):
 class PingDataSubProcess(PingData):
     """The Class for handling the data retrieval using the ping binary."""
 
-    def __init__(self, hass, host, count) -> None:
-        """Initialize the data object."""
-        super().__init__(hass, host, count)
-
         if sys.platform == "win32":
             self._ping_cmd = [
                 "ping",

--- a/homeassistant/components/ping/const.py
+++ b/homeassistant/components/ping/const.py
@@ -1,3 +1,4 @@
 """Tracks devices by sending a ICMP echo request (ping)."""
 
 PING_TIMEOUT = 3
+PING_ATTEMPTS_COUNT = 3

--- a/homeassistant/components/ping/manifest.json
+++ b/homeassistant/components/ping/manifest.json
@@ -3,5 +3,6 @@
   "name": "Ping (ICMP)",
   "documentation": "https://www.home-assistant.io/integrations/ping",
   "codeowners": [],
+  "requirements": ["icmplib==1.1.1"],
   "quality_scale": "internal"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -784,6 +784,9 @@ ibm-watson==4.0.1
 # homeassistant.components.watson_iot
 ibmiotf==0.3.4
 
+# homeassistant.components.ping
+icmplib==1.1.1
+
 # homeassistant.components.iglo
 iglo==1.2.7
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a rework of https://github.com/home-assistant/core/pull/38490 to avoid the breaking change by accounting for systems that do not have access to raw sockets.

If the system can use `icmplib` then we avoid the `fork()/exec()` overhead of running the ping command.  If the system does not have permissions, we fallback to creating subprocesses.

CPU usage was ~80% less when using `icmplib`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38791
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
