### PR TITLE
Implement config flow for rfxtrx integration

### DIFF
--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -364,9 +364,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
         list_of_ports = {}
-        for p in ports:
-            list_of_ports[p.device] = f"{p}, s/n: {p.serial_number or 'n/a'}" + (
-                f" - {p.manufacturer}" if p.manufacturer else ""
+        for port in ports:
+            list_of_ports[port.device] = (
+                f"{port}, s/n: {port.serial_number or 'n/a'}"
+                + (f" - {port.manufacturer}" if port.manufacturer else "")
             )
         list_of_ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -1,9 +1,13 @@
 """Config flow for RFXCOM RFXtrx integration."""
 import logging
+import os
 
+import RFXtrx as rfxtrxmod
+import serial
+import serial.tools.list_ports
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant import config_entries, exceptions
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_COMMAND_OFF,
@@ -11,6 +15,9 @@ from homeassistant.const import (
     CONF_DEVICE,
     CONF_DEVICE_ID,
     CONF_DEVICES,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TYPE,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import (
@@ -37,6 +44,7 @@ from .switch import supported as switch_supported
 _LOGGER = logging.getLogger(__name__)
 
 CONF_EVENT_CODE = "event_code"
+CONF_MANUAL_PATH = "Enter Manually"
 
 
 def none_or_int(value, base):
@@ -292,14 +300,154 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
+    async def async_step_user(self, user_input=None):
+        """Step when user initializes a integration."""
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        errors = {}
+        if user_input is not None:
+            user_selection = user_input[CONF_TYPE]
+            if user_selection == "Serial":
+                return await self.async_step_setup_serial()
+
+            return await self.async_step_setup_network()
+
+        list_of_types = ["Serial", "Network"]
+
+        schema = vol.Schema({vol.Required(CONF_TYPE): vol.In(list_of_types)})
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_setup_network(self, user_input=None):
+        """Step when setting up network configuration."""
+        errors = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            port = user_input[CONF_PORT]
+
+            try:
+                data = await self.async_validate_rfx(host=host, port=port)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(title="RFXTRX", data=data)
+
+        schema = vol.Schema(
+            {vol.Required(CONF_HOST): str, vol.Required(CONF_PORT): int}
+        )
+        return self.async_show_form(
+            step_id="setup_network", data_schema=schema, errors=errors,
+        )
+
+    async def async_step_setup_serial(self, user_input=None):
+        """Step when setting up serial configuration."""
+        errors = {}
+        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        list_of_ports = [
+            f"{p}, s/n: {p.serial_number or 'n/a'}"
+            + (f" - {p.manufacturer}" if p.manufacturer else "")
+            for p in ports
+        ]
+        list_of_ports.append(CONF_MANUAL_PATH)
+
+        if user_input is not None:
+            user_selection = user_input[CONF_DEVICE]
+            if user_selection == CONF_MANUAL_PATH:
+                return await self.async_step_setup_serial_manual_path()
+
+            port = ports[list_of_ports.index(user_selection)]
+            dev_path = await self.hass.async_add_executor_job(
+                get_serial_by_id, port.device
+            )
+
+            try:
+                data = await self.async_validate_rfx(device=dev_path)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(title="RFXTRX", data=data)
+
+        schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(list_of_ports)})
+        return self.async_show_form(
+            step_id="setup_serial", data_schema=schema, errors=errors,
+        )
+
+    async def async_step_setup_serial_manual_path(self, user_input=None):
+        """Select path manually."""
+        errors = {}
+
+        if user_input is not None:
+            device = user_input[CONF_DEVICE]
+            try:
+                data = await self.async_validate_rfx(device=device)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(title="RFXTRX", data=data)
+
+        schema = vol.Schema({vol.Required(CONF_DEVICE): str})
+        return self.async_show_form(
+            step_id="setup_serial_manual_path", data_schema=schema, errors=errors,
+        )
+
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
+    async def async_validate_rfx(self, host=None, port=None, device=None):
+        """Create data for rfxtrx entry."""
+        if port is not None:
+            try:
+                conn = rfxtrxmod.PyNetworkTransport((host, port))
+            except OSError:
+                raise CannotConnect
+
+            conn.close()
+        else:
+            try:
+                conn = rfxtrxmod.PySerialTransport(device)
+            except serial.serialutil.SerialException:
+                raise CannotConnect
+
+            if conn.serial is None:
+                raise CannotConnect
+
+            conn.close()
+
+        data = {
+            CONF_HOST: host,
+            CONF_PORT: port,
+            CONF_DEVICE: device,
+            CONF_AUTOMATIC_ADD: False,
+            CONF_DEBUG: False,
+            CONF_DEVICES: {},
+        }
+        return data
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Get the options flow for this handler."""
         return OptionsFlow(config_entry)
+
+
+def get_serial_by_id(dev_path: str) -> str:
+    """Return a /dev/serial/by-id match for given device if available."""
+    by_id = "/dev/serial/by-id"
+    if not os.path.isdir(by_id):
+        return dev_path
+
+    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
+        if os.path.realpath(path) == dev_path:
+            return path
+    return dev_path
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "requirements": ["pyRFXtrx==0.25"],
   "codeowners": ["@danielhiversen", "@elupus", "@RobBie1221"],
-  "config_flow": false
+  "config_flow": true
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -1,5 +1,41 @@
 {
   "title": "Rfxtrx",
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "type": "Connection type"
+        },
+        "title": "Select connection type"
+      },
+      "setup_network": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "title": "Select connection address"
+      },
+      "setup_serial": {
+        "data": {
+          "device": "Select device"
+        },
+        "title": "Device"
+      },
+      "setup_serial_manual_path": {
+        "data": {
+          "device": "Select path"
+        },
+        "title": "Path"
+      }
+    }
+  },
   "options": {
     "step": {
       "prompt_options": {

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -5,8 +5,7 @@
       "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "step": {
       "user": {

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,4 +1,40 @@
 {
+    "config": {
+        "abort": {
+            "already_configured": "Already configured. Only a single configuration possible."
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "type": "Connection type"
+                },
+                "title": "Select connection type"
+            },
+            "setup_network": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "title": "Select connection address"
+            },
+            "setup_serial": {
+                "data": {
+                    "device": "Select device"
+                },
+                "title": "Device"
+            },
+            "setup_serial_manual_path": {
+                "data": {
+                    "device": "Select path"
+                },
+                "title": "Path"
+            }
+        }
+    },
     "options": {
         "step": {
             "prompt_options": {

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -4,8 +4,7 @@
             "already_configured": "Already configured. Only a single configuration possible."
         },
         "error": {
-            "cannot_connect": "Failed to connect",
-            "unknown": "Unexpected error"
+            "cannot_connect": "Failed to connect"
         },
         "step": {
             "user": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -141,6 +141,7 @@ FLOWS = [
     "pvpc_hourly_pricing",
     "rachio",
     "rainmachine",
+    "rfxtrx",
     "ring",
     "roku",
     "roomba",

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -1,18 +1,38 @@
 """Test the Tado config flow."""
+import os
+
+import serial.tools.list_ports
+
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.components.rfxtrx import DOMAIN, config_flow
 from homeassistant.helpers.device_registry import (
     async_entries_for_config_entry,
     async_get_registry,
 )
 
-from tests.async_mock import MagicMock, patch
+from tests.async_mock import MagicMock, patch, sentinel
 from tests.common import MockConfigEntry
 
 
 def SerialConnect(self):
     """Mock a serial connection."""
     self.serial = True
+
+
+def SerialConnectFail(self):
+    """Mock a failed serial connection."""
+    self.serial = None
+
+
+def com_port():
+    """Mock of a serial port."""
+    port = serial.tools.list_ports_common.ListPortInfo()
+    port.serial_number = "1234"
+    port.manufacturer = "Virtual serial port"
+    port.device = "/dev/ttyUSB1234"
+    port.description = "Some serial port"
+
+    return port
 
 
 @patch(
@@ -53,6 +73,53 @@ async def test_setup_network(hass):
     }
 
 
+@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    SerialConnect,
+)
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
+    MagicMock(return_value=None),
+)
+async def test_setup_serial(hass):
+    """Test we can setup serial."""
+    port = com_port()
+    port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": port_select}
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "RFXTRX"
+    assert result["data"] == {
+        "host": None,
+        "port": None,
+        "device": port.device,
+        "automatic_add": False,
+        "debug": False,
+        "devices": {},
+    }
+
+
+@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
     SerialConnect,
@@ -101,6 +168,112 @@ async def test_setup_serial_manual(hass):
         "debug": False,
         "devices": {},
     }
+
+
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport.connect",
+    MagicMock(side_effect=OSError),
+)
+async def test_setup_network_fail(hass):
+    """Test we can setup network."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Network"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_network"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"host": "10.10.0.1", "port": 1234}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_network"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    MagicMock(side_effect=serial.serialutil.SerialException),
+)
+async def test_setup_serial_fail(hass):
+    """Test setup serial failed connection."""
+    port = com_port()
+    port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": port_select}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    SerialConnectFail,
+)
+async def test_setup_serial_manual_fail(hass):
+    """Test setup serial failed connection."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": "Enter Manually"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": "/dev/ttyUSB0"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_import(hass):
@@ -461,3 +634,50 @@ async def test_options_add_and_configure_device(hass):
     assert entry.data["devices"]["0913000022670e013970"]["fire_event"]
     assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
     assert "delay_off" not in entry.data["devices"]["0913000022670e013970"]
+
+
+def test_get_serial_by_id_no_dir():
+    """Test serial by id conversion if there's no /dev/serial/by-id."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=False))
+    p2 = patch("os.scandir")
+    with p1 as is_dir_mock, p2 as scan_mock:
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 0
+
+
+def test_get_serial_by_id():
+    """Test serial by id conversion."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=True))
+    p2 = patch("os.scandir")
+
+    def _realpath(path):
+        if path is sentinel.matched_link:
+            return sentinel.path
+        return sentinel.serial_link_path
+
+    p3 = patch("os.path.realpath", side_effect=_realpath)
+    with p1 as is_dir_mock, p2 as scan_mock, p3:
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 1
+
+        entry1 = MagicMock(spec_set=os.DirEntry)
+        entry1.is_symlink.return_value = True
+        entry1.path = sentinel.some_path
+
+        entry2 = MagicMock(spec_set=os.DirEntry)
+        entry2.is_symlink.return_value = False
+        entry2.path = sentinel.other_path
+
+        entry3 = MagicMock(spec_set=os.DirEntry)
+        entry3.is_symlink.return_value = True
+        entry3.path = sentinel.matched_link
+
+        scan_mock.return_value = [entry1, entry2, entry3]
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.matched_link
+        assert is_dir_mock.call_count == 2
+        assert scan_mock.call_count == 2

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -37,9 +37,9 @@ def com_port():
 
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport.connect",
-    MagicMock(return_value=None),
+    return_value=None,
 )
-async def test_setup_network(hass):
+async def test_setup_network(connect_mock, hass):
     """Test we can setup network."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -74,16 +74,16 @@ async def test_setup_network(hass):
     }
 
 
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
     serial_connect,
 )
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
-    MagicMock(return_value=None),
+    return_value=None,
 )
-async def test_setup_serial(hass):
+async def test_setup_serial(com_mock, connect_mock, hass):
     """Test we can setup serial."""
     port = com_port()
 
@@ -120,16 +120,16 @@ async def test_setup_serial(hass):
     }
 
 
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
     serial_connect,
 )
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
-    MagicMock(return_value=None),
+    return_value=None,
 )
-async def test_setup_serial_manual(hass):
+async def test_setup_serial_manual(com_mock, connect_mock, hass):
     """Test we can setup serial with manual entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -174,9 +174,9 @@ async def test_setup_serial_manual(hass):
 
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport.connect",
-    MagicMock(side_effect=OSError),
+    side_effect=OSError,
 )
-async def test_setup_network_fail(hass):
+async def test_setup_network_fail(connect_mock, hass):
     """Test we can setup network."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -203,12 +203,12 @@ async def test_setup_network_fail(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    MagicMock(side_effect=serial.serialutil.SerialException),
+    side_effect=serial.serialutil.SerialException,
 )
-async def test_setup_serial_fail(hass):
+async def test_setup_serial_fail(com_mock, connect_mock, hass):
     """Test setup serial failed connection."""
     port = com_port()
 
@@ -237,12 +237,12 @@ async def test_setup_serial_fail(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
     serial_connect_fail,
 )
-async def test_setup_serial_manual_fail(hass):
+async def test_setup_serial_manual_fail(com_mock, hass):
     """Test setup serial failed connection."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -14,12 +14,12 @@ from tests.async_mock import MagicMock, patch, sentinel
 from tests.common import MockConfigEntry
 
 
-def SerialConnect(self):
+def serial_connect(self):
     """Mock a serial connection."""
     self.serial = True
 
 
-def SerialConnectFail(self):
+def serial_connect_fail(self):
     """Mock a failed serial connection."""
     self.serial = None
 
@@ -57,9 +57,10 @@ async def test_setup_network(hass):
     assert result["step_id"] == "setup_network"
     assert result["errors"] == {}
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"host": "10.10.0.1", "port": 1234}
-    )
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "10.10.0.1", "port": 1234}
+        )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "RFXTRX"
@@ -76,7 +77,7 @@ async def test_setup_network(hass):
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    SerialConnect,
+    serial_connect,
 )
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
@@ -103,9 +104,10 @@ async def test_setup_serial(hass):
     assert result["step_id"] == "setup_serial"
     assert result["errors"] == {}
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": port_select}
-    )
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"device": port_select}
+        )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "RFXTRX"
@@ -122,7 +124,7 @@ async def test_setup_serial(hass):
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    SerialConnect,
+    serial_connect,
 )
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
@@ -154,9 +156,10 @@ async def test_setup_serial_manual(hass):
     assert result["step_id"] == "setup_serial_manual_path"
     assert result["errors"] == {}
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": "/dev/ttyUSB0"}
-    )
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"device": "/dev/ttyUSB0"}
+        )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "RFXTRX"
@@ -239,7 +242,7 @@ async def test_setup_serial_fail(hass):
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 @patch(
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    SerialConnectFail,
+    serial_connect_fail,
 )
 async def test_setup_serial_manual_fail(hass):
     """Test setup serial failed connection."""

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -86,7 +86,6 @@ async def test_setup_network(hass):
 async def test_setup_serial(hass):
     """Test we can setup serial."""
     port = com_port()
-    port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -106,7 +105,7 @@ async def test_setup_serial(hass):
 
     with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"device": port_select}
+            result["flow_id"], {"device": port.device}
         )
 
     assert result["type"] == "create_entry"
@@ -212,7 +211,6 @@ async def test_setup_network_fail(hass):
 async def test_setup_serial_fail(hass):
     """Test setup serial failed connection."""
     port = com_port()
-    port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -231,7 +229,7 @@ async def test_setup_serial_fail(hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"device": port_select}
+        result["flow_id"], {"device": port.device}
     )
 
     assert result["type"] == "form"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR targets a different base branch and is part of UI rework for the rfxtrx integration.

This PR implements a config flow to be able to setup the integration from the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14158

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
